### PR TITLE
Fix security audit findings: fail-safe exit codes, interpreter allowlist, and hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -387,7 +387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -636,14 +636,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -652,7 +651,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -818,7 +817,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1001,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1012,7 +1011,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -1021,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1042,16 +1041,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1120,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1132,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1143,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -1223,7 +1222,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1390,16 +1389,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -1467,7 +1456,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1527,7 +1516,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tirith"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "clap",
@@ -1538,13 +1527,14 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "tirith-core",
  "uuid",
 ]
 
 [[package]]
 name = "tirith-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "base64",
  "chrono",
@@ -1579,7 +1569,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "windows-sys 0.61.2",
 ]
 
@@ -1899,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1928,7 +1918,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2273,18 +2263,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2353,6 +2343,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ members = ["crates/tirith-core", "crates/tirith"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 license = "AGPL-3.0-only"
 rust-version = "1.83"
 
 [workspace.dependencies]
-tirith-core = { version = "0.1.8", path = "crates/tirith-core" }
+tirith-core = { version = "0.1.9", path = "crates/tirith-core" }
 clap = { version = "4", features = ["derive"] }
 url = "2"
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ tirith init --shell fish | source
 
 That's it. Every command you run is now guarded. Zero friction on clean input. Sub-millisecond overhead. You forget it's there until it saves you.
 
-Also available via [npm](#npm), [cargo](#cargo), [apt/dnf](#linux-packages), and [more](#install).
+Also available via [npm](#cross-platform), [cargo](#cross-platform), [mise](#cross-platform), [apt/dnf](#linux-packages), and [more](#install).
 
 ---
 
@@ -171,7 +171,7 @@ npm install -g tirith
 cargo install tirith
 ```
 
-**Mise:**
+**[Mise](https://mise.jdx.dev/)** (official registry):
 
 ```bash
 mise use -g tirith
@@ -208,7 +208,7 @@ tirith init --shell fish | source   # in ~/.config/fish/config.fish
 | fish | fish_preexec event | 3.5+ |
 | PowerShell | PSReadLine handler | 7.0+ |
 
-In bash, enter mode is used by default, but SSH sessions automatically fall back to preexec mode for PTY compatibility.
+In bash, enter mode is used by default with a startup health gate and runtime self-healing. SSH sessions automatically fall back to preexec mode for PTY compatibility. If enter mode detects a failure, it auto-degrades to preexec and persists the decision across shells. Unexpected tirith errors (crashes, OOM-kills) trigger a mixed fail-safe policy: bash degrades to preexec, other shells warn and execute, paste paths always discard. See [troubleshooting](docs/troubleshooting.md#unexpected-tirith-exit-codes) for details.
 
 **Nix / Home-Manager:** tirith must be in your `$PATH` — the shell hooks call `tirith` by name at runtime. Adding it to `initContent` alone is not enough.
 

--- a/crates/tirith-core/src/audit.rs
+++ b/crates/tirith-core/src/audit.rs
@@ -1,5 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::PathBuf;
 
 use fs2::FileExt;
@@ -69,12 +71,23 @@ pub fn log_verdict(
     };
 
     // Open, lock, append, fsync, unlock
-    let file = OpenOptions::new().create(true).append(true).open(&path);
+    let mut open_opts = OpenOptions::new();
+    open_opts.create(true).append(true);
+    #[cfg(unix)]
+    open_opts.mode(0o600);
+    let file = open_opts.open(&path);
 
     let file = match file {
         Ok(f) => f,
         Err(_) => return,
     };
+
+    // Harden legacy files: enforce 0600 on existing files too
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+    }
 
     if file.lock_exclusive().is_err() {
         return;
@@ -142,5 +155,33 @@ mod tests {
 
         // Clean up env var
         std::env::remove_var("TIRITH_LOG");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_audit_log_permissions_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Test the OpenOptions pattern directly — avoids env var races with
+        // test_tirith_log_disabled (which sets TIRITH_LOG=0 in the same process).
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test_perms.jsonl");
+
+        {
+            use std::io::Write;
+            let mut open_opts = OpenOptions::new();
+            open_opts.create(true).append(true);
+            use std::os::unix::fs::OpenOptionsExt;
+            open_opts.mode(0o600);
+            let mut f = open_opts.open(&log_path).unwrap();
+            writeln!(f, "test").unwrap();
+        }
+
+        let meta = std::fs::metadata(&log_path).unwrap();
+        assert_eq!(
+            meta.permissions().mode() & 0o777,
+            0o600,
+            "audit log should be 0600"
+        );
     }
 }

--- a/crates/tirith-core/src/extract.rs
+++ b/crates/tirith-core/src/extract.rs
@@ -120,7 +120,19 @@ pub fn scan_bytes(input: &[u8]) -> ByteScanResult {
         }
 
         // Control characters (< 0x20, excluding common whitespace and ESC)
-        if b < 0x20 && b != b'\n' && b != b'\t' && b != 0x1b {
+        // For \r: only flag when followed by non-\n (display-overwriting attack).
+        // Trailing \r and \r\n (Windows line endings) are benign clipboard artifacts.
+        if b == b'\r' {
+            let is_attack_cr = i + 1 < len && input[i + 1] != b'\n';
+            if is_attack_cr {
+                result.has_control_chars = true;
+                result.details.push(ByteFinding {
+                    offset: i,
+                    byte: b,
+                    description: format!("control character 0x{b:02x}"),
+                });
+            }
+        } else if b < 0x20 && b != b'\n' && b != b'\t' && b != 0x1b {
             result.has_control_chars = true;
             result.details.push(ByteFinding {
                 offset: i,
@@ -848,5 +860,61 @@ mod tests {
             .expect("Generated exec pattern must be valid regex");
         Regex::new(tier1_generated::TIER1_PASTE_PATTERN)
             .expect("Generated paste pattern must be valid regex");
+    }
+
+    // ─── CR normalization tests ───
+
+    #[test]
+    fn test_scan_bytes_trailing_cr_not_flagged() {
+        let result = scan_bytes(b"/path\r");
+        assert!(
+            !result.has_control_chars,
+            "trailing \\r should not be flagged"
+        );
+    }
+
+    #[test]
+    fn test_scan_bytes_trailing_crlf_not_flagged() {
+        let result = scan_bytes(b"/path\r\n");
+        assert!(
+            !result.has_control_chars,
+            "trailing \\r\\n should not be flagged"
+        );
+    }
+
+    #[test]
+    fn test_scan_bytes_windows_multiline_not_flagged() {
+        let result = scan_bytes(b"line1\r\nline2\r\n");
+        assert!(
+            !result.has_control_chars,
+            "Windows \\r\\n line endings should not be flagged"
+        );
+    }
+
+    #[test]
+    fn test_scan_bytes_embedded_cr_still_flagged() {
+        let result = scan_bytes(b"safe\rmalicious");
+        assert!(
+            result.has_control_chars,
+            "embedded \\r before non-\\n should be flagged"
+        );
+    }
+
+    #[test]
+    fn test_scan_bytes_mixed_crlf_and_attack_cr() {
+        let result = scan_bytes(b"line1\r\nfake\roverwrite\r\n");
+        assert!(
+            result.has_control_chars,
+            "attack \\r mixed with \\r\\n should be flagged"
+        );
+    }
+
+    #[test]
+    fn test_scan_bytes_only_cr() {
+        let result = scan_bytes(b"\r");
+        assert!(
+            !result.has_control_chars,
+            "lone trailing \\r should not be flagged"
+        );
     }
 }

--- a/crates/tirith-core/src/policy.rs
+++ b/crates/tirith-core/src/policy.rs
@@ -334,6 +334,15 @@ pub fn config_dir() -> Option<PathBuf> {
     Some(base.config_dir().join("tirith"))
 }
 
+/// Get tirith state directory.
+/// Must match bash-hook.bash path: ${XDG_STATE_HOME:-$HOME/.local/state}/tirith
+pub fn state_dir() -> Option<PathBuf> {
+    match std::env::var("XDG_STATE_HOME") {
+        Ok(val) if !val.trim().is_empty() => Some(PathBuf::from(val.trim()).join("tirith")),
+        _ => home::home_dir().map(|h| h.join(".local/state/tirith")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tirith-core/src/receipt.rs
+++ b/crates/tirith-core/src/receipt.rs
@@ -2,6 +2,27 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+fn validate_sha256(sha256: &str) -> Result<(), String> {
+    if sha256.len() != 64
+        || !sha256
+            .bytes()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return Err(format!(
+            "invalid sha256: expected 64 lowercase hex characters, got '{}'",
+            crate::util::truncate_bytes(sha256, 16)
+        ));
+    }
+    Ok(())
+}
+
+/// Safe short prefix of a hash for display. Uses the existing UTF-8-safe
+/// `truncate_bytes` utility to handle any string safely, including
+/// corrupted receipt JSON with non-ASCII sha256 values.
+pub fn short_hash(s: &str) -> String {
+    crate::util::truncate_bytes(s, 12)
+}
+
 /// A receipt for a script that was downloaded and analyzed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Receipt {
@@ -23,6 +44,7 @@ pub struct Receipt {
 impl Receipt {
     /// Save receipt atomically (temp file + rename).
     pub fn save(&self) -> Result<PathBuf, String> {
+        validate_sha256(&self.sha256)?;
         let dir = receipts_dir().ok_or("cannot determine receipts directory")?;
         fs::create_dir_all(&dir).map_err(|e| format!("create dir: {e}"))?;
 
@@ -31,7 +53,19 @@ impl Receipt {
 
         let json = serde_json::to_string_pretty(self).map_err(|e| format!("serialize: {e}"))?;
 
-        fs::write(&tmp_path, &json).map_err(|e| format!("write: {e}"))?;
+        {
+            use std::io::Write;
+            let mut opts = fs::OpenOptions::new();
+            opts.write(true).create(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            let mut f = opts.open(&tmp_path).map_err(|e| format!("write: {e}"))?;
+            f.write_all(json.as_bytes())
+                .map_err(|e| format!("write: {e}"))?;
+        }
         fs::rename(&tmp_path, &path).map_err(|e| format!("rename: {e}"))?;
 
         Ok(path)
@@ -39,6 +73,7 @@ impl Receipt {
 
     /// Load a receipt by SHA256.
     pub fn load(sha256: &str) -> Result<Self, String> {
+        validate_sha256(sha256)?;
         let dir = receipts_dir().ok_or("cannot determine receipts directory")?;
         let path = dir.join(format!("{sha256}.json"));
         let content = fs::read_to_string(&path).map_err(|e| format!("read: {e}"))?;
@@ -76,6 +111,7 @@ impl Receipt {
 
     /// Verify a receipt: check if the file at the cached path still matches sha256.
     pub fn verify(&self) -> Result<bool, String> {
+        validate_sha256(&self.sha256)?;
         let cache_dir = cache_dir().ok_or("cannot determine cache directory")?;
         let cached = cache_dir.join(&self.sha256);
         if !cached.exists() {
@@ -101,4 +137,83 @@ fn sha2_hex(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
     format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_sha256_valid() {
+        let hash = "a".repeat(64);
+        assert!(validate_sha256(&hash).is_ok());
+    }
+
+    #[test]
+    fn test_validate_sha256_too_short() {
+        assert!(validate_sha256("abc").is_err());
+    }
+
+    #[test]
+    fn test_validate_sha256_path_traversal() {
+        assert!(validate_sha256("../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_sha256_uppercase_rejected() {
+        let hash = "A".repeat(64);
+        assert!(validate_sha256(&hash).is_err());
+    }
+
+    #[test]
+    fn test_short_hash_short_input() {
+        assert_eq!(short_hash("abc"), "abc");
+    }
+
+    #[test]
+    fn test_short_hash_normal() {
+        let hash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        assert_eq!(short_hash(hash), "abcdef012345");
+    }
+
+    #[test]
+    fn test_short_hash_non_ascii() {
+        // Multi-byte UTF-8: each char is 3 bytes, so 12 bytes = 4 chars
+        let s = "日本語テスト";
+        let result = short_hash(s);
+        assert!(!result.is_empty());
+        assert!(result.len() <= 12);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_receipt_save_permissions_0600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let receipts_dir = dir.path().join("receipts");
+        std::fs::create_dir_all(&receipts_dir).unwrap();
+
+        let sha = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+        // Write a receipt file with 0600 permissions using the same pattern as save()
+        let path = receipts_dir.join(format!("{sha}.json"));
+        let json = r#"{"test": true}"#;
+        {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create(true).truncate(true);
+            opts.mode(0o600);
+            let mut f = opts.open(&path).unwrap();
+            f.write_all(json.as_bytes()).unwrap();
+        }
+
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(
+            meta.permissions().mode() & 0o777,
+            0o600,
+            "receipt file should be 0600"
+        );
+    }
 }

--- a/crates/tirith-core/src/rules/terminal.rs
+++ b/crates/tirith-core/src/rules/terminal.rs
@@ -28,7 +28,7 @@ pub fn check_bytes(input: &[u8]) -> Vec<Finding> {
             rule_id: RuleId::ControlChars,
             severity: Severity::High,
             title: "Control characters in pasted content".to_string(),
-            description: "Pasted content contains control characters (carriage return, backspace) that could hide the true command being executed".to_string(),
+            description: "Pasted content contains control characters (display-overwriting carriage return, backspace, etc.) that could hide the true command being executed".to_string(),
             evidence: scan.details.iter()
                 .filter(|d| d.description.contains("control"))
                 .map(|d| Evidence::ByteSequence {

--- a/crates/tirith/Cargo.toml
+++ b/crates/tirith/Cargo.toml
@@ -28,6 +28,9 @@ uuid = { workspace = true }
 home = { workspace = true }
 libc = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3"
+
 [package.metadata.deb]
 maintainer = "Shivom Sharma <shivomsharma03@gmail.com>"
 section = "utils"

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -1,12 +1,28 @@
 #!/usr/bin/env bash
 # tirith bash hook
 # Two modes controlled by TIRITH_BASH_MODE:
-#   enter (default outside SSH): bind -x Enter override. Can block execution.
-#   preexec: DEBUG trap warn-only. Cannot block.
+#   enter (default outside SSH): bind -x Enter override. Can block + intercept paste.
+#     Startup health gate + pending-not-consumed detection auto-degrade to preexec.
+#   preexec: DEBUG trap warn-only. Cannot block. No paste interception.
 
-# Guard against double-loading
-[[ -n "$_TIRITH_BASH_LOADED" ]] && return
+# Guard against double-loading (session-local only).
+# If inherited from environment (exported by attacker/parent), ignore it.
+if [[ -n "$_TIRITH_BASH_LOADED" ]]; then
+  if [[ "$(declare -p _TIRITH_BASH_LOADED 2>/dev/null)" =~ ^declare\ -[a-zA-Z]*x ]]; then
+    unset _TIRITH_BASH_LOADED  # Inherited from env — ignore and load fresh
+  else
+    return  # Set in this session — genuine double-source guard
+  fi
+fi
 _TIRITH_BASH_LOADED=1
+
+# Clear attacker-controllable env vars before any hooks are installed.
+# _TIRITH_PENDING_EVAL/_PENDING_SOURCE: pre-set value would be eval'd on first prompt.
+unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_SOURCE
+# _TIRITH_TEST_*: only clear if inherited from environment (exported by parent).
+# Session-local values (set without export) are trusted test overrides.
+[[ "$(declare -p _TIRITH_TEST_SKIP_HEALTH 2>/dev/null)" =~ ^declare\ -[a-zA-Z]*x ]] && unset _TIRITH_TEST_SKIP_HEALTH
+[[ "$(declare -p _TIRITH_TEST_FAIL_HEALTH 2>/dev/null)" =~ ^declare\ -[a-zA-Z]*x ]] && unset _TIRITH_TEST_FAIL_HEALTH
 
 # Output helper: use stderr for Warp terminal (which doesn't display /dev/tty properly),
 # otherwise use /dev/tty for proper terminal output that doesn't mix with command output.
@@ -19,8 +35,120 @@ _tirith_output() {
   fi
 }
 
+# ─── Persistent safe mode infrastructure ───
+
+# Trim whitespace to match Rust policy.rs:state_dir() behavior
+_TIRITH_STATE_DIR="${XDG_STATE_HOME:-}"
+_TIRITH_STATE_DIR="${_TIRITH_STATE_DIR#"${_TIRITH_STATE_DIR%%[![:space:]]*}"}"
+_TIRITH_STATE_DIR="${_TIRITH_STATE_DIR%"${_TIRITH_STATE_DIR##*[![:space:]]}"}"
+_TIRITH_STATE_DIR="${_TIRITH_STATE_DIR:-$HOME/.local/state}/tirith"
+_TIRITH_SAFE_MODE_FLAG="$_TIRITH_STATE_DIR/bash-safe-mode"
+
+_tirith_check_safe_mode() { [[ -f "$_TIRITH_SAFE_MODE_FLAG" ]]; }
+
+_tirith_persist_safe_mode() {
+  mkdir -p "$_TIRITH_STATE_DIR" 2>/dev/null || return
+  printf '1\n' > "$_TIRITH_SAFE_MODE_FLAG" 2>/dev/null || return
+}
+
+# ─── Preexec function (used by both preexec mode and degrade fallback) ───
+
+_tirith_preexec() {
+  # Only run once per command (guard against DEBUG firing multiple times)
+  [[ "${_tirith_last_cmd:-}" == "$BASH_COMMAND" ]] && return
+  _tirith_last_cmd="$BASH_COMMAND"
+
+  # Warn-only: command is already committed, we can only print warnings
+  tirith check --shell posix -- "$BASH_COMMAND" || true
+}
+
+# ─── Degrade function ───
+
+_tirith_degrade_to_preexec() {
+  local reason="${1:-unknown}"
+  # Only print warnings in interactive shells
+  if [[ $- == *i* ]]; then
+    _tirith_output "tirith: enter mode failed ($reason) — switching to preexec"
+    _tirith_output "  Persistent. Re-enable: TIRITH_BASH_MODE=enter"
+  fi
+
+  # Safe deterministic degrade: set known-safe defaults for current session.
+  # Custom bindings from .inputrc/.bashrc return on next shell (safe mode persisted,
+  # so tirith won't install bind-x on restart).
+  if [[ "${_TIRITH_BINDS_INSTALLED:-0}" == "1" ]]; then
+    bind '"\C-m": accept-line' 2>/dev/null || true
+    bind '"\C-j": accept-line' 2>/dev/null || true
+    # Restore bracketed paste to readline default if available, otherwise unbind
+    bind '"\e[200~": bracketed-paste-begin' 2>/dev/null || bind -r '"\e[200~"' 2>/dev/null || true
+    _TIRITH_BINDS_INSTALLED=0
+  fi
+
+  trap '_tirith_preexec' DEBUG
+  _TIRITH_BASH_MODE="preexec"
+  _tirith_persist_safe_mode
+  if [[ $- == *i* ]]; then
+    _tirith_output "  Restart your shell for full custom keybindings to return."
+  fi
+}
+
+# ─── PROMPT_COMMAND management ───
+
+_tirith_prompt_hook() {
+  local pending_eval="${_TIRITH_PENDING_EVAL:-}"
+  local pending_source="${_TIRITH_PENDING_SOURCE:-}"
+  unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_SOURCE
+
+  if [[ -n "$pending_source" ]]; then
+    source "$pending_source"
+    rm -f "$pending_source"
+  elif [[ -n "$pending_eval" ]]; then
+    eval -- "$pending_eval"
+  fi
+}
+
+_tirith_is_prompt_hook_attached() {
+  local pc_decl
+  pc_decl="$(declare -p PROMPT_COMMAND 2>/dev/null)" || return 1
+
+  if [[ "$pc_decl" == "declare -a"* ]]; then
+    local entry
+    for entry in "${PROMPT_COMMAND[@]}"; do
+      [[ "$entry" == "_tirith_prompt_hook" ]] && return 0
+    done
+    return 1
+  else
+    # String form: use regex to match _tirith_prompt_hook as a semicolon-delimited
+    # token with optional surrounding whitespace.
+    [[ "$PROMPT_COMMAND" =~ (^|;)[[:space:]]*_tirith_prompt_hook[[:space:]]*(;|$) ]] && return 0
+    return 1
+  fi
+}
+
+_tirith_ensure_prompt_hook() {
+  _tirith_is_prompt_hook_attached && return 0
+
+  local pc_decl
+  pc_decl="$(declare -p PROMPT_COMMAND 2>/dev/null)" || pc_decl=""
+
+  if [[ "$pc_decl" == "declare -a"* ]]; then
+    PROMPT_COMMAND=(_tirith_prompt_hook "${PROMPT_COMMAND[@]}") 2>/dev/null || return 1
+  elif [[ -n "${PROMPT_COMMAND:-}" ]]; then
+    PROMPT_COMMAND="_tirith_prompt_hook;${PROMPT_COMMAND}" 2>/dev/null || return 1
+  else
+    PROMPT_COMMAND="_tirith_prompt_hook" 2>/dev/null || return 1
+  fi
+  return 0
+}
+
+# ─── Mode selection ───
+
 if [[ -n "${TIRITH_BASH_MODE:-}" ]]; then
   _TIRITH_BASH_MODE="$TIRITH_BASH_MODE"
+elif _tirith_check_safe_mode; then
+  _TIRITH_BASH_MODE="preexec"
+  # Only print warning in interactive shells (avoid polluting scripted output)
+  [[ $- == *i* ]] && _tirith_output "tirith: safe mode active (preexec) — previous enter-mode failure detected"
+  [[ $- == *i* ]] && _tirith_output "  Re-enable: TIRITH_BASH_MODE=enter or tirith doctor --reset-bash-safe-mode"
 elif [[ -n "${SSH_CONNECTION:-}" || -n "${SSH_TTY:-}" || -n "${SSH_CLIENT:-}" ]]; then
   # SSH PTY environments are more reliable with DEBUG-trap preexec mode.
   _TIRITH_BASH_MODE="preexec"
@@ -28,33 +156,7 @@ else
   _TIRITH_BASH_MODE="enter"
 fi
 
-# Queue command execution into PROMPT_COMMAND so interactive commands
-# (ssh, gcloud compute ssh, etc.) run outside the bind -x callback.
-_tirith_register_prompt_hook() {
-  [[ -n "${_TIRITH_PROMPT_HOOKED:-}" ]] && return
-  _TIRITH_PROMPT_HOOKED=1
-
-  _tirith_prompt_hook() {
-    local pending_eval="${_TIRITH_PENDING_EVAL:-}"
-    local pending_source="${_TIRITH_PENDING_SOURCE:-}"
-    unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_SOURCE
-
-    if [[ -n "$pending_source" ]]; then
-      source "$pending_source"
-      rm -f "$pending_source"
-    elif [[ -n "$pending_eval" ]]; then
-      eval -- "$pending_eval"
-    fi
-  }
-
-  if declare -p PROMPT_COMMAND >/dev/null 2>&1 && [[ "$(declare -p PROMPT_COMMAND)" == "declare -a"* ]]; then
-    PROMPT_COMMAND=(_tirith_prompt_hook "${PROMPT_COMMAND[@]}")
-  elif [[ -n "${PROMPT_COMMAND:-}" ]]; then
-    PROMPT_COMMAND="_tirith_prompt_hook;${PROMPT_COMMAND}"
-  else
-    PROMPT_COMMAND="_tirith_prompt_hook"
-  fi
-}
+# ─── Helpers ───
 
 # Check if a command is unsafe to eval (heredocs, multiline, etc.)
 _tirith_unsafe_to_eval() {
@@ -94,61 +196,110 @@ _tirith_unsafe_to_eval() {
   return 1
 }
 
-if [[ "$_TIRITH_BASH_MODE" == "enter" ]]; then
-  # Mode: enter — bind -x Enter override with full block+warn capability
+# ─── Startup health gate ───
 
-  _tirith_register_prompt_hook
+_tirith_startup_health_check() {
+  # Test-only override: bypass startup gate to reach runtime failure paths in PTY tests.
+  [[ "${_TIRITH_TEST_SKIP_HEALTH:-}" == "1" ]] && return 0
+  # Test-only override for CI (avoids needing PTY)
+  [[ "${_TIRITH_TEST_FAIL_HEALTH:-}" == "1" ]] && return 1
+  # Verify both \C-m and \C-j are bound to _tirith_enter
+  local binds
+  binds="$(bind -X 2>/dev/null)" || return 1
+  [[ "$binds" =~ \\C-m.*_tirith_enter ]] || return 1
+  [[ "$binds" =~ \\C-j.*_tirith_enter ]] || return 1
+  # Verify prompt hook is still attached
+  _tirith_is_prompt_hook_attached || return 1
+  return 0
+}
 
-  _tirith_enter() {
-    # Save terminal state — bind -x can corrupt echo in some PTY environments (gcloud ssh, etc.)
-    local _saved_stty
-    _saved_stty=$(stty -g 2>/dev/null) || true
+# ─── Enter mode (interactive only) ───
 
-    # Ensure terminal state is restored on exit
-    trap 'stty "$_saved_stty" 2>/dev/null || true' RETURN
+if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
+  # Enter mode: interactive shell only (bind-x requires readline).
+  # Non-interactive sourcing (bash -c, scripts, BASH_ENV) skips this entire block.
+  # Mode variable stays "enter" but nothing is installed — effectively a no-op.
+  # No traps, no bindings, no state writes in non-interactive context.
+  _TIRITH_BINDS_INSTALLED=0
 
-    # Empty input: just return (shows new prompt)
-    if [[ -z "$READLINE_LINE" ]]; then
-      READLINE_LINE=""
-      READLINE_POINT=0
-      return
-    fi
+  # Attach prompt hook (gates further setup)
+  if ! _tirith_ensure_prompt_hook; then
+    _tirith_degrade_to_preexec "PROMPT_COMMAND is readonly or unattachable"
+  else
+    _tirith_enter() {
+      # Save terminal state — bind -x can corrupt echo in some PTY environments (gcloud ssh, etc.)
+      local _saved_stty
+      _saved_stty=$(stty -g 2>/dev/null) || true
 
-    # Check for incomplete input (open quotes, unclosed blocks)
-    local syntax_err
-    syntax_err=$(bash -n <<< "$READLINE_LINE" 2>&1)
-    local syntax_rc=$?
-    if [[ $syntax_rc -ne 0 ]] && [[ "$syntax_err" == *"unexpected EOF"* || "$syntax_err" == *"unexpected end of file"* ]]; then
-      # Incomplete input: insert newline for continued editing
-      READLINE_LINE+=$'\n'
-      READLINE_POINT=${#READLINE_LINE}
-      return
-    fi
+      # Ensure terminal state is restored on exit
+      trap 'stty "$_saved_stty" 2>/dev/null || true' RETURN
 
-    # Run tirith check, use temp file to prevent tty leakage in bind -x context
-    local tmpfile=$(mktemp)
-    tirith check --non-interactive --shell posix -- "$READLINE_LINE" >"$tmpfile" 2>&1
-    local rc=$?
-    local output=$(<"$tmpfile")
-    rm -f "$tmpfile"
+      # Self-heal: verify prompt hook is still attached
+      if ! _tirith_ensure_prompt_hook; then
+        _tirith_degrade_to_preexec "PROMPT_COMMAND reattachment failed"
+        return  # READLINE_LINE stays intact
+      fi
 
-    if [[ $rc -eq 1 ]]; then
-      # Block: show the command that was blocked, print warning, clear line
-      _tirith_output ""
-      _tirith_output "command> $READLINE_LINE"
-      [[ -n "$output" ]] && _tirith_output "$output"
-      READLINE_LINE=""
-      READLINE_POINT=0
-    elif [[ $rc -eq 2 ]]; then
-      # Warn: print warning then execute
-      _tirith_output ""
-      _tirith_output "command> $READLINE_LINE"
-      [[ -n "$output" ]] && _tirith_output "$output"
-      # Fall through to execute
-    fi
+      # Detect broken delivery: if previous pending was never consumed
+      if [[ -n "${_TIRITH_PENDING_EVAL:-}" || -n "${_TIRITH_PENDING_SOURCE:-}" ]]; then
+        [[ -n "${_TIRITH_PENDING_SOURCE:-}" ]] && rm -f "${_TIRITH_PENDING_SOURCE}"
+        unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_SOURCE
+        _tirith_degrade_to_preexec "previous command not delivered (check shell history)"
+        return  # READLINE_LINE stays intact
+      fi
 
-    if [[ $rc -ne 1 ]]; then
-      # Allow (0) or Warn (2): execute the command
+      # Empty input: just return (shows new prompt)
+      if [[ -z "$READLINE_LINE" ]]; then
+        READLINE_LINE=""
+        READLINE_POINT=0
+        return
+      fi
+
+      # Check for incomplete input (open quotes, unclosed blocks)
+      local syntax_err
+      syntax_err=$(bash -n <<< "$READLINE_LINE" 2>&1)
+      local syntax_rc=$?
+      if [[ $syntax_rc -ne 0 ]] && [[ "$syntax_err" == *"unexpected EOF"* || "$syntax_err" == *"unexpected end of file"* ]]; then
+        # Incomplete input: insert newline for continued editing
+        READLINE_LINE+=$'\n'
+        READLINE_POINT=${#READLINE_LINE}
+        return
+      fi
+
+      # Run tirith check, use temp file to prevent tty leakage in bind -x context
+      local tmpfile=$(mktemp)
+      tirith check --non-interactive --shell posix -- "$READLINE_LINE" >"$tmpfile" 2>&1
+      local rc=$?
+      local output=$(<"$tmpfile")
+      rm -f "$tmpfile"
+
+      if [[ $rc -eq 0 ]]; then
+        # Allow: execute silently (fall through to execute block)
+        :
+      elif [[ $rc -eq 2 ]]; then
+        # Warn: print warning then execute (fall through to execute block)
+        _tirith_output ""
+        _tirith_output "command> $READLINE_LINE"
+        [[ -n "$output" ]] && _tirith_output "$output"
+      elif [[ $rc -eq 1 ]]; then
+        # Block: tirith intentionally blocked this command
+        _tirith_output ""
+        _tirith_output "command> $READLINE_LINE"
+        [[ -n "$output" ]] && _tirith_output "$output"
+        READLINE_LINE=""
+        READLINE_POINT=0
+        return
+      else
+        # Unexpected exit code (crash, OOM, missing binary): degrade to preexec
+        # Block this command but don't break the terminal — use Issue #20 infrastructure
+        _tirith_output ""
+        _tirith_output "command> $READLINE_LINE"
+        [[ -n "$output" ]] && _tirith_output "$output"
+        _tirith_degrade_to_preexec "tirith returned unexpected exit code $rc"
+        return  # READLINE_LINE preserved for re-execution via preexec
+      fi
+
+      # rc was 0 or 2: execute the command
       local cmd="$READLINE_LINE"
       READLINE_LINE=""
       READLINE_POINT=0
@@ -173,71 +324,71 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]]; then
 
       history -s -- "$cmd"
       _TIRITH_PENDING_EVAL="$cmd"
-    fi
-  }
+    }
 
-  bind -x '"\C-m": _tirith_enter' || true
-  bind -x '"\C-j": _tirith_enter' || true
+    # Bracketed paste interception
+    _tirith_paste() {
+      # Save terminal state — bind -x can corrupt echo in some PTY environments (gcloud ssh, etc.)
+      local _saved_stty
+      _saved_stty=$(stty -g 2>/dev/null) || true
+      trap 'stty "$_saved_stty" 2>/dev/null || true' RETURN
 
-  # Bracketed paste interception
-  _tirith_paste() {
-    # Save terminal state — bind -x can corrupt echo in some PTY environments (gcloud ssh, etc.)
-    local _saved_stty
-    _saved_stty=$(stty -g 2>/dev/null) || true
-    trap 'stty "$_saved_stty" 2>/dev/null || true' RETURN
+      # Read pasted content until bracketed paste end sequence (\e[201~)
+      local pasted=""
+      local char
+      while IFS= read -r -n 1 -d '' -t 1 char; do
+        pasted+="$char"
+        # Check for end of bracketed paste
+        if [[ "$pasted" == *$'\e[201~' ]]; then
+          # Strip the end sequence
+          pasted="${pasted%$'\e[201~'}"
+          break
+        fi
+      done
 
-    # Read pasted content until bracketed paste end sequence (\e[201~)
-    local pasted=""
-    local char
-    while IFS= read -r -n 1 -t 1 char; do
-      pasted+="$char"
-      # Check for end of bracketed paste
-      if [[ "$pasted" == *$'\e[201~' ]]; then
-        # Strip the end sequence
-        pasted="${pasted%$'\e[201~'}"
-        break
+      if [[ -n "$pasted" ]]; then
+        # Check with tirith paste, use temp file to prevent tty leakage
+        local tmpfile=$(mktemp)
+        printf '%s' "$pasted" | tirith paste --shell posix >"$tmpfile" 2>&1
+        local rc=$?
+        local output=$(<"$tmpfile")
+        rm -f "$tmpfile"
+
+        if [[ $rc -eq 0 ]]; then
+          # Allow: fall through to insert
+          :
+        elif [[ $rc -eq 2 ]]; then
+          # Warn: show warning, fall through to insert
+          [[ -n "$output" ]] && { _tirith_output ""; _tirith_output "$output"; }
+        else
+          # Block (rc=1) or unexpected: discard paste (safe — user can re-paste)
+          _tirith_output ""
+          _tirith_output "paste> $pasted"
+          [[ -n "$output" ]] && _tirith_output "$output"
+          [[ $rc -ne 1 ]] && _tirith_output "tirith: paste check failed (exit code $rc)"
+          return
+        fi
       fi
-    done
 
-    if [[ -n "$pasted" ]]; then
-      # Check with tirith paste, use temp file to prevent tty leakage
-      local tmpfile=$(mktemp)
-      printf '%s' "$pasted" | tirith paste --shell posix >"$tmpfile" 2>&1
-      local rc=$?
-      local output=$(<"$tmpfile")
-      rm -f "$tmpfile"
+      # Allow: insert into readline buffer
+      READLINE_LINE="${READLINE_LINE:0:$READLINE_POINT}${pasted}${READLINE_LINE:$READLINE_POINT}"
+      READLINE_POINT=$((READLINE_POINT + ${#pasted}))
+    }
 
-      if [[ $rc -eq 1 ]]; then
-        # Block: show what was pasted, then warning, discard paste
-        _tirith_output ""
-        _tirith_output "paste> $pasted"
-        [[ -n "$output" ]] && _tirith_output "$output"
-        return
-      elif [[ $rc -eq 2 ]]; then
-        # Warn: show warning, keep paste
-        [[ -n "$output" ]] && { _tirith_output ""; _tirith_output "$output"; }
-      fi
+    # Install key bindings
+    bind -x '"\C-m": _tirith_enter' || true
+    bind -x '"\C-j": _tirith_enter' || true
+    bind -x '"\e[200~": _tirith_paste' || true
+    _TIRITH_BINDS_INSTALLED=1
+
+    # Startup health gate: verify bind-x took effect for BOTH keys
+    if ! _tirith_startup_health_check; then
+      _tirith_degrade_to_preexec "startup health check failed (bind-x or PROMPT_COMMAND)"
     fi
+  fi
 
-    # Allow: insert into readline buffer
-    READLINE_LINE="${READLINE_LINE:0:$READLINE_POINT}${pasted}${READLINE_LINE:$READLINE_POINT}"
-    READLINE_POINT=$((READLINE_POINT + ${#pasted}))
-  }
-
-  # Bind bracketed paste start sequence
-  bind -x '"\e[200~": _tirith_paste' || true
-
-elif [[ "$_TIRITH_BASH_MODE" == "preexec" ]]; then
-  # Mode: preexec — DEBUG trap, warn-only (cannot block)
-
-  _tirith_preexec() {
-    # Only run once per command (guard against DEBUG firing multiple times)
-    [[ "${_tirith_last_cmd:-}" == "$BASH_COMMAND" ]] && return
-    _tirith_last_cmd="$BASH_COMMAND"
-
-    # Warn-only: command is already committed, we can only print warnings
-    tirith check --shell posix -- "$BASH_COMMAND" || true
-  }
-
+elif [[ "$_TIRITH_BASH_MODE" == "preexec" ]] && [[ $- == *i* ]]; then
+  # Only install DEBUG trap in interactive shells.
+  # Non-interactive sourcing (bash -c, BASH_ENV, scripts) is a clean no-op.
   trap '_tirith_preexec' DEBUG
 fi

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -3,8 +3,15 @@
 # Overrides accept-line widget to check commands before execution.
 # Overrides bracketed-paste widget to check pasted content.
 
-# Guard against double-loading
-[[ -n "$_TIRITH_ZSH_LOADED" ]] && return
+# Guard against double-loading (session-local only).
+# If inherited from environment (exported by attacker/parent), ignore it.
+if [[ -n "$_TIRITH_ZSH_LOADED" ]]; then
+  if [[ "${(t)_TIRITH_ZSH_LOADED}" == *export* ]]; then
+    unset _TIRITH_ZSH_LOADED  # Inherited from env — ignore and load fresh
+  else
+    return  # Set in this session — genuine double-source guard
+  fi
+fi
 _TIRITH_ZSH_LOADED=1
 
 # Output helper: use stderr for Warp terminal (which doesn't display /dev/tty properly),
@@ -39,21 +46,25 @@ _tirith_accept_line() {
   local output=$(<"$tmpfile")
   rm -f "$tmpfile"
 
-  if [[ $rc -eq 1 ]]; then
-    # Block: show command and output
+  if [[ $rc -eq 0 ]]; then
+    zle _tirith_original_accept_line 2>/dev/null || zle .accept-line
+  elif [[ $rc -eq 2 ]]; then
+    _tirith_output ""
+    _tirith_output "command> $buf"
+    [[ -n "$output" ]] && _tirith_output "$output"
+    zle _tirith_original_accept_line 2>/dev/null || zle .accept-line
+  elif [[ $rc -eq 1 ]]; then
+    # Block: tirith intentionally blocked
     BUFFER=""
     _tirith_output ""
     _tirith_output "command> $buf"
     [[ -n "$output" ]] && _tirith_output "$output"
     zle send-break
-  elif [[ $rc -eq 2 ]]; then
-    # Warn: show command and output, then execute
-    _tirith_output ""
-    _tirith_output "command> $buf"
-    [[ -n "$output" ]] && _tirith_output "$output"
-    zle _tirith_original_accept_line 2>/dev/null || zle .accept-line
   else
-    # Allow: execute normally
+    # Unexpected rc: warn + execute (fail-open to avoid terminal breakage)
+    _tirith_output ""
+    [[ -n "$output" ]] && _tirith_output "$output"
+    _tirith_output "tirith: unexpected exit code $rc — running unprotected"
     zle _tirith_original_accept_line 2>/dev/null || zle .accept-line
   fi
 }
@@ -83,19 +94,22 @@ _tirith_bracketed_paste() {
     local output=$(<"$tmpfile")
     rm -f "$tmpfile"
 
-    if [[ $rc -eq 1 ]]; then
-      # Block: show paste content and output
+    if [[ $rc -eq 0 ]]; then
+      # Allow: fall through to keep paste
+      :
+    elif [[ $rc -eq 2 ]]; then
+      [[ -n "$output" ]] && { _tirith_output ""; _tirith_output "$output"; }
+    else
+      # Block or unexpected: revert paste
       BUFFER="$old_buffer"
       CURSOR=$old_cursor
       _tirith_output ""
       _tirith_output "paste> $pasted"
       [[ -n "$output" ]] && _tirith_output "$output"
+      [[ $rc -ne 1 ]] && _tirith_output "tirith: unexpected exit code $rc — paste blocked for safety"
       zle send-break
-    elif [[ $rc -eq 2 ]]; then
-      # Warn: show warning, keep paste
-      [[ -n "$output" ]] && { _tirith_output ""; _tirith_output "$output"; }
+      return
     fi
-    # Allow (0): keep the paste silently
   fi
 }
 

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -1,6 +1,10 @@
 use std::path::PathBuf;
 
-pub fn run(json: bool) -> i32 {
+pub fn run(json: bool, reset_bash_safe_mode: bool) -> i32 {
+    if reset_bash_safe_mode {
+        return reset_safe_mode();
+    }
+
     let info = gather_info();
 
     if json {
@@ -27,6 +31,7 @@ struct DoctorInfo {
     hooks_materialized: bool,
     shell_profile: Option<String>,
     hook_configured: bool,
+    bash_safe_mode: bool,
     policy_paths: Vec<String>,
     policy_root_env: Option<String>,
     data_dir: Option<String>,
@@ -57,6 +62,11 @@ fn gather_info() -> DoctorInfo {
 
     // Check if shell profile has tirith init configured
     let (shell_profile, hook_configured) = check_shell_profile(&detected_shell);
+
+    // Check if bash safe-mode flag exists (persistent preexec fallback)
+    let bash_safe_mode = tirith_core::policy::state_dir()
+        .map(|d| d.join("bash-safe-mode").exists())
+        .unwrap_or(false);
 
     let data_dir = tirith_core::policy::data_dir();
     let log_path = data_dir.as_ref().map(|d| d.join("log.jsonl"));
@@ -95,6 +105,7 @@ fn gather_info() -> DoctorInfo {
         hooks_materialized,
         shell_profile: shell_profile.map(|p| p.display().to_string()),
         hook_configured,
+        bash_safe_mode,
         policy_paths,
         policy_root_env,
         data_dir: data_dir.map(|d| d.display().to_string()),
@@ -145,6 +156,12 @@ fn print_human(info: &DoctorInfo) {
             }
         }
         eprintln!();
+    }
+    if info.bash_safe_mode {
+        eprintln!("  bash mode:    SAFE MODE (preexec fallback — previous enter-mode failure)");
+        eprintln!("                Reset: tirith doctor --reset-bash-safe-mode");
+    } else {
+        eprintln!("  bash mode:    normal");
     }
     if info.policy_paths.is_empty() {
         eprintln!("  policies:     (none found)");
@@ -223,4 +240,32 @@ fn check_shell_profile(shell: &str) -> (Option<PathBuf>, bool) {
     // Return the primary profile path even if it doesn't exist
     let primary = profile_candidates.into_iter().next();
     (primary, false)
+}
+
+fn reset_safe_mode() -> i32 {
+    let state_dir = match tirith_core::policy::state_dir() {
+        Some(d) => d,
+        None => {
+            eprintln!("tirith: could not determine state directory");
+            return 1;
+        }
+    };
+
+    let flag = state_dir.join("bash-safe-mode");
+    if flag.exists() {
+        match std::fs::remove_file(&flag) {
+            Ok(()) => {
+                eprintln!("tirith: bash safe-mode flag removed");
+                eprintln!("  Next shell will attempt enter mode again.");
+                0
+            }
+            Err(e) => {
+                eprintln!("tirith: failed to remove {}: {e}", flag.display());
+                1
+            }
+        }
+    } else {
+        eprintln!("tirith: no bash safe-mode flag found (enter mode is already enabled)");
+        0
+    }
 }

--- a/crates/tirith/src/cli/last_trigger.rs
+++ b/crates/tirith/src/cli/last_trigger.rs
@@ -34,7 +34,19 @@ pub fn write_last_trigger(verdict: &tirith_core::verdict::Verdict, cmd: &str) {
         };
 
         if let Ok(json) = serde_json::to_string_pretty(&trigger) {
-            let _ = std::fs::write(&tmp, &json);
+            {
+                use std::io::Write;
+                let mut opts = std::fs::OpenOptions::new();
+                opts.write(true).create(true).truncate(true);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt;
+                    opts.mode(0o600);
+                }
+                if let Ok(mut f) = opts.open(&tmp) {
+                    let _ = f.write_all(json.as_bytes());
+                }
+            }
             let _ = std::fs::rename(&tmp, &path);
         }
     }

--- a/crates/tirith/src/cli/paste.rs
+++ b/crates/tirith/src/cli/paste.rs
@@ -7,10 +7,19 @@ use tirith_core::output;
 use tirith_core::tokenize::ShellType;
 
 pub fn run(shell: &str, json: bool) -> i32 {
-    // Read raw bytes from stdin
+    // Read raw bytes from stdin with 1 MiB cap
+    const MAX_PASTE: u64 = 1024 * 1024; // 1 MiB
+
     let mut raw_bytes = Vec::new();
-    if let Err(e) = std::io::stdin().read_to_end(&mut raw_bytes) {
+    if let Err(e) = std::io::stdin()
+        .take(MAX_PASTE + 1)
+        .read_to_end(&mut raw_bytes)
+    {
         eprintln!("tirith: failed to read stdin: {e}");
+        return 1;
+    }
+    if raw_bytes.len() as u64 > MAX_PASTE {
+        eprintln!("tirith: paste input exceeds 1 MiB limit");
         return 1;
     }
 

--- a/crates/tirith/src/cli/receipt.rs
+++ b/crates/tirith/src/cli/receipt.rs
@@ -35,7 +35,7 @@ pub fn list(json: bool) -> i32 {
                 for r in &receipts {
                     eprintln!(
                         "  {} {} ({} bytes) {}",
-                        &r.sha256[..12],
+                        tirith_core::receipt::short_hash(&r.sha256),
                         r.url,
                         r.size,
                         r.timestamp
@@ -64,9 +64,15 @@ pub fn verify(sha256: &str, json: bool) -> i32 {
                     let _ = serde_json::to_writer_pretty(std::io::stdout().lock(), &out);
                     println!();
                 } else if valid {
-                    eprintln!("tirith: receipt {} verified OK", &sha256[..12]);
+                    eprintln!(
+                        "tirith: receipt {} verified OK",
+                        tirith_core::receipt::short_hash(sha256)
+                    );
                 } else {
-                    eprintln!("tirith: receipt {} FAILED verification", &sha256[..12]);
+                    eprintln!(
+                        "tirith: receipt {} FAILED verification",
+                        tirith_core::receipt::short_hash(sha256)
+                    );
                 }
                 if valid {
                     0

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -110,6 +110,9 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Remove persistent bash safe-mode flag (re-enables enter mode)
+        #[arg(long, conflicts_with = "json")]
+        reset_bash_safe_mode: bool,
     },
 
     /// Generate shell completions
@@ -176,7 +179,10 @@ fn main() {
 
         Commands::Init { shell } => cli::init::run(shell.as_deref()),
 
-        Commands::Doctor { json } => cli::doctor::run(json),
+        Commands::Doctor {
+            json,
+            reset_bash_safe_mode,
+        } => cli::doctor::run(json, reset_bash_safe_mode),
 
         Commands::Completions { shell } => cli::completions::run(shell),
 

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -2,6 +2,8 @@
 //! Tests exercise subcommands via process invocation.
 
 use std::fs;
+#[cfg(unix)]
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -282,7 +284,8 @@ fn bash_hook_defaults_to_preexec_in_ssh_sessions() {
         hook
     );
     let out = Command::new("bash")
-        .args(["-lc", &script])
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env_remove("_TIRITH_BASH_LOADED")
         .output()
         .expect("failed to run bash");
     assert_eq!(out.status.code(), Some(0));
@@ -305,7 +308,8 @@ fn bash_hook_respects_explicit_mode_override_in_ssh_sessions() {
         hook
     );
     let out = Command::new("bash")
-        .args(["-lc", &script])
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env_remove("_TIRITH_BASH_LOADED")
         .output()
         .expect("failed to run bash");
     assert_eq!(out.status.code(), Some(0));
@@ -448,5 +452,662 @@ fn receipt_list_empty() {
     assert!(
         out.status.code() == Some(0) || out.status.code() == Some(1),
         "receipt list should work"
+    );
+}
+
+// ─── CR paste normalization ───
+
+#[cfg(unix)]
+#[test]
+fn paste_trailing_cr_allows() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tirith"))
+        .args(["paste", "--shell", "posix"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn tirith");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"/some/path\r")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "trailing \\r should not trigger control_chars block"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn paste_embedded_cr_blocks() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tirith"))
+        .args(["paste", "--shell", "posix"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn tirith");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"safe\rmalicious")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "embedded \\r before non-\\n should trigger block"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn paste_windows_crlf_allows() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tirith"))
+        .args(["paste", "--shell", "posix"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn tirith");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"echo hello\r\necho world\r\n")
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "Windows \\r\\n line endings should not trigger block"
+    );
+}
+
+// ─── Bash hook mode selection ───
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_enter_default_outside_ssh() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let script = format!(
+        "unset TIRITH_BASH_MODE; unset SSH_CONNECTION; unset SSH_TTY; unset SSH_CLIENT; source '{}'; printf '%s' \"$_TIRITH_BASH_MODE\"",
+        hook
+    );
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        stdout, "enter",
+        "non-SSH sessions should default to enter mode"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_honors_persistent_safe_mode() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let state_dir = tmpdir.path().join("tirith");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(state_dir.join("bash-safe-mode"), "1\n").unwrap();
+
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let script = format!(
+        "unset TIRITH_BASH_MODE; unset SSH_CONNECTION; unset SSH_TTY; unset SSH_CLIENT; source '{}'; printf '%s' \"$_TIRITH_BASH_MODE\"",
+        hook
+    );
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        stdout, "preexec",
+        "persistent safe-mode flag should force preexec"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_explicit_override_trumps_safe_mode() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let state_dir = tmpdir.path().join("tirith");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(state_dir.join("bash-safe-mode"), "1\n").unwrap();
+
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let script = format!(
+        "export TIRITH_BASH_MODE=enter; source '{}'; printf '%s' \"$_TIRITH_BASH_MODE\"",
+        hook
+    );
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        stdout, "enter",
+        "explicit TIRITH_BASH_MODE should override safe-mode flag"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_prompt_hook_reattaches() {
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    // Source hook, overwrite PROMPT_COMMAND, call ensure, check re-attached
+    let script = format!(
+        "source '{}'; PROMPT_COMMAND='other_fn'; _tirith_ensure_prompt_hook; [[ \"$PROMPT_COMMAND\" == *_tirith_prompt_hook* ]] && printf 'reattached' || printf 'missing'",
+        hook
+    );
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        stdout, "reattached",
+        "_tirith_ensure_prompt_hook should reattach when overwritten"
+    );
+}
+
+// ─── Startup gate degrade + persistence ───
+
+#[cfg(unix)]
+fn expect_available() -> bool {
+    Command::new("sh")
+        .args(["-c", "command -v expect >/dev/null 2>&1"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(unix)]
+fn bash_major_version() -> Option<u32> {
+    let out = Command::new("bash").arg("--version").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let first = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    let marker = "version ";
+    let idx = first.find(marker)?;
+    let rest = &first[idx + marker.len()..];
+    let major = rest.split('.').next()?.trim().parse::<u32>().ok()?;
+    Some(major)
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_startup_gate_degrade_persists() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    // Step 1: Source hook in interactive bash with forced health gate failure.
+    // `bash --norc --noprofile -i -c` gives interactive context so enter mode activates
+    // without loading user config (which may set _TIRITH_BASH_LOADED).
+    // _TIRITH_TEST_FAIL_HEALTH=1 forces the health gate to fail.
+    let script = format!(
+        "_TIRITH_TEST_FAIL_HEALTH=1; source '{}'; printf '%s' \"$_TIRITH_BASH_MODE\"",
+        hook
+    );
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-i", "-c", &script])
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .env_remove("TIRITH_BASH_MODE")
+        .env_remove("SSH_CONNECTION")
+        .env_remove("SSH_TTY")
+        .env_remove("SSH_CLIENT")
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        stdout, "preexec",
+        "health gate failure should degrade to preexec"
+    );
+
+    // Step 2: Verify safe-mode flag was persisted
+    let flag = tmpdir.path().join("tirith/bash-safe-mode");
+    assert!(
+        flag.exists(),
+        "safe-mode flag should be persisted after degrade"
+    );
+
+    // Step 3: Source hook in new shell — should start in preexec from flag
+    let script2 = format!(
+        "unset TIRITH_BASH_MODE; unset SSH_CONNECTION; unset SSH_TTY; unset SSH_CLIENT; source '{}'; printf '%s' \"$_TIRITH_BASH_MODE\"",
+        hook
+    );
+    let out2 = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", &script2])
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    let stdout2 = String::from_utf8_lossy(&out2.stdout);
+    assert_eq!(
+        stdout2, "preexec",
+        "subsequent shells should start in preexec from persisted flag"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_runtime_delivery_failure_degrades_in_pty() {
+    if !expect_available() {
+        eprintln!("skipping PTY test: expect not available");
+        return;
+    }
+    if bash_major_version().map(|v| v < 5).unwrap_or(true) {
+        eprintln!("skipping PTY test: requires bash >= 5");
+        return;
+    }
+
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    // Exercise the runtime _tirith_enter failure path in a real interactive PTY:
+    // 1) Start in enter mode (startup gate bypassed for this test only).
+    // 2) Break PROMPT_COMMAND delivery by making it readonly without tirith hook.
+    // 3) Press Enter on a command and verify auto-degrade message appears.
+    let expect_script = r#"
+set timeout 20
+set hook $env(HOOK_PATH)
+spawn -noecho bash --norc --noprofile -i
+expect -re {[$#] $}
+send -- "export PS1='PROMPT> '\r"
+expect "PROMPT> "
+send -- "source '$hook'\r"
+expect "PROMPT> "
+send -- "PROMPT_COMMAND=':'; readonly PROMPT_COMMAND\r"
+expect "PROMPT> "
+send -- "echo PTY_RUNTIME_CHECK\r"
+expect {
+  -re {switching to preexec} {}
+  timeout { exit 2 }
+}
+send -- "\r"
+expect "PROMPT> "
+send -- "exit\r"
+expect eof
+"#;
+
+    let out = Command::new("expect")
+        .args(["-c", expect_script])
+        .env("HOOK_PATH", &hook)
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .env("_TIRITH_TEST_SKIP_HEALTH", "1")
+        .env_remove("TIRITH_BASH_MODE")
+        .env_remove("SSH_CONNECTION")
+        .env_remove("SSH_TTY")
+        .env_remove("SSH_CLIENT")
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run expect");
+
+    assert!(
+        out.status.success(),
+        "expect-driven PTY test failed (code {:?})\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let flag = tmpdir.path().join("tirith/bash-safe-mode");
+    assert!(
+        flag.exists(),
+        "runtime delivery failure should persist safe-mode flag"
+    );
+}
+
+// ─── Non-interactive policy tests ───
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_noninteractive_no_safe_mode_flag() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let script = format!(
+        "unset TIRITH_BASH_MODE; unset SSH_CONNECTION; unset SSH_TTY; unset SSH_CLIENT; source '{}'",
+        hook
+    );
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    assert_eq!(out.status.code(), Some(0));
+    let flag = tmpdir.path().join("tirith/bash-safe-mode");
+    assert!(
+        !flag.exists(),
+        "non-interactive sourcing should never write safe-mode flag"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_noninteractive_no_debug_trap() {
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let script = format!(
+        "unset TIRITH_BASH_MODE; unset SSH_CONNECTION; unset SSH_TTY; unset SSH_CLIENT; source '{}'; trap -p DEBUG",
+        hook
+    );
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.trim().is_empty(),
+        "non-interactive sourcing should not install DEBUG trap, got: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_noninteractive_mode_is_enter() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let script = format!(
+        "unset TIRITH_BASH_MODE; unset SSH_CONNECTION; unset SSH_TTY; unset SSH_CLIENT; source '{}'; printf '%s' \"$_TIRITH_BASH_MODE\"",
+        hook
+    );
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run bash");
+    assert_eq!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        stdout, "enter",
+        "non-interactive enter mode: variable is set but nothing installed"
+    );
+}
+
+// ─── Security audit fix tests ───
+
+#[cfg(unix)]
+#[test]
+fn paste_oversized_input_rejected() {
+    use std::io::Write;
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tirith"))
+        .args(["paste", "--shell", "posix"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn tirith");
+
+    // Write >1 MiB of data
+    let data = vec![b'A'; 1024 * 1024 + 100];
+    child.stdin.take().unwrap().write_all(&data).unwrap();
+
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(1), "paste >1MiB should exit 1");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("1 MiB"),
+        "stderr should mention 1 MiB limit, got: {stderr}"
+    );
+}
+
+#[test]
+fn receipt_verify_invalid_sha256_rejected() {
+    let out = tirith()
+        .args(["receipt", "verify", "../../etc/passwd"])
+        .output()
+        .expect("failed to run tirith");
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "path traversal sha256 should be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("invalid sha256"),
+        "stderr should mention invalid sha256, got: {stderr}"
+    );
+}
+
+// ─── Fail-safe regression tests (unexpected exit code) ───
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_unexpected_rc_logic_test() {
+    // Pure structural test: verify the if/elif/else branching for exit codes
+    let script = r#"
+for rc in 0 1 2 137; do
+  if [[ $rc -eq 0 ]]; then
+    printf "rc=%d:ALLOW\n" "$rc"
+  elif [[ $rc -eq 2 ]]; then
+    printf "rc=%d:WARN\n" "$rc"
+  elif [[ $rc -eq 1 ]]; then
+    printf "rc=%d:BLOCK\n" "$rc"
+  else
+    printf "rc=%d:UNEXPECTED\n" "$rc"
+  fi
+done
+"#;
+    let out = Command::new("bash")
+        .args(["--norc", "--noprofile", "-c", script])
+        .output()
+        .expect("failed to run bash");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("rc=0:ALLOW"), "rc=0 should ALLOW");
+    assert!(stdout.contains("rc=1:BLOCK"), "rc=1 should BLOCK");
+    assert!(stdout.contains("rc=2:WARN"), "rc=2 should WARN");
+    assert!(
+        stdout.contains("rc=137:UNEXPECTED"),
+        "rc=137 should be UNEXPECTED"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn zsh_unexpected_rc_branch_logic_test() {
+    // Structural test: verify zsh branching pattern
+    let script = r#"
+rc=137
+if [[ $rc -eq 0 ]]; then echo ALLOW
+elif [[ $rc -eq 2 ]]; then echo WARN
+elif [[ $rc -eq 1 ]]; then echo BLOCK
+else echo UNEXPECTED; fi
+"#;
+    let out = Command::new("zsh").args(["-c", script]).output();
+    match out {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            assert!(
+                stdout.trim() == "UNEXPECTED",
+                "zsh rc=137 should be UNEXPECTED, got: {stdout}"
+            );
+        }
+        Err(_) => {
+            eprintln!("skipping zsh branch test: zsh not available");
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn fish_unexpected_rc_branch_logic_test() {
+    // Structural test: verify fish branching pattern
+    let script = r#"set rc 137
+if test $rc -eq 0; echo ALLOW
+else if test $rc -eq 2; echo WARN
+else if test $rc -eq 1; echo BLOCK
+else; echo UNEXPECTED; end"#;
+    let out = Command::new("fish").args(["-c", script]).output();
+    match out {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            assert!(
+                stdout.trim() == "UNEXPECTED",
+                "fish rc=137 should be UNEXPECTED, got: {stdout}"
+            );
+        }
+        Err(_) => {
+            eprintln!("skipping fish branch test: fish not available");
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_hook_unexpected_rc_degrades_in_pty() {
+    if !expect_available() {
+        eprintln!("skipping PTY test: expect not available");
+        return;
+    }
+    if bash_major_version().map(|v| v < 5).unwrap_or(true) {
+        eprintln!("skipping PTY test: requires bash >= 5");
+        return;
+    }
+
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let hook = format!(
+        "{}/assets/shell/lib/bash-hook.bash",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let marker = tmpdir.path().join("marker");
+
+    // Create a fake tirith that always exits 137
+    let fake_tirith = tmpdir.path().join("tirith");
+    fs::write(&fake_tirith, "#!/bin/sh\nexit 137\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_tirith, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let marker_str = marker.display().to_string();
+    let fake_dir = tmpdir.path().display().to_string();
+
+    let expect_script = format!(
+        r#"
+set timeout 20
+set hook "{hook}"
+set marker "{marker_str}"
+set fake_dir "{fake_dir}"
+spawn -noecho bash --norc --noprofile -i
+expect -re {{[$#] $}}
+send -- "export PS1='PROMPT> '\r"
+expect "PROMPT> "
+send -- "export PATH=$fake_dir:$PATH\r"
+expect "PROMPT> "
+send -- "export TIRITH_BASH_MODE=enter\r"
+expect "PROMPT> "
+send -- "export _TIRITH_TEST_SKIP_HEALTH=1\r"
+expect "PROMPT> "
+send -- "source '$hook'\r"
+expect "PROMPT> "
+send -- "touch $marker\r"
+sleep 1
+send -- "\x15"
+sleep 0.5
+send -- "echo MODE=$_TIRITH_BASH_MODE\r"
+expect {{
+  -re {{MODE=preexec}} {{}}
+  timeout {{ exit 2 }}
+}}
+send -- "exit\r"
+expect eof
+"#
+    );
+
+    let out = Command::new("expect")
+        .args(["-c", &expect_script])
+        .env("XDG_STATE_HOME", tmpdir.path().join("state"))
+        .env_remove("TIRITH_BASH_MODE")
+        .env_remove("SSH_CONNECTION")
+        .env_remove("SSH_TTY")
+        .env_remove("SSH_CLIENT")
+        .env_remove("_TIRITH_BASH_LOADED")
+        .output()
+        .expect("failed to run expect");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Marker file should NOT exist (command was blocked/preserved)
+    assert!(
+        !marker.exists(),
+        "marker file should not exist — command should not have executed"
+    );
+
+    // Output should mention unexpected exit code or switching to preexec
+    assert!(
+        stdout.contains("unexpected exit code") || stdout.contains("switching to preexec"),
+        "output should mention degrade reason, got:\n{stdout}"
+    );
+
+    // Mode should have degraded to preexec
+    assert!(
+        stdout.contains("MODE=preexec"),
+        "mode should degrade to preexec, got:\n{stdout}"
+    );
+
+    // Safe-mode flag should be persisted
+    let flag = tmpdir.path().join("state/tirith/bash-safe-mode");
+    assert!(
+        flag.exists(),
+        "safe-mode flag should be persisted after unexpected rc degrade"
     );
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,10 +29,28 @@ exec zsh   # or exec bash / restart terminal
 ## Bash: Enter mode vs preexec mode
 
 tirith supports two bash integration modes:
-- **enter mode** (default outside SSH): Binds to Enter key via `bind -x`. Intercepts commands before execution.
-- **preexec mode**: Uses `DEBUG` trap. Compatible with more environments but slightly different behavior.
+- **enter mode** (default outside SSH): Binds to Enter key via `bind -x`. Intercepts commands and paste before execution. Includes startup health gate and runtime self-healing that auto-degrade to preexec if failures are detected.
+- **preexec mode**: Uses `DEBUG` trap (tirith owns this trap). Compatible with more environments but warn-only — cannot block commands. No paste interception.
 
 Set via: `export TIRITH_BASH_MODE=enter` or `export TIRITH_BASH_MODE=preexec` (set before `tirith init` in your shell rc)
+
+### Persistent safe mode
+
+If enter mode detects a failure (bind-x not taking effect, PROMPT_COMMAND delivery broken, etc.), it automatically degrades to preexec and writes a persistent flag at `~/.local/state/tirith/bash-safe-mode`. All subsequent shells will start in preexec until you explicitly re-enable enter mode.
+
+To re-enable enter mode after an auto-degrade:
+
+```bash
+# Option 1: CLI reset
+tirith doctor --reset-bash-safe-mode
+
+# Option 2: explicit override in your .bashrc (before tirith init)
+export TIRITH_BASH_MODE=enter
+```
+
+### DEBUG trap ownership
+
+In preexec mode (including after auto-degrade from enter mode), tirith sets the `DEBUG` trap. This is the same behavior used by default in SSH sessions. If you have custom `DEBUG` traps in your shell configuration, they will be overridden when tirith is in preexec mode.
 
 ## Bash: no visible input after `ssh` / `gcloud compute ssh`
 
@@ -83,6 +101,16 @@ export TIRITH_OUTPUT=stderr
 ```
 
 This forces tirith to output to stderr instead of `/dev/tty`, which Warp displays correctly.
+
+## Unexpected tirith exit codes
+
+Tirith uses a **mixed fail-safe policy** for unexpected exit codes (crashes, OOM-kills, missing binary). The policy balances safety against terminal usability:
+
+- **Bash enter mode**: Auto-degrades to preexec on unexpected tirith exit code. The current command is not executed; subsequent commands go through preexec warn-only mode. Recoverable via `tirith doctor --reset-bash-safe-mode` or `export TIRITH_BASH_MODE=enter`.
+- **Zsh / Fish / PowerShell**: Warns and executes on unexpected exit code. A diagnostic message is printed so you know protection is degraded. The terminal never breaks.
+- **All paste paths**: Fail-closed — discards paste on any unexpected exit code. Safe because you can re-paste.
+
+Expected exit codes: `0` (allow), `1` (block), `2` (warn). Anything else is treated as unexpected.
 
 ## Audit log location
 

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -1,12 +1,28 @@
 #!/usr/bin/env bash
 # tirith bash hook
 # Two modes controlled by TIRITH_BASH_MODE:
-#   enter (default outside SSH): bind -x Enter override. Can block execution.
-#   preexec: DEBUG trap warn-only. Cannot block.
+#   enter (default outside SSH): bind -x Enter override. Can block + intercept paste.
+#     Startup health gate + pending-not-consumed detection auto-degrade to preexec.
+#   preexec: DEBUG trap warn-only. Cannot block. No paste interception.
 
-# Guard against double-loading
-[[ -n "$_TIRITH_BASH_LOADED" ]] && return
+# Guard against double-loading (session-local only).
+# If inherited from environment (exported by attacker/parent), ignore it.
+if [[ -n "$_TIRITH_BASH_LOADED" ]]; then
+  if [[ "$(declare -p _TIRITH_BASH_LOADED 2>/dev/null)" =~ ^declare\ -[a-zA-Z]*x ]]; then
+    unset _TIRITH_BASH_LOADED  # Inherited from env — ignore and load fresh
+  else
+    return  # Set in this session — genuine double-source guard
+  fi
+fi
 _TIRITH_BASH_LOADED=1
+
+# Clear attacker-controllable env vars before any hooks are installed.
+# _TIRITH_PENDING_EVAL/_PENDING_SOURCE: pre-set value would be eval'd on first prompt.
+unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_SOURCE
+# _TIRITH_TEST_*: only clear if inherited from environment (exported by parent).
+# Session-local values (set without export) are trusted test overrides.
+[[ "$(declare -p _TIRITH_TEST_SKIP_HEALTH 2>/dev/null)" =~ ^declare\ -[a-zA-Z]*x ]] && unset _TIRITH_TEST_SKIP_HEALTH
+[[ "$(declare -p _TIRITH_TEST_FAIL_HEALTH 2>/dev/null)" =~ ^declare\ -[a-zA-Z]*x ]] && unset _TIRITH_TEST_FAIL_HEALTH
 
 # Output helper: use stderr for Warp terminal (which doesn't display /dev/tty properly),
 # otherwise use /dev/tty for proper terminal output that doesn't mix with command output.
@@ -19,8 +35,120 @@ _tirith_output() {
   fi
 }
 
+# ─── Persistent safe mode infrastructure ───
+
+# Trim whitespace to match Rust policy.rs:state_dir() behavior
+_TIRITH_STATE_DIR="${XDG_STATE_HOME:-}"
+_TIRITH_STATE_DIR="${_TIRITH_STATE_DIR#"${_TIRITH_STATE_DIR%%[![:space:]]*}"}"
+_TIRITH_STATE_DIR="${_TIRITH_STATE_DIR%"${_TIRITH_STATE_DIR##*[![:space:]]}"}"
+_TIRITH_STATE_DIR="${_TIRITH_STATE_DIR:-$HOME/.local/state}/tirith"
+_TIRITH_SAFE_MODE_FLAG="$_TIRITH_STATE_DIR/bash-safe-mode"
+
+_tirith_check_safe_mode() { [[ -f "$_TIRITH_SAFE_MODE_FLAG" ]]; }
+
+_tirith_persist_safe_mode() {
+  mkdir -p "$_TIRITH_STATE_DIR" 2>/dev/null || return
+  printf '1\n' > "$_TIRITH_SAFE_MODE_FLAG" 2>/dev/null || return
+}
+
+# ─── Preexec function (used by both preexec mode and degrade fallback) ───
+
+_tirith_preexec() {
+  # Only run once per command (guard against DEBUG firing multiple times)
+  [[ "${_tirith_last_cmd:-}" == "$BASH_COMMAND" ]] && return
+  _tirith_last_cmd="$BASH_COMMAND"
+
+  # Warn-only: command is already committed, we can only print warnings
+  tirith check --shell posix -- "$BASH_COMMAND" || true
+}
+
+# ─── Degrade function ───
+
+_tirith_degrade_to_preexec() {
+  local reason="${1:-unknown}"
+  # Only print warnings in interactive shells
+  if [[ $- == *i* ]]; then
+    _tirith_output "tirith: enter mode failed ($reason) — switching to preexec"
+    _tirith_output "  Persistent. Re-enable: TIRITH_BASH_MODE=enter"
+  fi
+
+  # Safe deterministic degrade: set known-safe defaults for current session.
+  # Custom bindings from .inputrc/.bashrc return on next shell (safe mode persisted,
+  # so tirith won't install bind-x on restart).
+  if [[ "${_TIRITH_BINDS_INSTALLED:-0}" == "1" ]]; then
+    bind '"\C-m": accept-line' 2>/dev/null || true
+    bind '"\C-j": accept-line' 2>/dev/null || true
+    # Restore bracketed paste to readline default if available, otherwise unbind
+    bind '"\e[200~": bracketed-paste-begin' 2>/dev/null || bind -r '"\e[200~"' 2>/dev/null || true
+    _TIRITH_BINDS_INSTALLED=0
+  fi
+
+  trap '_tirith_preexec' DEBUG
+  _TIRITH_BASH_MODE="preexec"
+  _tirith_persist_safe_mode
+  if [[ $- == *i* ]]; then
+    _tirith_output "  Restart your shell for full custom keybindings to return."
+  fi
+}
+
+# ─── PROMPT_COMMAND management ───
+
+_tirith_prompt_hook() {
+  local pending_eval="${_TIRITH_PENDING_EVAL:-}"
+  local pending_source="${_TIRITH_PENDING_SOURCE:-}"
+  unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_SOURCE
+
+  if [[ -n "$pending_source" ]]; then
+    source "$pending_source"
+    rm -f "$pending_source"
+  elif [[ -n "$pending_eval" ]]; then
+    eval -- "$pending_eval"
+  fi
+}
+
+_tirith_is_prompt_hook_attached() {
+  local pc_decl
+  pc_decl="$(declare -p PROMPT_COMMAND 2>/dev/null)" || return 1
+
+  if [[ "$pc_decl" == "declare -a"* ]]; then
+    local entry
+    for entry in "${PROMPT_COMMAND[@]}"; do
+      [[ "$entry" == "_tirith_prompt_hook" ]] && return 0
+    done
+    return 1
+  else
+    # String form: use regex to match _tirith_prompt_hook as a semicolon-delimited
+    # token with optional surrounding whitespace.
+    [[ "$PROMPT_COMMAND" =~ (^|;)[[:space:]]*_tirith_prompt_hook[[:space:]]*(;|$) ]] && return 0
+    return 1
+  fi
+}
+
+_tirith_ensure_prompt_hook() {
+  _tirith_is_prompt_hook_attached && return 0
+
+  local pc_decl
+  pc_decl="$(declare -p PROMPT_COMMAND 2>/dev/null)" || pc_decl=""
+
+  if [[ "$pc_decl" == "declare -a"* ]]; then
+    PROMPT_COMMAND=(_tirith_prompt_hook "${PROMPT_COMMAND[@]}") 2>/dev/null || return 1
+  elif [[ -n "${PROMPT_COMMAND:-}" ]]; then
+    PROMPT_COMMAND="_tirith_prompt_hook;${PROMPT_COMMAND}" 2>/dev/null || return 1
+  else
+    PROMPT_COMMAND="_tirith_prompt_hook" 2>/dev/null || return 1
+  fi
+  return 0
+}
+
+# ─── Mode selection ───
+
 if [[ -n "${TIRITH_BASH_MODE:-}" ]]; then
   _TIRITH_BASH_MODE="$TIRITH_BASH_MODE"
+elif _tirith_check_safe_mode; then
+  _TIRITH_BASH_MODE="preexec"
+  # Only print warning in interactive shells (avoid polluting scripted output)
+  [[ $- == *i* ]] && _tirith_output "tirith: safe mode active (preexec) — previous enter-mode failure detected"
+  [[ $- == *i* ]] && _tirith_output "  Re-enable: TIRITH_BASH_MODE=enter or tirith doctor --reset-bash-safe-mode"
 elif [[ -n "${SSH_CONNECTION:-}" || -n "${SSH_TTY:-}" || -n "${SSH_CLIENT:-}" ]]; then
   # SSH PTY environments are more reliable with DEBUG-trap preexec mode.
   _TIRITH_BASH_MODE="preexec"
@@ -28,33 +156,7 @@ else
   _TIRITH_BASH_MODE="enter"
 fi
 
-# Queue command execution into PROMPT_COMMAND so interactive commands
-# (ssh, gcloud compute ssh, etc.) run outside the bind -x callback.
-_tirith_register_prompt_hook() {
-  [[ -n "${_TIRITH_PROMPT_HOOKED:-}" ]] && return
-  _TIRITH_PROMPT_HOOKED=1
-
-  _tirith_prompt_hook() {
-    local pending_eval="${_TIRITH_PENDING_EVAL:-}"
-    local pending_source="${_TIRITH_PENDING_SOURCE:-}"
-    unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_SOURCE
-
-    if [[ -n "$pending_source" ]]; then
-      source "$pending_source"
-      rm -f "$pending_source"
-    elif [[ -n "$pending_eval" ]]; then
-      eval -- "$pending_eval"
-    fi
-  }
-
-  if declare -p PROMPT_COMMAND >/dev/null 2>&1 && [[ "$(declare -p PROMPT_COMMAND)" == "declare -a"* ]]; then
-    PROMPT_COMMAND=(_tirith_prompt_hook "${PROMPT_COMMAND[@]}")
-  elif [[ -n "${PROMPT_COMMAND:-}" ]]; then
-    PROMPT_COMMAND="_tirith_prompt_hook;${PROMPT_COMMAND}"
-  else
-    PROMPT_COMMAND="_tirith_prompt_hook"
-  fi
-}
+# ─── Helpers ───
 
 # Check if a command is unsafe to eval (heredocs, multiline, etc.)
 _tirith_unsafe_to_eval() {
@@ -94,61 +196,110 @@ _tirith_unsafe_to_eval() {
   return 1
 }
 
-if [[ "$_TIRITH_BASH_MODE" == "enter" ]]; then
-  # Mode: enter — bind -x Enter override with full block+warn capability
+# ─── Startup health gate ───
 
-  _tirith_register_prompt_hook
+_tirith_startup_health_check() {
+  # Test-only override: bypass startup gate to reach runtime failure paths in PTY tests.
+  [[ "${_TIRITH_TEST_SKIP_HEALTH:-}" == "1" ]] && return 0
+  # Test-only override for CI (avoids needing PTY)
+  [[ "${_TIRITH_TEST_FAIL_HEALTH:-}" == "1" ]] && return 1
+  # Verify both \C-m and \C-j are bound to _tirith_enter
+  local binds
+  binds="$(bind -X 2>/dev/null)" || return 1
+  [[ "$binds" =~ \\C-m.*_tirith_enter ]] || return 1
+  [[ "$binds" =~ \\C-j.*_tirith_enter ]] || return 1
+  # Verify prompt hook is still attached
+  _tirith_is_prompt_hook_attached || return 1
+  return 0
+}
 
-  _tirith_enter() {
-    # Save terminal state — bind -x can corrupt echo in some PTY environments (gcloud ssh, etc.)
-    local _saved_stty
-    _saved_stty=$(stty -g 2>/dev/null) || true
+# ─── Enter mode (interactive only) ───
 
-    # Ensure terminal state is restored on exit
-    trap 'stty "$_saved_stty" 2>/dev/null || true' RETURN
+if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
+  # Enter mode: interactive shell only (bind-x requires readline).
+  # Non-interactive sourcing (bash -c, scripts, BASH_ENV) skips this entire block.
+  # Mode variable stays "enter" but nothing is installed — effectively a no-op.
+  # No traps, no bindings, no state writes in non-interactive context.
+  _TIRITH_BINDS_INSTALLED=0
 
-    # Empty input: just return (shows new prompt)
-    if [[ -z "$READLINE_LINE" ]]; then
-      READLINE_LINE=""
-      READLINE_POINT=0
-      return
-    fi
+  # Attach prompt hook (gates further setup)
+  if ! _tirith_ensure_prompt_hook; then
+    _tirith_degrade_to_preexec "PROMPT_COMMAND is readonly or unattachable"
+  else
+    _tirith_enter() {
+      # Save terminal state — bind -x can corrupt echo in some PTY environments (gcloud ssh, etc.)
+      local _saved_stty
+      _saved_stty=$(stty -g 2>/dev/null) || true
 
-    # Check for incomplete input (open quotes, unclosed blocks)
-    local syntax_err
-    syntax_err=$(bash -n <<< "$READLINE_LINE" 2>&1)
-    local syntax_rc=$?
-    if [[ $syntax_rc -ne 0 ]] && [[ "$syntax_err" == *"unexpected EOF"* || "$syntax_err" == *"unexpected end of file"* ]]; then
-      # Incomplete input: insert newline for continued editing
-      READLINE_LINE+=$'\n'
-      READLINE_POINT=${#READLINE_LINE}
-      return
-    fi
+      # Ensure terminal state is restored on exit
+      trap 'stty "$_saved_stty" 2>/dev/null || true' RETURN
 
-    # Run tirith check, use temp file to prevent tty leakage in bind -x context
-    local tmpfile=$(mktemp)
-    tirith check --non-interactive --shell posix -- "$READLINE_LINE" >"$tmpfile" 2>&1
-    local rc=$?
-    local output=$(<"$tmpfile")
-    rm -f "$tmpfile"
+      # Self-heal: verify prompt hook is still attached
+      if ! _tirith_ensure_prompt_hook; then
+        _tirith_degrade_to_preexec "PROMPT_COMMAND reattachment failed"
+        return  # READLINE_LINE stays intact
+      fi
 
-    if [[ $rc -eq 1 ]]; then
-      # Block: show the command that was blocked, print warning, clear line
-      _tirith_output ""
-      _tirith_output "command> $READLINE_LINE"
-      [[ -n "$output" ]] && _tirith_output "$output"
-      READLINE_LINE=""
-      READLINE_POINT=0
-    elif [[ $rc -eq 2 ]]; then
-      # Warn: print warning then execute
-      _tirith_output ""
-      _tirith_output "command> $READLINE_LINE"
-      [[ -n "$output" ]] && _tirith_output "$output"
-      # Fall through to execute
-    fi
+      # Detect broken delivery: if previous pending was never consumed
+      if [[ -n "${_TIRITH_PENDING_EVAL:-}" || -n "${_TIRITH_PENDING_SOURCE:-}" ]]; then
+        [[ -n "${_TIRITH_PENDING_SOURCE:-}" ]] && rm -f "${_TIRITH_PENDING_SOURCE}"
+        unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_SOURCE
+        _tirith_degrade_to_preexec "previous command not delivered (check shell history)"
+        return  # READLINE_LINE stays intact
+      fi
 
-    if [[ $rc -ne 1 ]]; then
-      # Allow (0) or Warn (2): execute the command
+      # Empty input: just return (shows new prompt)
+      if [[ -z "$READLINE_LINE" ]]; then
+        READLINE_LINE=""
+        READLINE_POINT=0
+        return
+      fi
+
+      # Check for incomplete input (open quotes, unclosed blocks)
+      local syntax_err
+      syntax_err=$(bash -n <<< "$READLINE_LINE" 2>&1)
+      local syntax_rc=$?
+      if [[ $syntax_rc -ne 0 ]] && [[ "$syntax_err" == *"unexpected EOF"* || "$syntax_err" == *"unexpected end of file"* ]]; then
+        # Incomplete input: insert newline for continued editing
+        READLINE_LINE+=$'\n'
+        READLINE_POINT=${#READLINE_LINE}
+        return
+      fi
+
+      # Run tirith check, use temp file to prevent tty leakage in bind -x context
+      local tmpfile=$(mktemp)
+      tirith check --non-interactive --shell posix -- "$READLINE_LINE" >"$tmpfile" 2>&1
+      local rc=$?
+      local output=$(<"$tmpfile")
+      rm -f "$tmpfile"
+
+      if [[ $rc -eq 0 ]]; then
+        # Allow: execute silently (fall through to execute block)
+        :
+      elif [[ $rc -eq 2 ]]; then
+        # Warn: print warning then execute (fall through to execute block)
+        _tirith_output ""
+        _tirith_output "command> $READLINE_LINE"
+        [[ -n "$output" ]] && _tirith_output "$output"
+      elif [[ $rc -eq 1 ]]; then
+        # Block: tirith intentionally blocked this command
+        _tirith_output ""
+        _tirith_output "command> $READLINE_LINE"
+        [[ -n "$output" ]] && _tirith_output "$output"
+        READLINE_LINE=""
+        READLINE_POINT=0
+        return
+      else
+        # Unexpected exit code (crash, OOM, missing binary): degrade to preexec
+        # Block this command but don't break the terminal — use Issue #20 infrastructure
+        _tirith_output ""
+        _tirith_output "command> $READLINE_LINE"
+        [[ -n "$output" ]] && _tirith_output "$output"
+        _tirith_degrade_to_preexec "tirith returned unexpected exit code $rc"
+        return  # READLINE_LINE preserved for re-execution via preexec
+      fi
+
+      # rc was 0 or 2: execute the command
       local cmd="$READLINE_LINE"
       READLINE_LINE=""
       READLINE_POINT=0
@@ -173,71 +324,71 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]]; then
 
       history -s -- "$cmd"
       _TIRITH_PENDING_EVAL="$cmd"
-    fi
-  }
+    }
 
-  bind -x '"\C-m": _tirith_enter' || true
-  bind -x '"\C-j": _tirith_enter' || true
+    # Bracketed paste interception
+    _tirith_paste() {
+      # Save terminal state — bind -x can corrupt echo in some PTY environments (gcloud ssh, etc.)
+      local _saved_stty
+      _saved_stty=$(stty -g 2>/dev/null) || true
+      trap 'stty "$_saved_stty" 2>/dev/null || true' RETURN
 
-  # Bracketed paste interception
-  _tirith_paste() {
-    # Save terminal state — bind -x can corrupt echo in some PTY environments (gcloud ssh, etc.)
-    local _saved_stty
-    _saved_stty=$(stty -g 2>/dev/null) || true
-    trap 'stty "$_saved_stty" 2>/dev/null || true' RETURN
+      # Read pasted content until bracketed paste end sequence (\e[201~)
+      local pasted=""
+      local char
+      while IFS= read -r -n 1 -d '' -t 1 char; do
+        pasted+="$char"
+        # Check for end of bracketed paste
+        if [[ "$pasted" == *$'\e[201~' ]]; then
+          # Strip the end sequence
+          pasted="${pasted%$'\e[201~'}"
+          break
+        fi
+      done
 
-    # Read pasted content until bracketed paste end sequence (\e[201~)
-    local pasted=""
-    local char
-    while IFS= read -r -n 1 -t 1 char; do
-      pasted+="$char"
-      # Check for end of bracketed paste
-      if [[ "$pasted" == *$'\e[201~' ]]; then
-        # Strip the end sequence
-        pasted="${pasted%$'\e[201~'}"
-        break
+      if [[ -n "$pasted" ]]; then
+        # Check with tirith paste, use temp file to prevent tty leakage
+        local tmpfile=$(mktemp)
+        printf '%s' "$pasted" | tirith paste --shell posix >"$tmpfile" 2>&1
+        local rc=$?
+        local output=$(<"$tmpfile")
+        rm -f "$tmpfile"
+
+        if [[ $rc -eq 0 ]]; then
+          # Allow: fall through to insert
+          :
+        elif [[ $rc -eq 2 ]]; then
+          # Warn: show warning, fall through to insert
+          [[ -n "$output" ]] && { _tirith_output ""; _tirith_output "$output"; }
+        else
+          # Block (rc=1) or unexpected: discard paste (safe — user can re-paste)
+          _tirith_output ""
+          _tirith_output "paste> $pasted"
+          [[ -n "$output" ]] && _tirith_output "$output"
+          [[ $rc -ne 1 ]] && _tirith_output "tirith: paste check failed (exit code $rc)"
+          return
+        fi
       fi
-    done
 
-    if [[ -n "$pasted" ]]; then
-      # Check with tirith paste, use temp file to prevent tty leakage
-      local tmpfile=$(mktemp)
-      printf '%s' "$pasted" | tirith paste --shell posix >"$tmpfile" 2>&1
-      local rc=$?
-      local output=$(<"$tmpfile")
-      rm -f "$tmpfile"
+      # Allow: insert into readline buffer
+      READLINE_LINE="${READLINE_LINE:0:$READLINE_POINT}${pasted}${READLINE_LINE:$READLINE_POINT}"
+      READLINE_POINT=$((READLINE_POINT + ${#pasted}))
+    }
 
-      if [[ $rc -eq 1 ]]; then
-        # Block: show what was pasted, then warning, discard paste
-        _tirith_output ""
-        _tirith_output "paste> $pasted"
-        [[ -n "$output" ]] && _tirith_output "$output"
-        return
-      elif [[ $rc -eq 2 ]]; then
-        # Warn: show warning, keep paste
-        [[ -n "$output" ]] && { _tirith_output ""; _tirith_output "$output"; }
-      fi
+    # Install key bindings
+    bind -x '"\C-m": _tirith_enter' || true
+    bind -x '"\C-j": _tirith_enter' || true
+    bind -x '"\e[200~": _tirith_paste' || true
+    _TIRITH_BINDS_INSTALLED=1
+
+    # Startup health gate: verify bind-x took effect for BOTH keys
+    if ! _tirith_startup_health_check; then
+      _tirith_degrade_to_preexec "startup health check failed (bind-x or PROMPT_COMMAND)"
     fi
+  fi
 
-    # Allow: insert into readline buffer
-    READLINE_LINE="${READLINE_LINE:0:$READLINE_POINT}${pasted}${READLINE_LINE:$READLINE_POINT}"
-    READLINE_POINT=$((READLINE_POINT + ${#pasted}))
-  }
-
-  # Bind bracketed paste start sequence
-  bind -x '"\e[200~": _tirith_paste' || true
-
-elif [[ "$_TIRITH_BASH_MODE" == "preexec" ]]; then
-  # Mode: preexec — DEBUG trap, warn-only (cannot block)
-
-  _tirith_preexec() {
-    # Only run once per command (guard against DEBUG firing multiple times)
-    [[ "${_tirith_last_cmd:-}" == "$BASH_COMMAND" ]] && return
-    _tirith_last_cmd="$BASH_COMMAND"
-
-    # Warn-only: command is already committed, we can only print warnings
-    tirith check --shell posix -- "$BASH_COMMAND" || true
-  }
-
+elif [[ "$_TIRITH_BASH_MODE" == "preexec" ]] && [[ $- == *i* ]]; then
+  # Only install DEBUG trap in interactive shells.
+  # Non-interactive sourcing (bash -c, BASH_ENV, scripts) is a clean no-op.
   trap '_tirith_preexec' DEBUG
 fi

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -3,8 +3,15 @@
 # Overrides accept-line widget to check commands before execution.
 # Overrides bracketed-paste widget to check pasted content.
 
-# Guard against double-loading
-[[ -n "$_TIRITH_ZSH_LOADED" ]] && return
+# Guard against double-loading (session-local only).
+# If inherited from environment (exported by attacker/parent), ignore it.
+if [[ -n "$_TIRITH_ZSH_LOADED" ]]; then
+  if [[ "${(t)_TIRITH_ZSH_LOADED}" == *export* ]]; then
+    unset _TIRITH_ZSH_LOADED  # Inherited from env — ignore and load fresh
+  else
+    return  # Set in this session — genuine double-source guard
+  fi
+fi
 _TIRITH_ZSH_LOADED=1
 
 # Output helper: use stderr for Warp terminal (which doesn't display /dev/tty properly),
@@ -39,21 +46,25 @@ _tirith_accept_line() {
   local output=$(<"$tmpfile")
   rm -f "$tmpfile"
 
-  if [[ $rc -eq 1 ]]; then
-    # Block: show command and output
+  if [[ $rc -eq 0 ]]; then
+    zle _tirith_original_accept_line 2>/dev/null || zle .accept-line
+  elif [[ $rc -eq 2 ]]; then
+    _tirith_output ""
+    _tirith_output "command> $buf"
+    [[ -n "$output" ]] && _tirith_output "$output"
+    zle _tirith_original_accept_line 2>/dev/null || zle .accept-line
+  elif [[ $rc -eq 1 ]]; then
+    # Block: tirith intentionally blocked
     BUFFER=""
     _tirith_output ""
     _tirith_output "command> $buf"
     [[ -n "$output" ]] && _tirith_output "$output"
     zle send-break
-  elif [[ $rc -eq 2 ]]; then
-    # Warn: show command and output, then execute
-    _tirith_output ""
-    _tirith_output "command> $buf"
-    [[ -n "$output" ]] && _tirith_output "$output"
-    zle _tirith_original_accept_line 2>/dev/null || zle .accept-line
   else
-    # Allow: execute normally
+    # Unexpected rc: warn + execute (fail-open to avoid terminal breakage)
+    _tirith_output ""
+    [[ -n "$output" ]] && _tirith_output "$output"
+    _tirith_output "tirith: unexpected exit code $rc — running unprotected"
     zle _tirith_original_accept_line 2>/dev/null || zle .accept-line
   fi
 }
@@ -83,19 +94,22 @@ _tirith_bracketed_paste() {
     local output=$(<"$tmpfile")
     rm -f "$tmpfile"
 
-    if [[ $rc -eq 1 ]]; then
-      # Block: show paste content and output
+    if [[ $rc -eq 0 ]]; then
+      # Allow: fall through to keep paste
+      :
+    elif [[ $rc -eq 2 ]]; then
+      [[ -n "$output" ]] && { _tirith_output ""; _tirith_output "$output"; }
+    else
+      # Block or unexpected: revert paste
       BUFFER="$old_buffer"
       CURSOR=$old_cursor
       _tirith_output ""
       _tirith_output "paste> $pasted"
       [[ -n "$output" ]] && _tirith_output "$output"
+      [[ $rc -ne 1 ]] && _tirith_output "tirith: unexpected exit code $rc — paste blocked for safety"
       zle send-break
-    elif [[ $rc -eq 2 ]]; then
-      # Warn: show warning, keep paste
-      [[ -n "$output" ]] && { _tirith_output ""; _tirith_output "$output"; }
+      return
     fi
-    # Allow (0): keep the paste silently
   fi
 }
 

--- a/tests/fixtures/terminal.toml
+++ b/tests/fixtures/terminal.toml
@@ -19,6 +19,33 @@ expected_rules = ["control_chars"]
 raw_bytes = [101, 99, 104, 111, 32, 115, 97, 102, 101, 13, 109, 97, 108, 105, 99, 105, 111, 117, 115]
 
 [[fixture]]
+name = "control_char_trailing_cr_paste"
+min_milestone = 1
+input = "/some/path"
+context = "paste"
+expected_action = "allow"
+expected_rules = []
+raw_bytes = [47, 115, 111, 109, 101, 47, 112, 97, 116, 104, 13]
+
+[[fixture]]
+name = "control_char_trailing_crlf_paste"
+min_milestone = 1
+input = "/some/path"
+context = "paste"
+expected_action = "allow"
+expected_rules = []
+raw_bytes = [47, 115, 111, 109, 101, 47, 112, 97, 116, 104, 13, 10]
+
+[[fixture]]
+name = "control_char_windows_multiline_paste"
+min_milestone = 1
+input = "echo hello\r\necho world\r\n"
+context = "paste"
+expected_action = "allow"
+expected_rules = []
+raw_bytes = [101, 99, 104, 111, 32, 104, 101, 108, 108, 111, 13, 10, 101, 99, 104, 111, 32, 119, 111, 114, 108, 100, 13, 10]
+
+[[fixture]]
 name = "control_char_backspace_paste"
 min_milestone = 1
 input = "echo safe\u0008malicious"


### PR DESCRIPTION
## Summary

Six security fixes from external audit, plus Issue #20 bash enter mode infrastructure:

- **SEC-CRIT-01**: Handle unexpected tirith exit codes in all 4 shell hooks (bash/zsh/fish/PowerShell). Bash enter mode degrades to preexec via persistent safe mode; zsh/fish/PS warn + execute; all paste paths fail-closed (discard).
- **SEC-HIGH-01**: Interpreter allowlist in `runner.rs` — two-tier matching (exact names like `sh`/`bash` + versioned families like `python3.11`). Check runs before user confirmation prompt.
- **SEC-HIGH-03**: Bounded stdin read in `paste.rs` — 1 MiB cap via `Read::take()`.
- **SEC-HIGH-04**: File permissions `0600` on audit log, receipts, cache, and last-trigger files (new files via `OpenOptionsExt::mode()` + legacy hardening via `set_permissions`).
- **SEC-MED-03**: SHA256 hex validation in receipt `load()`/`save()`/`verify()` — prevents path traversal via crafted hash values.
- **Short-hash panic guard**: `short_hash()` via `truncate_bytes()` replaces all `&sha256[..12]` slice operations.

Also includes bash enter mode infrastructure (bind-x Enter override, startup health gate, persistent safe mode, PROMPT_COMMAND delivery, degrade-to-preexec) and CR normalization improvements.

**230 tests passing** (148 unit + 44 integration + 18 golden + 17 policy + 3 CLI).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 230/230 pass
- [x] Shell hook asset copies match source (`embedded_shell_hooks_match_repo_hooks`)
- [x] PTY-backed bash degrade test (`bash_hook_unexpected_rc_degrades_in_pty`)
- [x] Oversized paste rejection (`paste_oversized_input_rejected`)
- [x] Invalid SHA256 receipt rejection (`receipt_verify_invalid_sha256_rejected`)
- [x] Branch logic tests for zsh/fish unexpected exit codes
- [x] File permission tests (audit log, receipt, cache — all 0600)
- [x] Manual: `echo "test" | tirith paste --shell posix` → exit 0
- [x] Manual: `yes | head -c 2000000 | tirith paste --shell posix` → "exceeds 1 MiB"
- [x] Manual: `tirith receipt verify "../../etc/passwd"` → "invalid sha256"