### PR TITLE
feat: add HTTPie and XH to monitored CLI downloaders

### DIFF
--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -249,6 +249,18 @@ const PATTERN_TABLE: &[PatternEntry] = &[
         notes: "wget download command",
     },
     PatternEntry {
+        id: "httpie",
+        tier1_exec_fragments: &[r"(?:^|\s)https?\s"],
+        tier1_paste_only_fragments: &[],
+        notes: "HTTPie CLI download command (http/https)",
+    },
+    PatternEntry {
+        id: "xh",
+        tier1_exec_fragments: &[r"(?:^|\s)xh\s"],
+        tier1_paste_only_fragments: &[],
+        notes: "xh CLI download command (HTTPie-compatible)",
+    },
+    PatternEntry {
         id: "scp",
         tier1_exec_fragments: &[r"scp\s"],
         tier1_paste_only_fragments: &[],

--- a/crates/tirith-core/src/extract.rs
+++ b/crates/tirith-core/src/extract.rs
@@ -467,6 +467,9 @@ fn is_source_command(cmd: &str) -> bool {
         cmd,
         "curl"
             | "wget"
+            | "http"
+            | "https"
+            | "xh"
             | "fetch"
             | "scp"
             | "rsync"

--- a/crates/tirith-core/src/rules/terminal.rs
+++ b/crates/tirith-core/src/rules/terminal.rs
@@ -115,7 +115,7 @@ pub fn check_hidden_multiline(input: &str) -> Vec<Finding> {
 
 fn looks_like_hidden_command(line: &str) -> bool {
     let suspicious = [
-        "curl ", "wget ", "bash", "/bin/", "sudo ", "rm ", "chmod ", "eval ", "exec ", "> /",
+        "curl ", "wget ", "http ", "https ", "xh ", "bash", "/bin/", "sudo ", "rm ", "chmod ", "eval ", "exec ", "> /",
         ">> /", "| sh",
     ];
     suspicious.iter().any(|p| line.contains(p))

--- a/crates/tirith-core/src/script_analysis.rs
+++ b/crates/tirith-core/src/script_analysis.rs
@@ -48,7 +48,11 @@ pub fn analyze(content: &str, interpreter: &str) -> ScriptAnalysis {
         has_sudo: content.contains("sudo "),
         has_eval: content.contains("eval ") || content.contains("eval("),
         has_base64: content.contains("base64"),
-        has_curl_wget: content.contains("curl ") || content.contains("wget "),
+        has_curl_wget: content.contains("curl ")
+            || content.contains("wget ")
+            || content.contains("http ")
+            || content.contains("https ")
+            || content.contains("xh "),
         interpreter: interpreter.to_string(),
     }
 }

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -39,6 +39,8 @@ pub enum RuleId {
     PipeToInterpreter,
     CurlPipeShell,
     WgetPipeShell,
+    HttpiePipeShell,
+    XhPipeShell,
     DotfileOverwrite,
     ArchiveExtract,
 

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -586,7 +586,7 @@ fn test_extractor_ids_cover_rule_triggers() {
         ("path rules", &["standard_url"]),
         (
             "transport rules",
-            &["standard_url", "curl", "wget", "scp", "rsync"],
+            &["standard_url", "curl", "wget", "httpie", "xh", "scp", "rsync"],
         ),
         ("ecosystem rules", &["standard_url", "docker_command"]),
         // Command shape rules need their own patterns


### PR DESCRIPTION
## Summary

Add support for monitoring HTTPie (`http`/`https` commands) and XH (`xh` command) as CLI downloaders, extending tirith's protection beyond `curl` and `wget`.

Closes #13

## Changes

### Core detection (`tirith-core`)

- **`build.rs`** — Added `httpie` and `xh` entries to the declarative `PATTERN_TABLE`, generating Tier 1 regex triggers for these commands at compile time.
- **`src/verdict.rs`** — Added `HttpiePipeShell` and `XhPipeShell` variants to the `RuleId` enum for specific pipe-to-shell detection.
- **`src/rules/command.rs`** — Added `http`, `https`, and `xh` to `is_source_command()` for TLS flag inspection, and mapped them to their respective `RuleId` variants in the pipe-to-interpreter check.
- **`src/extract.rs`** — Added `http`, `https`, and `xh` to `is_source_command()` for sink-context URL extraction (schemeless host detection).
- **`src/script_analysis.rs`** — Extended `has_curl_wget` detection to also match `http `, `https `, and `xh ` in script content.
- **`src/rules/terminal.rs`** — Added `http `, `https `, and `xh ` to the suspicious command fragment list for hidden-command detection.

### Tests

- **`src/rules/command.rs`** — Added 6 new unit tests covering HTTPie and XH pipe-to-shell detection, source command recognition, and sudo piping.
- **`tests/golden_fixtures.rs`** — Updated extractor ID coverage assertions to include `httpie` and `xh`.

All existing tests continue to pass (35 unit + 17 policy integration + 18 golden fixture tests).