### PR TITLE
Fix syntax, encoding, and scoping errors for PS5.1

### DIFF
--- a/shell/lib/powershell-hook.ps1
+++ b/shell/lib/powershell-hook.ps1
@@ -10,7 +10,7 @@ if ($global:_TIRITH_PS_LOADED) {
         $global:_TIRITH_PS_LOADED = $false
         # Fall through to load fresh
     } else {
-        return  # Set in this session — genuine double-source guard
+        return  # Set in this session - genuine double-source guard
     }
 }
 $global:_TIRITH_PS_LOADED = $true
@@ -27,9 +27,9 @@ if (-not $psrlModule) {
     return
 }
 
-# ─── Approval workflow helpers (ADR-7) ───
+# --- Approval workflow helpers (ADR-7) ---
 
-function _tirith_parse_approval {
+function global:_tirith_parse_approval {
     param($FilePath)
     $script:_tirith_ap_required = "no"
     $script:_tirith_ap_timeout = 0
@@ -86,7 +86,7 @@ function _tirith_parse_approval {
 
 # Read a single line with timeout using Console.KeyAvailable polling.
 # Returns the user's input, or empty string on timeout.
-function _tirith_read_with_timeout {
+function global:_tirith_read_with_timeout {
     param([int]$TimeoutSecs, [string]$Prompt)
     Write-Host -NoNewline $Prompt
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSecs)
@@ -141,7 +141,7 @@ Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
     } else {
         # Unexpected rc: warn + execute (fail-open to avoid terminal breakage)
         if (-not [string]::IsNullOrWhiteSpace($output)) { Write-Host $output }
-        Write-Host "tirith: unexpected exit code $rc — running unprotected"
+        Write-Host "tirith: unexpected exit code $rc - running unprotected"
         if (-not [string]::IsNullOrWhiteSpace($approvalPath)) {
             Remove-Item $approvalPath.Trim() -Force -ErrorAction SilentlyContinue
         }
@@ -159,7 +159,7 @@ Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
                 Write-Host "  $($script:_tirith_ap_desc)"
             }
             if ($script:_tirith_ap_timeout -gt 0) {
-                $response = _tirith_read_with_timeout -TimeoutSecs $script:_tirith_ap_timeout -Prompt "Approve? ($($script:_tirith_ap_timeout)s timeout) [y/N] "
+                $response = _tirith_read_with_timeout -TimeoutSecs $script:_tirith_ap_timeout -Prompt "Approve? ($($script:_tirith_ap_timeout) sec timeout) [y/N] "
             } else {
                 Write-Host -NoNewline "Approve? [y/N] "
                 $response = Read-Host
@@ -169,13 +169,13 @@ Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
             } else {
                 switch ($script:_tirith_ap_fallback) {
                     "allow" {
-                        Write-Host "tirith: approval not granted — fallback: allow"
+                        Write-Host "tirith: approval not granted - fallback: allow"
                     }
                     "warn" {
-                        Write-Host "tirith: approval not granted — fallback: warn"
+                        Write-Host "tirith: approval not granted - fallback: warn"
                     }
                     default {
-                        Write-Host "tirith: approval not granted — fallback: block"
+                        Write-Host "tirith: approval not granted - fallback: block"
                         [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
                         return
                     }
@@ -220,7 +220,7 @@ Set-PSReadLineKeyHandler -Key Ctrl+v -ScriptBlock {
         # Block or unexpected: discard paste
         Write-Host "paste> $pasted"
         if (-not [string]::IsNullOrWhiteSpace($output)) { Write-Host $output }
-        if ($rc -ne 1) { Write-Host "tirith: unexpected exit code $rc — paste blocked for safety" }
+        if ($rc -ne 1) { Write-Host "tirith: unexpected exit code $rc - paste blocked for safety" }
         return
     }
 


### PR DESCRIPTION
Opening a fresh PR to wrap all the fixes into one clean commit!

This resolves a cascade of parser errors that prevents the PowerShell hook from loading natively on Windows PowerShell 5.1 (the default built-in Windows shell).

* **File Encoding / Parser Fix:** `tirith` generates the hook as UTF-8 without a BOM. When PS5.1 tries to read this, it defaults to ANSI (Windows-1252), causing the 3-byte UTF-8 em-dashes (`—`) to be read as multi-byte garbage characters (`â€”`). This corrupts the parser's byte count and throws cascading `Missing closing '}'` errors that completely break the hook. Replaced the em-dashes with standard ASCII hyphens (`-`) to make the script encoding-agnostic.
* **String Format Fix:** Fixed a string interpolation syntax error on line 162 (`$($script:_tirith_ap_timeout)s` -> `$($script:_tirith_ap_timeout) sec`).
* **Scoping Fix:** Added the `global:` scope modifier to the `_tirith_parse_approval` and `_tirith_read_with_timeout` functions. This prevents them from dropping out of scope when the user dot-sources the profile.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Define `global:_tirith_parse_approval` and `global:_tirith_read_with_timeout` in [powershell-hook.ps1](https://github.com/sheeki03/tirith/pull/56/files#diff-bf41899c14d76f1a7172d1d2e2410cbf93ea5e75cac8308bafec865834c91b6e) to fix PS5.1 scoping and adjust prompt text to use "X sec timeout"
> Set key functions to global scope and standardize user-facing prompt text in [powershell-hook.ps1](https://github.com/sheeki03/tirith/pull/56/files#diff-bf41899c14d76f1a7172d1d2e2410cbf93ea5e75cac8308bafec865834c91b6e).
>
> #### 📍Where to Start
> Start with the function declarations for `global:_tirith_parse_approval` and `global:_tirith_read_with_timeout` in [powershell-hook.ps1](https://github.com/sheeki03/tirith/pull/56/files#diff-bf41899c14d76f1a7172d1d2e2410cbf93ea5e75cac8308bafec865834c91b6e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9669505.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->