### PR TITLE
chore: threatdb manifest v24763404182

### DIFF
--- a/threatdb-manifest.json
+++ b/threatdb-manifest.json
@@ -1,0 +1,1 @@
+{"version":24763404182,"sha256":"e58419291b9c89a816017b6a7d02df69641637b10f3a178688c38f876f25a133","size":1690501,"url":"https://github.com/sheeki03/tirith/releases/download/threatdb-24763404182-1/tirith-threatdb.dat","signature":"/xwIzDlCt6x4svuoGehkNtj65/PNGQGHsY4I+JVwOdMF35AniQS4YKTihsj3DM5/WSes/FYp3vHnJ2ySaeU8AA=="}


### PR DESCRIPTION
Auto-generated by threatdb CI (manual retry — bot label didn't exist, blocking the auto-PR step in workflow run 24763404182).