### PR TITLE
fix: doctor policy discovery (#112) and bash degrade-state exports (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`tirith doctor` reported `policies: (none found)` for a policy created by `tirith policy init` (#112)** — `doctor` now resolves the active policy through the same local discovery the engine uses — `TIRITH_POLICY_ROOT`, walk-up from the cwd to the `.git` boundary, then the user config dir — via a new shared `discover_local_policy_path` resolver. `tirith policy validate` resolves through it too, so it now locates and reports on a present-but-corrupt policy instead of reporting "no policy file found"; and `doctor --fix` gained an existence guard so it never overwrites an existing policy file. Previously `doctor` only checked the user config dir and `TIRITH_POLICY_ROOT`, never walking up from the cwd.
+- **Bash enter-mode auto-degrade left `tirith doctor` reporting stale shell state (#111)** — when an interactive bash shell degrades from enter mode to preexec, `_tirith_degrade_to_preexec` now re-exports `TIRITH_BASH_EFFECTIVE_MODE=preexec` and `TIRITH_BASH_EFFECTIVE_PROTECTION=warn-only`, so a child `tirith doctor` reports the real post-degrade state instead of the stale `enter`/`blocks` values exported at shell startup. `tirith doctor` also now warns when a persisted bash safe-mode flag is being overridden by `TIRITH_BASH_MODE=enter`. The bash 5.3 enter-mode delivery regression that *triggers* the degrade is not addressed here — #111 remains open for it.
+
 ## [0.3.1] - 2026-05-08
 
 ### Fixed

--- a/crates/tirith-core/src/policy.rs
+++ b/crates/tirith-core/src/policy.rs
@@ -442,22 +442,9 @@ impl Policy {
 
     /// Discover local policy only (no remote fetch).
     fn discover_local(cwd: Option<&str>) -> Self {
-        if let Ok(root) = std::env::var("TIRITH_POLICY_ROOT") {
-            if let Some(path) = find_policy_in_dir(&PathBuf::from(&root).join(".tirith")) {
-                return Self::load_from_path(&path);
-            }
-        }
-
-        match discover_policy_path(cwd) {
+        match discover_local_policy_path(cwd) {
             Some(path) => Self::load_from_path(&path),
-            None => {
-                if let Some(user_path) = user_policy_path() {
-                    if user_path.exists() {
-                        return Self::load_from_path(&user_path);
-                    }
-                }
-                Policy::default()
-            }
+            None => Policy::default(),
         }
     }
 
@@ -756,6 +743,25 @@ fn discover_policy_path(cwd: Option<&str>) -> Option<PathBuf> {
     None
 }
 
+/// Resolve the path of the local policy that `discover_local` would load, without
+/// reading or parsing it. Mirrors `discover_local`'s resolution order exactly:
+/// `TIRITH_POLICY_ROOT/.tirith` -> walk-up from cwd to the `.git` boundary -> the
+/// user config dir. Returns `None` when no local policy file exists.
+///
+/// Existence-based: a present-but-unparseable policy file still yields its path
+/// here (callers that need a parsed policy use `Policy::discover`).
+pub fn discover_local_policy_path(cwd: Option<&str>) -> Option<PathBuf> {
+    if let Ok(root) = std::env::var("TIRITH_POLICY_ROOT") {
+        if let Some(path) = find_policy_in_dir(&PathBuf::from(&root).join(".tirith")) {
+            return Some(path);
+        }
+    }
+    if let Some(path) = discover_policy_path(cwd) {
+        return Some(path);
+    }
+    user_policy_path()
+}
+
 /// Find the repository root (directory containing .git).
 pub fn find_repo_root(cwd: Option<&str>) -> Option<PathBuf> {
     let start = cwd
@@ -935,5 +941,105 @@ mod tests {
 
         unsafe { std::env::remove_var("TIRITH_API_KEY") };
         unsafe { std::env::remove_var("TIRITH_SERVER_URL") };
+    }
+
+    /// Snapshot an env var on construction and restore it on `Drop`.
+    /// `TEST_ENV_LOCK` serializes env-mutating tests but does not restore
+    /// values; this guard does, so a test cannot leak into another.
+    struct EnvVarGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::remove_var(key) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn discover_local_policy_path_prefers_policy_root_over_walkup() {
+        let _lock = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let isolated_config = tempfile::tempdir().unwrap();
+        let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", isolated_config.path());
+
+        // Both the TIRITH_POLICY_ROOT repo and the cwd carry their own policy.
+        let root_repo = tempfile::tempdir().unwrap();
+        let cwd_repo = tempfile::tempdir().unwrap();
+        for base in [root_repo.path(), cwd_repo.path()] {
+            std::fs::create_dir_all(base.join(".tirith")).unwrap();
+            std::fs::write(base.join(".tirith/policy.yaml"), "fail_mode: open\n").unwrap();
+        }
+        let _root = EnvVarGuard::set("TIRITH_POLICY_ROOT", root_repo.path());
+
+        assert_eq!(
+            discover_local_policy_path(Some(cwd_repo.path().to_str().unwrap())),
+            Some(root_repo.path().join(".tirith/policy.yaml")),
+            "TIRITH_POLICY_ROOT must win over cwd walk-up",
+        );
+    }
+
+    #[test]
+    fn discover_local_policy_path_walks_up_to_repo_root() {
+        let _lock = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let isolated_config = tempfile::tempdir().unwrap();
+        let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", isolated_config.path());
+        let _root = EnvVarGuard::unset("TIRITH_POLICY_ROOT");
+
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join(".git")).unwrap();
+        std::fs::create_dir_all(repo.path().join(".tirith")).unwrap();
+        std::fs::write(repo.path().join(".tirith/policy.yaml"), "fail_mode: open\n").unwrap();
+        let subdir = repo.path().join("a/b/c");
+        std::fs::create_dir_all(&subdir).unwrap();
+
+        assert_eq!(
+            discover_local_policy_path(Some(subdir.to_str().unwrap())),
+            Some(repo.path().join(".tirith/policy.yaml")),
+            "walk-up from a subdir must find the repo-root policy",
+        );
+    }
+
+    #[test]
+    fn discover_local_policy_path_finds_cwd_policy_without_git() {
+        let _lock = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let isolated_config = tempfile::tempdir().unwrap();
+        let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", isolated_config.path());
+        let _root = EnvVarGuard::unset("TIRITH_POLICY_ROOT");
+
+        // Mimics `tirith policy init` run outside a git repo (e.g. in $HOME):
+        // it writes cwd/.tirith/policy.yaml with no .git boundary anywhere.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".tirith")).unwrap();
+        std::fs::write(dir.path().join(".tirith/policy.yaml"), "fail_mode: open\n").unwrap();
+
+        assert_eq!(
+            discover_local_policy_path(Some(dir.path().to_str().unwrap())),
+            Some(dir.path().join(".tirith/policy.yaml")),
+            "a cwd-local .tirith/policy.yaml must be found without a .git boundary",
+        );
     }
 }

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -438,6 +438,13 @@ _tirith_degrade_to_preexec() {
   _TIRITH_BASH_MODE="preexec"
   _tirith_persist_safe_mode
   if [[ $- == *i* ]]; then
+    # Re-export the effective-state contract so a child `tirith doctor` sees the
+    # post-degrade truth, not the stale enter/blocks values exported at startup.
+    # Hardcoded warn-only: a shell that degrades out of enter mode never had
+    # preexec enforcement enabled (enforcement is evaluated only at startup for
+    # shells that START in preexec).
+    export TIRITH_BASH_EFFECTIVE_MODE="preexec"
+    export TIRITH_BASH_EFFECTIVE_PROTECTION="warn-only"
     _tirith_output "  Restart your shell for full custom keybindings to return."
   fi
 }

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -198,16 +198,17 @@ fn policy_missing() -> bool {
 }
 
 /// Build the de-duplicated list of policy paths `doctor` should display. The
-/// first entry (if any) is the policy the engine would actually load; the rest
-/// are present-but-shadowed policy files (user config dir, TIRITH_POLICY_ROOT).
+/// first entry (if any) is the policy the engine would actually load. A second
+/// entry can appear only for a present-but-shadowed user-config-dir policy — a
+/// `TIRITH_POLICY_ROOT` policy, when present, has top resolution priority, so it
+/// is always the active first entry and never a shadowed one.
 fn collect_policy_paths(cwd: Option<&str>) -> Vec<String> {
     let mut paths: Vec<String> = Vec::new();
 
+    // The active policy is the first entry; `paths` is empty here, so the dedup
+    // guard the later push sites use is not needed.
     if let Some(active) = tirith_core::policy::discover_local_policy_path(cwd) {
-        let s = active.display().to_string();
-        if !paths.contains(&s) {
-            paths.push(s);
-        }
+        paths.push(active.display().to_string());
     }
     if let Some(config) = tirith_core::policy::config_dir() {
         for ext in &["policy.yaml", "policy.yml"] {

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -187,20 +187,54 @@ fn hooks_stale() -> bool {
     }
 }
 
-/// Check whether any policy file can be discovered.
+/// Check whether any policy file can be discovered, using the same local
+/// discovery the engine uses (TIRITH_POLICY_ROOT, walk-up to the `.git`
+/// boundary, then the user config dir). Existence-based: no network fetch.
 fn policy_missing() -> bool {
-    if let Ok(root) = std::env::var("TIRITH_POLICY_ROOT") {
-        let tirith_dir = PathBuf::from(&root).join(".tirith");
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|p| p.display().to_string());
+    tirith_core::policy::discover_local_policy_path(cwd.as_deref()).is_none()
+}
+
+/// Build the de-duplicated list of policy paths `doctor` should display. The
+/// first entry (if any) is the policy the engine would actually load; the rest
+/// are present-but-shadowed policy files (user config dir, TIRITH_POLICY_ROOT).
+fn collect_policy_paths(cwd: Option<&str>) -> Vec<String> {
+    let mut paths: Vec<String> = Vec::new();
+
+    if let Some(active) = tirith_core::policy::discover_local_policy_path(cwd) {
+        let s = active.display().to_string();
+        if !paths.contains(&s) {
+            paths.push(s);
+        }
+    }
+    if let Some(config) = tirith_core::policy::config_dir() {
         for ext in &["policy.yaml", "policy.yml"] {
-            if tirith_dir.join(ext).exists() {
-                return false;
+            let p = config.join(ext);
+            if p.exists() {
+                let s = p.display().to_string();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
+                break;
             }
         }
     }
-
-    // discover_partial is local-only — doctor must not trigger a network fetch.
-    let policy = tirith_core::policy::Policy::discover_partial(None);
-    policy.path.is_none()
+    if let Ok(root) = std::env::var("TIRITH_POLICY_ROOT") {
+        let tirith_dir = PathBuf::from(&root).join(".tirith");
+        for ext in &["policy.yaml", "policy.yml"] {
+            let p = tirith_dir.join(ext);
+            if p.exists() {
+                let s = p.display().to_string();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
+                break;
+            }
+        }
+    }
+    paths
 }
 
 /// One detected AI coding tool. `configured_scope` carries the scope at
@@ -342,6 +376,12 @@ blocklist: []
         let policy_dir = repo_root.join(".tirith");
         if std::fs::create_dir_all(&policy_dir).is_ok() {
             let path = policy_dir.join("policy.yaml");
+            if path.exists() {
+                return Err(format!(
+                    "policy already exists at {} — not overwriting",
+                    path.display()
+                ));
+            }
             return std::fs::write(&path, content)
                 .map(|()| path)
                 .map_err(|e| e.to_string());
@@ -352,6 +392,12 @@ blocklist: []
     if let Some(config) = tirith_core::policy::config_dir() {
         if std::fs::create_dir_all(&config).is_ok() {
             let path = config.join("policy.yaml");
+            if path.exists() {
+                return Err(format!(
+                    "policy already exists at {} — not overwriting",
+                    path.display()
+                ));
+            }
             return std::fs::write(&path, content)
                 .map(|()| path)
                 .map_err(|e| e.to_string());
@@ -604,27 +650,11 @@ fn gather_info() -> DoctorInfo {
     let log_path = data_dir.as_ref().map(|d| d.join("log.jsonl"));
     let last_trigger_path = data_dir.as_ref().map(|d| d.join("last_trigger.json"));
 
-    let mut policy_paths = Vec::new();
-    if let Some(config) = tirith_core::policy::config_dir() {
-        for ext in &["policy.yaml", "policy.yml"] {
-            let user_policy = config.join(ext);
-            if user_policy.exists() {
-                policy_paths.push(user_policy.display().to_string());
-                break;
-            }
-        }
-    }
+    let policy_cwd = std::env::current_dir()
+        .ok()
+        .map(|p| p.display().to_string());
+    let policy_paths = collect_policy_paths(policy_cwd.as_deref());
     let policy_root_env = std::env::var("TIRITH_POLICY_ROOT").ok();
-    if let Some(ref root) = policy_root_env {
-        let tirith_dir = PathBuf::from(root).join(".tirith");
-        for ext in &["policy.yaml", "policy.yml"] {
-            let p = tirith_dir.join(ext);
-            if p.exists() {
-                policy_paths.push(p.display().to_string());
-                break;
-            }
-        }
-    }
 
     let shadow_binaries = super::find_shadow_binaries();
     let detection_gaps = check_detection_gaps();
@@ -1144,7 +1174,7 @@ fn reset_safe_mode() -> i32 {
 #[cfg(unix)]
 mod tests {
     use super::*;
-    use crate::cli::test_harness::with_fake_env;
+    use crate::cli::test_harness::{with_fake_env, EnvGuard};
 
     fn first_kiro(tools: &[DetectedTool]) -> Option<&DetectedTool> {
         tools.iter().find(|t| t.name == "kiro")
@@ -1324,6 +1354,109 @@ mod tests {
             let k = first_kiro(&tools).expect("kiro detected");
             assert_eq!(k.configured_scope, Some("user"));
             assert_eq!(count_named(&tools, "kiro"), 1);
+        });
+    }
+
+    // --- collect_policy_paths (#112) ---------------------------------------
+    //
+    // Every test isolates BOTH `TIRITH_POLICY_ROOT` and `XDG_CONFIG_HOME`:
+    // `with_fake_env` fakes `$HOME` but not those, and a machine-level
+    // `XDG_CONFIG_HOME`/`TIRITH_POLICY_ROOT` would otherwise leak into the
+    // assertions. cwd is passed explicitly so process cwd is never relied on.
+
+    #[test]
+    fn collect_policy_paths_finds_repo_root_policy() {
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            let _root = EnvGuard::remove("TIRITH_POLICY_ROOT");
+            let _xdg = EnvGuard::remove("XDG_CONFIG_HOME");
+            std::fs::create_dir_all(cwd.join(".git")).unwrap();
+            std::fs::create_dir_all(cwd.join(".tirith")).unwrap();
+            std::fs::write(cwd.join(".tirith/policy.yaml"), "fail_mode: open\n").unwrap();
+
+            let expected = cwd.join(".tirith/policy.yaml").display().to_string();
+            assert_eq!(
+                collect_policy_paths(cwd.to_str()),
+                vec![expected],
+                "doctor must list the repo-root policy",
+            );
+        });
+    }
+
+    #[test]
+    fn collect_policy_paths_walks_up_from_subdir() {
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            let _root = EnvGuard::remove("TIRITH_POLICY_ROOT");
+            let _xdg = EnvGuard::remove("XDG_CONFIG_HOME");
+            std::fs::create_dir_all(cwd.join(".git")).unwrap();
+            std::fs::create_dir_all(cwd.join(".tirith")).unwrap();
+            std::fs::write(cwd.join(".tirith/policy.yaml"), "fail_mode: open\n").unwrap();
+            let subdir = cwd.join("src/inner");
+            std::fs::create_dir_all(&subdir).unwrap();
+
+            let expected = cwd.join(".tirith/policy.yaml").display().to_string();
+            assert_eq!(
+                collect_policy_paths(subdir.to_str()),
+                vec![expected],
+                "walk-up from a subdir must surface the repo-root policy",
+            );
+        });
+    }
+
+    #[test]
+    fn collect_policy_paths_finds_cwd_policy_without_git() {
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            let _root = EnvGuard::remove("TIRITH_POLICY_ROOT");
+            let _xdg = EnvGuard::remove("XDG_CONFIG_HOME");
+            // `tirith policy init` run outside a git repo (e.g. in $HOME) writes
+            // cwd/.tirith/policy.yaml with no .git boundary — the literal #112 repro.
+            std::fs::create_dir_all(cwd.join(".tirith")).unwrap();
+            std::fs::write(cwd.join(".tirith/policy.yaml"), "fail_mode: open\n").unwrap();
+
+            let expected = cwd.join(".tirith/policy.yaml").display().to_string();
+            assert_eq!(
+                collect_policy_paths(cwd.to_str()),
+                vec![expected],
+                "a cwd-local policy with no .git must still be listed (#112 repro)",
+            );
+        });
+    }
+
+    #[test]
+    fn collect_policy_paths_finds_user_config_policy_and_dedups() {
+        with_fake_env(true, |home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            let _root = EnvGuard::remove("TIRITH_POLICY_ROOT");
+            let _xdg = EnvGuard::remove("XDG_CONFIG_HOME");
+            // Only the user config dir has a policy; cwd has none.
+            let config = home.join(".config/tirith");
+            std::fs::create_dir_all(&config).unwrap();
+            std::fs::write(config.join("policy.yaml"), "fail_mode: open\n").unwrap();
+
+            let expected = config.join("policy.yaml").display().to_string();
+            let paths = collect_policy_paths(cwd.to_str());
+            assert_eq!(
+                paths.len(),
+                1,
+                "active policy == user config policy must dedup to one entry: {paths:?}",
+            );
+            assert_eq!(paths, vec![expected]);
+        });
+    }
+
+    #[test]
+    fn collect_policy_paths_empty_when_no_policy() {
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            let _root = EnvGuard::remove("TIRITH_POLICY_ROOT");
+            let _xdg = EnvGuard::remove("XDG_CONFIG_HOME");
+            // Empty cwd tempdir, no .git, fake $HOME has no config policy.
+            assert!(
+                collect_policy_paths(cwd.to_str()).is_empty(),
+                "no policy anywhere must yield an empty list",
+            );
         });
     }
 }

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -358,6 +358,14 @@ fn env_is_truthy(s: &str) -> bool {
     )
 }
 
+/// True when a persisted bash safe-mode flag exists but `TIRITH_BASH_MODE=enter`
+/// overrides it, so the hook re-attempts enter mode on every new shell despite
+/// the recorded prior failure. Exact, case-sensitive match — mirrors the hook's
+/// `[[ "$_TIRITH_BASH_MODE" == "enter" ]]`.
+fn safe_mode_overridden_by_env(bash_safe_mode: bool, requested_mode: Option<&str>) -> bool {
+    bash_safe_mode && requested_mode == Some("enter")
+}
+
 /// Create a minimal starter policy at .tirith/policy.yaml in the repo root,
 /// or fall back to the user config dir.
 fn create_default_policy() -> Result<PathBuf, String> {
@@ -872,6 +880,18 @@ fn print_human(info: &DoctorInfo) {
             println!("                        Reset: tirith doctor --reset-bash-safe-mode");
         } else {
             println!("  safe mode:            off");
+        }
+        if safe_mode_overridden_by_env(info.bash_safe_mode, info.bash_requested_mode.as_deref()) {
+            println!(
+                "  warning:              TIRITH_BASH_MODE=enter overrides the safe-mode flag —"
+            );
+            println!(
+                "                        enter mode is re-attempted (and may keep failing) on"
+            );
+            println!(
+                "                        every new shell. Unset TIRITH_BASH_MODE to honor the"
+            );
+            println!("                        recorded failure and stay in preexec.");
         }
     } else if info.bash_safe_mode {
         // Non-bash shell but safe-mode flag exists: still surface it.
@@ -1458,5 +1478,14 @@ mod tests {
                 "no policy anywhere must yield an empty list",
             );
         });
+    }
+
+    #[test]
+    fn safe_mode_overridden_only_when_flag_and_enter() {
+        assert!(safe_mode_overridden_by_env(true, Some("enter")));
+        assert!(!safe_mode_overridden_by_env(false, Some("enter"))); // no flag
+        assert!(!safe_mode_overridden_by_env(true, Some("preexec"))); // not enter
+        assert!(!safe_mode_overridden_by_env(true, None)); // env unset
+        assert!(!safe_mode_overridden_by_env(true, Some("Enter"))); // case-sensitive
     }
 }

--- a/crates/tirith/src/cli/policy.rs
+++ b/crates/tirith/src/cli/policy.rs
@@ -465,6 +465,10 @@ fn resolve_policy_path(explicit: Option<&str>) -> Option<PathBuf> {
         return None;
     }
 
-    let policy = tirith_core::policy::Policy::discover(None);
-    policy.path.map(PathBuf::from)
+    // Existence-based local discovery — the same resolver the engine and
+    // `doctor` use. `Policy::discover` would parse the policy and, on a parse
+    // error, drop the path, so `validate` could not even locate a corrupt
+    // policy to report on; it would also resolve to an unreadable `remote:` URL
+    // when a remote policy server is configured.
+    tirith_core::policy::discover_local_policy_path(None)
 }

--- a/crates/tirith/src/cli/test_harness.rs
+++ b/crates/tirith/src/cli/test_harness.rs
@@ -28,6 +28,13 @@ impl EnvGuard {
         unsafe { std::env::set_var(key, val) };
         Self { key, old }
     }
+
+    /// Remove `key` for the test's duration, restoring the prior value on Drop.
+    pub(crate) fn remove(key: &'static str) -> Self {
+        let old = std::env::var_os(key);
+        unsafe { std::env::remove_var(key) };
+        Self { key, old }
+    }
 }
 
 impl Drop for EnvGuard {

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -246,3 +246,56 @@ fn doctor_default_requested_mode_shown_when_env_unset() {
         "effective mode missing, got:\n{stdout}"
     );
 }
+
+/// Source the hook in an interactive subshell, run `body`, then dump the two
+/// effective-state exports. Like `source_hook_and_dump_exports`, but lets a
+/// test drive a state transition (e.g. a degrade) before the dump.
+fn source_hook_run_and_dump(extra_env: &[(&str, &str)], body: &str) -> String {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let hook = hook_path();
+    let script = format!(
+        "source '{hook}' 2>/dev/null; {body}; \
+         printf 'MODE=%s\\nPROT=%s\\n' \
+           \"${{TIRITH_BASH_EFFECTIVE_MODE:-}}\" \
+           \"${{TIRITH_BASH_EFFECTIVE_PROTECTION:-}}\""
+    );
+
+    let mut cmd = Command::new("bash");
+    cmd.args(["--norc", "--noprofile", "-i", "-c", &script])
+        .env_clear()
+        .env("HOME", std::env::var("HOME").unwrap_or_default())
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("XDG_STATE_HOME", tmpdir.path());
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("failed to run bash");
+    assert!(
+        out.status.success(),
+        "bash exited non-zero: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// #111: an enter->preexec auto-degrade must refresh the exported effective
+/// state, so a child `tirith doctor` after a degrade reports the truth instead
+/// of the stale `enter`/`blocks` values exported at shell startup.
+#[test]
+fn degrade_to_preexec_reexports_effective_state() {
+    // `_TIRITH_TEST_SKIP_HEALTH=1` keeps the hook in enter mode — it would
+    // otherwise auto-degrade at the startup health gate in a non-PTY shell, so
+    // the explicit degrade below would not be the transition under test.
+    let out = source_hook_run_and_dump(
+        &[("_TIRITH_TEST_SKIP_HEALTH", "1")],
+        "_tirith_degrade_to_preexec degrade-test",
+    );
+    assert!(
+        out.contains("MODE=preexec"),
+        "degrade must re-export TIRITH_BASH_EFFECTIVE_MODE=preexec, got:\n{out}"
+    );
+    assert!(
+        out.contains("PROT=warn-only"),
+        "degrade must re-export TIRITH_BASH_EFFECTIVE_PROTECTION=warn-only, got:\n{out}"
+    );
+}

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -23,13 +23,31 @@ fn hook_path() -> String {
     )
 }
 
+/// Split `extra_env` into a session-local shell prelude and real process env
+/// vars. `_TIRITH_TEST_*` overrides MUST be session-local: the hook
+/// deliberately unsets exported (env-inherited) `_TIRITH_TEST_*` values —
+/// treating them as attacker-controllable — and honors only session-local ones.
+fn split_test_env(extra_env: &[(&str, &str)]) -> (String, Vec<(String, String)>) {
+    let mut prelude = String::new();
+    let mut env_vars = Vec::new();
+    for (k, v) in extra_env {
+        if k.starts_with("_TIRITH_TEST_") {
+            prelude.push_str(&format!("{k}='{v}'; "));
+        } else {
+            env_vars.push((k.to_string(), v.to_string()));
+        }
+    }
+    (prelude, env_vars)
+}
+
 /// Source the hook inside a clean, interactive bash subshell with a fresh
 /// state dir and print the two exported vars in `key=value` form.
 fn source_hook_and_dump_exports(extra_env: &[(&str, &str)]) -> String {
     let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
     let hook = hook_path();
+    let (prelude, env_vars) = split_test_env(extra_env);
     let script = format!(
-        "source '{hook}' 2>/dev/null; \
+        "{prelude}source '{hook}' 2>/dev/null; \
          printf 'MODE=%s\\nPROT=%s\\n' \
            \"${{TIRITH_BASH_EFFECTIVE_MODE:-}}\" \
            \"${{TIRITH_BASH_EFFECTIVE_PROTECTION:-}}\""
@@ -42,7 +60,7 @@ fn source_hook_and_dump_exports(extra_env: &[(&str, &str)]) -> String {
         .env("HOME", std::env::var("HOME").unwrap_or_default())
         .env("PATH", std::env::var("PATH").unwrap_or_default())
         .env("XDG_STATE_HOME", tmpdir.path());
-    for (k, v) in extra_env {
+    for (k, v) in &env_vars {
         cmd.env(k, v);
     }
     let out = cmd.output().expect("failed to run bash");
@@ -56,7 +74,12 @@ fn source_hook_and_dump_exports(extra_env: &[(&str, &str)]) -> String {
 
 #[test]
 fn hook_exports_enter_by_default_outside_ssh() {
-    let out = source_hook_and_dump_exports(&[]);
+    // Skip the startup health gate: in a non-PTY `bash -i -c` — including on
+    // macOS's ancient /bin/bash 3.2, which CI runs — `bind -x` may not register,
+    // so the gate would degrade enter->preexec. This test verifies *mode
+    // resolution* (enter is the default outside SSH), independent of bind-x
+    // viability; the PTY conformance harness covers actual delivery.
+    let out = source_hook_and_dump_exports(&[("_TIRITH_TEST_SKIP_HEALTH", "1")]);
     assert!(
         out.contains("MODE=enter"),
         "expected MODE=enter, got:\n{out}"
@@ -253,8 +276,9 @@ fn doctor_default_requested_mode_shown_when_env_unset() {
 fn source_hook_run_and_dump(extra_env: &[(&str, &str)], body: &str) -> String {
     let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
     let hook = hook_path();
+    let (prelude, env_vars) = split_test_env(extra_env);
     let script = format!(
-        "source '{hook}' 2>/dev/null; {body}; \
+        "{prelude}source '{hook}' 2>/dev/null; {body}; \
          printf 'MODE=%s\\nPROT=%s\\n' \
            \"${{TIRITH_BASH_EFFECTIVE_MODE:-}}\" \
            \"${{TIRITH_BASH_EFFECTIVE_PROTECTION:-}}\""
@@ -266,7 +290,7 @@ fn source_hook_run_and_dump(extra_env: &[(&str, &str)], body: &str) -> String {
         .env("HOME", std::env::var("HOME").unwrap_or_default())
         .env("PATH", std::env::var("PATH").unwrap_or_default())
         .env("XDG_STATE_HOME", tmpdir.path());
-    for (k, v) in extra_env {
+    for (k, v) in &env_vars {
         cmd.env(k, v);
     }
     let out = cmd.output().expect("failed to run bash");

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -1857,3 +1857,38 @@ fn warn_only_json_output_matches_plain_when_timings_stripped() {
         "exit codes must match"
     );
 }
+
+/// #112: `tirith policy validate` (no --file) must locate a present-but-corrupt
+/// policy and report its error, rather than collapsing to "no policy file found"
+/// the way the old parse-aware discovery (`Policy::discover().path`) did.
+#[test]
+fn policy_validate_finds_present_but_corrupt_policy() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tirith_dir = dir.path().join(".tirith");
+    fs::create_dir_all(&tirith_dir).expect("create .tirith");
+    // Unparseable YAML: `Policy::discover` would parse this, fail, and drop the
+    // path — so the old resolver reported "no policy file found".
+    fs::write(tirith_dir.join("policy.yaml"), "{{invalid yaml\n").expect("write policy");
+
+    let out = tirith()
+        .args(["policy", "validate"])
+        .current_dir(dir.path())
+        .env_remove("TIRITH_POLICY_ROOT")
+        .output()
+        .expect("failed to run tirith");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("no policy file found"),
+        "validate must locate the present policy, not claim none exists: {stderr}"
+    );
+    assert!(
+        stderr.contains("YAML parse error"),
+        "validate must report the corrupt policy's parse error: {stderr}"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "a corrupt policy is an error-level issue (exit 1)"
+    );
+}

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -438,6 +438,13 @@ _tirith_degrade_to_preexec() {
   _TIRITH_BASH_MODE="preexec"
   _tirith_persist_safe_mode
   if [[ $- == *i* ]]; then
+    # Re-export the effective-state contract so a child `tirith doctor` sees the
+    # post-degrade truth, not the stale enter/blocks values exported at startup.
+    # Hardcoded warn-only: a shell that degrades out of enter mode never had
+    # preexec enforcement enabled (enforcement is evaluated only at startup for
+    # shells that START in preexec).
+    export TIRITH_BASH_EFFECTIVE_MODE="preexec"
+    export TIRITH_BASH_EFFECTIVE_PROTECTION="warn-only"
     _tirith_output "  Restart your shell for full custom keybindings to return."
   fi
 }


### PR DESCRIPTION
## Summary

Two trust-gate fixes from the shell / `doctor` reliability work.

**#112 — `tirith doctor` could not see a policy created by `tirith policy init`.**
`doctor` only checked the user config dir and `TIRITH_POLICY_ROOT`, never the cwd
walk-up the engine itself uses, so it reported `policies: (none found)` for a
`.tirith/policy.yaml` that `policy init` had just written. This adds a shared
`discover_local_policy_path` resolver in `tirith-core` (TIRITH_POLICY_ROOT ->
walk-up to the `.git` boundary -> user config dir) and routes `doctor`,
`policy_missing`, and `tirith policy validate` through it. `tirith policy validate`
now also locates a present-but-corrupt policy and reports its parse error instead
of "no policy file found", and `create_default_policy` gained an `exists()` guard.
Closes #112.

**#111 (partial) — stale `tirith doctor` state after an enter->preexec degrade.**
`_tirith_degrade_to_preexec` now re-exports `TIRITH_BASH_EFFECTIVE_MODE=preexec`
and `TIRITH_BASH_EFFECTIVE_PROTECTION=warn-only`, so a child `tirith doctor`
reports the true post-degrade state instead of the stale `enter`/`blocks` values.
`doctor` also warns when `TIRITH_BASH_MODE=enter` overrides a persisted safe-mode
flag. This fixes only the stale-state sub-bug — the bash 5.3 enter-mode *delivery*
failure that #111 primarily reports is **not** addressed here; #111 stays open for it.

## Tests

New regression coverage: `discover_local_policy_path` resolver tests in tirith-core,
`collect_policy_paths` tests in `doctor`, a `policy validate` corrupt-policy
integration test, and a bash degrade-export test. `cargo fmt --check`, `cargo clippy
--workspace --all-targets -D warnings`, and `cargo test --workspace` all pass
(shell tests run against bash 5.x).

Refs #111.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent reliability bugs: `tirith doctor` failing to discover policies created by `tirith policy init` (#112), and stale shell-state exports after a bash enter→preexec auto-degrade (#111 partial). Both fixes are narrowly scoped and do not change the policy-loading semantics for the engine.

- **#112 — Policy discovery**: Extracts a new public `discover_local_policy_path` in `tirith-core` that mirrors `discover_local`'s full resolution order (`TIRITH_POLICY_ROOT` → cwd walk-up to `.git` boundary → user config dir) without parsing the file. `doctor`, `policy validate`, and `create_default_policy` all route through it; `policy validate` can now locate and surface parse errors on corrupt policies rather than falling back to \"no policy file found\".
- **#111 (partial) — Bash degrade exports**: `_tirith_degrade_to_preexec` now re-exports `TIRITH_BASH_EFFECTIVE_MODE=preexec` and `TIRITH_BASH_EFFECTIVE_PROTECTION=warn-only` inside the interactive-shell branch so child processes see post-degrade truth; `doctor` also warns when `TIRITH_BASH_MODE=enter` overrides a persisted safe-mode flag.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all core logic changes are correct and well-tested. One new test makes a Linux-specific path assumption that will break on macOS CI if any is added later.

The policy-discovery refactor is clean and the dedup in `collect_policy_paths` is correct. The bash degrade export is correctly scoped to interactive shells. The only non-trivial finding is that `collect_policy_paths_finds_user_config_policy_and_dedups` hardcodes a Linux XDG path after removing `XDG_CONFIG_HOME`, which would cause it to write to a directory `etcetera` never looks at on macOS.

crates/tirith/src/cli/doctor.rs — the new `collect_policy_paths_finds_user_config_policy_and_dedups` test needs a platform-safe config-dir setup to be portable beyond Linux

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/policy.rs | Adds public `discover_local_policy_path` (existence-based, mirrors `discover_local` priority order) and refactors `discover_local` to delegate to it; three well-isolated unit tests added with proper env isolation via `EnvVarGuard` |
| crates/tirith/src/cli/doctor.rs | Replaces the old partial policy-discovery logic with `discover_local_policy_path`; adds `collect_policy_paths`, `safe_mode_overridden_by_env`, and existence guards in `create_default_policy`; one new test has a platform-specific path assumption that will fail on macOS |
| crates/tirith/src/cli/policy.rs | Switches `resolve_policy_path` from parse-aware `Policy::discover().path` to existence-based `discover_local_policy_path`, correctly enabling `validate` to locate and report on corrupt policies |
| crates/tirith/assets/shell/lib/bash-hook.bash | Adds re-export of effective-state env vars inside `_tirith_degrade_to_preexec`; correctly scoped to interactive shells |
| crates/tirith/tests/bash_hook_exports.rs | Adds `degrade_to_preexec_reexports_effective_state` integration test with correct use of `_TIRITH_TEST_SKIP_HEALTH=1` |
| crates/tirith/tests/cli_integration.rs | Adds `policy_validate_finds_present_but_corrupt_policy`; cleanly exercises the #112 regression path |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftirith%2Fsrc%2Fcli%2Fdoctor.rs%3A206-210%0A**Dead%20condition%20on%20first%20dedup%20check**%0A%0A%60paths%60%20is%20always%20empty%20when%20the%20first%20%60if%20!paths.contains%28%26s%29%60%20runs%2C%20so%20the%20guard%20is%20always%20%60true%60%20and%20provides%20no%20dedup.%20The%20dedup%20only%20matters%20for%20steps%202%20and%203.%20This%20is%20harmless%20today%20%28there%20are%20only%20two%20remaining%20push%20sites%29%2C%20but%20it%20creates%20a%20misleading%20impression%20that%20the%20active%20path%20could%20already%20be%20present%20at%20that%20moment.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftirith%2Fsrc%2Fcli%2Fdoctor.rs%3A1449-1472%0A**%60collect_policy_paths_finds_user_config_policy_and_dedups%60%20may%20fail%20on%20macOS**%0A%0AThe%20test%20removes%20%60XDG_CONFIG_HOME%60%20then%20writes%20the%20policy%20to%20%60home.join%28%22.config%2Ftirith%22%29%60%20%E2%80%94%20a%20hardcoded%20XDG%20path.%20On%20macOS%2C%20%60etcetera%3A%3Achoose_base_strategy%28%29%60%20without%20%60XDG_CONFIG_HOME%60%20resolves%20%60config_dir%28%29%60%20to%20%60%24HOME%2FLibrary%2FApplication%20Support%60%2C%20not%20%60%24HOME%2F.config%60.%20So%20%60user_policy_path%28%29%60%20and%20%60config_dir%28%29%60%20both%20look%20in%20the%20macOS%20location%20and%20find%20nothing%2C%20causing%20%60collect_policy_paths%60%20to%20return%20an%20empty%20vec%20and%20the%20assertion%20to%20fail.%20The%20sibling%20tests%20in%20%60tirith-core%2Fsrc%2Fpolicy.rs%60%20avoid%20this%20by%20**setting**%20%60XDG_CONFIG_HOME%60%20to%20a%20known%20temp%20dir%20rather%20than%20removing%20it.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftirith%2Fsrc%2Fcli%2Fdoctor.rs%3A200-203%0A**Doc%20comment%20overstates%20what%20%60TIRITH_POLICY_ROOT%60%20shadowing%20can%20look%20like**%0A%0AThe%20comment%20says%20%22the%20rest%20are%20present-but-shadowed%20policy%20files%20%28user%20config%20dir%2C%20TIRITH_POLICY_ROOT%29%22.%20In%20practice%2C%20%60TIRITH_POLICY_ROOT%60%20has%20the%20highest%20resolution%20priority%2C%20so%20if%20it%20contains%20a%20policy%20it%20is%20always%20the%20*active*%20entry%20%28step%201%29%20and%20is%20deduped%20out%20in%20step%203%20%E2%80%94%20it%20can%20never%20appear%20as%20a%20shadowed%20entry.%20Only%20the%20user%20config%20dir%20can%20appear%20as%20a%20shadowed%20entry.%0A%0A&repo=sheeki03%2Ftirith&pr=113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(bash-hook): re-export effective stat..."](https://github.com/sheeki03/tirith/commit/631bdfdc77e1973d2470113c4c6a2fd542062098) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33217486)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->