### PR TITLE
docs: roadmap/README/compatibility truth cleanup (M1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,55 @@ Nothing. Zero output. You forget tirith is running.
 
 ---
 
+## What tirith does NOT protect against
+
+Tirith analyzes the **structure** of commands, pasted text, and files *before*
+they execute. It is a pre-execution gate, not a runtime defense. By design, it
+does not cover:
+
+- **Runtime sandboxing** — tirith does not sandbox or contain a command once it
+  runs. It decides whether to warn or block; it does not isolate execution.
+- **Post-execution network monitoring** — tirith does not inspect network
+  traffic after a command runs. What a process does on the network once
+  launched is out of scope.
+- **Malware / payload detection** — tirith analyzes command and file
+  *structure*, not payload behavior. It is not an antivirus and does not
+  detonate or signature-match payloads. (`tirith run` analyzes a downloaded
+  script's structure before execution, but it is still not malware analysis.)
+- **A privileged root/admin attacker** — a user who is already root or admin can
+  bypass tirith trivially. Tirith defends against tricked input, not against an
+  attacker who already owns the machine.
+- **Anti-debugging / anti-tampering** — tirith does not resist analysis or
+  reverse engineering, and does not protect its own binary from a local
+  attacker.
+
+See [docs/threat-model.md](docs/threat-model.md) for the full threat model and
+explicit non-goals.
+
+---
+
+## Known limitations
+
+- **Shell-hook fragility** — tirith protection depends on a shell hook staying
+  correctly installed and active. Hooks can break or silently degrade across
+  shells (zsh, bash, fish, PowerShell), shell versions, prompt frameworks, and
+  history tools. Run `tirith doctor` to check live hook state, and watch for
+  warn-only degradation messages.
+- **Unix-only features** — daemon mode and `tirith setup` are Unix-only today.
+  `tirith run` and `tirith fetch` are likewise Unix-only.
+- **Package-name extraction scope** — package-name matching against the threat
+  database covers language ecosystems (pip, npm/yarn/pnpm/bun, cargo, gem, go,
+  composer, dotnet, mvn/gradle). It does **not** cover distro-level package
+  managers (`apt`, `dnf`, `yum`, `pacman`).
+- **AI-agent integration caveats** — shell-hook interception only guards
+  commands that actually go through a hooked interactive shell; an agent that
+  spawns a non-interactive shell, calls `exec` directly, or runs in an
+  environment where the hook is not loaded is not covered. MCP-based protection
+  requires the agent to actually call the tirith MCP tools — it is advisory, not
+  enforced.
+
+---
+
 ## Threat intelligence
 
 Tirith ships a signed local threat database for package, hostname, and IP reputation. When a shell hook or `tirith check` sees a package install or suspicious infrastructure reference, it matches that input against the database before the command executes, instead of relying only on static heuristics.
@@ -500,11 +549,29 @@ tirith daemon stop
 
 ## Design principles
 
-- **Offline by default** — `check`, `paste`, `score`, `diff`, and `why` make zero network calls. All detection runs locally.
-- **No command rewriting** — tirith never modifies what you typed
-- **No telemetry** — no analytics, no crash reporting, no phone-home behavior
-- **No background processes by default** — invoked per-command, exits immediately. Optional `tirith daemon start` keeps patterns warm for faster checks.
-- **Network only when you ask or configure it** — `run`, `fetch`, and `audit report --upload` reach the network on explicit invocation. Daemon mode adds network-aware URL resolution. Optional webhook and policy-server integrations can also make outbound requests when configured. Core detection itself does not phone home.
+- **Detection runs locally** — `paste`, `score`, `diff`, and `why` make zero
+  network calls; all of their analysis is local. `tirith check` (including the
+  `--approval-check` path that shell hooks use) also analyzes locally, but
+  before analysis it triggers a *periodic background threat-DB refresh check*
+  (see below) — so `check` is not strictly offline.
+- **Periodic background threat-DB refresh** — `tirith check` and the shell hooks
+  trigger a cheap background check, at most once every 24 hours by default
+  (`threat_intel.auto_update_hours`), to keep the signed threat database fresh.
+  The check is detached and does not block the command; set
+  `auto_update_hours: 0` in policy to disable it entirely. `tirith paste` does
+  **not** trigger this — it goes straight through the local engine.
+- **No command rewriting** — tirith never modifies what you typed.
+- **No telemetry** — no analytics, no crash reporting, no phone-home behavior.
+- **No long-lived background processes by default** — tirith is invoked
+  per-command and exits immediately. The threat-DB refresh above is a
+  short-lived detached update, not a resident process. Optional `tirith daemon
+  start` is the only resident process, and it is opt-in.
+- **Network only when you ask, configure it, or for the threat-DB refresh** —
+  `run`, `fetch`, and `audit report --upload` reach the network on explicit
+  invocation. The periodic threat-DB refresh check reaches the network on the
+  schedule above. Daemon mode adds network-aware URL resolution. Optional
+  webhook and policy-server integrations can also make outbound requests when
+  configured. Core detection itself does not phone home.
 
 ---
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -70,10 +70,12 @@ the following:
 - **CLI deprecation policy** — flags and behaviors are removed only through a
   documented deprecation cycle, never abruptly.
 
-These criteria are applied **first** to the integration-critical commands —
-`check`, `scan`, `doctor`, and the MCP tools — because shell hooks, CI
-pipelines, and AI agents depend on them most directly. Other experimental
-commands graduate after the integration-critical surface is locked down.
+These criteria are prioritised for the **experimental** integration-critical
+surface — `scan`, `doctor`, and the MCP tools — because CI pipelines and AI
+agents depend on them most directly. (`check` is already Stable; the
+already-stable commands are held to these same guarantees as maintenance
+invariants.) Other experimental commands graduate after that surface is locked
+down.
 
 ## Exit Codes
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,34 +1,79 @@
 # Compatibility and Stability
 
-## Stable Subcommands
+## Stability Tiers
 
-The following subcommands are considered stable. Their flags, exit codes, and output format will not change in a backwards-incompatible way within a major version:
+Tirith subcommands fall into two stability tiers:
 
-- `check` — analyze a command before execution
-- `paste` — analyze pasted content
-- `score` — risk score a URL
-- `diff` — compare URL against known-good
-- `why` — explain last triggered rule
-- `receipt` — manage execution receipts
-- `init` — initialize shell hooks
+- **Stable** — flags, exit codes, and output format will not change in a
+  backwards-incompatible way within a major version.
+- **Experimental** — surface may change without notice while the command and
+  its schema are still being shaped.
 
-## Experimental Subcommands
+## Per-Command Stability Matrix
 
-These subcommands may change without notice:
+This table reflects the **current** state of each subcommand. It is descriptive,
+not a promise of future classification — see "Graduation criteria" below for
+what an experimental command must satisfy to move to stable.
 
-- `run` — safe script download/execute
-- `scan` — file and directory scanning for hidden content and config poisoning
-- `fetch` — server-side cloaking detection
-- `checkpoint` — file checkpoint and rollback
-- `gateway` — MCP gateway proxy for AI agent security
-- `setup` — configure tirith for AI coding tools
-- `audit` — audit log export, stats, and compliance reports
-- `activate` — license key activation
-- `license` — license status and management
-- `mcp-server` — MCP server mode (JSON-RPC over stdio)
-- `doctor` — diagnostic output
-- `completions` — shell completion generation (hidden)
-- `manpage` — man page generation (hidden)
+| Command | Stability | Notes |
+|---------|-----------|-------|
+| `check` | Stable | Analyze a command before execution. Integration-critical (shell hooks, MCP). |
+| `paste` | Stable | Analyze pasted content. |
+| `score` | Stable | Risk-score a URL. |
+| `diff` | Stable | Compare a URL against known-good patterns. |
+| `why` | Stable | Explain the last triggered rule. |
+| `receipt` | Stable | Manage execution receipts. |
+| `init` | Stable | Initialize shell hooks. |
+| `scan` | Experimental | File/directory scanning for hidden content and config poisoning. Integration-critical (CI, MCP). |
+| `doctor` | Experimental | Installation and configuration diagnostics. Integration-critical. |
+| `run` | Experimental | Safe script download/execute (Unix only). |
+| `fetch` | Experimental | Server-side cloaking detection (Unix only). |
+| `checkpoint` | Experimental | File checkpoint and rollback. |
+| `gateway` | Experimental | MCP gateway proxy for AI-agent security. |
+| `setup` | Experimental | Configure tirith for AI coding tools. |
+| `policy` | Experimental | Policy `init` / `validate` / `test`. |
+| `trust` | Experimental | Manage trusted patterns (allowlist entries with TTL and scoping). |
+| `warnings` | Experimental | Show accumulated session warnings. |
+| `threat-db` | Experimental | Manage the threat intelligence database. |
+| `daemon` | Experimental | Background daemon (Unix only). |
+| `audit` | Experimental | Audit log export, stats, and compliance reports. |
+| `activate` | Experimental | License key activation. |
+| `license` | Experimental | License status and management. |
+| `mcp-server` | Experimental | MCP server mode (JSON-RPC over stdio). |
+| `completions` | Experimental | Shell completion generation (hidden). |
+| `manpage` | Experimental | Man page generation (hidden). |
+
+The MCP tools exposed by `mcp-server` (`tirith_check_command`, `tirith_check_url`,
+`tirith_check_paste`, `tirith_scan_file`, `tirith_scan_directory`,
+`tirith_verify_mcp_config`, `tirith_fetch_cloaking`) are also treated as an
+integration-critical surface for graduation purposes.
+
+## Graduation Criteria
+
+An experimental command graduates to **stable** only once it satisfies all of
+the following:
+
+- **Stable JSON schema** — the `--format json` output has a fixed, documented
+  schema. `schema_version` is emitted, and existing fields are not removed or
+  retyped within a major version.
+- **Golden snapshot tests** — representative inputs are covered by golden
+  snapshot tests so output drift is caught in CI.
+- **Versioned config/policy migration** — any config or policy keys the command
+  reads have a defined migration path; format changes are versioned, not silent.
+- **Exit-code compatibility promise** — the command's exit codes are documented
+  and committed to (see "Exit Codes" below).
+- **`--format json` consistency** — the JSON output is consistent with the
+  shared output conventions used by the already-stable commands.
+- **Backward-compatible MCP tool schemas** — for commands exposed through the
+  MCP server, the corresponding tool input/output schemas evolve only in a
+  backward-compatible way.
+- **CLI deprecation policy** — flags and behaviors are removed only through a
+  documented deprecation cycle, never abruptly.
+
+These criteria are applied **first** to the integration-critical commands —
+`check`, `scan`, `doctor`, and the MCP tools — because shell hooks, CI
+pipelines, and AI agents depend on them most directly. Other experimental
+commands graduate after the integration-critical surface is locked down.
 
 ## Exit Codes
 
@@ -39,6 +84,11 @@ Exit codes are stable:
 | 0    | Allow (no issues found) |
 | 1    | Block (high/critical severity findings) |
 | 2    | Warn (medium/low severity findings) |
+| 3    | WarnAck — acknowledgement required (warn-ack hook protocol) |
+
+Exit code 3 is the warn-ack hook protocol path used by shell hooks under strict
+warn mode, not the normal direct-CLI contract. Non-hook callers should not
+normally see exit code 3.
 
 ## JSON Output
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,43 +1,69 @@
 # Roadmap
 
-## Phase 2 Backlog
+This roadmap tracks what has shipped, what is in progress, and what is planned.
+Priority and scope of unstarted work may change based on dogfooding feedback.
 
-These items are candidates for future development. Priority and scope may change based on dogfooding feedback.
+## Done
 
-### Interactive confirmation for strict_warn
-- Hook-mediated Y/N prompt for WARN-level findings in interactive mode
-- Allows users to acknowledge warnings without blocking
+Shipped and available in the current release line (see [CHANGELOG.md](../CHANGELOG.md)).
 
-### Socket/daemon mode
-- Persistent background process to avoid cold-start latency
-- Shell hooks connect via Unix socket instead of spawning a process
-- Target: <0.5ms hook latency
+- **Daemon mode (Unix)** — persistent background process for sub-millisecond
+  hook latency, with network-aware URL checks. `tirith daemon start/stop/status`.
+- **CI scanning with SARIF** — `tirith scan` exits non-zero in CI on a severity
+  threshold and emits SARIF for GitHub Code Scanning.
+- **GitHub Action** — `sheeki03/tirith@v1` wraps `tirith scan` for CI pipelines.
+- **Pre-commit hook** — `.pre-commit-hooks.yaml` entry for local scanning.
+- **`tirith policy init / validate / test`** — generate a starter policy,
+  validate YAML syntax and conflicts, and dry-run a command or file against the
+  active policy.
+- **`tirith explain --rule <id>`** — detailed per-rule documentation, including
+  examples and remediation, plus `--list` / `--category` filtering.
+- **`tirith scan` include/exclude/profile filters** — `--include`, `--exclude`,
+  and `--profile` (named profiles loaded from policy) for targeted scanning.
+- **Per-session warning accumulator** — `tirith warnings` CLI command and
+  shell exit summaries across all hooks.
+- **Strict-warn mode** — `strict_warn` policy key / `--strict-warn` flag, with a
+  dedicated `WarnAck` exit code (3) for the warn-ack hook protocol.
 
-### Network-aware checks
-- Resolve shortened URLs to final destination before analysis
-- Check certificate transparency logs for suspicious domains
-- DNS-based threat intelligence lookups
+## Now
 
-### `tirith scan` CI mode
-- Scan a file or directory for URLs and analyze them
-- Exit code reflects highest severity found
-- SARIF output for GitHub Code Scanning integration
+In progress — the current focus is shell-integration reliability and policy
+discovery consistency.
 
-### `tirith policy validate`
-- Validate policy YAML syntax and semantics
-- Check for conflicting allowlist/blocklist entries
-- Warn about deprecated or unknown fields
+- **Shell integration reliability** — fixing hook fragility across shells and
+  versions. Tracking [#111](https://github.com/sheeki03/tirith/issues/111)
+  (bash "previous command not delivered") and
+  [#103](https://github.com/sheeki03/tirith/issues/103)
+  (fish preexec/postexec functions not running).
+- **Policy discovery consistency** — `tirith policy init` writes a file that
+  `doctor` and `validate` then report as missing
+  ([#112](https://github.com/sheeki03/tirith/issues/112)); fix is in
+  [PR #113](https://github.com/sheeki03/tirith/pull/113).
+- **Doctor compatibility diagnostics** — surfacing shell/terminal compatibility
+  state more clearly in `tirith doctor`.
 
-### `tirith explain --rule <id>`
-- Show detailed rationale for a specific rule
-- Include examples of what it catches and why
-- Link to relevant threat documentation
+## Next
 
-### IDE integration
-- VS Code extension that analyzes terminal commands
-- Inline warnings for URLs in code and configuration files
+Planned, not yet started.
 
-### Custom rule authoring SDK
-- YAML or Lua-based rule definitions
-- User-defined patterns with custom severity and evidence
-- Rule testing framework
+- **`tirith doctor --compat`** — a dedicated compatibility report covering the
+  current shell, terminal, and prompt/history tooling.
+- **`tirith doctor --simulate-enter`** — dry-run the bash enter-mode enforcement
+  path to detect environments where blocking cannot work, before relying on it.
+- **Capability-based compatibility matrix** — classify each shell/terminal
+  combination by the capabilities tirith actually needs, rather than by name.
+- **Terminal / prompt / history-tool regression tests** — automated coverage
+  for the integrations that historically break hook delivery.
+- **Visible degraded-protection status indicator** — a clear, always-visible
+  signal when a session has downgraded from blocking to warn-only.
+
+## Later
+
+Longer-horizon ideas, not yet scheduled.
+
+- **IDE extension** — analyze terminal commands and inline URLs from inside an
+  editor.
+- **Custom rule SDK / DSL** — user-defined detection rules with custom severity
+  and evidence, plus a rule testing framework.
+- **Broader terminal-specific certification** — expanded, formalized
+  compatibility guarantees across the terminal ecosystem.


### PR DESCRIPTION
## Summary

Roadmap **Milestone 1** — docs-truth cleanup. tirith's docs had drifted from
reality; on a security tool, stale docs erode trust. Docs only — no code changes.

## Changes

- **`docs/roadmap.md`** — replaced the single stale "Phase 2 Backlog" (which
  still listed daemon mode, `scan`/CI/SARIF, `policy validate`, `explain --rule`
  as future, though all have shipped) with Done / Now / Next / Later. The "Done"
  list was verified against `CHANGELOG.md`.
- **`README.md`** — added "What tirith does NOT protect against" (the
  threat-model non-goals, surfaced near the top) and "Known limitations".
  Resolved a self-contradiction in "Design principles": it claimed both a 24h
  background refresh and "offline by default". Corrected — `tirith check` (and
  the `--approval-check` path the shell hooks use) triggers a periodic
  background threat-DB refresh, so it is not strictly offline;
  `paste`/`score`/`diff`/`why` remain local-only.
- **`docs/compatibility.md`** — added a per-command stability matrix and a
  graduation-criteria section (what an experimental command must satisfy to
  become stable), plus the exit-code-3 (WarnAck) row.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a docs-only cleanup PR that corrects documentation drift in three files, with no code changes. The primary fix is resolving a direct self-contradiction in README.md's "Design principles" where `tirith check` was described as both "offline by default" and as triggering a periodic background threat-DB refresh.

- **README.md** — adds a "What tirith does NOT protect against" threat-model non-goals section and a "Known limitations" section, and rewrites the "Design principles" bullets to accurately describe the network behavior of `check` vs. the local-only commands.
- **docs/compatibility.md** — replaces the flat stable/experimental lists with a per-command stability matrix, a graduation-criteria checklist, and adds the exit code 3 (WarnAck) row. Contains an internal contradiction: `check` is marked Stable in the matrix but is also included in the graduation-priority paragraph.
- **docs/roadmap.md** — replaces the single stale "Phase 2 Backlog" with Done / Now / Next / Later sections, with issue and PR links for in-flight work.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are documentation-only with no code impact.

The README and roadmap updates are accurate and internally consistent. The compatibility.md file has one factual contradiction — `check` appears in both the Stable row of the matrix and in the graduation-priority paragraph — which could mislead integrators about whether `check`'s stability guarantee is still pending.

docs/compatibility.md — the graduation-criteria paragraph needs a second look to remove the reference to `check` from the experimental graduation queue.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Adds "What tirith does NOT protect against" non-goals section and "Known limitations" near the top, and resolves the contradiction between "offline by default" and the real periodic threat-DB refresh behavior. The linked threat-model.md exists; all cross-references are valid. |
| docs/compatibility.md | Adds per-command stability matrix and graduation criteria. Contains an internal contradiction: `check` is listed as Stable in the matrix but also appears in the graduation-priority paragraph. Exit code 3 stability scope could be clearer. |
| docs/roadmap.md | Replaces the stale single-phase backlog with Done/Now/Next/Later structure. "Done" items correspond to features referenced in compatibility.md and CHANGELOG.md; issue/PR links in "Now" are real. No factual issues identified. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tirith check / shell hook] -->|local analysis| B[Detection Engine]
    B -->|exit 0| C[Allow]
    B -->|exit 1| D[Block]
    B -->|exit 2| E[Warn]
    B -->|exit 3 - hook protocol only| F[WarnAck]
    A -->|periodic, detached, max once/24h| G[Threat-DB Refresh]
    G -->|network call| H[Signed DB Update]
    I[tirith paste / score / diff / why] -->|local only, zero network| B
    style G fill:#ffe0b2,stroke:#f57c00
    style H fill:#ffe0b2,stroke:#f57c00
    style F fill:#e8f5e9,stroke:#388e3c
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/compatibility.md`, line 80-91 ([link](https://github.com/sheeki03/tirith/blob/0c3382a8bb618e56cafaa6081f099cfbacda7775/docs/compatibility.md#L80-L91)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Exit code 3 scope ambiguity under the "stable" heading**

   The section header is "Exit codes are stable" and the table lists all four codes (0–3) together, which naturally implies all four are part of the general stable CLI contract. The subsequent note does clarify that code 3 is hook-specific and "non-hook callers should not normally see" it, but a reader scanning the table will likely assume the same stability guarantee applies uniformly. Consider separating code 3 into a sub-table or clearly marking it as stable for the hook protocol only, so tool authors don't add handling for exit code 3 in direct CLI integrations that will never encounter it.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fcompatibility.md%0ALine%3A%2080-91%0A%0AComment%3A%0A**Exit%20code%203%20scope%20ambiguity%20under%20the%20%22stable%22%20heading**%0A%0AThe%20section%20header%20is%20%22Exit%20codes%20are%20stable%22%20and%20the%20table%20lists%20all%20four%20codes%20%280%E2%80%933%29%20together%2C%20which%20naturally%20implies%20all%20four%20are%20part%20of%20the%20general%20stable%20CLI%20contract.%20The%20subsequent%20note%20does%20clarify%20that%20code%203%20is%20hook-specific%20and%20%22non-hook%20callers%20should%20not%20normally%20see%22%20it%2C%20but%20a%20reader%20scanning%20the%20table%20will%20likely%20assume%20the%20same%20stability%20guarantee%20applies%20uniformly.%20Consider%20separating%20code%203%20into%20a%20sub-table%20or%20clearly%20marking%20it%20as%20stable%20for%20the%20hook%20protocol%20only%2C%20so%20tool%20authors%20don't%20add%20handling%20for%20exit%20code%203%20in%20direct%20CLI%20integrations%20that%20will%20never%20encounter%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Fcompatibility.md%3A73-76%0A**%60check%60%20listed%20for%20graduation%20despite%20already%20being%20Stable**%0A%0AThe%20paragraph%20says%20graduation%20criteria%20are%20%22applied%20first%22%20to%20%60check%60%2C%20%60scan%60%2C%20%60doctor%60%2C%20and%20the%20MCP%20tools%20%E2%80%94%20but%20%60check%60%20is%20already%20classified%20as%20Stable%20in%20the%20matrix%20above.%20Listing%20it%20here%20implies%20it%20is%20still%20in%20the%20experimental%20graduation%20queue%2C%20directly%20contradicting%20the%20table.%20Integrators%20who%20read%20this%20paragraph%20to%20understand%20which%20commands%20are%20still%20maturing%20will%20get%20a%20misleading%20picture.%20The%20intent%20seems%20to%20be%20that%20%60scan%60%20and%20%60doctor%60%20are%20the%20experimental%20commands%20that%20get%20priority%20because%20they%20are%20integration-critical.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fcompatibility.md%3A80-91%0A**Exit%20code%203%20scope%20ambiguity%20under%20the%20%22stable%22%20heading**%0A%0AThe%20section%20header%20is%20%22Exit%20codes%20are%20stable%22%20and%20the%20table%20lists%20all%20four%20codes%20%280%E2%80%933%29%20together%2C%20which%20naturally%20implies%20all%20four%20are%20part%20of%20the%20general%20stable%20CLI%20contract.%20The%20subsequent%20note%20does%20clarify%20that%20code%203%20is%20hook-specific%20and%20%22non-hook%20callers%20should%20not%20normally%20see%22%20it%2C%20but%20a%20reader%20scanning%20the%20table%20will%20likely%20assume%20the%20same%20stability%20guarantee%20applies%20uniformly.%20Consider%20separating%20code%203%20into%20a%20sub-table%20or%20clearly%20marking%20it%20as%20stable%20for%20the%20hook%20protocol%20only%2C%20so%20tool%20authors%20don't%20add%20handling%20for%20exit%20code%203%20in%20direct%20CLI%20integrations%20that%20will%20never%20encounter%20it.%0A%0A&repo=sheeki03%2Ftirith&pr=115&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): add non-goals + limitation..."](https://github.com/sheeki03/tirith/commit/0c3382a8bb618e56cafaa6081f099cfbacda7775) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33221803)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->