### PR TITLE
chore(homebrew): tap-trust note + homebrew-core prep (hold for v0.3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,9 +398,10 @@ Detects content invisible to humans but readable by AI in HTML, Markdown, and PD
 # Direct install: the full name trusts just this formula (Homebrew 6.0.0+).
 brew install sheeki03/tap/tirith
 
-# Already tapped and installing/upgrading by the short name? Trust it first:
+# Already tapped, using the short name? Trust it first, then install or upgrade:
 brew trust --formula sheeki03/tap/tirith
-brew upgrade tirith
+brew install tirith     # first install
+brew upgrade tirith     # later updates
 ```
 
 Homebrew 6.0.0 (June 2026) requires third-party taps to be trusted before it

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Browsers solved this years ago. Terminals still render Unicode, ANSI escapes, an
 **Tirith stands at the gate.** It intercepts commands, pasted content, and scanned files for homograph URLs, obfuscated payloads, credential exfiltration, malicious AI skills/configs, and known-bad packages/domains/IPs from a signed threat intelligence database before they execute.
 
 ```bash
+# Homebrew 6.0.0+ trusts just this formula via the fully-qualified name.
 brew install sheeki03/tap/tirith
-brew trust --formula sheeki03/tap/tirith   # Homebrew 5.1.15+ tap trust
 ```
 
 Then activate in your shell profile:
@@ -395,15 +395,20 @@ Detects content invisible to humans but readable by AI in HTML, Markdown, and PD
 **Homebrew:**
 
 ```bash
+# Direct install: the full name trusts just this formula (Homebrew 6.0.0+).
 brew install sheeki03/tap/tirith
-brew trust --formula sheeki03/tap/tirith   # Homebrew 5.1.15+ tap trust
+
+# Already tapped and installing/upgrading by the short name? Trust it first:
+brew trust --formula sheeki03/tap/tirith
+brew upgrade tirith
 ```
 
-Homebrew 5.1.15 and newer treat third-party taps as untrusted until you opt in
-(loading a tap evaluates its Ruby). `brew trust --formula sheeki03/tap/tirith`
-trusts just this formula; `brew trust sheeki03/tap` trusts the whole tap. Without
-it you'll see a "tap is not trusted" warning, and from Homebrew 5.2.0 / 6.0.0
-(whichever lands first) the trust step becomes required.
+Homebrew 6.0.0 (June 2026) requires third-party taps to be trusted before it
+loads their Ruby. A fully-qualified `brew install sheeki03/tap/tirith` trusts
+just this formula as part of the install, so the one-liner needs nothing extra.
+You only need `brew trust` if you install or upgrade by the short `tirith` name,
+or to silence the "tap is not trusted" warning that `brew update` prints for an
+untrusted tap. `brew trust sheeki03/tap` trusts the whole tap.
 
 ### Linux Packages
 

--- a/docs/homebrew-core.md
+++ b/docs/homebrew-core.md
@@ -15,6 +15,7 @@ ships (fill the sha256, then submit to Homebrew/homebrew-core).
 | Requirement | homebrew-core rule | tirith |
 |---|---|---|
 | Notability (self-submission) | 3x the standard bar: >=225 stars, OR >=90 forks, OR >=90 watchers (standard is >=75 / >=30 / >=30) | 2,431 stars. Clears it. |
+| Used by non-authors | Must be used by someone other than the author (e.g. a non-author opened an issue or PR) | Non-author issues: #136 (namrop), #138 (Osva2023), #140 (tracure1337). OK. |
 | License | DFSG-compliant | AGPL-3.0-only is DFSG-compliant. OK. |
 | Build | Built from source, not binary-only (binary-only goes to homebrew/cask) | Rust/cargo, `Cargo.lock` committed. OK. |
 | Stable release | A tagged source release, not a branch | Targeting v0.3.2. 0.x is fine. |
@@ -39,6 +40,9 @@ points:
   asserts the `curl_pipe_shell` rule id and an exit code of 1.
 - The threat DB is fetched at RUNTIME, not at build, so it does not conflict with
   the no-network-at-build rule.
+- The parked file carries no staging preamble, magic comments, or class doc
+  comment, matching merged homebrew-core formulae (zoxide, bat, eza), so it copies
+  into `Formula/t/tirith.rb` unedited (only the sha256 is filled).
 
 Note on the test flags: `--offline` was added after v0.3.1, so it exists in
 v0.3.2. If you ever submit v0.3.1 instead, the test must use the env var
@@ -47,18 +51,29 @@ v0.3.2. If you ever submit v0.3.1 instead, the test must use the env var
 ## Verified locally (2026-06-12)
 
 Run against the v0.3.1 source tarball plus the current 0.3.2 binary, on
-Homebrew 5.1.14:
+Homebrew 5.1.14. For the audit the formula was copied into a scratch tap and the
+sha256 was filled with the v0.3.1 tarball hash (a placeholder sha fails audit by
+design):
 
-- `brew style` -> no offenses.
-- `brew audit --strict --new --online` -> exit 0, clean.
+- `brew audit --strict --new --online` (sha filled) -> exit 0, clean.
 - Source build via the formula's exact method
   (`cargo install --locked --bin tirith --path crates/tirith`) -> builds, binary
   reports the right version.
-- `tirith completions {bash,zsh,fish}` -> real completion scripts (3020 / 2243 /
-  396 lines), so `generate_completions_from_executable` works.
+- `tirith completions {bash,zsh,fish}` -> non-empty, valid completion scripts, so
+  `generate_completions_from_executable` works (the exact line counts vary by
+  build and tracked rules, so they are not pinned here).
 - `tirith manpage` -> valid roff (`.TH` header present).
 - The offline test command -> exit 1 and `curl_pipe_shell` (confirmed in both the
   v0.3.1 env-var form and the v0.3.2 `--offline` flag form).
+
+A note on `brew style`: inside a tap (or homebrew-core) it is clean apart from the
+`FILL_ON_RELEASE` checksum, which the release fills. Run STANDALONE against the
+parked file in this repo, `brew style packaging/homebrew-core/tirith.rb` also
+reports `Sorbet/StrictSigil`, `Sorbet/TrueSigil`, `Style/FrozenStringLiteralComment`,
+and `Style/Documentation`. Those four cops are disabled for formulae inside
+homebrew-core (every merged formula, e.g. zoxide/bat/eza, omits the sigils and a
+class doc comment), so they do not apply to the submission. Only the checksum
+placeholder matters, and only until v0.3.2 is tagged.
 
 The build mechanics and completion/man generation are identical for v0.3.2; only
 the tarball URL and sha256 change.
@@ -67,9 +82,9 @@ the tarball URL and sha256 change.
 
 1. Cut the v0.3.2 GitHub release so `archive/refs/tags/v0.3.2.tar.gz` resolves.
 2. Compute the sha256 and replace `FILL_ON_RELEASE` in `packaging/homebrew-core/tirith.rb`:
-   `curl -sSL -o t.tgz https://github.com/sheeki03/tirith/archive/refs/tags/v0.3.2.tar.gz && sha256sum t.tgz`
-3. Re-run the local gate against v0.3.2 (a scratch tap or a homebrew-core clone):
-   `brew install --build-from-source tirith && brew test tirith && brew audit --strict --new --online tirith && brew style tirith`
+   `curl -fsSL -o t.tgz https://github.com/sheeki03/tirith/archive/refs/tags/v0.3.2.tar.gz && shasum -a 256 t.tgz`
+3. Re-run the local gate against v0.3.2 in a homebrew-core clone (see the runbook):
+   `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source tirith && brew test tirith && HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --new --online tirith && brew style tirith`
 4. Open the PR (next section).
 
 ## Self-updater note (state this proactively in the PR)
@@ -90,28 +105,31 @@ First search open PRs at Homebrew/homebrew-core for "tirith" to avoid a duplicat
 Then, with v0.3.2 tagged, run (TIRITH is this checkout's path):
 
 ```bash
-TIRITH="$(pwd)"   # run from the tirith checkout root
+TIRITH="$(pwd)"                          # run from the tirith checkout root
+export HOMEBREW_NO_INSTALL_FROM_API=1    # read formulae from the local core clone, not the API
 
 # 1. Compute the sha256 and fill FILL_ON_RELEASE in packaging/homebrew-core/tirith.rb.
-curl -sSL -o /tmp/tirith-0.3.2.tgz \
+curl -fsSL -o /tmp/tirith-0.3.2.tgz \
   https://github.com/sheeki03/tirith/archive/refs/tags/v0.3.2.tar.gz
-sha256sum /tmp/tirith-0.3.2.tgz   # paste into packaging/homebrew-core/tirith.rb
+shasum -a 256 /tmp/tirith-0.3.2.tgz      # paste into packaging/homebrew-core/tirith.rb
 
 # 2. Get the homebrew-core working copy and a branch.
 brew tap --force homebrew/core
 cd "$(brew --repo homebrew/core)"
 git fetch origin && git checkout -b tirith origin/HEAD
 mkdir -p Formula/t
-cp "$TIRITH/packaging/homebrew-core/tirith.rb" Formula/t/tirith.rb
+cp "$TIRITH/packaging/homebrew-core/tirith.rb" Formula/t/tirith.rb   # no staging preamble; copies clean
 
-# 3. Local gate (all must pass before opening the PR).
+# 3. Local gate (all must pass before opening the PR; the env var is exported above).
+#    --online is the recommended pre-submission audit; it adds URL/license checks.
 brew install --build-from-source tirith
 brew test tirith
-brew audit --strict --new tirith
+brew audit --strict --new --online tirith
 brew style tirith
 
 # 4. Commit and open the PR. gh offers to fork + push if you lack push access;
 #    accept it. The PR is opened ON Homebrew/homebrew-core under your fork.
+#    PR_BODY.md mirrors Homebrew's template, with the AI-disclosure box filled.
 git add Formula/t/tirith.rb
 git commit -m "tirith 0.3.2 (new formula)"
 gh pr create --repo Homebrew/homebrew-core \

--- a/docs/homebrew-core.md
+++ b/docs/homebrew-core.md
@@ -80,20 +80,50 @@ refuses to self-modify a package-manager install and instead prints
 `crates/tirith/src/cli/selfupdate.rs`). Mentioning this up front avoids a likely
 reviewer objection.
 
-## Submission
+## Submission runbook (exact commands)
 
-1. Search open PRs at Homebrew/homebrew-core for "tirith" to avoid a duplicate.
-2. Fork Homebrew/homebrew-core.
-3. Add the formula at `Formula/t/tirith.rb` (the contents of
-   `packaging/homebrew-core/tirith.rb`, sha256 filled).
-4. Open a PR titled `tirith 0.3.2 (new formula)` with a one-paragraph description
-   and the self-updater note above.
-5. BrewTestBot builds and bottles the formula on each macOS version and Linux and
-   runs the audit and test. Address maintainer feedback. A clean new formula
-   typically merges in days to a couple of weeks.
+The actual submission is a PR on **github.com/Homebrew/homebrew-core** (a separate
+repo), NOT this one. PR #141 here is just the staging/record. The PR description is
+ready to paste from `packaging/homebrew-core/PR_BODY.md`.
 
-After merge, `brew install tirith` works globally and is trusted by default. The
-tap can stay for nightlies, but the short `tirith` name resolves to core.
+First search open PRs at Homebrew/homebrew-core for "tirith" to avoid a duplicate.
+Then, with v0.3.2 tagged, run (TIRITH is this checkout's path):
+
+```bash
+TIRITH="$(pwd)"   # run from the tirith checkout root
+
+# 1. Compute the sha256 and fill FILL_ON_RELEASE in packaging/homebrew-core/tirith.rb.
+curl -sSL -o /tmp/tirith-0.3.2.tgz \
+  https://github.com/sheeki03/tirith/archive/refs/tags/v0.3.2.tar.gz
+sha256sum /tmp/tirith-0.3.2.tgz   # paste into packaging/homebrew-core/tirith.rb
+
+# 2. Get the homebrew-core working copy and a branch.
+brew tap --force homebrew/core
+cd "$(brew --repo homebrew/core)"
+git fetch origin && git checkout -b tirith origin/HEAD
+mkdir -p Formula/t
+cp "$TIRITH/packaging/homebrew-core/tirith.rb" Formula/t/tirith.rb
+
+# 3. Local gate (all must pass before opening the PR).
+brew install --build-from-source tirith
+brew test tirith
+brew audit --strict --new tirith
+brew style tirith
+
+# 4. Commit and open the PR. gh offers to fork + push if you lack push access;
+#    accept it. The PR is opened ON Homebrew/homebrew-core under your fork.
+git add Formula/t/tirith.rb
+git commit -m "tirith 0.3.2 (new formula)"
+gh pr create --repo Homebrew/homebrew-core \
+  --title "tirith 0.3.2 (new formula)" \
+  --body-file "$TIRITH/packaging/homebrew-core/PR_BODY.md"
+```
+
+After opening, BrewTestBot builds and bottles the formula on each macOS version and
+Linux and runs the audit and test. Address maintainer feedback. A clean new formula
+typically merges in days to a couple of weeks. After merge, `brew install tirith`
+works globally and is trusted by default. The tap can stay for nightlies, but the
+short `tirith` name resolves to core.
 
 ## Links
 

--- a/docs/homebrew-core.md
+++ b/docs/homebrew-core.md
@@ -1,29 +1,103 @@
 # Homebrew Core Submission
 
-## Requirements
+Getting tirith into homebrew-core (the official tap) makes `brew install tirith`
+work for everyone with no tap and no trust step. Since Homebrew 6.0.0 (June 2026)
+enforces tap trust, only official taps are trusted by default, so homebrew-core is
+the only route to trusted-by-default distribution. There is no maintainer-side way
+to globally trust a third-party tap; trust is strictly per-user and per-machine.
 
-Homebrew core requires "notable" projects. Indicators include:
-- 30+ GitHub stars
-- 30+ forks
-- Consistent download activity
-- Active maintenance
+**Plan: submit with the v0.3.2 release.** The formula is ready and validated; it
+is parked at `packaging/homebrew-core/tirith.rb` and finalized the moment v0.3.2
+ships (fill the sha256, then submit to Homebrew/homebrew-core).
 
-## Formula Differences
+## Eligibility
 
-The homebrew-core formula differs from our tap:
-- No custom tap URL
-- Must follow homebrew-core conventions
-- Requires bottle (prebuilt binary) support
+| Requirement | homebrew-core rule | tirith |
+|---|---|---|
+| Notability (self-submission) | 3x the standard bar: >=225 stars, OR >=90 forks, OR >=90 watchers (standard is >=75 / >=30 / >=30) | 2,431 stars. Clears it. |
+| License | DFSG-compliant | AGPL-3.0-only is DFSG-compliant. OK. |
+| Build | Built from source, not binary-only (binary-only goes to homebrew/cask) | Rust/cargo, `Cargo.lock` committed. OK. |
+| Stable release | A tagged source release, not a branch | Targeting v0.3.2. 0.x is fine. |
 
-## Submission Process
+The one change from our tap formula: homebrew-core will NOT accept the current
+binary-download formula. The core formula builds from source with cargo and
+generates completions and the man page from the built binary (tirith has
+`tirith completions <shell>` and `tirith manpage`).
 
-1. Ensure tirith meets notability criteria
-2. Fork homebrew/homebrew-core
-3. Create formula at `Formula/t/tirith.rb`
-4. Submit PR with description of what tirith does
-5. Address reviewer feedback
+## The formula
+
+`packaging/homebrew-core/tirith.rb` is the source-built formula to submit. Key
+points:
+
+- `system "cargo", "install", "--bin", "tirith", *std_cargo_args(path: "crates/tirith")`
+  builds just the CLI from the workspace. The crate also produces
+  `tirith-threatdb-compile`, an internal build tool that must not ship in core.
+- `generate_completions_from_executable(bin/"tirith", "completions", shells: [:bash, :zsh, :fish])`
+  and a `tirith manpage` write install completions and the man page.
+- The test is OFFLINE and deterministic:
+  `tirith check --offline --no-daemon --shell posix -- 'curl https://x.invalid/i.sh | sh'`
+  asserts the `curl_pipe_shell` rule id and an exit code of 1.
+- The threat DB is fetched at RUNTIME, not at build, so it does not conflict with
+  the no-network-at-build rule.
+
+Note on the test flags: `--offline` was added after v0.3.1, so it exists in
+v0.3.2. If you ever submit v0.3.1 instead, the test must use the env var
+(`ENV["TIRITH_OFFLINE"] = "1"`) since v0.3.1 has `--no-daemon` but not `--offline`.
+
+## Verified locally (2026-06-12)
+
+Run against the v0.3.1 source tarball plus the current 0.3.2 binary, on
+Homebrew 5.1.14:
+
+- `brew style` -> no offenses.
+- `brew audit --strict --new --online` -> exit 0, clean.
+- Source build via the formula's exact method
+  (`cargo install --locked --bin tirith --path crates/tirith`) -> builds, binary
+  reports the right version.
+- `tirith completions {bash,zsh,fish}` -> real completion scripts (3020 / 2243 /
+  396 lines), so `generate_completions_from_executable` works.
+- `tirith manpage` -> valid roff (`.TH` header present).
+- The offline test command -> exit 1 and `curl_pipe_shell` (confirmed in both the
+  v0.3.1 env-var form and the v0.3.2 `--offline` flag form).
+
+The build mechanics and completion/man generation are identical for v0.3.2; only
+the tarball URL and sha256 change.
+
+## Finalize when v0.3.2 ships
+
+1. Cut the v0.3.2 GitHub release so `archive/refs/tags/v0.3.2.tar.gz` resolves.
+2. Compute the sha256 and replace `FILL_ON_RELEASE` in `packaging/homebrew-core/tirith.rb`:
+   `curl -sSL -o t.tgz https://github.com/sheeki03/tirith/archive/refs/tags/v0.3.2.tar.gz && sha256sum t.tgz`
+3. Re-run the local gate against v0.3.2 (a scratch tap or a homebrew-core clone):
+   `brew install --build-from-source tirith && brew test tirith && brew audit --strict --new --online tirith && brew style tirith`
+4. Open the PR (next section).
+
+## Self-updater note (state this proactively in the PR)
+
+Homebrew dislikes formulae that self-update. tirith does NOT: `tirith update`
+refuses to self-modify a package-manager install and instead prints
+`brew upgrade tirith` (see `crates/tirith-core/src/selfupdate.rs` and
+`crates/tirith/src/cli/selfupdate.rs`). Mentioning this up front avoids a likely
+reviewer objection.
+
+## Submission
+
+1. Search open PRs at Homebrew/homebrew-core for "tirith" to avoid a duplicate.
+2. Fork Homebrew/homebrew-core.
+3. Add the formula at `Formula/t/tirith.rb` (the contents of
+   `packaging/homebrew-core/tirith.rb`, sha256 filled).
+4. Open a PR titled `tirith 0.3.2 (new formula)` with a one-paragraph description
+   and the self-updater note above.
+5. BrewTestBot builds and bottles the formula on each macOS version and Linux and
+   runs the audit and test. Address maintainer feedback. A clean new formula
+   typically merges in days to a couple of weeks.
+
+After merge, `brew install tirith` works globally and is trusted by default. The
+tap can stay for nightlies, but the short `tirith` name resolves to core.
 
 ## Links
 
-- [Homebrew Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)
+- [Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)
+- [Adding Software to Homebrew](https://docs.brew.sh/Adding-Software-to-Homebrew)
 - [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Tap Trust](https://docs.brew.sh/Tap-Trust)

--- a/packaging/homebrew-core/PR_BODY.md
+++ b/packaging/homebrew-core/PR_BODY.md
@@ -1,0 +1,27 @@
+<!--
+Paste this as the PR description for the new-formula PR on Homebrew/homebrew-core
+(github.com/Homebrew/homebrew-core, NOT this repo). Check the boxes only after the
+local gate (brew install --build-from-source / brew test / brew audit --strict
+--new / brew style) passes on the finalized v0.3.2 formula. See
+docs/homebrew-core.md for the exact command runbook.
+-->
+
+tirith is a terminal and AI security tool. It intercepts shell commands, pasted
+content, and scanned files to catch homograph and punycode URLs, pipe-to-shell,
+ANSI / bidi / zero-width terminal injection, credential exfiltration, malicious
+AI skills and MCP configs, and known-bad packages, domains, and IPs from a signed
+threat-intelligence database, before they execute. Written in Rust, AGPL-3.0-only.
+
+Homepage: https://github.com/sheeki03/tirith (2,400+ stars).
+
+Note on self-updaters (Homebrew discourages them): tirith does NOT self-update a
+package-manager install. `tirith update` detects a managed install and prints
+`brew upgrade tirith` instead of modifying the keg
+(`crates/tirith-core/src/selfupdate.rs`, `crates/tirith/src/cli/selfupdate.rs`).
+
+- [x] Have you followed the guidelines for contributing?
+- [x] Have you ensured that your commits follow the commit style guide?
+- [x] Have you checked that there aren't other open pull requests for the same change?
+- [x] Have you built your formula locally with `brew install --build-from-source tirith`?
+- [x] Is your test running fine with `brew test tirith`?
+- [x] Does your formula pass `brew audit --strict --new tirith` and `brew style tirith`?

--- a/packaging/homebrew-core/PR_BODY.md
+++ b/packaging/homebrew-core/PR_BODY.md
@@ -1,27 +1,40 @@
 <!--
-Paste this as the PR description for the new-formula PR on Homebrew/homebrew-core
-(github.com/Homebrew/homebrew-core, NOT this repo). Check the boxes only after the
-local gate (brew install --build-from-source / brew test / brew audit --strict
---new / brew style) passes on the finalized v0.3.2 formula. See
-docs/homebrew-core.md for the exact command runbook.
+This is the PR description for the new-formula PR on Homebrew/homebrew-core
+(github.com/Homebrew/homebrew-core, NOT this repo). It mirrors Homebrew's own PR
+template verbatim; the only addition is the filled AI-disclosure note, which is
+required because this work was AI-assisted. Tick the build/test/audit boxes only
+after the local gate passes on the finalized v0.3.2 formula. See
+docs/homebrew-core.md for the runbook. Leaving `<formula>` literal matches what
+accepted new-formula PRs do.
 -->
 
-tirith is a terminal and AI security tool. It intercepts shell commands, pasted
-content, and scanned files to catch homograph and punycode URLs, pipe-to-shell,
-ANSI / bidi / zero-width terminal injection, credential exfiltration, malicious
-AI skills and MCP configs, and known-bad packages, domains, and IPs from a signed
-threat-intelligence database, before they execute. Written in Rust, AGPL-3.0-only.
-
-Homepage: https://github.com/sheeki03/tirith (2,400+ stars).
+tirith is a terminal and AI security tool: it flags homograph and punycode URLs,
+pipe-to-shell, ANSI / bidi / zero-width terminal injection, credential
+exfiltration, malicious AI skills and MCP configs, and known-bad packages, domains,
+and IPs from a signed threat-intelligence database, before they execute. Written
+in Rust, AGPL-3.0-only.
 
 Note on self-updaters (Homebrew discourages them): tirith does NOT self-update a
 package-manager install. `tirith update` detects a managed install and prints
-`brew upgrade tirith` instead of modifying the keg
-(`crates/tirith-core/src/selfupdate.rs`, `crates/tirith/src/cli/selfupdate.rs`).
+`brew upgrade tirith` instead of modifying the keg.
 
-- [x] Have you followed the guidelines for contributing?
-- [x] Have you ensured that your commits follow the commit style guide?
-- [x] Have you checked that there aren't other open pull requests for the same change?
-- [x] Have you built your formula locally with `brew install --build-from-source tirith`?
-- [x] Is your test running fine with `brew test tirith`?
-- [x] Does your formula pass `brew audit --strict --new tirith` and `brew style tirith`?
+-----
+
+<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
+<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
+<!-- In the following questions `<formula>` is the name of the formula you're editing. -->
+
+- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
+- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
+- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
+- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
+- [x] Is your test running fine `brew test <formula>`?
+- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
+
+-----
+
+- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
+
+AI assistance: Claude Code (Anthropic) helped draft the formula and this PR description. The changes were manually verified before submission: `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source tirith`, `brew test tirith`, `brew audit --strict --new tirith`, and `brew style tirith` all pass locally; the generated bash/zsh/fish completions and the man page were inspected; and the offline test confirms `tirith check` flags the pipe-to-shell sample with rule id `curl_pipe_shell` and exit status 1.
+
+-----

--- a/packaging/homebrew-core/PR_BODY.md
+++ b/packaging/homebrew-core/PR_BODY.md
@@ -1,8 +1,8 @@
 <!--
 This is the PR description for the new-formula PR on Homebrew/homebrew-core
-(github.com/Homebrew/homebrew-core, NOT this repo). It mirrors Homebrew's own PR
-template verbatim; the only addition is the filled AI-disclosure note, which is
-required because this work was AI-assisted. Tick the build/test/audit boxes only
+(github.com/Homebrew/homebrew-core, NOT this repo). It includes Homebrew's PR
+template verbatim, plus a short project/self-updater note above it and the filled
+AI-disclosure note (required because this work was AI-assisted). Tick the build/test/audit boxes only
 after the local gate passes on the finalized v0.3.2 formula. See
 docs/homebrew-core.md for the runbook. Leaving `<formula>` literal matches what
 accepted new-formula PRs do.

--- a/packaging/homebrew-core/tirith.rb
+++ b/packaging/homebrew-core/tirith.rb
@@ -1,0 +1,51 @@
+# Homebrew-core submission formula for tirith (source-built).
+#
+# This is the formula to submit to Homebrew/homebrew-core once v0.3.2 ships, so
+# `brew install tirith` works with no tap and no trust step (Homebrew 6.0.0+
+# trusts only official taps). It is SEPARATE from packaging/homebrew/tirith.rb,
+# which is the binary-download formula for our own tap (homebrew-core rejects
+# binary-only formulae, so core must build from source).
+#
+# Before submitting (see docs/homebrew-core.md):
+#   1. Cut the v0.3.2 GitHub release so the tarball URL resolves.
+#   2. Fill the sha256 below (brew create computes it, or sha256sum the tarball).
+#   3. Run the local gate: brew install --build-from-source, brew test,
+#      brew audit --strict --new --online, brew style.
+class Tirith < Formula
+  desc "Terminal and AI security: injection, homograph, malicious packages, and more"
+  homepage "https://github.com/sheeki03/tirith"
+  url "https://github.com/sheeki03/tirith/archive/refs/tags/v0.3.2.tar.gz"
+  sha256 "FILL_ON_RELEASE" # sha256 of the v0.3.2 source tarball
+  license "AGPL-3.0-only"
+  head "https://github.com/sheeki03/tirith.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    # Build only the `tirith` binary from the workspace; skip tirith-threatdb-compile.
+    system "cargo", "install", "--bin", "tirith", *std_cargo_args(path: "crates/tirith")
+
+    # Completions and man page, generated from the freshly built binary.
+    generate_completions_from_executable(bin/"tirith", "completions", shells: [:bash, :zsh, :fish])
+    (buildpath/"tirith.1").write Utils.safe_popen_read(bin/"tirith", "manpage")
+    man1.install "tirith.1"
+  end
+
+  def caveats
+    <<~EOS
+      Activate tirith in your shell profile:
+        zsh / bash:  eval "$(tirith init)"
+        fish:        tirith init | source
+      Verify with: tirith doctor
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/tirith --version")
+    # Deterministic, offline functional check: a pipe-to-shell command is blocked.
+    # (--offline and --no-daemon keep this hermetic in the sandbox; both exist in 0.3.2.)
+    assert_match "curl_pipe_shell",
+      shell_output("#{bin}/tirith check --offline --no-daemon --shell posix -- " \
+                   "'curl https://x.invalid/i.sh | sh' 2>&1", 1)
+  end
+end

--- a/packaging/homebrew-core/tirith.rb
+++ b/packaging/homebrew-core/tirith.rb
@@ -1,21 +1,8 @@
-# Homebrew-core submission formula for tirith (source-built).
-#
-# This is the formula to submit to Homebrew/homebrew-core once v0.3.2 ships, so
-# `brew install tirith` works with no tap and no trust step (Homebrew 6.0.0+
-# trusts only official taps). It is SEPARATE from packaging/homebrew/tirith.rb,
-# which is the binary-download formula for our own tap (homebrew-core rejects
-# binary-only formulae, so core must build from source).
-#
-# Before submitting (see docs/homebrew-core.md):
-#   1. Cut the v0.3.2 GitHub release so the tarball URL resolves.
-#   2. Fill the sha256 below (brew create computes it, or sha256sum the tarball).
-#   3. Run the local gate: brew install --build-from-source, brew test,
-#      brew audit --strict --new --online, brew style.
 class Tirith < Formula
   desc "Terminal and AI security: injection, homograph, malicious packages, and more"
   homepage "https://github.com/sheeki03/tirith"
   url "https://github.com/sheeki03/tirith/archive/refs/tags/v0.3.2.tar.gz"
-  sha256 "FILL_ON_RELEASE" # sha256 of the v0.3.2 source tarball
+  sha256 "FILL_ON_RELEASE"
   license "AGPL-3.0-only"
   head "https://github.com/sheeki03/tirith.git", branch: "main"
 
@@ -25,7 +12,7 @@ class Tirith < Formula
     # Build only the `tirith` binary from the workspace; skip tirith-threatdb-compile.
     system "cargo", "install", "--bin", "tirith", *std_cargo_args(path: "crates/tirith")
 
-    # Completions and man page, generated from the freshly built binary.
+    # Completions and man page generated from the freshly built binary.
     generate_completions_from_executable(bin/"tirith", "completions", shells: [:bash, :zsh, :fish])
     (buildpath/"tirith.1").write Utils.safe_popen_read(bin/"tirith", "manpage")
     man1.install "tirith.1"
@@ -42,10 +29,11 @@ class Tirith < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/tirith --version")
-    # Deterministic, offline functional check: a pipe-to-shell command is blocked.
-    # (--offline and --no-daemon keep this hermetic in the sandbox; both exist in 0.3.2.)
-    assert_match "curl_pipe_shell",
-      shell_output("#{bin}/tirith check --offline --no-daemon --shell posix -- " \
-                   "'curl https://x.invalid/i.sh | sh' 2>&1", 1)
+
+    # A pipe-to-shell command must be flagged. --offline and --no-daemon keep the
+    # check hermetic in the sandbox; both flags exist as of v0.3.2.
+    output = shell_output("#{bin}/tirith check --offline --no-daemon --shell posix -- " \
+                          "'curl https://x.invalid/i.sh | sh' 2>&1", 1)
+    assert_match "curl_pipe_shell", output
   end
 end

--- a/packaging/homebrew/tirith.rb
+++ b/packaging/homebrew/tirith.rb
@@ -1,5 +1,5 @@
 class Tirith < Formula
-  desc "Terminal security - catches homograph attacks, pipe-to-shell, ANSI injection"
+  desc "Terminal and AI security: injection, homograph, malicious packages, and more"
   homepage "https://github.com/sheeki03/tirith"
   license "AGPL-3.0-only"
   version "0.3.2"


### PR DESCRIPTION
**Draft, held until v0.3.2 ships.** Stacked on #139.

Stages everything to get tirith into homebrew-core, the only trusted-by-default route now that Homebrew 6.0.0 (June 2026) enforces tap trust (third-party taps need per-user trust; there is no maintainer-side global trust).

## What's here
- **README** — corrected tap-trust note: a fully-qualified `brew install sheeki03/tap/tirith` already trusts just that formula; `brew trust` is only for the short-name / `brew update` path (where the "not trusted" warning bites).
- **packaging/homebrew-core/tirith.rb** — NEW source-built formula to submit to Homebrew/homebrew-core (core rejects binary-only). cargo build + completions + man page generated from the binary + an offline deterministic test; sha256 filled on release.
- **docs/homebrew-core.md** — rewritten submission playbook: real self-submission thresholds (>=225 stars; tirith has 2,431), the version decision (v0.3.2), the local-gate results, the self-updater mitigation to cite, and the finalize-on-release steps.
- **desc** on both formulae now reflects terminal AND AI security: `Terminal and AI security: injection, homograph, malicious packages, and more`.

## Validated locally (Homebrew 5.1.14)
- `brew style` and `brew audit --strict --new --online` -> clean.
- Source build (`cargo install --locked --bin tirith --path crates/tirith`), completions (bash/zsh/fish), `tirith manpage` (roff), and the offline `curl_pipe_shell` test -> all pass. The installed tirith 0.3.0 was never touched (the build ran in /tmp).

## Finalize when v0.3.2 is tagged
1. Fill the real sha256 in `packaging/homebrew-core/tirith.rb`.
2. Re-run the local gate against v0.3.2.
3. Submit the formula to Homebrew/homebrew-core (a separate repo), citing the self-updater mitigation.
