### PR TITLE
fix(hook): resolve env command error in fish hook

### DIFF
--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -145,7 +145,7 @@ if functions -q fish_clipboard_paste; and not functions -q _tirith_original_fish
         end
 
         set -l tmpfile (mktemp)
-        echo -n "$content" | env _TIRITH_HOOK=1 command tirith paste --shell fish --interactive >$tmpfile 2>&1
+        echo -n "$content" | env _TIRITH_HOOK=1 tirith paste --shell fish --interactive >$tmpfile 2>&1
         set -l rc $status
         set -l output (string collect < $tmpfile)
         command rm -f $tmpfile
@@ -193,7 +193,7 @@ function _tirith_check_command
     # and command substitution (set -l x (cmd)) can hang in that context.
     set -l outfile (mktemp)
     set -l errfile (mktemp)
-    env _TIRITH_HOOK=1 command tirith check --approval-check --non-interactive --interactive --shell fish -- "$cmd" >$outfile 2>$errfile
+    env _TIRITH_HOOK=1 tirith check --approval-check --non-interactive --interactive --shell fish -- "$cmd" >$outfile 2>$errfile
     set -l rc $status
     # Read stdout lines: line 1 = approval path, line 2 = warn-ack path (exit code 3 only)
     set -l approval_path ""


### PR DESCRIPTION
Fixes the error "env: ‘command’: No such file or directory" which was caused by nesting the `command` builtin inside the `env` call. Since `command` is a shell builtin, the external `env` binary cannot resolve it, leading to a tirith failure with exit code 127 (running unprotected).

The `command` prefix is removed as `env` natively bypasses fish functions and aliases by searching directly in the PATH.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `command` builtin prefix from the `tirith` invocation inside an `env` call in the fish hook, fixing exit code 127 errors. Since `env` is an external binary it cannot resolve fish shell builtins like `command`, so passing `command tirith` caused `env` to search for a binary named `command` — which does not exist — instead of the real `tirith` executable.

- The `command` prefix was redundant here because `env` already searches `PATH` directly, bypassing fish functions and aliases, so removing it preserves the intended bypass behaviour while eliminating the error.
- No other logic in the hook is altered; the rest of the file (including the remaining `command rm -f` call on line 214, which is correctly invoked as a plain fish builtin outside of `env`) is untouched.

<h3>Confidence Score: 5/5</h3>

The change is a minimal, targeted removal of a shell builtin that was incorrectly nested inside an external env call, fixing a well-understood exit-code-127 failure with no side effects.

The single-line fix correctly eliminates the erroneous `command` prefix. The remaining use of `command rm` on line 214 is unrelated and invoked correctly as a plain fish builtin outside of `env`. No logic, argument list, or environment variable passing is altered.

No files require special attention; the change is isolated to one line in `shell/lib/fish-hook.fish`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shell/lib/fish-hook.fish | Removes `command` builtin prefix from `env tirith ...` call; fix is correct and minimal — `env` already resolves executables from PATH without needing a fish builtin. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Fish as Fish Shell (key binding)
    participant env as env (external binary)
    participant tirith as tirith (binary in PATH)

    note over Fish,tirith: Before fix
    Fish->>env: "env _TIRITH_HOOK=1 command tirith check ..."
    env-->>Fish: exit 127 (cannot find binary "command")

    note over Fish,tirith: After fix
    Fish->>env: "env _TIRITH_HOOK=1 tirith check ..."
    env->>tirith: "execve("tirith", [...], [_TIRITH_HOOK=1, ...])"
    tirith-->>Fish: "approval/block result (rc = 0/2/3/other)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Fish as Fish Shell (key binding)
    participant env as env (external binary)
    participant tirith as tirith (binary in PATH)

    note over Fish,tirith: Before fix
    Fish->>env: "env _TIRITH_HOOK=1 command tirith check ..."
    env-->>Fish: exit 127 (cannot find binary "command")

    note over Fish,tirith: After fix
    Fish->>env: "env _TIRITH_HOOK=1 tirith check ..."
    env->>tirith: "execve("tirith", [...], [_TIRITH_HOOK=1, ...])"
    tirith-->>Fish: "approval/block result (rc = 0/2/3/other)"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(hook): resolve env command error in ..."](https://github.com/sheeki03/tirith/commit/28a141fdee6f546f202d85ff902cf9be2e6939af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37867278)</sub>

<!-- /greptile_comment -->