### PR TITLE
A1: VersionIntent and constraint-aware package threat assessment

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,2 @@
 [advisories]
-# time 0.3.46 DoS via RFC 2822 stack exhaustion — fix (0.3.47) requires Rust 1.88,
-# but our MSRV is 1.83. Not exploitable: lopdf (our only consumer) doesn't parse
-# user-provided RFC 2822 date strings. Will resolve when MSRV is bumped.
-ignore = ["RUSTSEC-2026-0009"]
+ignore = []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - run: cargo test --workspace --locked
 
   msrv:
-    name: MSRV (1.83)
+    name: MSRV (1.88)
     runs-on: ubuntu-latest
     # Match the main test job: treat prolonged runner hangs as failures.
     timeout-minutes: 20
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.83"
+          toolchain: "1.88"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --workspace --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -25,8 +25,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -36,8 +47,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.4",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -131,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -195,21 +206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "attohttpc"
-version = "0.28.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
-dependencies = [
- "http 1.4.0",
- "log",
- "rustls 0.23.36",
- "serde",
- "serde_json",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,32 +223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-creds"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
-dependencies = [
- "attohttpc",
- "home",
- "log",
- "quick-xml",
- "rust-ini",
- "serde",
- "thiserror 1.0.69",
- "time",
- "url",
-]
-
-[[package]]
-name = "aws-region"
-version = "0.25.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
-dependencies = [
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,10 +232,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -293,8 +263,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -303,12 +273,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -330,9 +294,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -341,6 +305,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -360,6 +342,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
+]
 
 [[package]]
 name = "cc"
@@ -388,6 +379,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -442,8 +444,18 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -536,34 +548,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
@@ -572,10 +560,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -637,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -665,6 +668,15 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -694,7 +706,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -704,9 +716,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -738,24 +750,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
- "serde",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_arbitrary"
@@ -774,9 +813,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -785,7 +835,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -801,19 +851,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "ecb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
+dependencies = [
+ "cipher 0.5.2",
+]
 
 [[package]]
 name = "ed25519"
@@ -835,7 +885,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -972,7 +1022,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -994,17 +1043,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1093,10 +1131,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasip2",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1121,7 +1171,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1151,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1188,7 +1238,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1198,17 +1248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -1223,23 +1262,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1250,8 +1278,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1268,26 +1296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "0.14.32"
+name = "hybrid-array"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
+ "typenum",
 ]
 
 [[package]]
@@ -1301,8 +1315,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1315,33 +1329,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1350,18 +1350,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1495,12 +1495,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1510,6 +1510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1559,6 +1569,59 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -1622,20 +1685,30 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "5e2ec995d822e05cabc3f06d196ee43650af3fe4fe38012cacb35e0c3d113b68"
 dependencies = [
+ "aes 0.9.2",
+ "bitflags 2.13.1",
+ "cbc",
  "chrono",
+ "ecb",
  "encoding_rs",
  "flate2",
+ "getrandom 0.4.3",
  "indexmap",
  "itoa",
+ "jiff",
  "log",
  "md-5",
  "nom",
+ "rand 0.10.2",
  "rangemap",
  "rayon",
+ "sha2 0.11.0",
+ "stringprep",
+ "thiserror 2.0.18",
  "time",
  "weezl",
 ]
@@ -1675,31 +1748,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "maybe-async"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1712,12 +1768,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1750,14 +1800,14 @@ dependencies = [
  "bytes",
  "colored",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand",
+ "rand 0.9.3",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1771,7 +1821,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -1779,12 +1829,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1798,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1826,7 +1875,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -1838,7 +1887,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -1849,7 +1898,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1868,7 +1917,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1879,7 +1928,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1907,22 +1956,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "owo-colors"
@@ -2042,9 +2075,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2102,16 +2150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,8 +2161,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.36",
- "socket2 0.6.2",
+ "rustls",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2133,17 +2171,18 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2161,7 +2200,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2182,6 +2221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2234,17 @@ checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2220,6 +2276,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,9 +2298,9 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2251,7 +2322,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2289,30 +2360,30 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -2320,7 +2391,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2349,59 +2420,12 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
-
-[[package]]
-name = "rust-s3"
-version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
-dependencies = [
- "async-trait",
- "aws-creds",
- "aws-region",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "futures",
- "hex",
- "hmac",
- "http 0.2.12",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "log",
- "maybe-async",
- "md5",
- "percent-encoding",
- "quick-xml",
- "rustls 0.21.12",
- "rustls-native-certs",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-stream",
- "url",
 ]
 
 [[package]]
@@ -2425,23 +2449,11 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -2453,30 +2465,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2491,19 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2532,52 +2513,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2702,8 +2641,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2782,16 +2732,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -2815,6 +2755,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2923,42 +2874,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -3012,7 +2953,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "tirith"
 version = "0.3.3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "clap",
  "clap_complete",
@@ -3031,7 +2972,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tiny_http",
  "tirith-core",
@@ -3048,7 +2989,7 @@ name = "tirith-core"
 version = "0.3.3"
 dependencies = [
  "arboard",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "criterion",
  "csv",
@@ -3063,14 +3004,14 @@ dependencies = [
  "once_cell",
  "owo-colors",
  "percent-encoding",
- "rand",
+ "rand 0.9.3",
  "rand_core 0.6.4",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "toml",
@@ -3087,7 +3028,7 @@ version = "0.3.3"
 dependencies = [
  "aes-gcm",
  "axum",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "ed25519-dalek",
  "hex",
@@ -3095,10 +3036,9 @@ dependencies = [
  "rand_core 0.6.4",
  "reqwest",
  "rusqlite",
- "rust-s3",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tower-http",
  "tracing",
@@ -3110,7 +3050,7 @@ dependencies = [
 name = "tirith-sign"
 version = "0.3.3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "clap",
  "ed25519-dalek",
@@ -3130,7 +3070,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3148,32 +3088,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
+ "rustls",
  "tokio",
 ]
 
@@ -3267,11 +3186,11 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.3",
@@ -3396,9 +3315,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
@@ -3416,6 +3341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-script"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3427,7 +3358,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -3612,15 +3543,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
@@ -3630,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.12"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+checksum = "d4ca08e5ef825b65b056d9efbd95c8750683f0a6d0466d02e96dc2e4e360f3d2"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 version = "0.3.3"
 edition = "2021"
 license = "AGPL-3.0-only"
-rust-version = "1.83"
+rust-version = "1.88"
 
 [workspace.dependencies]
 tirith-core = { version = "0.3.3", path = "crates/tirith-core" }
@@ -30,20 +30,12 @@ thiserror = "2"
 clap_complete = "4"
 clap_mangen = "0.2"
 uuid = { version = "1", features = ["v4"] }
-# Pin home <0.5.12 — v0.5.12 requires edition 2024 (Rust 1.85+), breaks MSRV 1.83
-home = ">=0.5, <0.5.12"
-# Pin time <0.3.38 — v0.3.38+ requires time-core >=0.1.3 which needs Rust 1.85+,
-# and v0.3.46+ needs time-core 0.1.8 (Rust 1.88). Advisory RUSTSEC-2026-0009
-# is ignored in deny.toml (tirith never parses user-controlled RFC 2822 dates).
-time = ">=0.3, <0.3.38"
-# Pin base64ct <1.8 — v1.8+ uses edition 2024 (Rust 1.85+), breaks MSRV 1.83.
-# Transitive dep via ed25519-dalek → ed25519 → pkcs8 → spki → base64ct.
-base64ct = ">=1, <1.8"
+home = "0.5"
 libc = "0.2"
 walkdir = "2"
 csv = "1"
 tokio = { version = "1", features = ["rt", "net", "io-util", "signal", "macros"] }
-lopdf = "0.34"
+lopdf = "0.44"
 owo-colors = "4"
 ed25519-dalek = { version = "2", default-features = false, features = ["std", "rand_core"] }
 # arboard 3.x — cross-platform clipboard (X11/Wayland/macOS NSPasteboard/Windows).

--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -1334,6 +1334,17 @@ examples_good = ["pip install requests", "npm install lodash"]
 false_positive_guidance = "This is a heuristic check. Legitimate packages may have names similar to popular ones. Review the package on its registry page to confirm it is the intended package."
 remediation = "Double-check the package name. If it is a typo, correct it to the popular package name shown in the evidence. If it is intentional, you can suppress this rule via policy allowlist."
 
+[[rule]]
+id = "threat_unresolved_malicious_package"
+title = "Unresolved malicious package version"
+category = "threatintel"
+severity_rationale = "Medium — the package name is in the malicious-package database but the exact version was not pinned, so the resolver might or might not pull an affected version. A confirmed exact or all-versions hit is reported as the Critical threat_malicious_package instead."
+description = "The package being installed is listed as malicious for specific versions, but the request did not pin an exact version (an unpinned install) or used a version range that overlaps the affected versions. tirith cannot prove the resolver will avoid the malicious version, so it warns. A range that provably excludes every affected version does not trigger this rule."
+examples_bad = ["pip install malicious-pkg-example", "pip install malicious-pkg-example>=1.0,<2.0"]
+examples_good = ["pip install malicious-pkg-example==9.9.9-known-safe", "pip install requests"]
+false_positive_guidance = "This is a precautionary warning, not a confirmed match for the version you will install. If you pin an exact non-affected version, the warning is replaced by a clean result. Consult the reference URL for the affected version list."
+remediation = "Pin the package to a specific version known to be unaffected, or choose a different package. Check the affected versions in the finding evidence before installing."
+
 # ── Threat intelligence rules (Phase B — keyed feeds, stubs) ───────────
 
 [[rule]]

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -970,6 +970,10 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
     ("threat_malicious_ip", "ThreatMaliciousIp"),
     ("threat_package_typosquat", "ThreatPackageTyposquat"),
     ("threat_package_similar_name", "ThreatPackageSimilarName"),
+    (
+        "threat_unresolved_malicious_package",
+        "ThreatUnresolvedMaliciousPackage",
+    ),
     // Threat intelligence — supplemental feeds
     ("threat_malicious_url", "ThreatMaliciousUrl"),
     ("threat_phishing_url", "ThreatPhishingUrl"),

--- a/crates/tirith-core/src/command_card.rs
+++ b/crates/tirith-core/src/command_card.rs
@@ -212,7 +212,7 @@ pub fn hex_encode(bytes: &[u8]) -> String {
 /// non-hex char or odd length.
 pub fn hex_decode(s: &str) -> Option<Vec<u8>> {
     let s = s.trim();
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return None;
     }
     let mut out = Vec::with_capacity(s.len() / 2);

--- a/crates/tirith-core/src/custom_rule_dsl.rs
+++ b/crates/tirith-core/src/custom_rule_dsl.rs
@@ -524,7 +524,7 @@ pub fn satisfiable_contexts(clause: &WhenClause) -> ContextSet {
                 k += 1;
                 inner = c.as_ref();
             }
-            let even = k % 2 == 0;
+            let even = k.is_multiple_of(2);
             match inner {
                 // constant-FALSE innermost.
                 WhenClause::Any(cs) if cs.is_empty() => {

--- a/crates/tirith-core/src/deobfuscate.rs
+++ b/crates/tirith-core/src/deobfuscate.rs
@@ -348,7 +348,7 @@ fn try_decode_base64(run: &str) -> Option<Vec<u8>> {
 /// malformed pair (defensive: callers only pass validated even-length hex runs).
 fn try_decode_hex(run: &str) -> Option<Vec<u8>> {
     let bytes = run.as_bytes();
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return None;
     }
     let hex_val = |b: u8| -> Option<u8> {
@@ -453,7 +453,7 @@ fn hex_forms(input: &str, record_range: bool) -> Vec<NormalizedForm> {
         }
         let mut end = i;
         // Decode only an even-length prefix (drop a trailing odd nibble).
-        if (end - start) % 2 != 0 {
+        if !(end - start).is_multiple_of(2) {
             end -= 1;
         }
         if end - start < MIN_HEX_CANDIDATE_LEN {
@@ -520,7 +520,7 @@ pub fn has_encoded_blob(input: &str) -> bool {
             i += 1;
         }
         let mut len = i - start;
-        if len % 2 != 0 {
+        if !len.is_multiple_of(2) {
             len -= 1;
         }
         if len >= MIN_HEX_CANDIDATE_LEN {

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -514,7 +514,12 @@ fn python_requirement_spec(line: &str) -> String {
             _ => {}
         }
     }
-    match buf.find(['=', '<', '>', '!', '~']) {
+    // Search for a version operator ONLY in the part before the `;` marker, so a
+    // comparator INSIDE the marker (`python_version < "3.9"`) is not mistaken for the
+    // dependency's version. When a real operator IS found before the marker, keep the
+    // whole tail (marker included) so `from_pep440_specifier` still rejects the marker.
+    let before_marker = buf.split(';').next().unwrap_or(buf.as_str());
+    match before_marker.find(['=', '<', '>', '!', '~']) {
         Some(i) => buf[i..].trim().to_string(),
         None => String::new(),
     }
@@ -2724,6 +2729,16 @@ git+https://github.com/x/y.git
         assert!(names.contains(&"requests"));
         assert!(names.contains(&"flask"), "extras must be stripped");
         assert!(names.contains(&"django"), "env markers must be stripped");
+        // The `<` inside the marker must NOT be read as django's version spec.
+        let django = deps
+            .iter()
+            .find(|d| d.name == "django")
+            .expect("django dep");
+        assert_eq!(
+            django.version,
+            crate::version_intent::VersionIntent::Unspecified,
+            "a marker comparator must not be read as a version constraint"
+        );
         assert!(names.contains(&"numpy"), "inline comment must be stripped");
         // pip directives and VCS installs must NOT yield a name.
         assert!(!names.iter().any(|n| n.contains("other-requirements")));

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -789,13 +789,12 @@ fn parse_gemfile(text: &str) -> Vec<DeclaredDependency> {
             block_stack.push(is_dev_group);
             continue;
         }
-        if let Some(name) = gemfile_gem_name(line) {
+        if let Some((name, version)) = gemfile_gem_spec(line) {
             if seen.insert(name.clone()) {
                 out.push(DeclaredDependency {
                     name,
                     ecosystem: Ecosystem::RubyGems,
-                    // Gemfile parsing keeps only the name today.
-                    version: VersionIntent::Unspecified,
+                    version,
                     dev: block_stack.iter().any(|&is_dev| is_dev),
                 });
             }
@@ -804,20 +803,30 @@ fn parse_gemfile(text: &str) -> Vec<DeclaredDependency> {
     out
 }
 
-/// Extract the gem name from a `gem "name", ...` Gemfile line.
-fn gemfile_gem_name(line: &str) -> Option<String> {
+/// Extract the gem name and version intent from a `gem "name", "<spec>", ...` Gemfile line.
+/// The version is the quoted token that DIRECTLY follows the name (`gem "x", "= 1.0"`); an
+/// option hash (`gem "x", :require => false`) carries no version, so the intent is
+/// Unspecified.
+fn gemfile_gem_spec(line: &str) -> Option<(String, VersionIntent)> {
     let rest = line.strip_prefix("gem ")?.trim_start();
-    let (quote, after) = match rest.chars().next()? {
-        '"' => ('"', &rest[1..]),
-        '\'' => ('\'', &rest[1..]),
+    let quote = match rest.chars().next()? {
+        '"' => '"',
+        '\'' => '\'',
         _ => return None,
     };
-    let name = after.split(quote).next()?.trim();
+    // Split on the quote char: parts = ["", name, sep, version, ...]. A version is present
+    // only when `sep` (between the name's closing quote and the next opening quote) is just
+    // a comma - otherwise the next quoted token is an option value, not a version.
+    let parts: Vec<&str> = rest.split(quote).collect();
+    let name = parts.get(1)?.trim();
     if name.is_empty() || !is_plausible_package_name(name) {
-        None
-    } else {
-        Some(name.to_string())
+        return None;
     }
+    let version = match (parts.get(2), parts.get(3)) {
+        (Some(sep), Some(spec)) if sep.trim() == "," => VersionIntent::from_gem_version(spec),
+        _ => VersionIntent::Unspecified,
+    };
+    Some((name.to_string(), version))
 }
 
 /// `true` when `name` is shaped like a real package name. Deliberately
@@ -2985,6 +2994,32 @@ end
         assert!(names.contains(&"puma"));
         let rspec = deps.iter().find(|d| d.name == "rspec").unwrap();
         assert!(rspec.dev, "a gem in a :test group must be dev-tagged");
+    }
+
+    #[test]
+    fn parse_gemfile_carries_version_intent() {
+        // The Gemfile parser must carry version intent (like requirements.txt / Cargo.toml)
+        // so a safe PINNED version does not raise a version-agnostic false-positive warning.
+        let text = "\
+gem 'pinned', '= 1.2.3'
+gem 'bare', '4.5.6'
+gem 'ranged', '~> 2.0'
+gem 'optioned', require: false
+gem 'plain'
+";
+        let deps = parse_gemfile(text);
+        let v = |n: &str| deps.iter().find(|d| d.name == n).map(|d| d.version.clone());
+        // `= 1.2.3` and a bare `4.5.6` are exact gem pins.
+        assert_eq!(v("pinned"), Some(VersionIntent::Exact("1.2.3".to_string())));
+        assert_eq!(v("bare"), Some(VersionIntent::Exact("4.5.6".to_string())));
+        // `~> 2.0` is a range constraint.
+        assert!(matches!(
+            v("ranged"),
+            Some(VersionIntent::Constraint { .. })
+        ));
+        // An option value (not a version) and a bare name are Unspecified.
+        assert_eq!(v("optioned"), Some(VersionIntent::Unspecified));
+        assert_eq!(v("plain"), Some(VersionIntent::Unspecified));
     }
 
     #[test]

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -23,8 +23,9 @@ use serde::Serialize;
 use crate::package_risk::{
     self, ApiSignals, ContentSignals, NameVsPopular, PackageSignals, RiskBreakdown,
 };
-use crate::threatdb::{Ecosystem, ThreatDb};
+use crate::threatdb::{Ecosystem, PackageThreatAssessment, ThreatDb};
 use crate::verdict::{Action, Evidence, Finding, RuleId, Severity, Timings, Verdict};
+use crate::version_intent::VersionIntent;
 
 /// Maximum directory depth the manifest walk descends.
 pub const MAX_WALK_DEPTH: usize = 6;
@@ -206,15 +207,43 @@ pub struct DeclaredDependency {
     /// The ecosystem the manifest is for.
     #[serde(serialize_with = "serialize_ecosystem")]
     pub ecosystem: Ecosystem,
-    /// The version / version-range string as written, when the manifest gives one.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
+    /// How the version / version-range was written, when the manifest gives one.
+    /// Serializes as the version string (or is omitted when unspecified), so the
+    /// JSON shape is unchanged from the prior `Option<String>` field; the typed
+    /// form lets the threat assessment tell an exact pin from a range.
+    #[serde(
+        serialize_with = "serialize_version_intent",
+        skip_serializing_if = "version_intent_is_unspecified"
+    )]
+    pub version: VersionIntent,
     /// Whether the manifest declares this as a development-only dependency.
     pub dev: bool,
 }
 
 fn serialize_ecosystem<S: serde::Serializer>(eco: &Ecosystem, s: S) -> Result<S::Ok, S::Error> {
     s.serialize_str(&eco.to_string())
+}
+
+/// Serialize a [`VersionIntent`] as the original version string, preserving the
+/// JSON shape of the former `version: Option<String>` field. `Unspecified` is
+/// skipped via [`version_intent_is_unspecified`], so this only runs for the
+/// other variants (which all have a string form).
+fn serialize_version_intent<S: serde::Serializer>(
+    intent: &VersionIntent,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    match intent.as_version_str() {
+        Some(v) => s.serialize_str(v),
+        // Unreachable in practice (Unspecified is skipped), but serialize a unit
+        // rather than panic if the skip predicate is ever bypassed.
+        None => s.serialize_none(),
+    }
+}
+
+/// Skip predicate matching the old `Option::is_none`: omit the field only when
+/// no version was given.
+fn version_intent_is_unspecified(intent: &VersionIntent) -> bool {
+    matches!(intent, VersionIntent::Unspecified)
 }
 
 /// Parse a manifest's text into the dependencies it declares. Total, never
@@ -251,10 +280,17 @@ fn parse_package_json(text: &str) -> Option<Vec<DeclaredDependency>> {
                 if name.is_empty() {
                     continue;
                 }
+                let version = match ver.as_str().filter(|s| !s.is_empty()) {
+                    // package.json declares a semver range/version (not parsed
+                    // for npm); a plain version is an exact pin, a range stays
+                    // unresolved.
+                    Some(v) => VersionIntent::from_explicit_version(v),
+                    None => VersionIntent::Unspecified,
+                };
                 out.push(DeclaredDependency {
                     name: name.to_string(),
                     ecosystem: Ecosystem::Npm,
-                    version: ver.as_str().map(str::to_string).filter(|s| !s.is_empty()),
+                    version,
                     dev,
                 });
             }
@@ -287,7 +323,8 @@ fn parse_package_lock(text: &str) -> Option<Vec<DeclaredDependency>> {
                 out.push(DeclaredDependency {
                     name,
                     ecosystem: Ecosystem::Npm,
-                    version,
+                    // A lockfile pins a concrete resolved version.
+                    version: lock_version_intent(version),
                     dev,
                 });
             }
@@ -300,6 +337,16 @@ fn parse_package_lock(text: &str) -> Option<Vec<DeclaredDependency>> {
     }
 
     Some(out)
+}
+
+/// Map a lockfile's resolved version string to a [`VersionIntent`]. A lockfile
+/// pins one concrete version, so a present value is `Resolved`; an absent one is
+/// `Unspecified`.
+fn lock_version_intent(version: Option<String>) -> VersionIntent {
+    match version {
+        Some(v) => VersionIntent::Resolved(v),
+        None => VersionIntent::Unspecified,
+    }
 }
 
 /// Extract the package name from a `package-lock.json` v2/v3 path key — the
@@ -339,7 +386,8 @@ fn collect_lock_v1_deps(
             out.push(DeclaredDependency {
                 name: name.to_string(),
                 ecosystem: Ecosystem::Npm,
-                version,
+                // A lockfile pins a concrete resolved version.
+                version: lock_version_intent(version),
                 dev,
             });
         }
@@ -376,7 +424,8 @@ fn parse_requirements_txt(text: &str) -> Vec<DeclaredDependency> {
             out.push(DeclaredDependency {
                 name,
                 ecosystem: Ecosystem::PyPI,
-                version: None,
+                // requirements.txt parsing keeps only the name today.
+                version: VersionIntent::Unspecified,
                 dev: false,
             });
         }
@@ -424,7 +473,8 @@ fn parse_pyproject_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
             out.push(DeclaredDependency {
                 name: name.to_string(),
                 ecosystem: Ecosystem::PyPI,
-                version: None,
+                // pyproject parsing keeps only the name today.
+                version: VersionIntent::Unspecified,
                 dev,
             });
         }
@@ -534,7 +584,11 @@ fn parse_cargo_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
                     out.push(DeclaredDependency {
                         name: real_name.to_string(),
                         ecosystem: Ecosystem::Crates,
-                        version,
+                        // Cargo semver requirement: not parsed; plain is exact,
+                        // a range stays unresolved.
+                        version: version
+                            .map(|v| VersionIntent::from_explicit_version(&v))
+                            .unwrap_or(VersionIntent::Unspecified),
                         dev,
                     });
                 }
@@ -613,7 +667,10 @@ fn go_mod_require_entry(entry: &str) -> Option<DeclaredDependency> {
     Some(DeclaredDependency {
         name: module.to_string(),
         ecosystem: Ecosystem::Go,
-        version,
+        // go.mod pins a concrete module version (e.g. `v1.2.3`).
+        version: version
+            .map(|v| VersionIntent::from_explicit_version(&v))
+            .unwrap_or(VersionIntent::Unspecified),
         dev: false,
     })
 }
@@ -655,7 +712,8 @@ fn parse_gemfile(text: &str) -> Vec<DeclaredDependency> {
                 out.push(DeclaredDependency {
                     name,
                     ecosystem: Ecosystem::RubyGems,
-                    version: None,
+                    // Gemfile parsing keeps only the name today.
+                    version: VersionIntent::Unspecified,
                     dev: block_stack.iter().any(|&is_dev| is_dev),
                 });
             }
@@ -978,9 +1036,62 @@ pub struct DependencyAssessment {
     pub risk: RiskBreakdown,
     /// The slopsquat heuristic verdict.
     pub slopsquat: SlopsquatAssessment,
+    /// The constraint-aware threat-DB assessment for this dependency's
+    /// `(ecosystem, name, version-intent)`. A serializable summary, never a
+    /// `ThreatMatch`. Omitted from JSON when there is no record so a clean
+    /// report gains no `"no_record"` noise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threat_assessment: Option<PackageThreatAssessment>,
     /// `true` when a policy allowlist entry suppressed this dependency's
     /// findings (the assessment is still reported, for transparency).
     pub allowlisted: bool,
+}
+
+/// Build the Medium/Warn finding for a dependency whose malicious-package
+/// version could not be resolved (an unpinned/range manifest entry over a
+/// version-specific record, or a constraint that overlaps the affected
+/// versions). Advises pinning to a known non-affected version.
+fn unresolved_dependency_finding(
+    dep: &DeclaredDependency,
+    manifest: &str,
+    summary: &crate::threatdb::ThreatMatchSummary,
+    affected_versions: &[String],
+) -> Finding {
+    let affected_list = if affected_versions.is_empty() {
+        "unknown".to_string()
+    } else {
+        affected_versions.join(", ")
+    };
+    let declared = dep
+        .version
+        .as_version_str()
+        .map(|v| format!("declared as '{v}'"))
+        .unwrap_or_else(|| "declared without a version".to_string());
+    Finding {
+        rule_id: RuleId::ThreatUnresolvedMaliciousPackage,
+        severity: Severity::Medium,
+        title: format!(
+            "Unresolved malicious {} dependency: {}",
+            dep.ecosystem, dep.name
+        ),
+        description: format!(
+            "The {} dependency '{}' {declared} in {} is flagged as malicious by {} for \
+             specific versions ({affected_list}), but the request could not be resolved to a \
+             definite version. Pin an exact non-affected version (or remove the dependency) to \
+             clear this warning.",
+            dep.ecosystem, dep.name, manifest, summary.source_label,
+        ),
+        evidence: vec![Evidence::ThreatIntel {
+            source: summary.source_label.clone(),
+            threat_type: "unresolved_malicious_package".to_string(),
+            confidence: summary.confidence,
+            reference: summary.reference_url.clone(),
+        }],
+        human_view: None,
+        agent_view: None,
+        mitre_id: None,
+        custom_rule_id: None,
+    }
 }
 
 /// Build the [`Finding`]s a single [`DependencyAssessment`] produces, reusing
@@ -998,6 +1109,69 @@ pub fn findings_for(
     let mut findings = Vec::new();
     let dep = &assessment.dependency;
     let manifest = &assessment.manifest;
+
+    // 0 — constraint-aware threat-DB assessment (A1e). An exact/all-versions
+    // hit dominates and stands alone (returns); an unresolved or intersecting
+    // constraint emits the Medium/Warn but falls through, since the name may
+    // ALSO be a typosquat or near-popular.
+    match &assessment.threat_assessment {
+        Some(PackageThreatAssessment::ExactMatch(summary)) => {
+            findings.push(Finding {
+                rule_id: RuleId::ThreatMaliciousPackage,
+                severity: crate::rules::threatintel::confidence_to_severity(summary.confidence),
+                title: format!("Known malicious {} dependency: {}", dep.ecosystem, dep.name),
+                description: format!(
+                    "The {} dependency '{}' declared in {} is flagged as malicious by {}. {}",
+                    dep.ecosystem,
+                    dep.name,
+                    manifest,
+                    summary.source_label,
+                    if summary.all_versions_malicious {
+                        "All versions are affected."
+                    } else {
+                        "Specific version(s) affected."
+                    }
+                ),
+                evidence: vec![Evidence::ThreatIntel {
+                    source: summary.source_label.clone(),
+                    threat_type: "malicious_package".to_string(),
+                    confidence: summary.confidence,
+                    reference: summary.reference_url.clone(),
+                }],
+                human_view: None,
+                agent_view: None,
+                mitre_id: None,
+                custom_rule_id: None,
+            });
+            return findings;
+        }
+        Some(PackageThreatAssessment::ConstraintIntersectsAffected {
+            summary,
+            affected_versions,
+        }) => {
+            findings.push(unresolved_dependency_finding(
+                dep,
+                manifest,
+                summary,
+                affected_versions,
+            ));
+        }
+        Some(PackageThreatAssessment::Unresolved {
+            summary,
+            affected_versions,
+            ..
+        }) => {
+            findings.push(unresolved_dependency_finding(
+                dep,
+                manifest,
+                summary,
+                affected_versions,
+            ));
+        }
+        Some(PackageThreatAssessment::ConstraintExcludesAffected)
+        | Some(PackageThreatAssessment::NoRecord)
+        | None => {}
+    }
 
     // 1 — confirmed malicious typosquat from the threat DB; stands alone.
     if let Some(target) = &assessment.risk.malicious_typosquat_of {
@@ -1638,8 +1812,15 @@ pub fn scan(request: &ScanRequest) -> EcosystemScanReport {
             findings.extend(policy_findings_for_assessment(assessment, effective_policy));
         }
     }
-    // tier_reached is 3 — `ecosystem scan` does the full analysis.
-    let verdict = Verdict::from_findings(findings, 3, Timings::default());
+    // tier_reached is 3 — `ecosystem scan` does the full analysis. Assemble via
+    // the shared finalizer so policy `action_overrides` (and severity overrides
+    // and paranoia) are honored here, not only on the engine hot path.
+    let verdict = crate::escalation::finalize_static_verdict(
+        findings,
+        effective_policy,
+        3,
+        Timings::default(),
+    );
 
     EcosystemScanReport {
         scan_root: root_display,
@@ -1973,7 +2154,8 @@ fn read_node_package(
         DeclaredDependency {
             name: name.to_string(),
             ecosystem: Ecosystem::Npm,
-            version,
+            // An installed package reports its own concrete version.
+            version: lock_version_intent(version),
             dev: false,
         },
         label,
@@ -2064,7 +2246,8 @@ fn walk_site_packages(
             DeclaredDependency {
                 name,
                 ecosystem: Ecosystem::PyPI,
-                version,
+                // An installed distribution reports its own concrete version.
+                version: lock_version_intent(version),
                 dev: false,
             },
             label,
@@ -2133,7 +2316,8 @@ fn walk_vendor_go(
                 DeclaredDependency {
                     name: module.to_string(),
                     ecosystem: Ecosystem::Go,
-                    version,
+                    // `modules.txt` records the concrete resolved module version.
+                    version: lock_version_intent(version),
                     dev: false,
                 },
                 label.clone(),
@@ -2169,7 +2353,8 @@ fn walk_vendor_go(
                     DeclaredDependency {
                         name: rel,
                         ecosystem: Ecosystem::Go,
-                        version: None,
+                        // Vendored layout carries no version on disk.
+                        version: VersionIntent::Unspecified,
                         dev: false,
                     },
                     label,
@@ -2219,7 +2404,8 @@ fn parse_cargo_lock(text: &str) -> Vec<DeclaredDependency> {
             out.push(DeclaredDependency {
                 name: name.to_string(),
                 ecosystem: Ecosystem::Crates,
-                version,
+                // Cargo.lock pins a concrete resolved version.
+                version: lock_version_intent(version),
                 dev: false,
             });
         }
@@ -2256,7 +2442,7 @@ fn assess_dependency(
         ecosystem: dep.ecosystem,
         name: dep.name.clone(),
         // Manifest-declared version, carried through to OSV correlation.
-        version: dep.version.clone(),
+        version: dep.version.as_version_str().map(str::to_string),
         threat_db_missing: request.db.is_none(),
         name_vs_popular: name_vs_popular.clone(),
         malicious_typosquat_of,
@@ -2269,6 +2455,17 @@ fn assess_dependency(
 
     let slopsquat = slopsquat(&dep.name, &name_vs_popular, request.db, dep.ecosystem);
 
+    // Constraint-aware threat-DB assessment (A1e). A clean `NoRecord` is dropped
+    // so reports gain no noise; only an actual signal is stored. No-DB stays
+    // fail-open (no assessment).
+    let threat_assessment =
+        request.db.and_then(
+            |db| match db.assess_package(dep.ecosystem, &dep.name, &dep.version) {
+                PackageThreatAssessment::NoRecord => None,
+                other => Some(other),
+            },
+        );
+
     let allowlisted = (request.is_allowlisted)(dep.ecosystem, &dep.name);
 
     DependencyAssessment {
@@ -2276,6 +2473,7 @@ fn assess_dependency(
         manifest: manifest.to_string(),
         risk,
         slopsquat,
+        threat_assessment,
         allowlisted,
     }
 }
@@ -2354,7 +2552,16 @@ mod tests {
         assert_eq!(deps.len(), 3);
         let react = deps.iter().find(|d| d.name == "react").unwrap();
         assert!(!react.dev);
-        assert_eq!(react.version.as_deref(), Some("^18.0.0"));
+        // A semver range is preserved as an unresolved Constraint (its text is
+        // still reported as the version string).
+        assert_eq!(react.version.as_version_str(), Some("^18.0.0"));
+        assert!(matches!(
+            react.version,
+            VersionIntent::Constraint { parsed: None, .. }
+        ));
+        // A plain version is an exact pin.
+        let lodash = deps.iter().find(|d| d.name == "lodash").unwrap();
+        assert_eq!(lodash.version, VersionIntent::Exact("4.17.21".to_string()));
         let jest = deps.iter().find(|d| d.name == "jest").unwrap();
         assert!(jest.dev, "devDependencies must be tagged dev");
     }
@@ -2773,12 +2980,13 @@ gem 'toplevelgem'
             dependency: DeclaredDependency {
                 name: name.to_string(),
                 ecosystem: Ecosystem::Npm,
-                version: None,
+                version: VersionIntent::Unspecified,
                 dev: false,
             },
             manifest: "package.json".to_string(),
             risk: package_risk::score_package(&signals),
             slopsquat: slop,
+            threat_assessment: None,
             allowlisted,
         }
     }
@@ -2914,12 +3122,13 @@ gem 'toplevelgem'
             dependency: DeclaredDependency {
                 name: "totally-unknown-pkg".to_string(),
                 ecosystem: Ecosystem::Npm,
-                version: None,
+                version: VersionIntent::Unspecified,
                 dev: false,
             },
             manifest: "package.json".to_string(),
             risk: breakdown,
             slopsquat: SlopsquatAssessment::clear(),
+            threat_assessment: None,
             allowlisted: false,
         };
         let policy = crate::policy::Policy::default();
@@ -2974,12 +3183,13 @@ gem 'toplevelgem'
             dependency: DeclaredDependency {
                 name: "ordinary-pkg".to_string(),
                 ecosystem: Ecosystem::Npm,
-                version: None,
+                version: VersionIntent::Unspecified,
                 dev: false,
             },
             manifest: "package.json".to_string(),
             risk: breakdown,
             slopsquat: SlopsquatAssessment::clear(),
+            threat_assessment: None,
             allowlisted: false,
         };
         let policy = crate::policy::Policy::default();
@@ -3014,12 +3224,13 @@ gem 'toplevelgem'
             dependency: DeclaredDependency {
                 name: "reaqt".to_string(),
                 ecosystem: Ecosystem::Npm,
-                version: None,
+                version: VersionIntent::Unspecified,
                 dev: false,
             },
             manifest: "package.json".to_string(),
             risk: breakdown,
             slopsquat: SlopsquatAssessment::clear(),
+            threat_assessment: None,
             allowlisted: false,
         };
         // Configure a typosquat-distance policy threshold.
@@ -3230,9 +3441,103 @@ gem 'toplevelgem'
         assert_eq!(report.assessments[0].dependency.name, "evil-package");
         assert_eq!(
             report.assessments[0].dependency.version,
-            Some("1.0.0".to_string())
+            VersionIntent::Resolved("1.0.0".to_string())
         );
         assert_eq!(report.assessments[0].dependency.ecosystem, Ecosystem::Npm);
+    }
+
+    /// Build an in-memory signed threat DB whose only record is a PyPI package
+    /// `eco_name` malicious at exactly `affected` (version-specific, not
+    /// all-versions). Used to exercise the installed-METADATA path (A1e).
+    fn threat_db_with_pypi_version(eco_name: &str, affected: &str) -> ThreatDb {
+        use ed25519_dalek::SigningKey;
+        use rand_core::OsRng;
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = crate::threatdb::ThreatDbWriter::new(1700000000, 5);
+        writer.add_package(
+            Ecosystem::PyPI,
+            eco_name,
+            &[affected],
+            crate::threatdb::ThreatSource::OssfMalicious,
+            crate::threatdb::Confidence::Confirmed,
+            false,
+            Some("https://example.com/advisory/installed"),
+        );
+        let bytes = writer.build(&key).expect("build test DB");
+        ThreatDb::from_bytes(bytes, 0).expect("load test DB")
+    }
+
+    /// Plant a `<root>/site-packages/<name>-<ver>.dist-info/METADATA` file.
+    fn plant_dist_info(root: &Path, name: &str, version: &str) {
+        let dist = root
+            .join("site-packages")
+            .join(format!("{name}-{version}.dist-info"));
+        std::fs::create_dir_all(&dist).unwrap();
+        std::fs::write(
+            dist.join("METADATA"),
+            format!("Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn installed_mode_known_malicious_metadata_blocks() {
+        // An installed distribution whose concrete version is in the malicious
+        // record is an EXACT match: it blocks via ThreatMaliciousPackage, not
+        // the unresolved warn.
+        let dir = tempfile::tempdir().unwrap();
+        plant_dist_info(dir.path(), "evil-installed", "2.3.4");
+        let db = threat_db_with_pypi_version("evil-installed", "2.3.4");
+
+        let request = ScanRequest {
+            root: dir.path(),
+            db: Some(&db),
+            online: OnlineMode::Off,
+            is_allowlisted: &never_allow,
+            mode: ScanMode::Installed,
+            installed_max_entries: DEFAULT_MAX_INSTALLED_ENTRIES,
+            policy: None,
+        };
+        let report = scan(&request);
+        assert_eq!(report.dependency_count, 1);
+        assert_eq!(report.assessments[0].dependency.name, "evil-installed");
+        assert_eq!(
+            report.assessments[0].dependency.version,
+            VersionIntent::Resolved("2.3.4".to_string())
+        );
+        assert_eq!(report.verdict.action, Action::Block);
+        let rules: Vec<RuleId> = report.verdict.findings.iter().map(|f| f.rule_id).collect();
+        assert!(
+            rules.contains(&RuleId::ThreatMaliciousPackage),
+            "an installed affected version must block as a confirmed exact match; got {rules:?}"
+        );
+        assert!(
+            !rules.contains(&RuleId::ThreatUnresolvedMaliciousPackage),
+            "a resolved exact hit must NOT emit the unresolved warn"
+        );
+    }
+
+    #[test]
+    fn installed_mode_non_affected_metadata_is_clean() {
+        // The installed version is NOT in the malicious record, so there is no
+        // finding at all (NoRecord for this exact version).
+        let dir = tempfile::tempdir().unwrap();
+        plant_dist_info(dir.path(), "evil-installed", "9.9.9");
+        let db = threat_db_with_pypi_version("evil-installed", "2.3.4");
+
+        let request = ScanRequest {
+            root: dir.path(),
+            db: Some(&db),
+            online: OnlineMode::Off,
+            is_allowlisted: &never_allow,
+            mode: ScanMode::Installed,
+            installed_max_entries: DEFAULT_MAX_INSTALLED_ENTRIES,
+            policy: None,
+        };
+        let report = scan(&request);
+        assert_eq!(report.dependency_count, 1);
+        assert_eq!(report.verdict.action, Action::Allow);
+        assert!(report.assessments[0].threat_assessment.is_none());
     }
 
     #[test]

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -325,9 +325,16 @@ fn npm_partial_xrange(v: &str) -> Option<String> {
         .split('.')
         .map(|s| s.parse::<u64>().ok())
         .collect::<Option<_>>()?;
+    // `checked_add` so a pathological segment (`18446744073709551615`) returns None
+    // (treated as an exact pin) instead of overflowing: a panic in debug, or a bogus
+    // `>=MAX,<0` range in release that would never match.
     match nums.as_slice() {
-        [major] => Some(format!(">={major}.0.0,<{}.0.0", major + 1)),
-        [major, minor] => Some(format!(">={major}.{minor}.0,<{major}.{}.0", minor + 1)),
+        [major] => major
+            .checked_add(1)
+            .map(|hi| format!(">={major}.0.0,<{hi}.0.0")),
+        [major, minor] => minor
+            .checked_add(1)
+            .map(|hi| format!(">={major}.{minor}.0,<{major}.{hi}.0")),
         _ => None,
     }
 }
@@ -2777,6 +2784,11 @@ git+https://github.com/x/y.git
         assert_eq!(
             npm_manifest_intent("1.2.3"),
             VersionIntent::Exact("1.2.3".to_string())
+        );
+        // A pathological u64::MAX segment must not overflow: it stays an exact pin.
+        assert_eq!(
+            npm_manifest_intent("18446744073709551615"),
+            VersionIntent::Exact("18446744073709551615".to_string())
         );
     }
 

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -281,10 +281,11 @@ fn parse_package_json(text: &str) -> Option<Vec<DeclaredDependency>> {
                     continue;
                 }
                 let version = match ver.as_str().filter(|s| !s.is_empty()) {
-                    // package.json declares a semver range/version (not parsed
-                    // for npm); a plain version is an exact pin, a range stays
-                    // unresolved.
-                    Some(v) => VersionIntent::from_explicit_version(v),
+                    // package.json declares a semver range/version (not fully
+                    // parsed for npm). A full bare version (`1.2.3`) is an exact
+                    // pin; a PARTIAL bare version (`1`, `1.2`) is an X-range, not
+                    // a too-narrow exact; explicit ranges stay unresolved.
+                    Some(v) => npm_manifest_intent(v),
                     None => VersionIntent::Unspecified,
                 };
                 out.push(DeclaredDependency {
@@ -297,6 +298,38 @@ fn parse_package_json(text: &str) -> Option<Vec<DeclaredDependency>> {
         }
     }
     Some(out)
+}
+
+/// Classify an npm `package.json` version requirement. node-semver treats a full
+/// bare version (`1.2.3`) as an exact pin but a PARTIAL bare version as an X-range
+/// (`1` == `1.x.x`, `1.2` == `1.2.x`); explicit operators stay unresolved. This
+/// keeps a partial spec from being mistaken for a too-narrow exact match.
+fn npm_manifest_intent(spec: &str) -> VersionIntent {
+    match VersionIntent::from_explicit_version(spec) {
+        VersionIntent::Exact(v) => match npm_partial_xrange(&v) {
+            Some(range) => VersionIntent::from_pep440_specifier(&range),
+            None => VersionIntent::Exact(v),
+        },
+        other => other,
+    }
+}
+
+/// Map an npm PARTIAL version (`1`, `1.2`) to an explicit `>=lo,<hi` X-range, or
+/// `None` for a full `x.y.z` version (an exact pin) or any prerelease/build tail.
+fn npm_partial_xrange(v: &str) -> Option<String> {
+    if v.contains('-') || v.contains('+') {
+        return None;
+    }
+    let body = v.strip_prefix(['v', 'V']).unwrap_or(v);
+    let nums: Vec<u64> = body
+        .split('.')
+        .map(|s| s.parse::<u64>().ok())
+        .collect::<Option<_>>()?;
+    match nums.as_slice() {
+        [major] => Some(format!(">={major}.0.0,<{}.0.0", major + 1)),
+        [major, minor] => Some(format!(">={major}.{minor}.0,<{major}.{}.0", minor + 1)),
+        _ => None,
+    }
 }
 
 /// npm `package-lock.json`: the fully-resolved tree. v2/v3 keys `packages` by
@@ -424,8 +457,10 @@ fn parse_requirements_txt(text: &str) -> Vec<DeclaredDependency> {
             out.push(DeclaredDependency {
                 name,
                 ecosystem: Ecosystem::PyPI,
-                // requirements.txt parsing keeps only the name today.
-                version: VersionIntent::Unspecified,
+                // Capture the PEP 508 version specifier so a real pin (`==1.4.0`)
+                // is assessed (Exact/Constraint) instead of degrading to a
+                // spurious "unresolved" warning; a bare name stays Unspecified.
+                version: VersionIntent::from_pep440_specifier(&python_requirement_spec(line)),
                 dev: false,
             });
         }
@@ -452,6 +487,29 @@ fn python_requirement_name(line: &str) -> Option<String> {
     }
 }
 
+/// Extract the version specifier from a PEP 508 requirement line: the part after
+/// the name and optional `[extras]`, before any `;` environment marker. Returns an
+/// empty string for a bare name (which `from_pep440_specifier` maps to Unspecified).
+fn python_requirement_spec(line: &str) -> String {
+    // Drop the environment marker, then any `[extras]` so neither is mistaken for a
+    // specifier; the specifier starts at the first comparison operator.
+    let before_marker = line.split(';').next().unwrap_or(line);
+    let mut buf = String::with_capacity(before_marker.len());
+    let mut depth = 0u32;
+    for c in before_marker.chars() {
+        match c {
+            '[' => depth += 1,
+            ']' => depth = depth.saturating_sub(1),
+            _ if depth == 0 => buf.push(c),
+            _ => {}
+        }
+    }
+    match buf.find(['=', '<', '>', '!', '~']) {
+        Some(i) => buf[i..].trim().to_string(),
+        None => String::new(),
+    }
+}
+
 /// Python `pyproject.toml`: PEP 621 `[project].dependencies` /
 /// `[project.optional-dependencies]`, plus Poetry's
 /// `[tool.poetry.dependencies]` / `[tool.poetry.group.*.dependencies]`.
@@ -460,25 +518,25 @@ fn parse_pyproject_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
     let mut out = Vec::new();
     let mut seen: BTreeSet<String> = BTreeSet::new();
 
-    let mut push = |name: &str, dev: bool, out: &mut Vec<DeclaredDependency>| {
-        let name = name.trim();
-        if name.is_empty() || !is_plausible_package_name(name) {
-            return;
-        }
-        // `python` is the interpreter constraint in Poetry tables, not a dep.
-        if name.eq_ignore_ascii_case("python") {
-            return;
-        }
-        if seen.insert(name.to_lowercase()) {
-            out.push(DeclaredDependency {
-                name: name.to_string(),
-                ecosystem: Ecosystem::PyPI,
-                // pyproject parsing keeps only the name today.
-                version: VersionIntent::Unspecified,
-                dev,
-            });
-        }
-    };
+    let mut push =
+        |name: &str, version: VersionIntent, dev: bool, out: &mut Vec<DeclaredDependency>| {
+            let name = name.trim();
+            if name.is_empty() || !is_plausible_package_name(name) {
+                return;
+            }
+            // `python` is the interpreter constraint in Poetry tables, not a dep.
+            if name.eq_ignore_ascii_case("python") {
+                return;
+            }
+            if seen.insert(name.to_lowercase()) {
+                out.push(DeclaredDependency {
+                    name: name.to_string(),
+                    ecosystem: Ecosystem::PyPI,
+                    version,
+                    dev,
+                });
+            }
+        };
 
     // PEP 621 `[project].dependencies` — an array of requirement strings.
     if let Some(deps) = doc
@@ -489,7 +547,9 @@ fn parse_pyproject_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
         for item in deps {
             if let Some(req) = item.as_str() {
                 if let Some(name) = python_requirement_name(req) {
-                    push(&name, false, &mut out);
+                    let version =
+                        VersionIntent::from_pep440_specifier(&python_requirement_spec(req));
+                    push(&name, version, false, &mut out);
                 }
             }
         }
@@ -505,7 +565,9 @@ fn parse_pyproject_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
                 for item in items {
                     if let Some(req) = item.as_str() {
                         if let Some(name) = python_requirement_name(req) {
-                            push(&name, true, &mut out);
+                            let version =
+                                VersionIntent::from_pep440_specifier(&python_requirement_spec(req));
+                            push(&name, version, true, &mut out);
                         }
                     }
                 }
@@ -520,7 +582,9 @@ fn parse_pyproject_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
         .and_then(|d| d.as_table())
     {
         for name in deps.keys() {
-            push(name, false, &mut out);
+            // Poetry value specs (`^2.0`, `{ version = "^2.0" }`) are not modeled;
+            // keep the name with an Unspecified intent.
+            push(name, VersionIntent::Unspecified, false, &mut out);
         }
     }
     // Poetry dev groups + legacy `[tool.poetry.dev-dependencies]`.
@@ -531,7 +595,7 @@ fn parse_pyproject_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
         for group in groups.values() {
             if let Some(deps) = group.get("dependencies").and_then(|d| d.as_table()) {
                 for name in deps.keys() {
-                    push(name, true, &mut out);
+                    push(name, VersionIntent::Unspecified, true, &mut out);
                 }
             }
         }
@@ -541,7 +605,7 @@ fn parse_pyproject_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
         .and_then(|d| d.as_table())
     {
         for name in deps.keys() {
-            push(name, true, &mut out);
+            push(name, VersionIntent::Unspecified, true, &mut out);
         }
     }
 
@@ -2671,6 +2735,49 @@ git+https://github.com/x/y.git
             Some("pkg")
         );
         assert_eq!(python_requirement_name(""), None);
+    }
+
+    #[test]
+    fn requirements_txt_pinned_dep_carries_version_intent() {
+        let deps = parse_requirements_txt("requests==2.28.1\nflask>=2.0,<3.0\nbare-pkg\n");
+        let requests = deps.iter().find(|d| d.name == "requests").unwrap();
+        assert_eq!(requests.version, VersionIntent::Exact("2.28.1".to_string()));
+        let flask = deps.iter().find(|d| d.name == "flask").unwrap();
+        assert!(matches!(
+            flask.version,
+            VersionIntent::Constraint {
+                parsed: Some(_),
+                ..
+            }
+        ));
+        let bare = deps.iter().find(|d| d.name == "bare-pkg").unwrap();
+        assert_eq!(bare.version, VersionIntent::Unspecified);
+    }
+
+    #[test]
+    fn pyproject_pep621_pinned_dep_is_exact() {
+        let toml = "[project]\ndependencies = [\"requests==2.28.1\", \"flask\"]\n";
+        let deps = parse_pyproject_toml(toml).unwrap();
+        let requests = deps.iter().find(|d| d.name == "requests").unwrap();
+        assert_eq!(requests.version, VersionIntent::Exact("2.28.1".to_string()));
+        let flask = deps.iter().find(|d| d.name == "flask").unwrap();
+        assert_eq!(flask.version, VersionIntent::Unspecified);
+    }
+
+    #[test]
+    fn npm_partial_version_is_range_not_exact() {
+        // node-semver: `1.2` == `1.2.x` (a range); full `1.2.3` is exact.
+        assert!(matches!(
+            npm_manifest_intent("1.2"),
+            VersionIntent::Constraint {
+                parsed: Some(_),
+                ..
+            }
+        ));
+        assert_eq!(
+            npm_manifest_intent("1.2.3"),
+            VersionIntent::Exact("1.2.3".to_string())
+        );
     }
 
     #[test]

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -514,6 +514,14 @@ fn python_requirement_spec(line: &str) -> String {
             _ => {}
         }
     }
+    // Drop an inline `#` comment (pip treats ` #` / `\t#` as a comment start): without this,
+    // `malware==1.0.0 # pinned` carries the comment into the version token, so an EXACT pin
+    // degrades to a Constraint/Unresolved - a confirmed Critical hit silently downgraded to
+    // a Warn, and a safe pin (`malware==99.9.9 # not the bad one`) gets a spurious warn.
+    let buf = match buf.split_once(" #").or_else(|| buf.split_once("\t#")) {
+        Some((before, _)) => before.trim_end().to_string(),
+        None => buf,
+    };
     // Search for a version operator ONLY in the part before the `;` marker, so a
     // comparator INSIDE the marker (`python_version < "3.9"`) is not mistaken for the
     // dependency's version. When a real operator IS found before the marker, keep the
@@ -2772,6 +2780,23 @@ git+https://github.com/x/y.git
             Some("pkg")
         );
         assert_eq!(python_requirement_name(""), None);
+    }
+
+    #[test]
+    fn python_requirement_spec_strips_inline_comment() {
+        // An inline `#` comment must not leak into the version token: otherwise an EXACT pin
+        // (`malware==1.0.0 # note`) degrades to a Constraint/Unresolved and a confirmed
+        // Critical hit is silently downgraded to a Warn.
+        assert_eq!(
+            python_requirement_spec("malware==1.0.0 # pinned safe version"),
+            "==1.0.0"
+        );
+        assert_eq!(
+            python_requirement_spec("pkg==2.3.4\t# tab comment"),
+            "==2.3.4"
+        );
+        // No inline comment: unchanged (a `#` without leading whitespace is not a comment).
+        assert_eq!(python_requirement_spec("pkg>=1.0,<2.0"), ">=1.0,<2.0");
     }
 
     #[test]

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -2315,10 +2315,14 @@ fn walk_site_packages(
             rd.filter_map(Result::ok)
                 .map(|e| e.path())
                 .filter(|p| {
+                    // Case-INsensitive `.dist-info` match: on a case-insensitive filesystem a
+                    // distribution installed as `Foo-1.0.DIST-INFO` still imports, so a
+                    // case-sensitive suffix check would skip enumerating it and its name/version
+                    // would never be matched against the threat DB.
                     p.is_dir()
                         && p.file_name()
                             .and_then(|n| n.to_str())
-                            .is_some_and(|n| n.ends_with(".dist-info"))
+                            .is_some_and(|n| n.to_ascii_lowercase().ends_with(".dist-info"))
                 })
                 .collect()
         })

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -304,7 +304,7 @@ fn parse_package_json(text: &str) -> Option<Vec<DeclaredDependency>> {
 /// bare version (`1.2.3`) as an exact pin but a PARTIAL bare version as an X-range
 /// (`1` == `1.x.x`, `1.2` == `1.2.x`); explicit operators stay unresolved. This
 /// keeps a partial spec from being mistaken for a too-narrow exact match.
-fn npm_manifest_intent(spec: &str) -> VersionIntent {
+pub(crate) fn npm_manifest_intent(spec: &str) -> VersionIntent {
     match VersionIntent::from_explicit_version(spec) {
         VersionIntent::Exact(v) => match npm_partial_xrange(&v) {
             Some(range) => VersionIntent::from_pep440_specifier(&range),

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -663,10 +663,13 @@ fn parse_cargo_toml(text: &str) -> Option<Vec<DeclaredDependency>> {
                     out.push(DeclaredDependency {
                         name: real_name.to_string(),
                         ecosystem: Ecosystem::Crates,
-                        // Cargo semver requirement: not parsed; plain is exact,
-                        // a range stays unresolved.
+                        // A Cargo.toml requirement is a SemVer range: a plain `1.0.193` is
+                        // a caret requirement (^1.0.193); only `=1.0.193` is an exact pin.
+                        // Use from_cargo_version so the manifest scanner resolves the real
+                        // installed version (deps.dev), matching the CLI cargo path, rather
+                        // than pinning the literal token as Exact.
                         version: version
-                            .map(|v| VersionIntent::from_explicit_version(&v))
+                            .map(|v| VersionIntent::from_cargo_version(&v))
                             .unwrap_or(VersionIntent::Unspecified),
                         dev,
                     });
@@ -2887,6 +2890,31 @@ cc = "1.0"
         assert!(names.contains(&"cc"));
         let criterion = deps.iter().find(|d| d.name == "criterion").unwrap();
         assert!(criterion.dev);
+    }
+
+    #[test]
+    fn parse_cargo_toml_version_is_a_caret_constraint_not_exact() {
+        // A Cargo.toml requirement is a SemVer range: a plain `serde = "1.0.193"` is a
+        // caret requirement (^1.0.193), NOT an exact pin (only `=1.0.193` is). The manifest
+        // scanner must use from_cargo_version like the CLI cargo path, or it silently
+        // misses a threat whose resolved version differs from the literal token.
+        let text = r#"
+[package]
+name = "app"
+
+[dependencies]
+serde = "1.0.193"
+pinned = "=2.3.4"
+"#;
+        let deps = parse_cargo_toml(text).expect("valid TOML parses");
+        let serde = deps.iter().find(|d| d.name == "serde").unwrap();
+        assert!(
+            matches!(&serde.version, VersionIntent::Constraint { raw, .. } if raw == "1.0.193"),
+            "a plain Cargo.toml version is a caret constraint, got {:?}",
+            serde.version
+        );
+        let pinned = deps.iter().find(|d| d.name == "pinned").unwrap();
+        assert_eq!(pinned.version, VersionIntent::Exact("2.3.4".to_string()));
     }
 
     #[test]

--- a/crates/tirith-core/src/ecosystem_scan.rs
+++ b/crates/tirith-core/src/ecosystem_scan.rs
@@ -495,15 +495,18 @@ fn python_requirement_name(line: &str) -> Option<String> {
 }
 
 /// Extract the version specifier from a PEP 508 requirement line: the part after
-/// the name and optional `[extras]`, before any `;` environment marker. Returns an
-/// empty string for a bare name (which `from_pep440_specifier` maps to Unspecified).
+/// the name and optional `[extras]`. Returns an empty string for a bare name (which
+/// `from_pep440_specifier` maps to Unspecified). A `;` environment marker is KEPT in
+/// the specifier so a marker-qualified requirement degrades to an unresolved
+/// Constraint rather than a false exact pin.
 fn python_requirement_spec(line: &str) -> String {
-    // Drop the environment marker, then any `[extras]` so neither is mistaken for a
-    // specifier; the specifier starts at the first comparison operator.
-    let before_marker = line.split(';').next().unwrap_or(line);
-    let mut buf = String::with_capacity(before_marker.len());
+    // Drop any `[extras]` so its contents are not mistaken for a specifier. The
+    // environment marker is KEPT: a marker-qualified requirement only applies under an
+    // unsupported condition, so keeping the `;` makes `from_pep440_specifier` reject it
+    // (its `looks_like_plain_version` rejects `;`) and degrade to unresolved.
+    let mut buf = String::with_capacity(line.len());
     let mut depth = 0u32;
-    for c in before_marker.chars() {
+    for c in line.chars() {
         match c {
             '[' => depth += 1,
             ']' => depth = depth.saturating_sub(1),
@@ -2746,9 +2749,18 @@ git+https://github.com/x/y.git
 
     #[test]
     fn requirements_txt_pinned_dep_carries_version_intent() {
-        let deps = parse_requirements_txt("requests==2.28.1\nflask>=2.0,<3.0\nbare-pkg\n");
+        let deps = parse_requirements_txt(
+            "requests==2.28.1\nflask>=2.0,<3.0\nbare-pkg\nevil==1.0; python_version<\"3.9\"\n",
+        );
         let requests = deps.iter().find(|d| d.name == "requests").unwrap();
         assert_eq!(requests.version, VersionIntent::Exact("2.28.1".to_string()));
+        // A marker-qualified pin only applies conditionally -> unresolved, not Exact.
+        let evil = deps.iter().find(|d| d.name == "evil").unwrap();
+        assert!(
+            matches!(evil.version, VersionIntent::Constraint { parsed: None, .. }),
+            "marker-qualified pin must be an unresolved Constraint: {:?}",
+            evil.version
+        );
         let flask = deps.iter().find(|d| d.name == "flask").unwrap();
         assert!(matches!(
             flask.version,

--- a/crates/tirith-core/src/engine.rs
+++ b/crates/tirith-core/src/engine.rs
@@ -159,8 +159,12 @@ pub fn build_dsl_backing(
             // `package.*` casing-dependent — matching `requests` but missing
             // `Requests` (CodeRabbit M13 PR #132 R6-2).
             let name = pkg.name.to_lowercase();
-            let reputation =
-                package_reputation(pkg.ecosystem, &name, pkg.version.as_deref(), threat_db);
+            let reputation = package_reputation(
+                pkg.ecosystem,
+                &name,
+                pkg.version.as_version_str(),
+                threat_db,
+            );
             packages.push((pkg.ecosystem.to_string(), name, reputation));
         }
     }

--- a/crates/tirith-core/src/engine.rs
+++ b/crates/tirith-core/src/engine.rs
@@ -5007,8 +5007,7 @@ mod tests {
         let urls = verdict.urls_extracted_count.unwrap_or(0);
         assert!(
             !verdict.findings.is_empty() || urls > 0,
-            "env-assignment URL must still be extracted/analyzed, got {:?}",
-            verdict
+            "env-assignment URL must still be extracted/analyzed, got {verdict:?}"
         );
     }
 

--- a/crates/tirith-core/src/escalation.rs
+++ b/crates/tirith-core/src/escalation.rs
@@ -283,6 +283,57 @@ pub fn apply_action_overrides(
     (action, causal)
 }
 
+/// Assemble a verdict from a set of findings for a STATIC (non-session)
+/// analysis surface (ecosystem scan, artifact evaluation, generic file scan,
+/// `package inspect`), honoring policy levers that the bare
+/// [`Verdict::from_findings`] constructor does not.
+///
+/// Unlike [`post_process_verdict`], this takes no session/approval/escalation
+/// path (those need a session id and a command string); it applies, in order:
+/// per-rule severity overrides, action derivation, per-rule action overrides
+/// (`block`), then paranoia filtering. Paranoia must never downgrade an action
+/// an override forced to Block, mirroring `post_process_verdict`'s
+/// "never downgrade a causal action" rule. This closes the gap where
+/// `ecosystem_scan` built its verdict via `Verdict::from_findings` directly and
+/// so ignored `action_overrides`.
+pub fn finalize_static_verdict(
+    mut findings: Vec<Finding>,
+    policy: &crate::policy::Policy,
+    tier: u8,
+    timings: crate::verdict::Timings,
+) -> Verdict {
+    // 1. Per-rule severity overrides, applied before the action is derived.
+    for finding in &mut findings {
+        if let Some(override_sev) = policy.severity_override(&finding.rule_id) {
+            finding.severity = override_sev;
+        }
+    }
+
+    // 2. Derive the action from (overridden) severities.
+    let mut verdict = Verdict::from_findings(findings, tier, timings);
+
+    // 3. Per-rule action overrides operate on the full finding set, before any
+    // paranoia filter removes the causal finding.
+    let mut override_forced_block = false;
+    if !policy.action_overrides.is_empty() {
+        let (new_action, caused_by) =
+            apply_action_overrides(verdict.action, &verdict.findings, &policy.action_overrides);
+        if !caused_by.is_empty() && action_rank(new_action) > action_rank(verdict.action) {
+            override_forced_block = true;
+        }
+        verdict.action = new_action;
+    }
+
+    // 4. Paranoia filtering, but never downgrade an override-forced Block.
+    let pre_paranoia_action = verdict.action;
+    crate::engine::filter_findings_by_paranoia(&mut verdict, policy.paranoia);
+    if override_forced_block && action_rank(pre_paranoia_action) > action_rank(verdict.action) {
+        verdict.action = pre_paranoia_action;
+    }
+
+    verdict
+}
+
 /// True if `a` is at least as strict as `b`.
 fn action_gte(a: Action, b: Action) -> bool {
     action_rank(a) >= action_rank(b)
@@ -1697,6 +1748,60 @@ mod tests {
             mitre_id: None,
             custom_rule_id: None,
         }
+    }
+
+    #[test]
+    fn finalize_static_verdict_derives_action_from_findings() {
+        // Baseline: a Medium finding under the default policy derives Warn.
+        let findings = vec![make_finding(
+            RuleId::ThreatUnresolvedMaliciousPackage,
+            Severity::Medium,
+        )];
+        let policy = crate::policy::Policy::default();
+        let verdict = finalize_static_verdict(findings, &policy, 3, Timings::default());
+        assert_eq!(verdict.action, Action::Warn);
+        assert_eq!(verdict.findings.len(), 1);
+    }
+
+    #[test]
+    fn finalize_static_verdict_honors_action_override() {
+        // The bug this closes: a static verdict must honor `action_overrides`,
+        // which `Verdict::from_findings` ignored. A Medium finding (Warn) with a
+        // `block` override must Block.
+        let findings = vec![make_finding(
+            RuleId::ThreatUnresolvedMaliciousPackage,
+            Severity::Medium,
+        )];
+        let mut policy = crate::policy::Policy::default();
+        policy.action_overrides.insert(
+            "threat_unresolved_malicious_package".to_string(),
+            "block".to_string(),
+        );
+        let verdict = finalize_static_verdict(findings, &policy, 3, Timings::default());
+        assert_eq!(
+            verdict.action,
+            Action::Block,
+            "action_overrides must be honored at static-verdict assembly"
+        );
+        // The causal finding must survive (default paranoia keeps Medium, and an
+        // override-forced Block must never be downgraded).
+        assert!(verdict
+            .findings
+            .iter()
+            .any(|f| f.rule_id == RuleId::ThreatUnresolvedMaliciousPackage));
+    }
+
+    #[test]
+    fn finalize_static_verdict_applies_severity_override_before_action() {
+        // Lowering a High finding to Info via severity_override drops it to Allow
+        // (Info derives Allow, and default paranoia removes it).
+        let findings = vec![make_finding(RuleId::ThreatMaliciousPackage, Severity::High)];
+        let mut policy = crate::policy::Policy::default();
+        policy
+            .severity_overrides
+            .insert("threat_malicious_package".to_string(), Severity::Info);
+        let verdict = finalize_static_verdict(findings, &policy, 3, Timings::default());
+        assert_eq!(verdict.action, Action::Allow);
     }
 
     fn empty_session() -> SessionWarnings {

--- a/crates/tirith-core/src/escalation.rs
+++ b/crates/tirith-core/src/escalation.rs
@@ -315,11 +315,23 @@ pub fn finalize_static_verdict(
     // 3. Per-rule action overrides operate on the full finding set, before any
     // paranoia filter removes the causal finding.
     let mut override_forced_block = false;
+    let mut causal_findings: Vec<Finding> = Vec::new();
     if !policy.action_overrides.is_empty() {
         let (new_action, caused_by) =
             apply_action_overrides(verdict.action, &verdict.findings, &policy.action_overrides);
         if !caused_by.is_empty() && action_rank(new_action) > action_rank(verdict.action) {
             override_forced_block = true;
+            // Snapshot the findings that forced the override BEFORE paranoia can drop
+            // them, so a restored Block still carries its explanation (mirrors
+            // `post_process_verdict`).
+            let causal: std::collections::HashSet<&str> =
+                caused_by.iter().map(String::as_str).collect();
+            causal_findings = verdict
+                .findings
+                .iter()
+                .filter(|f| causal.contains(f.rule_id.to_string().as_str()))
+                .cloned()
+                .collect();
         }
         verdict.action = new_action;
     }
@@ -329,6 +341,20 @@ pub fn finalize_static_verdict(
     crate::engine::filter_findings_by_paranoia(&mut verdict, policy.paranoia);
     if override_forced_block && action_rank(pre_paranoia_action) > action_rank(verdict.action) {
         verdict.action = pre_paranoia_action;
+        // Re-add any causal finding paranoia removed, so the restored Block is not left
+        // without an explaining finding (a static caller would otherwise see a blocking
+        // verdict with no cause).
+        for cf in &causal_findings {
+            let already_present = verdict.findings.iter().any(|ef| {
+                ef.rule_id == cf.rule_id
+                    && ef.severity == cf.severity
+                    && ef.title == cf.title
+                    && ef.description == cf.description
+            });
+            if !already_present {
+                verdict.findings.push(cf.clone());
+            }
+        }
     }
 
     verdict
@@ -1802,6 +1828,31 @@ mod tests {
             .insert("threat_malicious_package".to_string(), Severity::Info);
         let verdict = finalize_static_verdict(findings, &policy, 3, Timings::default());
         assert_eq!(verdict.action, Action::Allow);
+    }
+
+    #[test]
+    fn finalize_static_verdict_reexposes_override_causal_finding_after_paranoia() {
+        // An Info finding (default paranoia removes Info) carrying a `block` override
+        // must still Block AND keep its causal finding, so the restored Block is not
+        // left without an explanation.
+        let findings = vec![make_finding(
+            RuleId::ThreatUnresolvedMaliciousPackage,
+            Severity::Info,
+        )];
+        let mut policy = crate::policy::Policy::default();
+        policy.action_overrides.insert(
+            "threat_unresolved_malicious_package".to_string(),
+            "block".to_string(),
+        );
+        let verdict = finalize_static_verdict(findings, &policy, 3, Timings::default());
+        assert_eq!(verdict.action, Action::Block, "override must force Block");
+        assert!(
+            verdict
+                .findings
+                .iter()
+                .any(|f| f.rule_id == RuleId::ThreatUnresolvedMaliciousPackage),
+            "the override-causal finding must be re-exposed after paranoia filtering"
+        );
     }
 
     fn empty_session() -> SessionWarnings {

--- a/crates/tirith-core/src/extract.rs
+++ b/crates/tirith-core/src/extract.rs
@@ -1090,14 +1090,12 @@ pub fn extract_urls(input: &str, shell: ShellType) -> Vec<ExtractedUrl> {
                         == Some("tirith")
                     {
                         0
-                    } else if let Some(at) = segment
-                        .args
-                        .iter()
-                        .position(|a| command_base_name(a) == "tirith")
-                    {
-                        at + 1
                     } else {
-                        return None;
+                        segment
+                            .args
+                            .iter()
+                            .position(|a| command_base_name(a) == "tirith")?
+                            + 1
                     };
                 // Skip flags (e.g. `--quiet`) to land on the subcommand token.
                 let mut i = start_from;

--- a/crates/tirith-core/src/install_txn.rs
+++ b/crates/tirith-core/src/install_txn.rs
@@ -24,6 +24,7 @@ use crate::rules::threatintel::{self, PackageRef};
 use crate::threatdb::{Ecosystem, ThreatDb};
 use crate::tokenize::{self, ShellType};
 use crate::verdict::{Action, Evidence, Finding, RuleId, Severity, Verdict};
+use crate::version_intent::VersionIntent;
 
 /// Which package manager an install transaction drives. (The `url` form of
 /// `tirith install` is handled by the CLI via [`crate::runner`], not here.)
@@ -641,15 +642,15 @@ fn parse_docker_specs(user_args: &[String]) -> Vec<PackageRef> {
                 Some(reg) => format!("{reg}/{image}"),
                 None => image,
             };
-            let version = match (tag, digest) {
-                (_, Some(d)) => Some(d),
-                (Some(t), None) => Some(t),
-                (None, None) => Some("latest".to_string()),
+            let version_token = match (tag, digest) {
+                (_, Some(d)) => d,
+                (Some(t), None) => t,
+                (None, None) => "latest".to_string(),
             };
             out.push(PackageRef {
                 ecosystem: Ecosystem::Docker,
                 name,
-                version,
+                version: VersionIntent::from_explicit_version(&version_token),
             });
         }
         i += 1;
@@ -704,9 +705,9 @@ fn parse_go_specs(user_args: &[String]) -> Vec<PackageRef> {
         if arg.starts_with('-') {
             continue;
         }
-        let (name, version) = match arg.rsplit_once('@') {
-            Some((n, v)) if !n.is_empty() && !v.is_empty() => (n, Some(v.to_string())),
-            _ => (arg.as_str(), Some("latest".to_string())),
+        let (name, version_token) = match arg.rsplit_once('@') {
+            Some((n, v)) if !n.is_empty() && !v.is_empty() => (n, v.to_string()),
+            _ => (arg.as_str(), "latest".to_string()),
         };
         // Reject local-path targets (`./cmd/foo`, `/abs/...`, `~/repo/...`):
         // they're filesystem paths, not registry modules.
@@ -726,7 +727,7 @@ fn parse_go_specs(user_args: &[String]) -> Vec<PackageRef> {
         out.push(PackageRef {
             ecosystem: Ecosystem::Go,
             name: name.to_string(),
-            version,
+            version: VersionIntent::from_explicit_version(&version_token),
         });
     }
     out
@@ -765,7 +766,7 @@ fn gather_package_signals(
         ecosystem: eco,
         name: pkg.name.clone(),
         // M6 ch6 — carry version through so OSV can pin to (eco, name, version).
-        version: pkg.version.clone(),
+        version: pkg.version.as_version_str().map(str::to_string),
         threat_db_missing: db.is_none(),
         name_vs_popular,
         malicious_typosquat_of,
@@ -1505,7 +1506,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::Npm,
             name: "raect".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         let existing = vec![Finding {
             rule_id: RuleId::ThreatPackageSimilarName,
@@ -1549,7 +1550,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::PyPI,
             name: "reqeusts".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         use crate::package_risk::NameVsPopular;
         let signals = PackageSignals {
@@ -1691,21 +1692,24 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::Docker);
         assert_eq!(pkgs[0].name, "library/alpine");
-        assert_eq!(pkgs[0].version.as_deref(), Some("latest"));
+        assert_eq!(pkgs[0].version.as_version_str(), Some("latest"));
 
         // Explicit tag.
         let pkgs = parse_docker_specs(&["alpine:3.18".to_string()]);
-        assert_eq!(pkgs[0].version.as_deref(), Some("3.18"));
+        assert_eq!(pkgs[0].version.as_version_str(), Some("3.18"));
 
         // Digest form — version carries `sha256:...`.
         let pkgs = parse_docker_specs(&["alpine@sha256:abcdef0123456789".to_string()]);
         assert_eq!(pkgs.len(), 1);
-        assert_eq!(pkgs[0].version.as_deref(), Some("sha256:abcdef0123456789"));
+        assert_eq!(
+            pkgs[0].version.as_version_str(),
+            Some("sha256:abcdef0123456789")
+        );
 
         // Registry prefix preserved.
         let pkgs = parse_docker_specs(&["ghcr.io/owner/img:v1".to_string()]);
         assert_eq!(pkgs[0].name, "ghcr.io/owner/img");
-        assert_eq!(pkgs[0].version.as_deref(), Some("v1"));
+        assert_eq!(pkgs[0].version.as_version_str(), Some("v1"));
 
         // Flags are skipped.
         let pkgs =
@@ -1748,15 +1752,15 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::Go);
         assert_eq!(pkgs[0].name, "github.com/spf13/cobra");
-        assert_eq!(pkgs[0].version.as_deref(), Some("latest"));
+        assert_eq!(pkgs[0].version.as_version_str(), Some("latest"));
 
         // Explicit @latest.
         let pkgs = parse_go_specs(&["github.com/spf13/cobra@latest".to_string()]);
-        assert_eq!(pkgs[0].version.as_deref(), Some("latest"));
+        assert_eq!(pkgs[0].version.as_version_str(), Some("latest"));
 
         // Explicit @v1.8.0.
         let pkgs = parse_go_specs(&["github.com/spf13/cobra@v1.8.0".to_string()]);
-        assert_eq!(pkgs[0].version.as_deref(), Some("v1.8.0"));
+        assert_eq!(pkgs[0].version.as_version_str(), Some("v1.8.0"));
 
         // A non-module-shaped bareword (`nginx`) is skipped.
         let pkgs = parse_go_specs(&["nginx".to_string()]);
@@ -1852,7 +1856,7 @@ mod tests {
         assert_eq!(plan.packages[0].reference.ecosystem, Ecosystem::Docker);
         assert_eq!(plan.packages[0].reference.name, "library/alpine");
         assert_eq!(
-            plan.packages[0].reference.version.as_deref(),
+            plan.packages[0].reference.version.as_version_str(),
             Some("latest")
         );
     }
@@ -1879,7 +1883,7 @@ mod tests {
         assert_eq!(plan.packages.len(), 1);
         assert_eq!(plan.packages[0].reference.name, "github.com/spf13/cobra");
         assert_eq!(
-            plan.packages[0].reference.version.as_deref(),
+            plan.packages[0].reference.version.as_version_str(),
             Some("latest")
         );
     }
@@ -1943,7 +1947,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::Npm,
             name: "missing-pkg".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         let provenance = ApiProvenance {
             source: "npm".to_string(),
@@ -1975,7 +1979,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::Npm,
             name: "some-pkg".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         let provenance = ApiProvenance {
             source: "npm".to_string(),
@@ -2004,7 +2008,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::Npm,
             name: "fresh-pkg".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         let provenance = ApiProvenance {
             source: "npm".to_string(),
@@ -2037,7 +2041,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::PyPI,
             name: "reqeusts".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         let provenance = ApiProvenance {
             source: "pypi".to_string(),
@@ -2070,7 +2074,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::Npm,
             name: "unknown-pkg".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         let provenance = ApiProvenance {
             source: "npm".to_string(),
@@ -2106,7 +2110,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::PyPI,
             name: "unfamiliar".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         let provenance = ApiProvenance {
             source: "pypi".to_string(),
@@ -2151,7 +2155,7 @@ mod tests {
         let pkg = PackageRef {
             ecosystem: Ecosystem::Npm,
             name: "test-pkg".to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         };
         let breakdown = breakdown_with_provenance(
             "test-pkg",

--- a/crates/tirith-core/src/lib.rs
+++ b/crates/tirith-core/src/lib.rs
@@ -82,6 +82,7 @@ pub mod url_validate;
 pub mod util;
 pub mod util_build_dirs;
 pub mod verdict;
+pub mod version_intent;
 pub mod webhook;
 
 #[cfg(unix)]

--- a/crates/tirith-core/src/license.rs
+++ b/crates/tirith-core/src/license.rs
@@ -258,10 +258,7 @@ fn decode_signed_token(
 
     // exp is required on signed tokens and must be an i64 Unix timestamp.
     // Wrong type → None (fail-closed), and comparison is exclusive.
-    let exp = match payload.get("exp") {
-        Some(v) => v.as_i64()?,
-        None => return None,
-    };
+    let exp = payload.get("exp")?.as_i64()?;
     if now.timestamp() >= exp {
         return None;
     }

--- a/crates/tirith-core/src/mcp/output_filter.rs
+++ b/crates/tirith-core/src/mcp/output_filter.rs
@@ -333,6 +333,7 @@ fn is_injection_seed_rule(rule_id: RuleId) -> bool {
         | RuleId::ThreatMaliciousIp
         | RuleId::ThreatPackageTyposquat
         | RuleId::ThreatPackageSimilarName
+        | RuleId::ThreatUnresolvedMaliciousPackage
         | RuleId::ThreatMaliciousUrl
         | RuleId::ThreatPhishingUrl
         | RuleId::ThreatTorExitNode

--- a/crates/tirith-core/src/mcp/output_filter.rs
+++ b/crates/tirith-core/src/mcp/output_filter.rs
@@ -1564,7 +1564,7 @@ mod tests {
         blank_spans(&mut text, &[2..4, 6..8]);
         assert_eq!(
             text,
-            format!("01{p}45{p}89", p = REDACTION_PLACEHOLDER),
+            format!("01{REDACTION_PLACEHOLDER}45{REDACTION_PLACEHOLDER}89"),
             "two disjoint spans replaced in place"
         );
 

--- a/crates/tirith-core/src/package_risk.rs
+++ b/crates/tirith-core/src/package_risk.rs
@@ -945,8 +945,7 @@ pub fn api_factors(p: &ApiProvenance) -> Vec<RiskFactor> {
                     points: OWNERSHIP_TRANSFER_DIFF_WEIGHT as i32,
                     detail: format!(
                         "Snapshot diff: every previous maintainer is gone and a new set is in \
-                         place. Contributing {} points.",
-                        OWNERSHIP_TRANSFER_DIFF_WEIGHT
+                         place. Contributing {OWNERSHIP_TRANSFER_DIFF_WEIGHT} points."
                     ),
                 });
             }

--- a/crates/tirith-core/src/parse.rs
+++ b/crates/tirith-core/src/parse.rs
@@ -167,11 +167,8 @@ impl UrlLike {
 /// `Url::parse` IDNA-normalizes the host, hiding the homograph/punycode signals
 /// the hostname rules depend on.
 pub fn extract_raw_host(url_str: &str) -> Option<String> {
-    let after_scheme = if let Some(idx) = url_str.find("://") {
-        &url_str[idx + 3..]
-    } else {
-        return None;
-    };
+    let idx = url_str.find("://")?;
+    let after_scheme = &url_str[idx + 3..];
 
     let authority_end = after_scheme
         .find(['/', '?', '#'])

--- a/crates/tirith-core/src/persistence.rs
+++ b/crates/tirith-core/src/persistence.rs
@@ -933,8 +933,7 @@ mod tests {
         assert_eq!(added.len(), 1);
         assert!(
             !added[0].contains("AKIAIOSFODNN7EXAMPLE"),
-            "credential must be redacted, got {:?}",
-            added
+            "credential must be redacted, got {added:?}"
         );
         assert!(added[0].contains("[REDACTED"));
     }

--- a/crates/tirith-core/src/policy_validate.rs
+++ b/crates/tirith-core/src/policy_validate.rs
@@ -517,8 +517,7 @@ fn validate_scan_config(policy: &crate::policy::Policy, issues: &mut Vec<PolicyI
             issues.push(PolicyIssue {
                 level: IssueLevel::Error,
                 message: format!(
-                    "scan.fail_on: invalid severity '{}' (valid: INFO, LOW, MEDIUM, HIGH, CRITICAL)",
-                    fail_on
+                    "scan.fail_on: invalid severity '{fail_on}' (valid: INFO, LOW, MEDIUM, HIGH, CRITICAL)"
                 ),
                 field: Some("scan.fail_on".into()),
             });

--- a/crates/tirith-core/src/repo_hooks.rs
+++ b/crates/tirith-core/src/repo_hooks.rs
@@ -2103,8 +2103,7 @@ mod tests {
             findings
                 .iter()
                 .any(|f| f.severity == Severity::Info && f.detail.contains("unreadable")),
-            "a blocked lefthook.yml must surface the Info unreadable finding under a git leader, got {:?}",
-            findings
+            "a blocked lefthook.yml must surface the Info unreadable finding under a git leader, got {findings:?}"
         );
     }
 

--- a/crates/tirith-core/src/repo_mismatch.rs
+++ b/crates/tirith-core/src/repo_mismatch.rs
@@ -245,10 +245,11 @@ fn parse_known_git_host(url: &str) -> Option<KnownGitHost> {
         (HostKind::GitLab, rest)
     } else if let Some(rest) = url.strip_prefix("https://bitbucket.org/") {
         (HostKind::Bitbucket, rest)
-    } else if let Some(rest) = url.strip_prefix("http://bitbucket.org/") {
-        (HostKind::Bitbucket, rest)
     } else {
-        return None;
+        (
+            HostKind::Bitbucket,
+            url.strip_prefix("http://bitbucket.org/")?,
+        )
     };
     let mut parts = after_host.split('/');
     let owner = parts.next().filter(|p| !p.is_empty())?.to_string();

--- a/crates/tirith-core/src/rules/codefile.rs
+++ b/crates/tirith-core/src/rules/codefile.rs
@@ -462,8 +462,7 @@ fn emit_exfil_finding(findings: &mut Vec<Finding>, call_snippet: &str, sens_str:
         severity: Severity::Medium,
         title: "Suspicious code exfiltration pattern".to_string(),
         description: format!(
-            "HTTP call passes sensitive data '{}' as argument — potential data exfiltration",
-            sens_str
+            "HTTP call passes sensitive data '{sens_str}' as argument — potential data exfiltration"
         ),
         evidence: vec![Evidence::CommandPattern {
             pattern: "sensitive data inside HTTP call arguments".to_string(),

--- a/crates/tirith-core/src/rules/mcpdrift.rs
+++ b/crates/tirith-core/src/rules/mcpdrift.rs
@@ -1090,8 +1090,7 @@ mod tests {
         assert_eq!(
             drift_finding.severity,
             Severity::High,
-            "drift adding a tool outside the allowed set must be High: {:?}",
-            drift_finding,
+            "drift adding a tool outside the allowed set must be High: {drift_finding:?}",
         );
     }
 
@@ -1132,8 +1131,7 @@ mod tests {
         assert_eq!(
             drift_finding.severity,
             Severity::Medium,
-            "drift adding only allowed tools must stay Medium: {:?}",
-            drift_finding,
+            "drift adding only allowed tools must stay Medium: {drift_finding:?}",
         );
     }
 
@@ -1204,8 +1202,7 @@ mod tests {
             drift_finding.severity,
             Severity::High,
             "an Added server exposing a tool outside the allowed set must be \
-             High (symmetric with the Changed-path ladder): {:?}",
-            drift_finding,
+             High (symmetric with the Changed-path ladder): {drift_finding:?}",
         );
     }
 
@@ -1240,8 +1237,7 @@ mod tests {
         assert_eq!(
             drift_finding.severity,
             Severity::Medium,
-            "an Added server with only allowed tools must stay Medium: {:?}",
-            drift_finding,
+            "an Added server with only allowed tools must stay Medium: {drift_finding:?}",
         );
     }
 
@@ -1278,8 +1274,7 @@ mod tests {
             drift_finding.severity,
             Severity::Medium,
             "an Added server unlisted in mcp_allowed_tools is unconstrained \
-             and must stay Medium: {:?}",
-            drift_finding,
+             and must stay Medium: {drift_finding:?}",
         );
     }
 
@@ -1312,8 +1307,7 @@ mod tests {
             drift_finding.severity,
             Severity::High,
             "an Added server under an empty `[]` allow-list exposing any tool \
-             must be High: {:?}",
-            drift_finding,
+             must be High: {drift_finding:?}",
         );
     }
 
@@ -1347,8 +1341,7 @@ mod tests {
             Severity::Medium,
             "an Added server with no declared tools must stay Medium even \
              under an empty allow-list — there is no tool to violate the \
-             ladder: {:?}",
-            drift_finding,
+             ladder: {drift_finding:?}",
         );
     }
 

--- a/crates/tirith-core/src/rules/prompt_injection.rs
+++ b/crates/tirith-core/src/rules/prompt_injection.rs
@@ -468,8 +468,7 @@ mod tests {
         let findings = check("This is a normal log line with no injection markers.\n");
         assert!(
             findings.is_empty(),
-            "clean text must not fire: {:?}",
-            findings
+            "clean text must not fire: {findings:?}"
         );
     }
 
@@ -591,8 +590,7 @@ mod tests {
         let findings = check("From now on the build is faster and the tests are green.");
         assert!(
             findings.is_empty(),
-            "benign 'from now on ...' prose must not fire: {:?}",
-            findings
+            "benign 'from now on ...' prose must not fire: {findings:?}"
         );
     }
 
@@ -604,8 +602,7 @@ mod tests {
         let findings = check("From now on your build is faster, and the warning is ignored.");
         assert!(
             findings.is_empty(),
-            "benign 'from now on your/ignored ...' prose must not fire: {:?}",
-            findings
+            "benign 'from now on your/ignored ...' prose must not fire: {findings:?}"
         );
     }
 

--- a/crates/tirith-core/src/rules/rendered.rs
+++ b/crates/tirith-core/src/rules/rendered.rs
@@ -566,6 +566,8 @@ fn check_markdown_comments(
 /// Check PDF bytes for hidden text via sub-pixel scale transforms: font-size 0
 /// or scales that render text below 1px — invisible to humans but extracted by
 /// AI tools. Detection is free (ADR-13).
+const PDF_PAGE_CONTENT_BYTES_CAP: usize = 16 * 1024 * 1024;
+
 pub fn check_pdf(raw_bytes: &[u8]) -> Vec<Finding> {
     let mut findings = Vec::new();
 
@@ -580,7 +582,7 @@ pub fn check_pdf(raw_bytes: &[u8]) -> Vec<Finding> {
     let mut hidden_texts: Vec<(u32, String)> = Vec::new();
 
     for (page_num, page_id) in doc.get_pages() {
-        let content = match doc.get_page_content(page_id) {
+        let content = match doc.get_page_content_with_limit(page_id, PDF_PAGE_CONTENT_BYTES_CAP) {
             Ok(c) => c,
             Err(_) => continue,
         };

--- a/crates/tirith-core/src/rules/threatintel.rs
+++ b/crates/tirith-core/src/rules/threatintel.rs
@@ -1,34 +1,41 @@
 use std::net::Ipv4Addr;
 
 use crate::extract::ExtractedUrl;
-use crate::threatdb::{self, Ecosystem, ThreatDb};
+use crate::threatdb::{self, Ecosystem, PackageThreatAssessment, ThreatDb};
 use crate::tokenize::{Segment, ShellType};
 use crate::verdict::{Evidence, Finding, RuleId, Severity};
+use crate::version_intent::VersionIntent;
 
 /// A reference to a package extracted from a shell command.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PackageRef {
     pub ecosystem: Ecosystem,
     pub name: String,
-    pub version: Option<String>,
+    /// How the version was expressed. An unpinned install is `Unspecified`; an
+    /// unparsed range is a `Constraint` and is treated as unresolved, never
+    /// silently as an exact pin.
+    pub version: VersionIntent,
 }
 
-/// Split a `name<sep>version` string (e.g. `serde@1.0`). `(name, None)` when
-/// `sep` is absent or the version part is empty.
-fn split_name_version(s: &str, sep: char) -> (&str, Option<String>) {
+/// Split a `name<sep>version` string (e.g. `serde@1.0`) into a name and an
+/// explicit [`VersionIntent`]. The version part is interpreted as an explicit
+/// single token (exact pin if plain, unresolved constraint otherwise).
+fn split_name_version(s: &str, sep: char) -> (&str, VersionIntent) {
     if let Some(pos) = s.find(sep) {
         let name = &s[..pos];
         let ver = &s[pos + 1..];
-        (
-            name,
-            if ver.is_empty() {
-                None
-            } else {
-                Some(ver.to_string())
-            },
-        )
+        (name, VersionIntent::from_explicit_version(ver))
     } else {
-        (s, None)
+        (s, VersionIntent::Unspecified)
+    }
+}
+
+/// Build a [`VersionIntent`] from an optional explicit version token; `None`
+/// (and empty) becomes [`Unspecified`](VersionIntent::Unspecified).
+fn intent_from_opt_token(token: Option<&str>) -> VersionIntent {
+    match token {
+        Some(v) => VersionIntent::from_explicit_version(v),
+        None => VersionIntent::Unspecified,
     }
 }
 
@@ -168,7 +175,10 @@ fn extract_pip_packages(args: &[String], packages: &mut Vec<PackageRef>) {
             continue;
         }
 
-        let version = extract_pip_version(rest);
+        // `rest` is the full PEP 440 specifier tail (e.g. `==1.2.3`, `>=1.4.4`,
+        // `>=1.2,<2.0`, or empty). Parse it so an exact pin stays exact and a
+        // range is resolved/excluded properly instead of being dropped.
+        let version = VersionIntent::from_pep440_specifier(rest);
         let normalized = normalize_pypi_name(name_part);
 
         packages.push(PackageRef {
@@ -185,17 +195,6 @@ fn normalize_pypi_name(name: &str) -> String {
         .chars()
         .map(|c| if c == '_' || c == '.' { '-' } else { c })
         .collect()
-}
-
-/// Exact pip version — only `==` (exact match) yields a version.
-fn extract_pip_version(spec: &str) -> Option<String> {
-    if let Some(ver) = spec.strip_prefix("==") {
-        let v = ver.trim();
-        if !v.is_empty() {
-            return Some(v.to_string());
-        }
-    }
-    None
 }
 
 /// Flags for npm/yarn/pnpm that consume the next argument.
@@ -301,7 +300,7 @@ fn parse_npm_package_spec(spec: &str) -> Option<PackageRef> {
     Some(PackageRef {
         ecosystem: Ecosystem::Npm,
         name: name.to_string(),
-        version: version.map(|v| v.to_string()),
+        version: intent_from_opt_token(version),
     })
 }
 
@@ -342,8 +341,10 @@ fn extract_cargo_packages(args: &[String], packages: &mut Vec<PackageRef>) {
                 if lower == "--version" || lower == "--vers" {
                     if let Some(ver) = iter.next() {
                         if let Some(last) = packages.last_mut() {
-                            if last.ecosystem == Ecosystem::Crates && last.version.is_none() {
-                                last.version = Some(ver.to_string());
+                            if last.ecosystem == Ecosystem::Crates
+                                && matches!(last.version, VersionIntent::Unspecified)
+                            {
+                                last.version = VersionIntent::from_explicit_version(ver);
                             }
                         }
                     }
@@ -394,8 +395,10 @@ fn extract_gem_packages(args: &[String], packages: &mut Vec<PackageRef>) {
                 if lower == "--version" || lower == "-v" {
                     if let Some(ver) = iter.next() {
                         if let Some(last) = packages.last_mut() {
-                            if last.ecosystem == Ecosystem::RubyGems && last.version.is_none() {
-                                last.version = Some(ver.to_string());
+                            if last.ecosystem == Ecosystem::RubyGems
+                                && matches!(last.version, VersionIntent::Unspecified)
+                            {
+                                last.version = VersionIntent::from_explicit_version(ver);
                             }
                         }
                     }
@@ -503,8 +506,10 @@ fn extract_dotnet_packages(args: &[String], packages: &mut Vec<PackageRef>) {
             if lower == "--version" || lower == "-v" {
                 if let Some(ver) = iter.next() {
                     if let Some(last) = packages.last_mut() {
-                        if last.ecosystem == Ecosystem::NuGet && last.version.is_none() {
-                            last.version = Some(ver.to_string());
+                        if last.ecosystem == Ecosystem::NuGet
+                            && matches!(last.version, VersionIntent::Unspecified)
+                        {
+                            last.version = VersionIntent::from_explicit_version(ver);
                         }
                     }
                 }
@@ -519,7 +524,7 @@ fn extract_dotnet_packages(args: &[String], packages: &mut Vec<PackageRef>) {
         packages.push(PackageRef {
             ecosystem: Ecosystem::NuGet,
             name: arg.to_string(),
-            version: None,
+            version: VersionIntent::Unspecified,
         });
     }
 }
@@ -535,13 +540,7 @@ fn extract_maven_packages(args: &[String], packages: &mut Vec<PackageRef>) {
             let parts: Vec<&str> = coord.splitn(4, ':').collect();
             if parts.len() >= 2 {
                 let name = format!("{}:{}", parts[0], parts[1]);
-                let version = parts.get(2).and_then(|v| {
-                    if v.is_empty() {
-                        None
-                    } else {
-                        Some(v.to_string())
-                    }
-                });
+                let version = intent_from_opt_token(parts.get(2).copied());
                 packages.push(PackageRef {
                     ecosystem: Ecosystem::Maven,
                     name,
@@ -559,13 +558,7 @@ fn extract_maven_packages(args: &[String], packages: &mut Vec<PackageRef>) {
         let parts: Vec<&str> = arg.splitn(4, ':').collect();
         if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
             let name = format!("{}:{}", parts[0], parts[1]);
-            let version = parts.get(2).and_then(|v| {
-                if v.is_empty() {
-                    None
-                } else {
-                    Some(v.to_string())
-                }
-            });
+            let version = intent_from_opt_token(parts.get(2).copied());
             packages.push(PackageRef {
                 ecosystem: Ecosystem::Maven,
                 name,
@@ -604,8 +597,9 @@ pub fn extract_ipv4_from_token(token: &str) -> Option<Ipv4Addr> {
     ip_str.parse::<Ipv4Addr>().ok()
 }
 
-/// Map threat-DB confidence to finding severity.
-fn confidence_to_severity(c: threatdb::Confidence) -> Severity {
+/// Map threat-DB confidence to finding severity. `pub(crate)` so the ecosystem
+/// scan path (A1e) maps an `ExactMatch` to the same severity as this command path.
+pub(crate) fn confidence_to_severity(c: threatdb::Confidence) -> Severity {
     match c {
         threatdb::Confidence::Confirmed => Severity::Critical,
         threatdb::Confidence::Medium => Severity::Medium,
@@ -668,6 +662,71 @@ fn ip_rule_for_source(source: threatdb::ThreatSource) -> (RuleId, Severity, &'st
     }
 }
 
+/// Which unresolved shape produced a [`RuleId::ThreatUnresolvedMaliciousPackage`].
+#[derive(Debug, Clone, Copy)]
+enum UnresolvedKind {
+    /// No definite version (unpinned install, or a constraint/affected version
+    /// outside the supported subset).
+    Unresolved,
+    /// A constraint that provably overlaps the affected versions.
+    ConstraintIntersects,
+}
+
+/// Build the Medium/Warn finding for a malicious-package name whose installed
+/// version could not be resolved to a definite hit. Advises pinning to a known
+/// non-affected version (the install-path resolution note).
+fn unresolved_package_finding(
+    pkg: &PackageRef,
+    summary: &threatdb::ThreatMatchSummary,
+    affected_versions: &[String],
+    kind: UnresolvedKind,
+) -> Finding {
+    let affected_list = if affected_versions.is_empty() {
+        "unknown".to_string()
+    } else {
+        affected_versions.join(", ")
+    };
+    let request_desc = match kind {
+        UnresolvedKind::Unresolved => match &pkg.version {
+            VersionIntent::Unspecified => "No version was pinned".to_string(),
+            VersionIntent::Constraint { raw, .. } => {
+                format!("The constraint '{raw}' could not be fully resolved")
+            }
+            // Exact/Resolved never reach the unresolved path.
+            other => format!("The request '{other:?}' could not be resolved"),
+        },
+        UnresolvedKind::ConstraintIntersects => match pkg.version.constraint_raw() {
+            Some(raw) => format!("The constraint '{raw}' overlaps the affected versions"),
+            None => "The request overlaps the affected versions".to_string(),
+        },
+    };
+    Finding {
+        rule_id: RuleId::ThreatUnresolvedMaliciousPackage,
+        severity: Severity::Medium,
+        title: format!(
+            "Unresolved malicious {} package: {}",
+            pkg.ecosystem, pkg.name
+        ),
+        description: format!(
+            "Package '{}' in {} is flagged as malicious by {} for specific versions \
+             ({affected_list}). {request_desc}, so the resolver might install an affected \
+             version. Pin an exact non-affected version (or choose a different package) to \
+             clear this warning.",
+            pkg.name, pkg.ecosystem, summary.source_label,
+        ),
+        evidence: vec![Evidence::ThreatIntel {
+            source: summary.source_label.clone(),
+            threat_type: "unresolved_malicious_package".to_string(),
+            confidence: summary.confidence,
+            reference: summary.reference_url.clone(),
+        }],
+        human_view: None,
+        agent_view: None,
+        mitre_id: None,
+        custom_rule_id: None,
+    }
+}
+
 /// Check input against the local threat intelligence database. Fail-open: a
 /// `None` db returns no findings. All lookups are in-memory, no network I/O.
 pub fn check(
@@ -689,35 +748,68 @@ pub fn check(
     for pkg in &packages {
         let db_eco = pkg.ecosystem;
 
-        if let Some(m) = db.check_package(db_eco, &pkg.name, pkg.version.as_deref()) {
-            findings.push(Finding {
-                rule_id: RuleId::ThreatMaliciousPackage,
-                severity: confidence_to_severity(m.confidence),
-                title: format!("Known malicious {} package: {}", pkg.ecosystem, pkg.name),
-                description: format!(
-                    "Package '{}' in {} is flagged as malicious by {}. {}",
-                    pkg.name,
-                    pkg.ecosystem,
-                    m.source.label(),
-                    if m.all_versions_malicious {
-                        "All versions are affected."
-                    } else {
-                        "Specific version(s) affected."
-                    }
-                ),
-                evidence: vec![Evidence::ThreatIntel {
-                    source: m.source.label().to_string(),
-                    threat_type: "malicious_package".to_string(),
-                    confidence: m.confidence,
-                    reference: m.reference_url,
-                }],
-                human_view: None,
-                agent_view: None,
-                mitre_id: None,
-                custom_rule_id: None,
-            });
-            // A confirmed-malicious finding suffices — skip the typosquat checks.
-            continue;
+        match db.assess_package(db_eco, &pkg.name, &pkg.version) {
+            PackageThreatAssessment::ExactMatch(summary) => {
+                findings.push(Finding {
+                    rule_id: RuleId::ThreatMaliciousPackage,
+                    severity: confidence_to_severity(summary.confidence),
+                    title: format!("Known malicious {} package: {}", pkg.ecosystem, pkg.name),
+                    description: format!(
+                        "Package '{}' in {} is flagged as malicious by {}. {}",
+                        pkg.name,
+                        pkg.ecosystem,
+                        summary.source_label,
+                        if summary.all_versions_malicious {
+                            "All versions are affected."
+                        } else {
+                            "Specific version(s) affected."
+                        }
+                    ),
+                    evidence: vec![Evidence::ThreatIntel {
+                        source: summary.source_label.clone(),
+                        threat_type: "malicious_package".to_string(),
+                        confidence: summary.confidence,
+                        reference: summary.reference_url.clone(),
+                    }],
+                    human_view: None,
+                    agent_view: None,
+                    mitre_id: None,
+                    custom_rule_id: None,
+                });
+                // A confirmed exact hit suffices — skip the weaker name-similarity
+                // checks for this package.
+                continue;
+            }
+            PackageThreatAssessment::ConstraintIntersectsAffected {
+                summary,
+                affected_versions,
+            } => {
+                findings.push(unresolved_package_finding(
+                    pkg,
+                    &summary,
+                    &affected_versions,
+                    UnresolvedKind::ConstraintIntersects,
+                ));
+                // Do NOT short-circuit: the name may ALSO be a typosquat or near
+                // a popular package, so fall through to those checks.
+            }
+            PackageThreatAssessment::Unresolved {
+                summary,
+                affected_versions,
+                ..
+            } => {
+                findings.push(unresolved_package_finding(
+                    pkg,
+                    &summary,
+                    &affected_versions,
+                    UnresolvedKind::Unresolved,
+                ));
+                // Fall through (see above).
+            }
+            // A proven exclusion or no record: nothing to add; the name-shape
+            // checks below still run.
+            PackageThreatAssessment::ConstraintExcludesAffected
+            | PackageThreatAssessment::NoRecord => {}
         }
 
         if let Some(t) = db.check_typosquat(db_eco, &pkg.name) {
@@ -880,7 +972,7 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::PyPI);
         assert_eq!(pkgs[0].name, "requests");
-        assert_eq!(pkgs[0].version, None);
+        assert_eq!(pkgs[0].version, VersionIntent::Unspecified);
     }
 
     #[test]
@@ -888,16 +980,22 @@ mod tests {
         let pkgs = tokenize_and_extract("pip install requests==2.31.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "requests");
-        assert_eq!(pkgs[0].version, Some("2.31.0".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("2.31.0".to_string()));
     }
 
     #[test]
-    fn pip_install_version_range_not_exact() {
+    fn pip_install_version_range_is_constraint() {
         let pkgs = tokenize_and_extract("pip install requests>=2.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "requests");
-        // Only `==` pins an exact version; ranges leave version as None.
-        assert_eq!(pkgs[0].version, None);
+        // A range is now preserved as a parsed Constraint (no longer dropped).
+        match &pkgs[0].version {
+            VersionIntent::Constraint { raw, parsed } => {
+                assert_eq!(raw, ">=2.0");
+                assert!(parsed.is_some());
+            }
+            other => panic!("expected Constraint, got {other:?}"),
+        }
     }
 
     #[test]
@@ -930,7 +1028,7 @@ mod tests {
         let pkgs = tokenize_and_extract("pip install requests[security]==2.31.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "requests");
-        assert_eq!(pkgs[0].version, Some("2.31.0".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("2.31.0".to_string()));
     }
 
     #[test]
@@ -975,7 +1073,7 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::Npm);
         assert_eq!(pkgs[0].name, "lodash");
-        assert_eq!(pkgs[0].version, None);
+        assert_eq!(pkgs[0].version, VersionIntent::Unspecified);
     }
 
     #[test]
@@ -983,7 +1081,7 @@ mod tests {
         let pkgs = tokenize_and_extract("npm install lodash@4.17.21");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "lodash");
-        assert_eq!(pkgs[0].version, Some("4.17.21".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("4.17.21".to_string()));
     }
 
     #[test]
@@ -991,7 +1089,7 @@ mod tests {
         let pkgs = tokenize_and_extract("npm install @angular/core@16.0.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "@angular/core");
-        assert_eq!(pkgs[0].version, Some("16.0.0".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("16.0.0".to_string()));
     }
 
     #[test]
@@ -999,7 +1097,7 @@ mod tests {
         let pkgs = tokenize_and_extract("npm install @types/node");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "@types/node");
-        assert_eq!(pkgs[0].version, None);
+        assert_eq!(pkgs[0].version, VersionIntent::Unspecified);
     }
 
     #[test]
@@ -1015,7 +1113,7 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::Npm);
         assert_eq!(pkgs[0].name, "react");
-        assert_eq!(pkgs[0].version, Some("18.2.0".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("18.2.0".to_string()));
     }
 
     #[test]
@@ -1077,7 +1175,7 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::Crates);
         assert_eq!(pkgs[0].name, "ripgrep");
-        assert_eq!(pkgs[0].version, None);
+        assert_eq!(pkgs[0].version, VersionIntent::Unspecified);
     }
 
     #[test]
@@ -1092,7 +1190,7 @@ mod tests {
         let pkgs = tokenize_and_extract("cargo add serde@1.0.193");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "serde");
-        assert_eq!(pkgs[0].version, Some("1.0.193".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("1.0.193".to_string()));
     }
 
     #[test]
@@ -1100,7 +1198,7 @@ mod tests {
         let pkgs = tokenize_and_extract("cargo install ripgrep --version 14.0.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "ripgrep");
-        assert_eq!(pkgs[0].version, Some("14.0.0".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("14.0.0".to_string()));
     }
 
     #[test]
@@ -1128,7 +1226,7 @@ mod tests {
         let pkgs = tokenize_and_extract("gem install rails --version 7.0.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "rails");
-        assert_eq!(pkgs[0].version, Some("7.0.0".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("7.0.0".to_string()));
     }
 
     #[test]
@@ -1136,7 +1234,7 @@ mod tests {
         let pkgs = tokenize_and_extract("gem install rails:7.0.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "rails");
-        assert_eq!(pkgs[0].version, Some("7.0.0".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("7.0.0".to_string()));
     }
 
     #[test]
@@ -1145,7 +1243,7 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::Go);
         assert_eq!(pkgs[0].name, "github.com/gin-gonic/gin");
-        assert_eq!(pkgs[0].version, None);
+        assert_eq!(pkgs[0].version, VersionIntent::Unspecified);
     }
 
     #[test]
@@ -1153,7 +1251,8 @@ mod tests {
         let pkgs = tokenize_and_extract("go get github.com/gin-gonic/gin@v1.9.1");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "github.com/gin-gonic/gin");
-        assert_eq!(pkgs[0].version, Some("v1.9.1".to_string()));
+        // Go's `v`-prefixed module version is kept as an exact pin.
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("v1.9.1".to_string()));
     }
 
     #[test]
@@ -1161,7 +1260,14 @@ mod tests {
         let pkgs = tokenize_and_extract("go install golang.org/x/tools/gopls@latest");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "golang.org/x/tools/gopls");
-        assert_eq!(pkgs[0].version, Some("latest".to_string()));
+        // `latest` is a dist-tag, not an exact version: an unparsed constraint.
+        match &pkgs[0].version {
+            VersionIntent::Constraint { raw, parsed } => {
+                assert_eq!(raw, "latest");
+                assert!(parsed.is_none());
+            }
+            other => panic!("expected Constraint, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1170,7 +1276,7 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::Packagist);
         assert_eq!(pkgs[0].name, "monolog/monolog");
-        assert_eq!(pkgs[0].version, None);
+        assert_eq!(pkgs[0].version, VersionIntent::Unspecified);
     }
 
     #[test]
@@ -1178,7 +1284,14 @@ mod tests {
         let pkgs = tokenize_and_extract("composer require monolog/monolog:^3.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "monolog/monolog");
-        assert_eq!(pkgs[0].version, Some("^3.0".to_string()));
+        // Composer's caret range is not in the parsed subset: unresolved constraint.
+        match &pkgs[0].version {
+            VersionIntent::Constraint { raw, parsed } => {
+                assert_eq!(raw, "^3.0");
+                assert!(parsed.is_none());
+            }
+            other => panic!("expected Constraint, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1187,7 +1300,7 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].ecosystem, Ecosystem::NuGet);
         assert_eq!(pkgs[0].name, "Newtonsoft.Json");
-        assert_eq!(pkgs[0].version, None);
+        assert_eq!(pkgs[0].version, VersionIntent::Unspecified);
     }
 
     #[test]
@@ -1195,7 +1308,7 @@ mod tests {
         let pkgs = tokenize_and_extract("dotnet add package Newtonsoft.Json --version 13.0.3");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "Newtonsoft.Json");
-        assert_eq!(pkgs[0].version, Some("13.0.3".to_string()));
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("13.0.3".to_string()));
     }
 
     #[test]

--- a/crates/tirith-core/src/rules/threatintel.rs
+++ b/crates/tirith-core/src/rules/threatintel.rs
@@ -30,6 +30,17 @@ fn split_name_version(s: &str, sep: char) -> (&str, VersionIntent) {
     }
 }
 
+/// Like [`split_name_version`] but for Cargo, where a PLAIN version is a caret
+/// REQUIREMENT (`serde@1.0` == `^1.0`), not an exact pin (see
+/// [`VersionIntent::from_cargo_version`]).
+fn split_name_version_cargo(s: &str, sep: char) -> (&str, VersionIntent) {
+    if let Some(pos) = s.find(sep) {
+        (&s[..pos], VersionIntent::from_cargo_version(&s[pos + 1..]))
+    } else {
+        (s, VersionIntent::Unspecified)
+    }
+}
+
 /// Build a [`VersionIntent`] from an optional explicit version token; `None`
 /// (and empty) becomes [`Unspecified`](VersionIntent::Unspecified).
 fn intent_from_opt_token(token: Option<&str>) -> VersionIntent {
@@ -350,7 +361,7 @@ fn extract_cargo_packages(args: &[String], packages: &mut Vec<PackageRef>) {
                             if last.ecosystem == Ecosystem::Crates
                                 && matches!(last.version, VersionIntent::Unspecified)
                             {
-                                last.version = VersionIntent::from_explicit_version(ver);
+                                last.version = VersionIntent::from_cargo_version(ver);
                             }
                         }
                     }
@@ -367,7 +378,7 @@ fn extract_cargo_packages(args: &[String], packages: &mut Vec<PackageRef>) {
             continue;
         }
 
-        let (name, version) = split_name_version(arg, '@');
+        let (name, version) = split_name_version_cargo(arg, '@');
 
         if !name.is_empty() {
             packages.push(PackageRef {
@@ -1193,18 +1204,38 @@ mod tests {
 
     #[test]
     fn cargo_add_with_version() {
+        // Cargo's plain `serde@1.0.193` is a caret REQUIREMENT (^1.0.193), not an exact
+        // pin: resolution selects the highest compatible release, so it is a Constraint
+        // (matching then resolves the real installed version, not the literal lower bound).
         let pkgs = tokenize_and_extract("cargo add serde@1.0.193");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "serde");
+        assert!(
+            matches!(&pkgs[0].version, VersionIntent::Constraint { raw, .. } if raw == "1.0.193"),
+            "cargo add serde@1.0.193 is a caret constraint, got {:?}",
+            pkgs[0].version
+        );
+    }
+
+    #[test]
+    fn cargo_add_equals_is_an_exact_pin() {
+        // Cargo's `=` operator IS an exact pin.
+        let pkgs = tokenize_and_extract("cargo add serde@=1.0.193");
+        assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].version, VersionIntent::Exact("1.0.193".to_string()));
     }
 
     #[test]
     fn cargo_install_with_version_flag() {
+        // `--version 14.0.0` is likewise a SemVer requirement, not an exact pin.
         let pkgs = tokenize_and_extract("cargo install ripgrep --version 14.0.0");
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "ripgrep");
-        assert_eq!(pkgs[0].version, VersionIntent::Exact("14.0.0".to_string()));
+        assert!(
+            matches!(&pkgs[0].version, VersionIntent::Constraint { raw, .. } if raw == "14.0.0"),
+            "cargo install --version 14.0.0 is a constraint, got {:?}",
+            pkgs[0].version
+        );
     }
 
     #[test]

--- a/crates/tirith-core/src/rules/threatintel.rs
+++ b/crates/tirith-core/src/rules/threatintel.rs
@@ -300,7 +300,13 @@ fn parse_npm_package_spec(spec: &str) -> Option<PackageRef> {
     Some(PackageRef {
         ecosystem: Ecosystem::Npm,
         name: name.to_string(),
-        version: intent_from_opt_token(version),
+        // npm treats a bare PARTIAL version as an X-range (`lodash@4` == `4.x`), so
+        // classify the CLI spec the same way the manifest path does instead of a bogus
+        // `Exact("4")` that would miss a threat record for the resolved `4.17.21`.
+        version: match version {
+            Some(v) => crate::ecosystem_scan::npm_manifest_intent(v),
+            None => VersionIntent::Unspecified,
+        },
     })
 }
 

--- a/crates/tirith-core/src/rules/threatintel.rs
+++ b/crates/tirith-core/src/rules/threatintel.rs
@@ -284,17 +284,14 @@ fn parse_npm_package_spec(spec: &str) -> Option<PackageRef> {
 
     let (name, version) = if spec.starts_with('@') {
         // Scoped `@scope/name@version` — find the version `@` after the scope.
-        if let Some(slash_pos) = spec.find('/') {
-            let after_scope = &spec[slash_pos + 1..];
-            if let Some(at_pos) = after_scope.find('@') {
-                let full_name = &spec[..slash_pos + 1 + at_pos];
-                let ver = &after_scope[at_pos + 1..];
-                (full_name, if ver.is_empty() { None } else { Some(ver) })
-            } else {
-                (spec, None)
-            }
+        let slash_pos = spec.find('/')?;
+        let after_scope = &spec[slash_pos + 1..];
+        if let Some(at_pos) = after_scope.find('@') {
+            let full_name = &spec[..slash_pos + 1 + at_pos];
+            let ver = &after_scope[at_pos + 1..];
+            (full_name, if ver.is_empty() { None } else { Some(ver) })
         } else {
-            return None; // invalid scoped package (no slash)
+            (spec, None)
         }
     } else if let Some(at_pos) = spec.find('@') {
         let name = &spec[..at_pos];
@@ -415,7 +412,7 @@ fn extract_gem_packages(args: &[String], packages: &mut Vec<PackageRef>) {
                             if last.ecosystem == Ecosystem::RubyGems
                                 && matches!(last.version, VersionIntent::Unspecified)
                             {
-                                last.version = VersionIntent::from_explicit_version(ver);
+                                last.version = VersionIntent::from_gem_version(ver);
                             }
                         }
                     }
@@ -1264,6 +1261,25 @@ mod tests {
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].name, "rails");
         assert_eq!(pkgs[0].version, VersionIntent::Exact("7.0.0".to_string()));
+    }
+
+    #[test]
+    fn gem_install_with_explicit_equality_version_flag() {
+        let pkgs = tokenize_and_extract(r#"gem install rails --version "= 7.0.0""#);
+        assert_eq!(pkgs.len(), 1);
+        assert_eq!(pkgs[0].name, "rails");
+        assert_eq!(pkgs[0].version, VersionIntent::Exact("7.0.0".to_string()));
+    }
+
+    #[test]
+    fn gem_install_with_quoted_range_stays_a_constraint() {
+        let pkgs = tokenize_and_extract(r#"gem install rails --version "~> 7.0""#);
+        assert_eq!(pkgs.len(), 1);
+        assert_eq!(pkgs[0].name, "rails");
+        assert!(matches!(
+            &pkgs[0].version,
+            VersionIntent::Constraint { raw, .. } if raw == "~> 7.0"
+        ));
     }
 
     #[test]

--- a/crates/tirith-core/src/rules/threatintel.rs
+++ b/crates/tirith-core/src/rules/threatintel.rs
@@ -884,7 +884,7 @@ pub fn check(
                 findings.push(Finding {
                     rule_id,
                     severity,
-                    title: format!("Threat intelligence hostname match: {}", host),
+                    title: format!("Threat intelligence hostname match: {host}"),
                     description: format!(
                         "Hostname '{}' appears in threat intelligence feed ({}).",
                         host,
@@ -911,7 +911,7 @@ pub fn check(
                         findings.push(Finding {
                             rule_id,
                             severity,
-                            title: format!("Threat intelligence IP match in URL: {}", ip),
+                            title: format!("Threat intelligence IP match in URL: {ip}"),
                             description: format!(
                                 "IP address {} (from URL) is flagged by {}.",
                                 ip,
@@ -944,7 +944,7 @@ pub fn check(
                         findings.push(Finding {
                             rule_id,
                             severity,
-                            title: format!("Threat intelligence IP match: {}", ip),
+                            title: format!("Threat intelligence IP match: {ip}"),
                             description: format!(
                                 "IP address {} is flagged by {}.",
                                 ip,

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -857,6 +857,9 @@ mod tests {
     #[test]
     fn is_threat_intel_rule_classifies_threat_family() {
         assert!(is_threat_intel_rule(RuleId::ThreatMaliciousPackage));
+        assert!(is_threat_intel_rule(
+            RuleId::ThreatUnresolvedMaliciousPackage
+        ));
         assert!(is_threat_intel_rule(RuleId::ThreatCisaKev));
         assert!(is_threat_intel_rule(RuleId::ThreatSafeBrowsing));
         assert!(!is_threat_intel_rule(RuleId::CurlPipeShell));

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -80,6 +80,7 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         | RuleId::ThreatMaliciousIp
         | RuleId::ThreatPackageTyposquat
         | RuleId::ThreatPackageSimilarName
+        | RuleId::ThreatUnresolvedMaliciousPackage
         | RuleId::ThreatMaliciousUrl
         | RuleId::ThreatPhishingUrl
         | RuleId::ThreatTorExitNode

--- a/crates/tirith-core/src/style.rs
+++ b/crates/tirith-core/src/style.rs
@@ -24,7 +24,7 @@ pub fn use_color_for(stream: Stream) -> bool {
 /// A bracketed severity label like `[CRITICAL]`, ANSI-colored when `stream`
 /// supports color, else plain.
 pub fn severity_label(severity: &Severity, stream: Stream) -> String {
-    let label = format!("[{}]", severity);
+    let label = format!("[{severity}]");
     if !use_color_for(stream) {
         return label;
     }

--- a/crates/tirith-core/src/sudo_session.rs
+++ b/crates/tirith-core/src/sudo_session.rs
@@ -182,13 +182,13 @@ pub fn parse_ttl(s: &str) -> Option<u64> {
 
 /// Format the duration as a short human string (`30m`, `2h`, `1d`).
 pub fn format_ttl(secs: u64) -> String {
-    if secs % (24 * 60 * 60) == 0 && secs >= 24 * 60 * 60 {
+    if secs.is_multiple_of(24 * 60 * 60) && secs >= 24 * 60 * 60 {
         return format!("{}d", secs / (24 * 60 * 60));
     }
-    if secs % (60 * 60) == 0 && secs >= 60 * 60 {
+    if secs.is_multiple_of(60 * 60) && secs >= 60 * 60 {
         return format!("{}h", secs / (60 * 60));
     }
-    if secs % 60 == 0 && secs >= 60 {
+    if secs.is_multiple_of(60) && secs >= 60 {
         return format!("{}m", secs / 60);
     }
     format!("{secs}s")

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -1124,6 +1124,16 @@ impl ThreatDb {
                         }
                     }
                 }
+                // A version-specific malicious record with NO affected versions gives
+                // us nothing to test the constraint against, so we cannot claim the
+                // constraint excludes it; stay unresolved rather than silently clean.
+                if parsed_affected.is_empty() {
+                    return PackageThreatAssessment::Unresolved {
+                        summary,
+                        reason: UnresolvedReason::AffectedVersionUnparsed,
+                        affected_versions: affected,
+                    };
+                }
                 let intersecting: Vec<String> = parsed_affected
                     .iter()
                     .filter(|(_, rv)| constraint.matches(rv))
@@ -3322,6 +3332,30 @@ mod tests {
         };
         assert!(matches!(
             db.assess_package(Ecosystem::Npm, "tagged-evil", &miss),
+            PackageThreatAssessment::Unresolved { .. }
+        ));
+    }
+
+    #[test]
+    fn constraint_against_empty_affected_versions_is_unresolved_not_excluded() {
+        // A version-specific malicious record with NO affected versions (and not
+        // all-versions-malicious) gives nothing to test a constraint against, so it
+        // must stay Unresolved, not be silently treated as a proven exclusion.
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = ThreatDbWriter::new(1700000000, 1);
+        writer.add_package(
+            Ecosystem::Npm,
+            "no-versions-evil",
+            &[],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false, // NOT all-versions-malicious
+            None,
+        );
+        let db = ThreatDb::from_bytes(writer.build(&key).expect("build"), 0).expect("load");
+        let constraint = crate::version_intent::VersionIntent::from_pep440_specifier(">=1.0,<2.0");
+        assert!(matches!(
+            db.assess_package(Ecosystem::Npm, "no-versions-evil", &constraint),
             PackageThreatAssessment::Unresolved { .. }
         ));
     }

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -1123,8 +1123,14 @@ impl ThreatDb {
                     // digest, a dist-tag like `latest`, a non-semver selector) still names a
                     // concrete identity. If it LITERALLY equals an affected version that is a
                     // definite malicious hit, not an unresolved guess, so return ExactMatch
-                    // rather than downgrading a known-bad pin to a Medium warning.
-                    if rec.versions.iter().any(|rv| rv == raw) {
+                    // rather than downgrading a known-bad pin to a Medium warning. A raw that
+                    // LOOKS LIKE A PLAIN VERSION is NOT such a token, though: it is a range
+                    // requirement we did not parse (e.g. Cargo's caret default, where
+                    // `1.0.0` means `^1.0.0`), so exact-matching it would wrongly upgrade a
+                    // range request to a confirmed hit. Those stay Unresolved (a warning).
+                    if !crate::version_intent::looks_like_plain_version(raw)
+                        && rec.versions.iter().any(|rv| rv == raw)
+                    {
                         return PackageThreatAssessment::ExactMatch(summary);
                     }
                     return PackageThreatAssessment::Unresolved {
@@ -3577,6 +3583,34 @@ mod tests {
             }
             other => panic!("expected Unresolved (AffectedVersionsMissing), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cargo_caret_constraint_does_not_become_exact_malicious_hit() {
+        // A Cargo plain version is a caret requirement: from_cargo_version("1.0.0") ->
+        // Constraint{parsed:None, raw:"1.0.0"}. Even though raw LITERALLY equals an affected
+        // version in the DB, it must NOT upgrade to a confirmed ExactMatch - it is a RANGE
+        // request, so it stays Unresolved (an overlap warning). The raw-token exact fallback
+        // is only for opaque concrete tokens (digests/dist-tags), not plain versions.
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = ThreatDbWriter::new(1700000000, 9);
+        writer.add_package(
+            Ecosystem::Crates,
+            "evil-crate",
+            &["1.0.0"],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false,
+            None,
+        );
+        let bytes = writer.build(&key).expect("build failed");
+        let db = ThreatDb::from_bytes(bytes, 0).expect("load failed");
+        let caret = VersionIntent::from_cargo_version("1.0.0");
+        let a = db.assess_package(Ecosystem::Crates, "evil-crate", &caret);
+        assert!(
+            matches!(a, PackageThreatAssessment::Unresolved { .. }),
+            "a cargo caret requirement must stay Unresolved, not become an ExactMatch; got {a:?}"
+        );
     }
 
     #[test]

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -370,6 +370,74 @@ pub struct ThreatMatch {
     pub all_versions_malicious: bool,
 }
 
+/// A serializable summary of a malicious-package match.
+///
+/// Neither [`ThreatMatch`] nor [`ThreatSource`] derive `Serialize` (the former
+/// carries non-wire fields, the latter is an on-disk discriminant), so the
+/// constraint-aware assessment carries wire strings instead. `Confidence` does
+/// derive `Serialize`, so it is kept as-is.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ThreatMatchSummary {
+    pub ecosystem: String,
+    pub name: String,
+    /// Stable machine-readable source id (e.g. `ossf_malicious`).
+    pub source_id: String,
+    /// Human-readable source label (e.g. `OSSF Malicious Packages`).
+    pub source_label: String,
+    pub confidence: Confidence,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_url: Option<String>,
+    pub all_versions_malicious: bool,
+}
+
+/// Why a malicious-package record could not be resolved to a definite hit or
+/// miss for the requested version intent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UnresolvedReason {
+    /// No version was specified, so a version-specific record cannot be
+    /// confirmed or excluded.
+    UnspecifiedVersion,
+    /// A constraint was given but is outside the supported PEP 440 subset (a
+    /// marker, epoch, local version, `~=`, `===`, wildcard, or a parse failure).
+    ConstraintUnsupported,
+    /// The constraint parsed, but at least one affected version in the record
+    /// is not a plain release version we can compare against.
+    AffectedVersionUnparsed,
+}
+
+/// Outcome of a constraint-aware package threat assessment.
+///
+/// Tagged serde enum so a `--format json` consumer can distinguish a proven
+/// exclusion (no warning) from an unresolved request (warning). The variants
+/// are ordered roughly by how alarming they are; see [`ThreatDb::assess_package`]
+/// for the precedence used when merging the primary DB with a supplemental
+/// overlay.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PackageThreatAssessment {
+    /// No malicious record for this `(ecosystem, name)`.
+    NoRecord,
+    /// The requested version (or an all-versions record) is a confirmed hit.
+    ExactMatch(ThreatMatchSummary),
+    /// A constraint was given and provably overlaps the affected versions.
+    ConstraintIntersectsAffected {
+        summary: ThreatMatchSummary,
+        affected_versions: Vec<String>,
+    },
+    /// A constraint was given and provably excludes every affected version
+    /// (the whole requirement parsed, every affected version parsed, all
+    /// evaluated false). Returned ONLY on proven exclusion.
+    ConstraintExcludesAffected,
+    /// A malicious record exists but the request cannot be resolved to a
+    /// definite hit or miss (see [`UnresolvedReason`]).
+    Unresolved {
+        summary: ThreatMatchSummary,
+        reason: UnresolvedReason,
+        affected_versions: Vec<String>,
+    },
+}
+
 /// Result of a typosquat lookup.
 #[derive(Debug, Clone)]
 pub struct TyposquatMatch {
@@ -936,6 +1004,136 @@ impl ThreatDb {
             .and_then(|db| db.check_package(eco, name, version))
     }
 
+    /// Constraint-aware, serializable package threat assessment.
+    ///
+    /// Unlike [`check_package`](Self::check_package) (a yes/no match kept as a
+    /// shim), this distinguishes an unpinned/constrained request that cannot be
+    /// resolved from one that provably excludes every affected version. An
+    /// `all_versions_malicious` record hard-matches even when the intent is
+    /// [`Unspecified`](crate::version_intent::VersionIntent::Unspecified).
+    ///
+    /// Supplemental precedence (merging this DB with its overlay): an exact
+    /// match wins (primary preferred); else if either layer is unresolved the
+    /// result is `Unresolved` with deduplicated affected versions; else a
+    /// concrete intersection; else a proven exclusion; else `NoRecord`. A
+    /// `ConstraintExcludesAffected` is therefore returned only when NO layer is
+    /// exact, intersecting, or unresolved.
+    pub fn assess_package(
+        &self,
+        eco: Ecosystem,
+        name: &str,
+        intent: &crate::version_intent::VersionIntent,
+    ) -> PackageThreatAssessment {
+        let here = self.assess_package_self(eco, name, intent);
+        let overlay = self
+            .supplemental
+            .as_deref()
+            .map(|db| db.assess_package(eco, name, intent));
+        match overlay {
+            Some(overlay) => merge_assessments(here, overlay),
+            None => here,
+        }
+    }
+
+    /// Assess against this DB layer only (no overlay recursion).
+    fn assess_package_self(
+        &self,
+        eco: Ecosystem,
+        name: &str,
+        intent: &crate::version_intent::VersionIntent,
+    ) -> PackageThreatAssessment {
+        use crate::version_intent::{ReleaseVersion, VersionIntent};
+
+        let target_hash = pkg_key_hash(eco, name.as_bytes());
+        let Some(idx) = self.binary_search_pkg_index(eco, name, target_hash) else {
+            return PackageThreatAssessment::NoRecord;
+        };
+        let Some((data_off, _)) = self.pkg_index_entry(idx) else {
+            return PackageThreatAssessment::NoRecord;
+        };
+        let Some(rec) = self.parse_pkg_record(data_off as usize) else {
+            return PackageThreatAssessment::NoRecord;
+        };
+
+        let summary = self.summarize_record(&rec);
+        let affected: Vec<String> = rec.versions.iter().map(|v| v.to_string()).collect();
+
+        // An all-versions-malicious record hard-matches regardless of intent.
+        if rec.all_versions_malicious {
+            return PackageThreatAssessment::ExactMatch(summary);
+        }
+
+        match intent {
+            VersionIntent::Exact(v) | VersionIntent::Resolved(v) => {
+                if rec.versions.iter().any(|rv| rv == v) {
+                    PackageThreatAssessment::ExactMatch(summary)
+                } else {
+                    // This concrete version is not the malicious one; no record
+                    // for the request in this layer.
+                    PackageThreatAssessment::NoRecord
+                }
+            }
+            VersionIntent::Unspecified => PackageThreatAssessment::Unresolved {
+                summary,
+                reason: UnresolvedReason::UnspecifiedVersion,
+                affected_versions: affected,
+            },
+            VersionIntent::Constraint { parsed, .. } => {
+                let Some(constraint) = parsed else {
+                    return PackageThreatAssessment::Unresolved {
+                        summary,
+                        reason: UnresolvedReason::ConstraintUnsupported,
+                        affected_versions: affected,
+                    };
+                };
+                // Every affected version must parse for a proven exclusion;
+                // otherwise we cannot claim the constraint excludes them.
+                let mut parsed_affected: Vec<(String, ReleaseVersion)> =
+                    Vec::with_capacity(rec.versions.len());
+                for v in &rec.versions {
+                    match ReleaseVersion::parse(v) {
+                        Some(rv) => parsed_affected.push((v.to_string(), rv)),
+                        None => {
+                            return PackageThreatAssessment::Unresolved {
+                                summary,
+                                reason: UnresolvedReason::AffectedVersionUnparsed,
+                                affected_versions: affected,
+                            };
+                        }
+                    }
+                }
+                let intersecting: Vec<String> = parsed_affected
+                    .iter()
+                    .filter(|(_, rv)| constraint.matches(rv))
+                    .map(|(s, _)| s.clone())
+                    .collect();
+                if intersecting.is_empty() {
+                    PackageThreatAssessment::ConstraintExcludesAffected
+                } else {
+                    PackageThreatAssessment::ConstraintIntersectsAffected {
+                        summary,
+                        affected_versions: intersecting,
+                    }
+                }
+            }
+        }
+    }
+
+    /// Build a serializable summary from a parsed package record.
+    fn summarize_record(&self, rec: &PkgRecord<'_>) -> ThreatMatchSummary {
+        ThreatMatchSummary {
+            ecosystem: rec.ecosystem.to_string(),
+            name: rec.name.to_string(),
+            source_id: rec.source.as_str().to_string(),
+            source_label: rec.source.label().to_string(),
+            confidence: rec.confidence,
+            reference_url: self
+                .read_string_table_entry(rec.reference_offset)
+                .map(String::from),
+            all_versions_malicious: rec.all_versions_malicious,
+        }
+    }
+
     fn binary_search_pkg_index(&self, eco: Ecosystem, name: &str, target_hash: u32) -> Option<u32> {
         if self.pkg_index_count == 0 {
             return None;
@@ -1295,6 +1493,107 @@ struct PkgRecord<'a> {
     all_versions_malicious: bool,
     versions: Vec<&'a str>,
     reference_offset: u32,
+}
+
+/// Combine a primary-layer assessment with a supplemental-layer assessment.
+///
+/// Precedence (`primary` preferred on ties): an exact match wins; else if
+/// either layer is unresolved the result is `Unresolved` with deduplicated
+/// affected versions drawn from every layer that names any (so the warning
+/// lists them all); else a concrete intersection (deduped); else a proven
+/// exclusion; else `NoRecord`. Crucially, `ConstraintExcludesAffected` (which
+/// emits NO warning) survives only when no layer is exact, unresolved, or
+/// intersecting, so the overlay can never silence a primary hit and vice versa.
+fn merge_assessments(
+    primary: PackageThreatAssessment,
+    overlay: PackageThreatAssessment,
+) -> PackageThreatAssessment {
+    use PackageThreatAssessment as P;
+
+    // 1. Exact match wins, primary preferred.
+    if let P::ExactMatch(s) = &primary {
+        return P::ExactMatch(s.clone());
+    }
+    if let P::ExactMatch(s) = &overlay {
+        return P::ExactMatch(s.clone());
+    }
+
+    // Collect affected versions named by either layer (for the merged lists).
+    let affected_from = |a: &PackageThreatAssessment| -> Vec<String> {
+        match a {
+            P::ConstraintIntersectsAffected {
+                affected_versions, ..
+            }
+            | P::Unresolved {
+                affected_versions, ..
+            } => affected_versions.clone(),
+            _ => Vec::new(),
+        }
+    };
+    let summary_from = |a: &PackageThreatAssessment| -> Option<ThreatMatchSummary> {
+        match a {
+            P::ConstraintIntersectsAffected { summary, .. } | P::Unresolved { summary, .. } => {
+                Some(summary.clone())
+            }
+            _ => None,
+        }
+    };
+    let merge_affected = || {
+        let mut v = affected_from(&primary);
+        v.extend(affected_from(&overlay));
+        v.sort();
+        v.dedup();
+        v
+    };
+
+    // 2. Any unresolved layer makes the result unresolved (primary's reason and
+    // summary preferred), carrying the union of affected versions.
+    let primary_unresolved = matches!(primary, P::Unresolved { .. });
+    let overlay_unresolved = matches!(overlay, P::Unresolved { .. });
+    if primary_unresolved || overlay_unresolved {
+        let (reason, summary) = if let P::Unresolved {
+            reason, summary, ..
+        } = &primary
+        {
+            (*reason, summary.clone())
+        } else if let P::Unresolved {
+            reason, summary, ..
+        } = &overlay
+        {
+            (*reason, summary.clone())
+        } else {
+            unreachable!("one layer is Unresolved")
+        };
+        return P::Unresolved {
+            summary,
+            reason,
+            affected_versions: merge_affected(),
+        };
+    }
+
+    // 3. A concrete intersection in either layer (primary summary preferred).
+    let primary_intersects = matches!(primary, P::ConstraintIntersectsAffected { .. });
+    let overlay_intersects = matches!(overlay, P::ConstraintIntersectsAffected { .. });
+    if primary_intersects || overlay_intersects {
+        let summary = summary_from(&primary)
+            .or_else(|| summary_from(&overlay))
+            .expect("an intersecting layer carries a summary");
+        return P::ConstraintIntersectsAffected {
+            summary,
+            affected_versions: merge_affected(),
+        };
+    }
+
+    // 4. A proven exclusion in either layer (no exact/unresolved/intersect
+    // anywhere, so this is safe to report as "no warning").
+    if matches!(primary, P::ConstraintExcludesAffected)
+        || matches!(overlay, P::ConstraintExcludesAffected)
+    {
+        return P::ConstraintExcludesAffected;
+    }
+
+    // 5. Neither layer had any record.
+    P::NoRecord
 }
 
 static CACHE: OnceLock<ThreatDbCache> = OnceLock::new();
@@ -2891,5 +3190,264 @@ mod tests {
             assert!(db.check_typosquat(eco, "nginx").is_none());
             assert!(db.check_popular_distance(eco, "nginx").is_none());
         }
+    }
+
+    // ── assess_package (A1b) ───────────────────────────────────────────────
+
+    use crate::version_intent::{VersionConstraint, VersionIntent};
+
+    /// A DB whose only record is `pypi/vuln-pkg` affected at 1.4.2 and 1.4.3
+    /// (matching the acceptance-criteria example), version-specific.
+    fn build_constraint_db(signing_key: &SigningKey) -> ThreatDb {
+        let mut writer = ThreatDbWriter::new(1700000000, 7);
+        writer.add_package(
+            Ecosystem::PyPI,
+            "vuln-pkg",
+            &["1.4.2", "1.4.3"],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false,
+            Some("https://example.com/advisory/vuln"),
+        );
+        let bytes = writer.build(signing_key).expect("build failed");
+        ThreatDb::from_bytes(bytes, 0).expect("load failed")
+    }
+
+    fn constraint_intent(raw: &str) -> VersionIntent {
+        VersionIntent::Constraint {
+            parsed: VersionConstraint::parse(raw),
+            raw: raw.to_string(),
+        }
+    }
+
+    #[test]
+    fn assess_exact_version_in_list_is_exact_match() {
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_test_db(&key);
+        let a = db.assess_package(
+            Ecosystem::Npm,
+            "evil-package",
+            &VersionIntent::Exact("1.0.0".to_string()),
+        );
+        match a {
+            PackageThreatAssessment::ExactMatch(s) => {
+                assert_eq!(s.name, "evil-package");
+                assert_eq!(s.source_id, "ossf_malicious");
+                assert!(!s.all_versions_malicious);
+            }
+            other => panic!("expected ExactMatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assess_exact_version_not_in_list_is_no_record() {
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_test_db(&key);
+        let a = db.assess_package(
+            Ecosystem::Npm,
+            "evil-package",
+            &VersionIntent::Exact("2.0.0".to_string()),
+        );
+        assert_eq!(a, PackageThreatAssessment::NoRecord);
+    }
+
+    #[test]
+    fn assess_unspecified_against_version_specific_is_unresolved() {
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_test_db(&key);
+        let a = db.assess_package(Ecosystem::Npm, "evil-package", &VersionIntent::Unspecified);
+        match a {
+            PackageThreatAssessment::Unresolved {
+                reason,
+                affected_versions,
+                ..
+            } => {
+                assert_eq!(reason, UnresolvedReason::UnspecifiedVersion);
+                assert_eq!(affected_versions, vec!["1.0.0", "1.0.1"]);
+            }
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assess_unspecified_against_all_versions_is_exact_match() {
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_test_db(&key);
+        let a = db.assess_package(Ecosystem::PyPI, "malware-pkg", &VersionIntent::Unspecified);
+        match a {
+            PackageThreatAssessment::ExactMatch(s) => {
+                assert!(s.all_versions_malicious);
+                assert_eq!(s.source_id, "datadog_malicious");
+            }
+            other => panic!("expected ExactMatch for all-versions record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assess_no_record_for_unknown_package() {
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_test_db(&key);
+        let a = db.assess_package(
+            Ecosystem::Npm,
+            "totally-fine",
+            &VersionIntent::Exact("1.0.0".to_string()),
+        );
+        assert_eq!(a, PackageThreatAssessment::NoRecord);
+    }
+
+    #[test]
+    fn assess_constraint_excludes_affected() {
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_constraint_db(&key);
+        // affected 1.4.2 / 1.4.3; >=1.4.4 excludes both.
+        let a = db.assess_package(Ecosystem::PyPI, "vuln-pkg", &constraint_intent(">=1.4.4"));
+        assert_eq!(a, PackageThreatAssessment::ConstraintExcludesAffected);
+    }
+
+    #[test]
+    fn assess_constraint_intersects_affected() {
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_constraint_db(&key);
+        // >=1.4.2,<1.4.4 overlaps both affected versions.
+        let a = db.assess_package(
+            Ecosystem::PyPI,
+            "vuln-pkg",
+            &constraint_intent(">=1.4.2,<1.4.4"),
+        );
+        match a {
+            PackageThreatAssessment::ConstraintIntersectsAffected {
+                affected_versions, ..
+            } => {
+                assert_eq!(affected_versions, vec!["1.4.2", "1.4.3"]);
+            }
+            other => panic!("expected ConstraintIntersectsAffected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assess_unparsed_constraint_is_unresolved_not_excludes() {
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_constraint_db(&key);
+        // `===1.4.4` (arbitrary equality) and a marker must never claim exclusion.
+        for raw in ["===1.4.4", ">=1.0 ; python_version < \"3.9\"", "==1.4.*"] {
+            let a = db.assess_package(Ecosystem::PyPI, "vuln-pkg", &constraint_intent(raw));
+            match a {
+                PackageThreatAssessment::Unresolved { reason, .. } => {
+                    assert_eq!(
+                        reason,
+                        UnresolvedReason::ConstraintUnsupported,
+                        "raw `{raw}` should be ConstraintUnsupported"
+                    );
+                }
+                other => panic!("expected Unresolved for `{raw}`, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn assess_affected_version_unparsed_is_unresolved() {
+        // A record whose affected version is not a plain release version cannot
+        // be proven excluded, so a constraint over it stays Unresolved.
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = ThreatDbWriter::new(1700000000, 9);
+        writer.add_package(
+            Ecosystem::PyPI,
+            "weird-ver",
+            &["1.0.0rc1"],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false,
+            None,
+        );
+        let bytes = writer.build(&key).expect("build failed");
+        let db = ThreatDb::from_bytes(bytes, 0).expect("load failed");
+        let a = db.assess_package(Ecosystem::PyPI, "weird-ver", &constraint_intent(">=1.0.0"));
+        match a {
+            PackageThreatAssessment::Unresolved { reason, .. } => {
+                assert_eq!(reason, UnresolvedReason::AffectedVersionUnparsed);
+            }
+            other => panic!("expected Unresolved (AffectedVersionUnparsed), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assess_supplemental_unresolved_dedups_affected() {
+        // Primary excludes (>=1.4.4 over 1.4.2/1.4.3) but a supplemental overlay
+        // is unresolved for the same name; the merge must surface Unresolved
+        // (never the primary's exclusion) with deduplicated affected versions.
+        let key = SigningKey::generate(&mut OsRng);
+        let primary_bytes = {
+            let mut w = ThreatDbWriter::new(1700000000, 11);
+            w.add_package(
+                Ecosystem::PyPI,
+                "split-pkg",
+                &["1.4.2", "1.4.3"],
+                ThreatSource::OssfMalicious,
+                Confidence::Confirmed,
+                false,
+                None,
+            );
+            w.build(&key).expect("build primary")
+        };
+        let supp_bytes = {
+            let mut w = ThreatDbWriter::new(1700000000, 12);
+            w.add_package(
+                Ecosystem::PyPI,
+                "split-pkg",
+                &["1.4.3", "1.4.9"],
+                ThreatSource::DatadogMalicious,
+                Confidence::Confirmed,
+                false,
+                None,
+            );
+            w.build(&key).expect("build supplemental")
+        };
+        let supplemental = ThreatDb::from_bytes(supp_bytes, 0).expect("load supp");
+        let db = ThreatDb::from_bytes(primary_bytes, 0)
+            .expect("load primary")
+            .with_supplemental(Some(supplemental));
+
+        // >=1.4.4 excludes the primary's {1.4.2,1.4.3}; for the supplemental
+        // {1.4.3,1.4.9} it intersects (1.4.9). The merged result must intersect.
+        let a = db.assess_package(Ecosystem::PyPI, "split-pkg", &constraint_intent(">=1.4.4"));
+        match a {
+            PackageThreatAssessment::ConstraintIntersectsAffected {
+                affected_versions, ..
+            } => {
+                assert_eq!(affected_versions, vec!["1.4.9"]);
+            }
+            other => panic!("expected ConstraintIntersectsAffected from overlay, got {other:?}"),
+        }
+
+        // An Unspecified request is unresolved in both layers; affected versions
+        // are the deduplicated union across both.
+        let a2 = db.assess_package(Ecosystem::PyPI, "split-pkg", &VersionIntent::Unspecified);
+        match a2 {
+            PackageThreatAssessment::Unresolved {
+                affected_versions, ..
+            } => {
+                assert_eq!(affected_versions, vec!["1.4.2", "1.4.3", "1.4.9"]);
+            }
+            other => panic!("expected Unresolved with merged affected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_package_shim_still_matches() {
+        // Regression: the kept `check_package` shim behaves exactly as before.
+        let key = SigningKey::generate(&mut OsRng);
+        let db = build_test_db(&key);
+        assert!(db
+            .check_package(Ecosystem::Npm, "evil-package", Some("1.0.0"))
+            .is_some());
+        assert!(db
+            .check_package(Ecosystem::Npm, "evil-package", Some("2.0.0"))
+            .is_none());
+        assert!(db
+            .check_package(Ecosystem::Npm, "evil-package", None)
+            .is_none());
+        assert!(db
+            .check_package(Ecosystem::PyPI, "malware-pkg", None)
+            .is_some());
     }
 }

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -1065,7 +1065,21 @@ impl ThreatDb {
 
         match intent {
             VersionIntent::Exact(v) | VersionIntent::Resolved(v) => {
-                if rec.versions.iter().any(|rv| rv == v) {
+                // Match on a literal string equal OR a numeric release equal, so
+                // a pin like `==1.4` still hits a record listing `1.4.0`. The
+                // numeric arm only fires when both sides parse as plain release
+                // versions; anything else (prereleases, locals) relies on the
+                // literal compare and falls through to NoRecord when it differs.
+                // Compare via `cmp` (not `==`): only `Ord` treats trailing-zero
+                // segments as equal, so `1.4` and `1.4.0` match here.
+                let matched = rec.versions.iter().any(|rv| {
+                    rv == v
+                        || matches!(
+                            (ReleaseVersion::parse(rv), ReleaseVersion::parse(v)),
+                            (Some(a), Some(b)) if a.cmp(&b) == std::cmp::Ordering::Equal
+                        )
+                });
+                if matched {
                     PackageThreatAssessment::ExactMatch(summary)
                 } else {
                     // This concrete version is not the malicious one; no record
@@ -3236,6 +3250,36 @@ mod tests {
                 assert!(!s.all_versions_malicious);
             }
             other => panic!("expected ExactMatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assess_exact_pin_matches_trailing_zero_record() {
+        // The record lists `1.4.0`; a pin of `==1.4` must still hit it. The
+        // literal string compare alone would miss (`"1.4" != "1.4.0"`), so the
+        // numeric-equality fallback is what makes this an ExactMatch.
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = ThreatDbWriter::new(1700000000, 11);
+        writer.add_package(
+            Ecosystem::PyPI,
+            "foo",
+            &["1.4.0"],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false,
+            None,
+        );
+        let bytes = writer.build(&key).expect("build failed");
+        let db = ThreatDb::from_bytes(bytes, 0).expect("load failed");
+
+        let intent = VersionIntent::from_pep440_specifier("==1.4");
+        assert_eq!(intent, VersionIntent::Exact("1.4".to_string()));
+        match db.assess_package(Ecosystem::PyPI, "foo", &intent) {
+            PackageThreatAssessment::ExactMatch(s) => {
+                assert_eq!(s.name, "foo");
+                assert!(!s.all_versions_malicious);
+            }
+            other => panic!("expected ExactMatch for `==1.4` vs `1.4.0`, got {other:?}"),
         }
     }
 

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -1092,8 +1092,16 @@ impl ThreatDb {
                 reason: UnresolvedReason::UnspecifiedVersion,
                 affected_versions: affected,
             },
-            VersionIntent::Constraint { parsed, .. } => {
+            VersionIntent::Constraint { parsed, raw } => {
                 let Some(constraint) = parsed else {
+                    // Raw-token exact fallback: an explicit-but-unparseable token (a Docker
+                    // digest, a dist-tag like `latest`, a non-semver selector) still names a
+                    // concrete identity. If it LITERALLY equals an affected version that is a
+                    // definite malicious hit, not an unresolved guess, so return ExactMatch
+                    // rather than downgrading a known-bad pin to a Medium warning.
+                    if rec.versions.iter().any(|rv| rv == raw) {
+                        return PackageThreatAssessment::ExactMatch(summary);
+                    }
                     return PackageThreatAssessment::Unresolved {
                         summary,
                         reason: UnresolvedReason::ConstraintUnsupported,
@@ -3281,6 +3289,41 @@ mod tests {
             }
             other => panic!("expected ExactMatch for `==1.4` vs `1.4.0`, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn constraint_unparsed_raw_token_exact_match_is_malicious() {
+        // A non-semver token (a dist-tag like `latest`) is preserved as
+        // Constraint{parsed:None,raw}. If it LITERALLY equals an affected version it
+        // is a definite malicious hit (ExactMatch), not a downgraded warn.
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = ThreatDbWriter::new(1700000000, 1);
+        writer.add_package(
+            Ecosystem::Npm,
+            "tagged-evil",
+            &["latest"],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false,
+            None,
+        );
+        let db = ThreatDb::from_bytes(writer.build(&key).expect("build"), 0).expect("load");
+        let hit = crate::version_intent::VersionIntent::Constraint {
+            parsed: None,
+            raw: "latest".to_string(),
+        };
+        assert!(matches!(
+            db.assess_package(Ecosystem::Npm, "tagged-evil", &hit),
+            PackageThreatAssessment::ExactMatch(_)
+        ));
+        let miss = crate::version_intent::VersionIntent::Constraint {
+            parsed: None,
+            raw: "sha256:beef".to_string(),
+        };
+        assert!(matches!(
+            db.assess_package(Ecosystem::Npm, "tagged-evil", &miss),
+            PackageThreatAssessment::Unresolved { .. }
+        ));
     }
 
     #[test]

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -1063,21 +1063,41 @@ impl ThreatDb {
             return PackageThreatAssessment::ExactMatch(summary);
         }
 
+        // A malicious record with NO affected versions (and not all-versions-malicious)
+        // gives nothing to match against or exclude, so NO intent can be proven a hit
+        // or an exclusion: it is Unresolved, never a silent NoRecord/clean.
+        if rec.versions.is_empty() {
+            return PackageThreatAssessment::Unresolved {
+                summary,
+                reason: UnresolvedReason::AffectedVersionUnparsed,
+                affected_versions: affected,
+            };
+        }
+
         match intent {
             VersionIntent::Exact(v) | VersionIntent::Resolved(v) => {
-                // Match on a literal string equal OR a numeric release equal, so
-                // a pin like `==1.4` still hits a record listing `1.4.0`. The
-                // numeric arm only fires when both sides parse as plain release
-                // versions; anything else (prereleases, locals) relies on the
-                // literal compare and falls through to NoRecord when it differs.
-                // Compare via `cmp` (not `==`): only `Ord` treats trailing-zero
-                // segments as equal, so `1.4` and `1.4.0` match here.
+                // Match on a literal string equal OR a numeric release equal, so a pin
+                // like `==1.4` still hits a record listing `1.4.0`. A PEP 440 LOCAL
+                // version (`1.0+ubuntu1`) ALSO matches a record for its base (`1.0`): a
+                // local build is a rebuild of the base release, so a malicious upstream
+                // is not missed, while an exact local record (`1.0+ubuntu1`) still
+                // matches via the literal compare. Compare via `cmp` (not `==`): only
+                // `Ord` treats trailing-zero segments as equal, so `1.4` == `1.4.0`.
+                let v_s: &str = v;
+                let base: &str = v_s.split('+').next().unwrap_or(v_s);
                 let matched = rec.versions.iter().any(|rv| {
-                    rv == v
+                    let rv: &str = rv;
+                    rv == v_s
                         || matches!(
-                            (ReleaseVersion::parse(rv), ReleaseVersion::parse(v)),
+                            (ReleaseVersion::parse(rv), ReleaseVersion::parse(v_s)),
                             (Some(a), Some(b)) if a.cmp(&b) == std::cmp::Ordering::Equal
                         )
+                        || (base != v_s
+                            && (rv == base
+                                || matches!(
+                                    (ReleaseVersion::parse(rv), ReleaseVersion::parse(base)),
+                                    (Some(a), Some(b)) if a.cmp(&b) == std::cmp::Ordering::Equal
+                                )))
                 });
                 if matched {
                     PackageThreatAssessment::ExactMatch(summary)
@@ -1123,16 +1143,6 @@ impl ThreatDb {
                             };
                         }
                     }
-                }
-                // A version-specific malicious record with NO affected versions gives
-                // us nothing to test the constraint against, so we cannot claim the
-                // constraint excludes it; stay unresolved rather than silently clean.
-                if parsed_affected.is_empty() {
-                    return PackageThreatAssessment::Unresolved {
-                        summary,
-                        reason: UnresolvedReason::AffectedVersionUnparsed,
-                        affected_versions: affected,
-                    };
                 }
                 let intersecting: Vec<String> = parsed_affected
                     .iter()
@@ -3357,6 +3367,50 @@ mod tests {
         assert!(matches!(
             db.assess_package(Ecosystem::Npm, "no-versions-evil", &constraint),
             PackageThreatAssessment::Unresolved { .. }
+        ));
+        // The guard runs BEFORE the intent match, so an Exact request is Unresolved too
+        // (not a silent NoRecord that would drop the malicious finding entirely).
+        let exact = crate::version_intent::VersionIntent::Exact("1.0".to_string());
+        assert!(matches!(
+            db.assess_package(Ecosystem::Npm, "no-versions-evil", &exact),
+            PackageThreatAssessment::Unresolved { .. }
+        ));
+    }
+
+    #[test]
+    fn exact_local_version_matches_base_record() {
+        // A PEP 440 local version (`1.0+ubuntu1`) is a rebuild of its base `1.0`: a
+        // record listing the malicious base must still hard-match the local pin, and an
+        // exact-local record must match literally. Neither may downgrade to Unresolved.
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = ThreatDbWriter::new(1700000000, 1);
+        writer.add_package(
+            Ecosystem::Npm,
+            "base-evil",
+            &["1.0"],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false,
+            None,
+        );
+        writer.add_package(
+            Ecosystem::Npm,
+            "exact-local-evil",
+            &["1.0+ubuntu1"],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false,
+            None,
+        );
+        let db = ThreatDb::from_bytes(writer.build(&key).expect("build"), 0).expect("load");
+        let local = crate::version_intent::VersionIntent::Exact("1.0+ubuntu1".to_string());
+        assert!(matches!(
+            db.assess_package(Ecosystem::Npm, "base-evil", &local),
+            PackageThreatAssessment::ExactMatch(_)
+        ));
+        assert!(matches!(
+            db.assess_package(Ecosystem::Npm, "exact-local-evil", &local),
+            PackageThreatAssessment::ExactMatch(_)
         ));
     }
 

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -1580,49 +1580,51 @@ fn merge_assessments(
             _ => None,
         }
     };
-    let merge_affected = || {
-        let mut v = affected_from(&primary);
-        v.extend(affected_from(&overlay));
-        v.sort();
-        v.dedup();
-        v
-    };
-
     // 2. Any unresolved layer makes the result unresolved (primary's reason and
-    // summary preferred), carrying the union of affected versions.
+    // summary preferred). The affected versions come from the SAME layer whose summary
+    // is returned, NOT a union of both: the merged finding phrases the list as flagged by
+    // that one summary's `source_label`, so unioning would misattribute an overlay-only
+    // version to the primary's source. (The package is still flagged regardless; only the
+    // affected-version list is scoped to the reported source.)
     let primary_unresolved = matches!(primary, P::Unresolved { .. });
     let overlay_unresolved = matches!(overlay, P::Unresolved { .. });
     if primary_unresolved || overlay_unresolved {
-        let (reason, summary) = if let P::Unresolved {
+        let (reason, summary, affected_versions) = if let P::Unresolved {
             reason, summary, ..
         } = &primary
         {
-            (*reason, summary.clone())
+            (*reason, summary.clone(), affected_from(&primary))
         } else if let P::Unresolved {
             reason, summary, ..
         } = &overlay
         {
-            (*reason, summary.clone())
+            (*reason, summary.clone(), affected_from(&overlay))
         } else {
             unreachable!("one layer is Unresolved")
         };
         return P::Unresolved {
             summary,
             reason,
-            affected_versions: merge_affected(),
+            affected_versions,
         };
     }
 
-    // 3. A concrete intersection in either layer (primary summary preferred).
+    // 3. A concrete intersection in either layer (primary summary preferred). Same
+    // provenance rule: the affected versions come from the layer whose summary is returned.
     let primary_intersects = matches!(primary, P::ConstraintIntersectsAffected { .. });
     let overlay_intersects = matches!(overlay, P::ConstraintIntersectsAffected { .. });
     if primary_intersects || overlay_intersects {
-        let summary = summary_from(&primary)
-            .or_else(|| summary_from(&overlay))
-            .expect("an intersecting layer carries a summary");
+        let (summary, affected_versions) = if let Some(s) = summary_from(&primary) {
+            (s, affected_from(&primary))
+        } else {
+            (
+                summary_from(&overlay).expect("an intersecting layer carries a summary"),
+                affected_from(&overlay),
+            )
+        };
         return P::ConstraintIntersectsAffected {
             summary,
-            affected_versions: merge_affected(),
+            affected_versions,
         };
     }
 

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -404,6 +404,11 @@ pub enum UnresolvedReason {
     /// The constraint parsed, but at least one affected version in the record
     /// is not a plain release version we can compare against.
     AffectedVersionUnparsed,
+    /// The record is version-specific (not all-versions-malicious) but enumerates
+    /// NO affected versions, so there is nothing to match or exclude against. Distinct
+    /// from `AffectedVersionUnparsed` (versions present but uncomparable) so a JSON
+    /// consumer can tell MISSING version metadata from a malformed version.
+    AffectedVersionsMissing,
 }
 
 /// Outcome of a constraint-aware package threat assessment.
@@ -1069,7 +1074,7 @@ impl ThreatDb {
         if rec.versions.is_empty() {
             return PackageThreatAssessment::Unresolved {
                 summary,
-                reason: UnresolvedReason::AffectedVersionUnparsed,
+                reason: UnresolvedReason::AffectedVersionsMissing,
                 affected_versions: affected,
             };
         }
@@ -3548,10 +3553,38 @@ mod tests {
     }
 
     #[test]
-    fn assess_supplemental_unresolved_dedups_affected() {
+    fn assess_record_with_no_versions_is_missing_not_unparsed() {
+        // A version-specific record (not all-versions-malicious) that enumerates NO affected
+        // versions is AffectedVersionsMissing - distinct from AffectedVersionUnparsed (a
+        // present-but-uncomparable version) - so a JSON consumer can tell the two apart.
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = ThreatDbWriter::new(1700000000, 9);
+        writer.add_package(
+            Ecosystem::PyPI,
+            "no-vers",
+            &[],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            false,
+            None,
+        );
+        let bytes = writer.build(&key).expect("build failed");
+        let db = ThreatDb::from_bytes(bytes, 0).expect("load failed");
+        let a = db.assess_package(Ecosystem::PyPI, "no-vers", &constraint_intent(">=1.0.0"));
+        match a {
+            PackageThreatAssessment::Unresolved { reason, .. } => {
+                assert_eq!(reason, UnresolvedReason::AffectedVersionsMissing);
+            }
+            other => panic!("expected Unresolved (AffectedVersionsMissing), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assess_supplemental_merge_keeps_per_layer_affected() {
         // Primary excludes (>=1.4.4 over 1.4.2/1.4.3) but a supplemental overlay
-        // is unresolved for the same name; the merge must surface Unresolved
-        // (never the primary's exclusion) with deduplicated affected versions.
+        // is unresolved for the same name; the merge must surface Unresolved (never the
+        // primary's exclusion). Affected versions come from the SAME layer whose summary is
+        // returned - NOT a union - so a version is never misattributed to another source.
         let key = SigningKey::generate(&mut OsRng);
         let primary_bytes = {
             let mut w = ThreatDbWriter::new(1700000000, 11);
@@ -3596,16 +3629,17 @@ mod tests {
             other => panic!("expected ConstraintIntersectsAffected from overlay, got {other:?}"),
         }
 
-        // An Unspecified request is unresolved in both layers; affected versions
-        // are the deduplicated union across both.
+        // An Unspecified request is unresolved in both layers; the merged result keeps the
+        // PRIMARY layer's summary AND the primary's affected versions (NOT a union), so the
+        // overlay-only version (1.4.9) is not misattributed to the primary's source_label.
         let a2 = db.assess_package(Ecosystem::PyPI, "split-pkg", &VersionIntent::Unspecified);
         match a2 {
             PackageThreatAssessment::Unresolved {
                 affected_versions, ..
             } => {
-                assert_eq!(affected_versions, vec!["1.4.2", "1.4.3", "1.4.9"]);
+                assert_eq!(affected_versions, vec!["1.4.2", "1.4.3"]);
             }
-            other => panic!("expected Unresolved with merged affected, got {other:?}"),
+            other => panic!("expected Unresolved with the primary layer's affected, got {other:?}"),
         }
     }
 

--- a/crates/tirith-core/src/threatdb_api.rs
+++ b/crates/tirith-core/src/threatdb_api.rs
@@ -55,7 +55,11 @@ pub fn enrich_command(
     let urls = extract::extract_urls(input, shell);
 
     for package in packages {
-        let effective_version = if let Some(version) = package.version.as_version_str() {
+        // Only a CONCRETE version (Exact/Resolved) is a valid OSV `version`; a range
+        // or constraint must NOT be sent as one (OSV would treat the range text as a
+        // literal version, degrading matching and skipping deps.dev fallback). A
+        // non-concrete intent falls through to resolution instead.
+        let effective_version = if let Some(version) = package.version.exact_version() {
             Some(version.to_string())
         } else if config.deps_dev_enabled {
             resolve_default_version(package.ecosystem, &package.name, deadline)

--- a/crates/tirith-core/src/threatdb_api.rs
+++ b/crates/tirith-core/src/threatdb_api.rs
@@ -55,8 +55,8 @@ pub fn enrich_command(
     let urls = extract::extract_urls(input, shell);
 
     for package in packages {
-        let effective_version = if let Some(version) = package.version.clone() {
-            Some(version)
+        let effective_version = if let Some(version) = package.version.as_version_str() {
+            Some(version.to_string())
         } else if config.deps_dev_enabled {
             resolve_default_version(package.ecosystem, &package.name, deadline)
         } else {

--- a/crates/tirith-core/src/threatdb_api.rs
+++ b/crates/tirith-core/src/threatdb_api.rs
@@ -138,8 +138,7 @@ pub fn enrich_command(
                             severity: Severity::High,
                             title: "Google Safe Browsing match".to_string(),
                             description: format!(
-                                "URL '{}' matched Google Safe Browsing threat type '{}'.",
-                                url, match_type
+                                "URL '{url}' matched Google Safe Browsing threat type '{match_type}'."
                             ),
                             evidence: vec![Evidence::ThreatIntel {
                                 source: "Google Safe Browsing".to_string(),
@@ -606,8 +605,7 @@ fn build_kev_finding(ecosystem: Ecosystem, name: &str, version: &str, cve_id: &s
         severity: Severity::High,
         title: format!("Package advisory is in CISA KEV: {name}@{version}"),
         description: format!(
-            "Package '{}' in {} version '{}' is associated with actively exploited CVE '{}'.",
-            name, ecosystem, version, cve_id
+            "Package '{name}' in {ecosystem} version '{version}' is associated with actively exploited CVE '{cve_id}'."
         ),
         evidence: vec![Evidence::ThreatIntel {
             source: "CISA KEV via OSV.dev".to_string(),
@@ -629,10 +627,10 @@ fn build_suspicious_package_finding(
 ) -> Finding {
     let mut parts = Vec::new();
     if let Some(days) = signal.first_release_days {
-        parts.push(format!("first release {} day(s) ago", days));
+        parts.push(format!("first release {days} day(s) ago"));
     }
     if let Some(maintainers) = signal.maintainers {
-        parts.push(format!("{} maintainer(s)", maintainers));
+        parts.push(format!("{maintainers} maintainer(s)"));
     }
 
     Finding {

--- a/crates/tirith-core/src/tokenize.rs
+++ b/crates/tirith-core/src/tokenize.rs
@@ -745,7 +745,7 @@ mod tests {
             "Get-Date && Set-ExecutionPolicy Bypass",
             ShellType::PowerShell,
         );
-        assert_eq!(segs.len(), 2, "expected 2 segments, got {:?}", segs);
+        assert_eq!(segs.len(), 2, "expected 2 segments, got {segs:?}");
         assert_eq!(segs[0].command.as_deref(), Some("Get-Date"));
         assert_eq!(segs[1].preceding_separator.as_deref(), Some("&&"));
         assert_eq!(segs[1].command.as_deref(), Some("Set-ExecutionPolicy"));
@@ -757,7 +757,7 @@ mod tests {
             "Get-Date || Set-ExecutionPolicy Bypass",
             ShellType::PowerShell,
         );
-        assert_eq!(segs.len(), 2, "expected 2 segments, got {:?}", segs);
+        assert_eq!(segs.len(), 2, "expected 2 segments, got {segs:?}");
         assert_eq!(segs[0].command.as_deref(), Some("Get-Date"));
         assert_eq!(segs[1].preceding_separator.as_deref(), Some("||"));
         assert_eq!(segs[1].command.as_deref(), Some("Set-ExecutionPolicy"));
@@ -768,7 +768,7 @@ mod tests {
         // Critical precedence check: `||` must be consumed as ONE separator,
         // not two pipes producing three segments.
         let segs = tokenize("a || b", ShellType::PowerShell);
-        assert_eq!(segs.len(), 2, "expected 2 segments (||), got {:?}", segs);
+        assert_eq!(segs.len(), 2, "expected 2 segments (||), got {segs:?}");
         assert_eq!(segs[1].preceding_separator.as_deref(), Some("||"));
     }
 
@@ -789,8 +789,7 @@ mod tests {
         assert_eq!(
             segs.len(),
             1,
-            "expected 1 segment (single & is not a separator), got {:?}",
-            segs
+            "expected 1 segment (single & is not a separator), got {segs:?}"
         );
     }
 

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -140,6 +140,16 @@ pub enum RuleId {
     ThreatMaliciousIp,
     ThreatPackageTyposquat,
     ThreatPackageSimilarName,
+    /// A1 — the package name is in the malicious-package DB but the requested
+    /// version could not be resolved to a definite hit: an unpinned install
+    /// (`pip install foo`) of a version-specific malicious record, or a version
+    /// constraint that provably overlaps the affected versions. Distinct from
+    /// `ThreatMaliciousPackage` (a confirmed exact/all-versions hit, which still
+    /// fires and may short-circuit weaker signals); this one is Medium/Warn
+    /// because the resolver MIGHT pick an affected version. A constraint that
+    /// provably excludes every affected version does NOT fire this. Emitted by
+    /// `rules::threatintel` (command path) and `ecosystem_scan` (manifest path).
+    ThreatUnresolvedMaliciousPackage,
     // Supplemental-feed rules are defined now so RuleId stays stable.
     ThreatMaliciousUrl,
     ThreatPhishingUrl,

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -145,6 +145,31 @@ impl VersionIntent {
             }
         }
     }
+
+    /// Build an intent from a Cargo version requirement (`cargo add serde@1.0`,
+    /// `cargo install --version 1.0`). Unlike pip's `==` or an npm FULL pin, Cargo treats a
+    /// PLAIN version as a caret REQUIREMENT (`1.0` == `^1.0`); resolution then selects the
+    /// highest SemVer-compatible release, so the literal token is NOT what gets installed.
+    /// A plain token is therefore a [`Constraint`] (matching resolves the real installed
+    /// version), NOT an [`Exact`] pin. Only Cargo's `=` operator (`=1.0.0`) is an exact pin.
+    pub fn from_cargo_version(token: &str) -> VersionIntent {
+        let t = token.trim();
+        if t.is_empty() {
+            return VersionIntent::Unspecified;
+        }
+        // Cargo's `=` operator is the only exact pin: `=1.0.0` -> Exact("1.0.0").
+        if let Some(pinned) = t.strip_prefix('=') {
+            let pinned = pinned.trim();
+            if looks_like_plain_version(pinned) {
+                return VersionIntent::Exact(pinned.to_string());
+            }
+        }
+        // A plain version (Cargo's caret default) or any other sigil/range is a Constraint.
+        VersionIntent::Constraint {
+            parsed: None,
+            raw: t.to_string(),
+        }
+    }
 }
 
 /// Whether a token looks like a plain, fully-specified version (an exact pin)

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -101,8 +101,10 @@ impl VersionIntent {
             // leading `=`), epochs (`!`), wildcards (`*`), and whitespace, so those fall
             // through to a Constraint (and thus UNRESOLVED) instead of becoming a bogus
             // Exact string that silently fails to match the DB. Prereleases (`1.0.0rc1`)
-            // are still accepted, matching the threat-DB literal/numeric compare.
-            if looks_like_plain_version(ver) {
+            // are still accepted, matching the threat-DB literal/numeric compare. A PEP 440
+            // LOCAL version (`+local`) is outside the comparable subset (it can never match
+            // a base record like `1.0`), so it stays UNRESOLVED rather than a false Exact.
+            if looks_like_plain_version(ver) && !ver.contains('+') {
                 return VersionIntent::Exact(ver.to_string());
             }
         }
@@ -157,8 +159,12 @@ fn looks_like_plain_version(t: &str) -> bool {
     }
     body.chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '+')
-        // A bare `x`/`X` wildcard segment (`1.x`) is a range, not an exact pin.
-        && !body.split(['.', '-', '+']).any(|seg| seg == "x" || seg == "X")
+        // Every segment must be non-empty and not a wildcard: this rejects an empty
+        // segment (`1.`, `1..2`, `1.+`, a malformed or Gradle-style dynamic selector)
+        // and a `x`/`X` wildcard (`1.x`), which are ranges, not exact pins.
+        && body
+            .split(['.', '-', '+'])
+            .all(|seg| !seg.is_empty() && seg != "x" && seg != "X")
 }
 
 /// A parsed PEP 440 version constraint: a conjunction (AND) of comparison
@@ -401,6 +407,17 @@ mod tests {
             VersionIntent::from_pep440_specifier("==1.0.0;python_version<\"3.9\""),
             VersionIntent::Constraint { parsed: None, .. }
         ));
+        // A PEP 440 local version, and malformed/dynamic versions with an empty
+        // segment, must NOT be Exact either (they cannot match a base DB record).
+        for spec in ["==1.0+ubuntu1", "==1.", "==1..2", "==1.+"] {
+            assert!(
+                matches!(
+                    VersionIntent::from_pep440_specifier(spec),
+                    VersionIntent::Constraint { .. }
+                ),
+                "{spec} must be an unresolved Constraint, not Exact"
+            );
+        }
         // A clean exact pin and a prerelease pin are still Exact.
         assert_eq!(
             VersionIntent::from_pep440_specifier("==1.2.3"),

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -98,13 +98,13 @@ impl VersionIntent {
             let ver = rest.trim();
             // Only a clean exact-looking version is an Exact pin. `looks_like_plain_version`
             // rejects environment markers (`;`), arbitrary equality (`===`, which leaves a
-            // leading `=`), epochs (`!`), wildcards (`*`), and whitespace, so those fall
-            // through to a Constraint (and thus UNRESOLVED) instead of becoming a bogus
-            // Exact string that silently fails to match the DB. Prereleases (`1.0.0rc1`)
-            // are still accepted, matching the threat-DB literal/numeric compare. A PEP 440
-            // LOCAL version (`+local`) is outside the comparable subset (it can never match
-            // a base record like `1.0`), so it stays UNRESOLVED rather than a false Exact.
-            if looks_like_plain_version(ver) && !ver.contains('+') {
+            // leading `=`), epochs (`!`), wildcards (`*`), empty segments, and whitespace,
+            // so those fall through to a Constraint (and thus UNRESOLVED) instead of a bogus
+            // Exact. Prereleases (`1.0.0rc1`) AND PEP 440 local versions (`1.0+ubuntu1`) are
+            // kept Exact: `assess_package_self` matches an exact-local DB record literally
+            // and a malicious base record via its base, and `ReleaseVersion::parse` rejects
+            // locals so the numeric fallback never produces a false base match.
+            if looks_like_plain_version(ver) {
                 return VersionIntent::Exact(ver.to_string());
             }
         }
@@ -407,9 +407,9 @@ mod tests {
             VersionIntent::from_pep440_specifier("==1.0.0;python_version<\"3.9\""),
             VersionIntent::Constraint { parsed: None, .. }
         ));
-        // A PEP 440 local version, and malformed/dynamic versions with an empty
-        // segment, must NOT be Exact either (they cannot match a base DB record).
-        for spec in ["==1.0+ubuntu1", "==1.", "==1..2", "==1.+"] {
+        // Malformed/dynamic versions with an empty segment are NOT Exact (they cannot
+        // be a real pin). A `+` local version is handled separately below.
+        for spec in ["==1.", "==1..2", "==1.+"] {
             assert!(
                 matches!(
                     VersionIntent::from_pep440_specifier(spec),
@@ -418,6 +418,13 @@ mod tests {
                 "{spec} must be an unresolved Constraint, not Exact"
             );
         }
+        // A PEP 440 local version IS Exact: `assess_package_self` matches it against an
+        // exact-local DB record literally and a malicious base record via its base, so
+        // it must not be downgraded to an unresolved Constraint.
+        assert_eq!(
+            VersionIntent::from_pep440_specifier("==1.0+ubuntu1"),
+            VersionIntent::Exact("1.0+ubuntu1".to_string())
+        );
         // A clean exact pin and a prerelease pin are still Exact.
         assert_eq!(
             VersionIntent::from_pep440_specifier("==1.2.3"),

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -1,0 +1,475 @@
+//! Package version intent: a lossless replacement for the old
+//! `version: Option<String>` carried on package references.
+//!
+//! A bare `Option<String>` could not distinguish "no version asked for" from
+//! "an exact pin" from "a range constraint", so a constrained request like
+//! `pip install foo>=1.4.4` was flattened to "no version" and silently treated
+//! as unpinned. [`VersionIntent`] keeps that distinction, and an unparsed or
+//! only-partially-understood constraint is preserved verbatim and treated as
+//! UNRESOLVED, never silently as an exact match.
+//!
+//! The constraint evaluator here is a deliberately small, conservative subset
+//! of PEP 440: numeric release segments and the comparison operators `==`,
+//! `!=`, `<`, `<=`, `>`, `>=`. Anything outside that subset (an environment
+//! marker, an epoch, a local version, a pre/post/dev release, a wildcard, the
+//! compatible-release `~=`, or arbitrary equality `===`) deliberately fails to
+//! parse so the caller falls back to UNRESOLVED instead of guessing. A full
+//! PEP 440 solver is intentionally out of scope; the contract is "prove
+//! exclusion only when every part is understood, otherwise stay unresolved".
+
+/// How a package's version was expressed at the point of reference.
+///
+/// `Exact` and `Resolved` both name a single concrete version; they are kept
+/// distinct because `Exact` is what the user typed (an `==` pin or `name@ver`)
+/// while `Resolved` is what a resolver/lockfile pinned. Both are treated the
+/// same by the threat-DB assessment (a single version to test), but keeping the
+/// provenance lets later milestones reason about pin vs resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionIntent {
+    /// No version was given (e.g. `pip install foo`). The resolver is free to
+    /// pick any version, so a version-specific malicious record cannot be
+    /// excluded.
+    Unspecified,
+    /// An exact pin the user wrote (`==1.2.3`, `name@1.2.3`).
+    Exact(String),
+    /// A range/constraint expression (`>=1.4.4`, `>=1.2,<2.0`, `^1.0`). `raw`
+    /// preserves the original text exactly; `parsed` is `Some` only when the
+    /// WHOLE expression is within the supported PEP 440 subset.
+    Constraint {
+        raw: String,
+        parsed: Option<VersionConstraint>,
+    },
+    /// A concrete version a resolver/lockfile already pinned.
+    Resolved(String),
+}
+
+impl VersionIntent {
+    /// The single concrete version this intent names, if any (`Exact` or
+    /// `Resolved`). `Unspecified` and `Constraint` return `None`.
+    pub fn exact_version(&self) -> Option<&str> {
+        match self {
+            VersionIntent::Exact(v) | VersionIntent::Resolved(v) => Some(v.as_str()),
+            VersionIntent::Unspecified | VersionIntent::Constraint { .. } => None,
+        }
+    }
+
+    /// The raw constraint text, if this is a `Constraint`.
+    pub fn constraint_raw(&self) -> Option<&str> {
+        match self {
+            VersionIntent::Constraint { raw, .. } => Some(raw.as_str()),
+            _ => None,
+        }
+    }
+
+    /// The version text as originally written, regardless of kind: the concrete
+    /// version for `Exact`/`Resolved`, the raw constraint for `Constraint`, and
+    /// `None` for `Unspecified`. This reconstructs the lossy `Option<String>`
+    /// the field replaced, for consumers (e.g. OSV correlation) that just want
+    /// "the version string the user typed, if any".
+    pub fn as_version_str(&self) -> Option<&str> {
+        match self {
+            VersionIntent::Exact(v) | VersionIntent::Resolved(v) => Some(v.as_str()),
+            VersionIntent::Constraint { raw, .. } => Some(raw.as_str()),
+            VersionIntent::Unspecified => None,
+        }
+    }
+
+    /// Build an intent from a pip-style version-specifier tail (the part after
+    /// the package name, e.g. `==1.2.3`, `>=1.4.4`, `>=1.2,<2.0`, or `""`).
+    ///
+    /// A lone `==<ver>` (no wildcard) is an [`Exact`](VersionIntent::Exact)
+    /// pin; an empty/whitespace tail is [`Unspecified`](VersionIntent::Unspecified);
+    /// anything else is a [`Constraint`](VersionIntent::Constraint) whose `parsed`
+    /// is populated only when the whole expression is understood.
+    pub fn from_pep440_specifier(spec: &str) -> VersionIntent {
+        let trimmed = spec.trim();
+        if trimmed.is_empty() {
+            return VersionIntent::Unspecified;
+        }
+
+        // A single `==<ver>` with a plain version (no wildcard, no extra
+        // clauses) is an exact pin.
+        if let Some(rest) = trimmed.strip_prefix("==") {
+            let ver = rest.trim();
+            if !ver.is_empty()
+                && !ver.contains(',')
+                && !ver.contains('*')
+                && ReleaseVersion::parse(ver).is_some()
+            {
+                return VersionIntent::Exact(ver.to_string());
+            }
+        }
+
+        VersionIntent::Constraint {
+            parsed: VersionConstraint::parse(trimmed),
+            raw: trimmed.to_string(),
+        }
+    }
+
+    /// Build an intent from a single explicit version token of a non-PyPI
+    /// ecosystem (`name@1.2.3`, `name:^3.0`, `--version 1.2.3`).
+    ///
+    /// A plain version-looking token (digits and dots, optionally with a build/
+    /// prerelease tail like `-beta.1`) is an [`Exact`](VersionIntent::Exact)
+    /// pin: the threat DB stores literal version strings, so this preserves the
+    /// pre-existing exact-string match behavior. Anything carrying a range
+    /// sigil, wildcard, dist-tag, or whitespace becomes an unparsed
+    /// [`Constraint`](VersionIntent::Constraint) (the constraint syntax of these
+    /// ecosystems is not modeled, so it stays unresolved rather than being
+    /// mistaken for an exact pin).
+    pub fn from_explicit_version(token: &str) -> VersionIntent {
+        let t = token.trim();
+        if t.is_empty() {
+            return VersionIntent::Unspecified;
+        }
+        if looks_like_plain_version(t) {
+            VersionIntent::Exact(t.to_string())
+        } else {
+            // The constraint syntax of non-PyPI ecosystems is not parsed; keep
+            // the raw text and leave it unresolved.
+            VersionIntent::Constraint {
+                parsed: None,
+                raw: t.to_string(),
+            }
+        }
+    }
+}
+
+/// Whether a token looks like a plain, fully-specified version (an exact pin)
+/// rather than a range/tag. Accepts an optional single leading `v`/`V` (the Go
+/// module convention `v1.9.1`), then a digit, then digits, dots, and a `-`/`+`
+/// prerelease/build tail (`1.2.3`, `1.2.3-beta.1`, `1.2.3+build.5`). Rejects
+/// range sigils (`^ ~ > < = | *`), wildcards (`1.x`), whitespace, and dist-tags
+/// (`latest`).
+fn looks_like_plain_version(t: &str) -> bool {
+    // Allow a single leading `v`/`V` so Go's `v1.9.1` stays an exact pin.
+    let body = t.strip_prefix(['v', 'V']).unwrap_or(t);
+    match body.chars().next() {
+        Some(c) if c.is_ascii_digit() => {}
+        _ => return false,
+    }
+    body.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '+')
+        // A bare `x`/`X` wildcard segment (`1.x`) is a range, not an exact pin.
+        && !body.split(['.', '-', '+']).any(|seg| seg == "x" || seg == "X")
+}
+
+/// A parsed PEP 440 version constraint: a conjunction (AND) of comparison
+/// clauses, all within the supported subset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionConstraint {
+    clauses: Vec<Clause>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Clause {
+    op: Operator,
+    version: ReleaseVersion,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Operator {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
+impl VersionConstraint {
+    /// Parse a comma-separated constraint expression. Returns `Some` only when
+    /// EVERY clause uses a supported operator and a parseable plain version.
+    /// Any unsupported form (`~=`, `===`, wildcard, marker, epoch, local, pre/
+    /// post/dev release) makes the whole parse fail, by design.
+    pub fn parse(raw: &str) -> Option<VersionConstraint> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return None;
+        }
+        // Environment markers (`; python_version < "3.9"`) are not understood.
+        if raw.contains(';') {
+            return None;
+        }
+        let mut clauses = Vec::new();
+        for part in raw.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                return None;
+            }
+            clauses.push(parse_clause(part)?);
+        }
+        if clauses.is_empty() {
+            return None;
+        }
+        Some(VersionConstraint { clauses })
+    }
+
+    /// Evaluate the constraint against a concrete version. Every clause must
+    /// hold (logical AND), matching PEP 440 specifier-set semantics.
+    pub fn matches(&self, version: &ReleaseVersion) -> bool {
+        self.clauses.iter().all(|c| c.matches(version))
+    }
+}
+
+impl Clause {
+    fn matches(&self, version: &ReleaseVersion) -> bool {
+        let ord = version.cmp(&self.version);
+        match self.op {
+            Operator::Eq => ord == std::cmp::Ordering::Equal,
+            Operator::Ne => ord != std::cmp::Ordering::Equal,
+            Operator::Lt => ord == std::cmp::Ordering::Less,
+            Operator::Le => ord != std::cmp::Ordering::Greater,
+            Operator::Gt => ord == std::cmp::Ordering::Greater,
+            Operator::Ge => ord != std::cmp::Ordering::Less,
+        }
+    }
+}
+
+/// Parse a single clause like `>=1.4.4`. Rejects `~=`, `===`, and wildcards.
+fn parse_clause(part: &str) -> Option<Clause> {
+    // Reject the compatible-release and arbitrary-equality operators outright:
+    // their semantics are not modeled, so a constraint using them is unresolved.
+    if part.starts_with("~=") || part.starts_with("===") {
+        return None;
+    }
+
+    // Order matters: try two-character operators before one-character ones.
+    let (op, rest) = if let Some(r) = part.strip_prefix("==") {
+        (Operator::Eq, r)
+    } else if let Some(r) = part.strip_prefix("!=") {
+        (Operator::Ne, r)
+    } else if let Some(r) = part.strip_prefix("<=") {
+        (Operator::Le, r)
+    } else if let Some(r) = part.strip_prefix(">=") {
+        (Operator::Ge, r)
+    } else if let Some(r) = part.strip_prefix('<') {
+        (Operator::Lt, r)
+    } else if let Some(r) = part.strip_prefix('>') {
+        (Operator::Gt, r)
+    } else {
+        // A bare version, a caret/tilde range, or anything else: not understood.
+        return None;
+    };
+
+    let ver = rest.trim();
+    if ver.contains('*') {
+        // `==1.4.*` prefix matching is not modeled.
+        return None;
+    }
+    let version = ReleaseVersion::parse(ver)?;
+    Some(Clause { op, version })
+}
+
+/// A plain PEP 440 release version: numeric segments only (`1`, `1.4`,
+/// `1.4.4`). Trailing-zero differences compare equal (`1.4` == `1.4.0`), per
+/// PEP 440 release-segment semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseVersion {
+    segments: Vec<u64>,
+}
+
+impl ReleaseVersion {
+    /// Parse a plain numeric release version. Returns `None` for anything with
+    /// an epoch (`1!2.0`), a local version (`1.0+abc`), a pre/post/dev suffix
+    /// (`1.0rc1`, `1.0.post1`, `1.0.dev0`), a wildcard, a leading `v`, or any
+    /// non-numeric/empty segment.
+    pub fn parse(s: &str) -> Option<ReleaseVersion> {
+        let s = s.trim();
+        if s.is_empty() {
+            return None;
+        }
+        // Epoch, local version, and wildcards are out of the supported subset.
+        if s.contains('!') || s.contains('+') || s.contains('*') {
+            return None;
+        }
+        let mut segments = Vec::new();
+        for seg in s.split('.') {
+            if seg.is_empty() {
+                return None;
+            }
+            // Reject any non-digit (covers `rc`, `a`, `b`, `post`, `dev`, `v`,
+            // whitespace, and sign characters).
+            if !seg.bytes().all(|b| b.is_ascii_digit()) {
+                return None;
+            }
+            segments.push(seg.parse::<u64>().ok()?);
+        }
+        if segments.is_empty() {
+            return None;
+        }
+        Some(ReleaseVersion { segments })
+    }
+}
+
+impl PartialOrd for ReleaseVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ReleaseVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Compare segment by segment, treating a missing trailing segment as 0
+        // so `1.4` and `1.4.0` are equal.
+        let len = self.segments.len().max(other.segments.len());
+        for i in 0..len {
+            let a = self.segments.get(i).copied().unwrap_or(0);
+            let b = other.segments.get(i).copied().unwrap_or(0);
+            match a.cmp(&b) {
+                std::cmp::Ordering::Equal => continue,
+                non_eq => return non_eq,
+            }
+        }
+        std::cmp::Ordering::Equal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_specifier_is_unspecified() {
+        assert_eq!(
+            VersionIntent::from_pep440_specifier(""),
+            VersionIntent::Unspecified
+        );
+        assert_eq!(
+            VersionIntent::from_pep440_specifier("   "),
+            VersionIntent::Unspecified
+        );
+    }
+
+    #[test]
+    fn exact_pin_is_exact() {
+        assert_eq!(
+            VersionIntent::from_pep440_specifier("==1.2.3"),
+            VersionIntent::Exact("1.2.3".to_string())
+        );
+    }
+
+    #[test]
+    fn exact_pin_with_wildcard_is_unresolved_constraint() {
+        // `==1.2.*` is prefix matching, not an exact pin; it must not parse.
+        let intent = VersionIntent::from_pep440_specifier("==1.2.*");
+        match intent {
+            VersionIntent::Constraint { raw, parsed } => {
+                assert_eq!(raw, "==1.2.*");
+                assert!(parsed.is_none(), "wildcard must not parse");
+            }
+            other => panic!("expected unresolved Constraint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn range_constraint_parses() {
+        let intent = VersionIntent::from_pep440_specifier(">=1.2,<2.0");
+        match intent {
+            VersionIntent::Constraint {
+                raw,
+                parsed: Some(c),
+            } => {
+                assert_eq!(raw, ">=1.2,<2.0");
+                assert!(c.matches(&ReleaseVersion::parse("1.5").unwrap()));
+                assert!(!c.matches(&ReleaseVersion::parse("2.0").unwrap()));
+                assert!(!c.matches(&ReleaseVersion::parse("1.1").unwrap()));
+            }
+            other => panic!("expected parsed Constraint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compatible_release_operator_does_not_parse() {
+        assert!(VersionConstraint::parse("~=1.4.4").is_none());
+    }
+
+    #[test]
+    fn arbitrary_equality_does_not_parse() {
+        assert!(VersionConstraint::parse("===1.4.4").is_none());
+    }
+
+    #[test]
+    fn marker_does_not_parse() {
+        assert!(VersionConstraint::parse(">=1.0 ; python_version < \"3.9\"").is_none());
+    }
+
+    #[test]
+    fn caret_range_does_not_parse() {
+        // npm/cargo `^1.0` is not PEP 440 and is not in the supported subset.
+        assert!(VersionConstraint::parse("^1.0").is_none());
+    }
+
+    #[test]
+    fn epoch_and_local_and_prerelease_versions_do_not_parse() {
+        assert!(ReleaseVersion::parse("1!2.0").is_none());
+        assert!(ReleaseVersion::parse("1.0+ubuntu1").is_none());
+        assert!(ReleaseVersion::parse("1.0rc1").is_none());
+        assert!(ReleaseVersion::parse("1.0.post1").is_none());
+        assert!(ReleaseVersion::parse("1.0.dev0").is_none());
+        assert!(ReleaseVersion::parse("v1.0").is_none());
+    }
+
+    #[test]
+    fn trailing_zero_segments_compare_equal() {
+        let a = ReleaseVersion::parse("1.4").unwrap();
+        let b = ReleaseVersion::parse("1.4.0").unwrap();
+        assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn ordering_is_numeric_not_lexical() {
+        let v9 = ReleaseVersion::parse("1.9").unwrap();
+        let v10 = ReleaseVersion::parse("1.10").unwrap();
+        assert!(v9 < v10, "1.9 must be less than 1.10");
+    }
+
+    #[test]
+    fn excluding_constraint_excludes_affected() {
+        let c = VersionConstraint::parse(">=1.4.4").unwrap();
+        assert!(!c.matches(&ReleaseVersion::parse("1.4.2").unwrap()));
+        assert!(!c.matches(&ReleaseVersion::parse("1.4.3").unwrap()));
+        assert!(c.matches(&ReleaseVersion::parse("1.4.4").unwrap()));
+    }
+
+    #[test]
+    fn not_equal_clause_evaluates() {
+        let c = VersionConstraint::parse("!=1.4.2").unwrap();
+        assert!(!c.matches(&ReleaseVersion::parse("1.4.2").unwrap()));
+        assert!(c.matches(&ReleaseVersion::parse("1.4.3").unwrap()));
+    }
+
+    #[test]
+    fn explicit_plain_version_is_exact() {
+        assert_eq!(
+            VersionIntent::from_explicit_version("4.17.21"),
+            VersionIntent::Exact("4.17.21".to_string())
+        );
+        // Prerelease/build tails are still exact pins.
+        assert_eq!(
+            VersionIntent::from_explicit_version("1.2.3-beta.1"),
+            VersionIntent::Exact("1.2.3-beta.1".to_string())
+        );
+    }
+
+    #[test]
+    fn explicit_range_is_unparsed_constraint() {
+        for raw in ["^4.0", "~4.0", ">=4.0", "1.x", "latest", "4.0 || 5.0"] {
+            match VersionIntent::from_explicit_version(raw) {
+                VersionIntent::Constraint { raw: r, parsed } => {
+                    assert_eq!(r, raw.trim());
+                    assert!(parsed.is_none(), "non-PyPI range `{raw}` stays unparsed");
+                }
+                other => panic!("expected unparsed Constraint for `{raw}`, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_empty_is_unspecified() {
+        assert_eq!(
+            VersionIntent::from_explicit_version(""),
+            VersionIntent::Unspecified
+        );
+    }
+}

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -96,7 +96,13 @@ impl VersionIntent {
         // which already returns Exact for prerelease tails.
         if let Some(rest) = trimmed.strip_prefix("==") {
             let ver = rest.trim();
-            if !ver.is_empty() && !ver.contains(',') && !ver.contains('*') {
+            // Only a clean exact-looking version is an Exact pin. `looks_like_plain_version`
+            // rejects environment markers (`;`), arbitrary equality (`===`, which leaves a
+            // leading `=`), epochs (`!`), wildcards (`*`), and whitespace, so those fall
+            // through to a Constraint (and thus UNRESOLVED) instead of becoming a bogus
+            // Exact string that silently fails to match the DB. Prereleases (`1.0.0rc1`)
+            // are still accepted, matching the threat-DB literal/numeric compare.
+            if looks_like_plain_version(ver) {
                 return VersionIntent::Exact(ver.to_string());
             }
         }
@@ -380,6 +386,30 @@ mod tests {
             }
             other => panic!("expected unresolved Constraint, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn pep440_arbitrary_equality_and_markers_are_not_exact() {
+        // `===1.0` (arbitrary equality, leaves a leading `=`) and a marker-qualified
+        // pin must NOT become a bogus Exact; they fall through to an unresolved
+        // Constraint per the conservative subset.
+        assert!(matches!(
+            VersionIntent::from_pep440_specifier("===1.0"),
+            VersionIntent::Constraint { parsed: None, .. }
+        ));
+        assert!(matches!(
+            VersionIntent::from_pep440_specifier("==1.0.0;python_version<\"3.9\""),
+            VersionIntent::Constraint { parsed: None, .. }
+        ));
+        // A clean exact pin and a prerelease pin are still Exact.
+        assert_eq!(
+            VersionIntent::from_pep440_specifier("==1.2.3"),
+            VersionIntent::Exact("1.2.3".to_string())
+        );
+        assert_eq!(
+            VersionIntent::from_pep440_specifier("==1.0.0rc1"),
+            VersionIntent::Exact("1.0.0rc1".to_string())
+        );
     }
 
     #[test]

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -87,15 +87,16 @@ impl VersionIntent {
             return VersionIntent::Unspecified;
         }
 
-        // A single `==<ver>` with a plain version (no wildcard, no extra
-        // clauses) is an exact pin.
+        // A single `==<ver>` (no wildcard, no extra clauses) is an exact pin,
+        // regardless of whether the version parses as a plain numeric release.
+        // The exact INTENT does not need a parseable version: the threat-DB
+        // match is a literal/numeric string compare, so a prerelease pin like
+        // `==1.0.0rc1` is still Exact (and would otherwise degrade to a
+        // Constraint and a mere Warn). This mirrors `from_explicit_version`,
+        // which already returns Exact for prerelease tails.
         if let Some(rest) = trimmed.strip_prefix("==") {
             let ver = rest.trim();
-            if !ver.is_empty()
-                && !ver.contains(',')
-                && !ver.contains('*')
-                && ReleaseVersion::parse(ver).is_some()
-            {
+            if !ver.is_empty() && !ver.contains(',') && !ver.contains('*') {
                 return VersionIntent::Exact(ver.to_string());
             }
         }
@@ -283,6 +284,14 @@ impl ReleaseVersion {
         if s.contains('!') || s.contains('+') || s.contains('*') {
             return None;
         }
+        // Bound the allocation on attacker-influenceable version strings. A real
+        // release version has a handful of segments; a string with more than 16
+        // dot-separated parts is not a version we model, so refuse it rather than
+        // grow `segments` in proportion to the input length.
+        const MAX_SEGMENTS: usize = 16;
+        if s.split('.').count() > MAX_SEGMENTS {
+            return None;
+        }
         let mut segments = Vec::new();
         for seg in s.split('.') {
             if seg.is_empty() {
@@ -350,6 +359,17 @@ mod tests {
     }
 
     #[test]
+    fn exact_pin_with_prerelease_is_exact() {
+        // A lone `==<prerelease>` is an exact INTENT even though the version is
+        // not a plain numeric release: the DB match is a literal string compare,
+        // so it must not degrade to an Unresolved Constraint (a mere Warn).
+        match VersionIntent::from_pep440_specifier("==1.0.0rc1") {
+            VersionIntent::Exact(v) => assert_eq!(v, "1.0.0rc1"),
+            other => panic!("expected Exact for `==1.0.0rc1`, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn exact_pin_with_wildcard_is_unresolved_constraint() {
         // `==1.2.*` is prefix matching, not an exact pin; it must not parse.
         let intent = VersionIntent::from_pep440_specifier("==1.2.*");
@@ -408,6 +428,13 @@ mod tests {
         assert!(ReleaseVersion::parse("1.0.post1").is_none());
         assert!(ReleaseVersion::parse("1.0.dev0").is_none());
         assert!(ReleaseVersion::parse("v1.0").is_none());
+    }
+
+    #[test]
+    fn excessive_segments_do_not_parse() {
+        // 17 dot-separated segments is past the cap; the parser refuses it
+        // rather than allocating a segment vector sized to the input.
+        assert!(ReleaseVersion::parse("1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.17").is_none());
     }
 
     #[test]

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -178,7 +178,7 @@ impl VersionIntent {
 /// prerelease/build tail (`1.2.3`, `1.2.3-beta.1`, `1.2.3+build.5`). Rejects
 /// range sigils (`^ ~ > < = | *`), wildcards (`1.x`), whitespace, and dist-tags
 /// (`latest`).
-fn looks_like_plain_version(t: &str) -> bool {
+pub(crate) fn looks_like_plain_version(t: &str) -> bool {
     // Allow a single leading `v`/`V` so Go's `v1.9.1` stays an exact pin.
     let body = t.strip_prefix(['v', 'V']).unwrap_or(t);
     match body.chars().next() {

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -170,6 +170,16 @@ impl VersionIntent {
             raw: t.to_string(),
         }
     }
+
+    /// Build an intent from a Ruby Gemfile version requirement (`gem "x", "= 1.0"`,
+    /// `gem "x", "~> 1.0"`). Unlike Cargo, a bare `1.0` and an explicit `= 1.0` are BOTH
+    /// exact pins; `~>`, `>=`, `<`, etc. are ranges. Strip a single leading `=` operator,
+    /// then reuse the plain-or-constraint logic (plain -> Exact, sigil -> Constraint).
+    pub fn from_gem_version(token: &str) -> VersionIntent {
+        let t = token.trim();
+        let stripped = t.strip_prefix('=').map(str::trim).unwrap_or(t);
+        Self::from_explicit_version(stripped)
+    }
 }
 
 /// Whether a token looks like a plain, fully-specified version (an exact pin)

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -11,11 +11,14 @@
 //! The constraint evaluator here is a deliberately small, conservative subset
 //! of PEP 440: numeric release segments and the comparison operators `==`,
 //! `!=`, `<`, `<=`, `>`, `>=`. Anything outside that subset (an environment
-//! marker, an epoch, a local version, a pre/post/dev release, a wildcard, the
-//! compatible-release `~=`, or arbitrary equality `===`) deliberately fails to
-//! parse so the caller falls back to UNRESOLVED instead of guessing. A full
-//! PEP 440 solver is intentionally out of scope; the contract is "prove
-//! exclusion only when every part is understood, otherwise stay unresolved".
+//! marker, an epoch, a pre/post/dev release, a wildcard, the compatible-release
+//! `~=`, or arbitrary equality `===`) deliberately fails to parse so the caller
+//! falls back to UNRESOLVED instead of guessing. A PEP 440 LOCAL version
+//! (`1.0+ubuntu1`) is the exception: an EXACT local pin is kept as `Exact` and
+//! matched against the threat DB literally and by its base release (a local build
+//! carries the base's code); only a local inside a RANGE stays unresolved. A full
+//! PEP 440 solver is intentionally out of scope; the contract is "prove exclusion
+//! only when every part is understood, otherwise stay unresolved".
 
 /// How a package's version was expressed at the point of reference.
 ///

--- a/crates/tirith-core/src/version_intent.rs
+++ b/crates/tirith-core/src/version_intent.rs
@@ -173,10 +173,20 @@ impl VersionIntent {
 
     /// Build an intent from a Ruby Gemfile version requirement (`gem "x", "= 1.0"`,
     /// `gem "x", "~> 1.0"`). Unlike Cargo, a bare `1.0` and an explicit `= 1.0` are BOTH
-    /// exact pins; `~>`, `>=`, `<`, etc. are ranges. Strip a single leading `=` operator,
-    /// then reuse the plain-or-constraint logic (plain -> Exact, sigil -> Constraint).
+    /// exact pins; `~>`, `>=`, `<`, etc. are ranges. A shell-tokenized CLI value may retain
+    /// one matching pair of quotes, so remove that pair before stripping a single leading `=`
+    /// operator, then reuse the plain-or-constraint logic (plain -> Exact, sigil -> Constraint).
     pub fn from_gem_version(token: &str) -> VersionIntent {
         let t = token.trim();
+        let t = t
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .or_else(|| {
+                t.strip_prefix('\'')
+                    .and_then(|value| value.strip_suffix('\''))
+            })
+            .unwrap_or(t)
+            .trim();
         let stripped = t.strip_prefix('=').map(str::trim).unwrap_or(t);
         Self::from_explicit_version(stripped)
     }
@@ -296,11 +306,9 @@ fn parse_clause(part: &str) -> Option<Clause> {
         (Operator::Ge, r)
     } else if let Some(r) = part.strip_prefix('<') {
         (Operator::Lt, r)
-    } else if let Some(r) = part.strip_prefix('>') {
-        (Operator::Gt, r)
     } else {
         // A bare version, a caret/tilde range, or anything else: not understood.
-        return None;
+        (Operator::Gt, part.strip_prefix('>')?)
     };
 
     let ver = rest.trim();

--- a/crates/tirith-core/tests/generate_test_fixtures.rs
+++ b/crates/tirith-core/tests/generate_test_fixtures.rs
@@ -93,7 +93,7 @@ fn build_test_db(signing_key: &SigningKey) {
     let dat_path = repo_root().join("tests/fixtures/test-threatdb.dat");
     writer
         .write_to(&dat_path, signing_key)
-        .unwrap_or_else(|e| panic!("Failed to write test DB: {}", e));
+        .unwrap_or_else(|e| panic!("Failed to write test DB: {e}"));
     eprintln!("Wrote test DB to {}", dat_path.display());
 
     // Structural reload only: verify_signature() fails until a rebuild embeds

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -602,6 +602,7 @@ const ALL_RULE_IDS: &[&str] = &[
     "threat_malicious_ip",
     "threat_package_typosquat",
     "threat_package_similar_name",
+    "threat_unresolved_malicious_package",
     // Threat intelligence — supplemental feeds
     "threat_malicious_url",
     "threat_phishing_url",
@@ -1182,6 +1183,7 @@ rule_id_variant_registry! {
     SvgExternalReference,
     // Threat intelligence — local DB
     ThreatMaliciousPackage, ThreatMaliciousIp, ThreatPackageTyposquat, ThreatPackageSimilarName,
+    ThreatUnresolvedMaliciousPackage,
     // Threat intelligence — supplemental feeds
     ThreatMaliciousUrl, ThreatPhishingUrl, ThreatTorExitNode, ThreatThreatFoxIoc,
     // Threat intelligence — real-time lookups
@@ -1340,6 +1342,8 @@ fn test_no_url_rules_have_no_url_fixtures() {
         // M8 ch5 — container-runtime rules fire without a URL in the input.
         "docker_run_privileged",           // docker run --privileged alpine
         "docker_run_sensitive_bind_mount", // docker run -v /var/run/docker.sock:...
+        // A1 — unpinned/constrained malicious package: npm install evil-package
+        "threat_unresolved_malicious_package",
     ]
     .into_iter()
     .collect();

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -1586,12 +1586,10 @@ fn test_tier1_matches_all_interpreters() {
     use tirith_core::rules::command::INTERPRETERS;
 
     for name in INTERPRETERS {
-        let input = format!("cat /tmp/s.sh | {}", name);
+        let input = format!("cat /tmp/s.sh | {name}");
         assert!(
             tier1_scan(&input, ScanContext::Exec),
-            "Tier-1 scan does not match plain interpreter '{}' in '{}'",
-            name,
-            input
+            "Tier-1 scan does not match plain interpreter '{name}' in '{input}'"
         );
     }
 

--- a/crates/tirith/src/bin/tirith_threatdb_compile.rs
+++ b/crates/tirith/src/bin/tirith_threatdb_compile.rs
@@ -1141,12 +1141,12 @@ fn main() {
     eprintln!("  IPs (Feodo):           {}", ips.len());
     eprintln!("  typosquats:            {}", typosquats.len());
     eprintln!("  popular packages:      {}", popular.len());
-    eprintln!("  CISA KEV CVEs:         {}", kev_count);
+    eprintln!("  CISA KEV CVEs:         {kev_count}");
     eprintln!(
         "  skipped (range-only):  {}",
         ossf_stats.skipped_range_only_count
     );
-    eprintln!("  skipped (corrupt):     {}", total_files_skipped);
+    eprintln!("  skipped (corrupt):     {total_files_skipped}");
     eprintln!(
         "  ecosystems:            {}",
         ecosystems_seen

--- a/crates/tirith/src/cli/agent.rs
+++ b/crates/tirith/src/cli/agent.rs
@@ -47,22 +47,22 @@ fn label_origin(origin: &AgentOrigin) -> String {
             }
         }
         AgentOrigin::Agent { tool, version } => match version {
-            Some(v) => format!("agent ({:?} {:?})", tool, v),
-            None => format!("agent ({:?})", tool),
+            Some(v) => format!("agent ({tool:?} {v:?})"),
+            None => format!("agent ({tool:?})"),
         },
         AgentOrigin::Mcp {
             client_name,
             client_version,
         } => match client_version {
-            Some(v) => format!("mcp ({:?} {:?})", client_name, v),
-            None => format!("mcp ({:?})", client_name),
+            Some(v) => format!("mcp ({client_name:?} {v:?})"),
+            None => format!("mcp ({client_name:?})"),
         },
         AgentOrigin::Gateway => "gateway".to_string(),
         AgentOrigin::Ci { provider } => match provider {
-            Some(p) => format!("ci ({:?})", p),
+            Some(p) => format!("ci ({p:?})"),
             None => "ci (generic)".to_string(),
         },
-        AgentOrigin::Ide { name } => format!("ide ({:?})", name),
+        AgentOrigin::Ide { name } => format!("ide ({name:?})"),
     }
 }
 
@@ -131,8 +131,8 @@ impl OriginGroupKey {
             ("human", _, None) => "human".to_string(),
             ("gateway", _, _) => "gateway".to_string(),
             ("ci", None, _) => "ci (generic)".to_string(),
-            ("ci", Some(p), _) => format!("ci ({:?})", p),
-            (kind, Some(p), _) => format!("{kind} ({:?})", p),
+            ("ci", Some(p), _) => format!("ci ({p:?})"),
+            (kind, Some(p), _) => format!("{kind} ({p:?})"),
             (kind, None, _) => kind.to_string(),
         }
     }
@@ -420,7 +420,7 @@ pub fn explain(query: &str, log_override: Option<&str>, json: bool) -> i32 {
         report_error(
             json,
             "tirith agent explain",
-            &format!("no matching audit entries for {:?}", query),
+            &format!("no matching audit entries for {query:?}"),
         );
         return 1;
     }
@@ -813,10 +813,7 @@ pub fn allow(kind_str: &str, tool: Option<&str>, json: bool) -> i32 {
         report_error(
             json,
             "tirith agent allow",
-            &format!(
-                "unknown kind {:?} (valid: human, agent, mcp, gateway, ci, ide)",
-                kind_str
-            ),
+            &format!("unknown kind {kind_str:?} (valid: human, agent, mcp, gateway, ci, ide)"),
         );
         return 1;
     };
@@ -910,10 +907,7 @@ pub fn block(kind_str: &str, payload: Option<&str>, command_pattern: &str, json:
         report_error(
             json,
             "tirith agent block",
-            &format!(
-                "unknown kind {:?} (valid: human, agent, mcp, gateway, ci, ide)",
-                kind_str
-            ),
+            &format!("unknown kind {kind_str:?} (valid: human, agent, mcp, gateway, ci, ide)"),
         );
         return 1;
     };

--- a/crates/tirith/src/cli/checkpoint.rs
+++ b/crates/tirith/src/cli/checkpoint.rs
@@ -19,34 +19,32 @@ pub fn list_checkpoints(json: bool) -> i32 {
                         "{}".to_string()
                     })
                 );
+            } else if entries.is_empty() {
+                println!("No checkpoints found.");
             } else {
-                if entries.is_empty() {
-                    println!("No checkpoints found.");
-                } else {
+                println!(
+                    "{id:<38} {created:<26} {files:<8} {size:<12} Trigger",
+                    id = "ID",
+                    created = "Created",
+                    files = "Files",
+                    size = "Size"
+                );
+                println!("{}", "-".repeat(100));
+                for e in &entries {
+                    let size = format_bytes(e.total_bytes);
+                    let trigger = e
+                        .trigger_command
+                        .as_deref()
+                        .unwrap_or("-")
+                        .chars()
+                        .take(30)
+                        .collect::<String>();
                     println!(
-                        "{id:<38} {created:<26} {files:<8} {size:<12} Trigger",
-                        id = "ID",
-                        created = "Created",
-                        files = "Files",
-                        size = "Size"
+                        "{:<38} {:<26} {:<8} {:<12} {}",
+                        e.id, e.created_at, e.file_count, size, trigger
                     );
-                    println!("{}", "-".repeat(100));
-                    for e in &entries {
-                        let size = format_bytes(e.total_bytes);
-                        let trigger = e
-                            .trigger_command
-                            .as_deref()
-                            .unwrap_or("-")
-                            .chars()
-                            .take(30)
-                            .collect::<String>();
-                        println!(
-                            "{:<38} {:<26} {:<8} {:<12} {}",
-                            e.id, e.created_at, e.file_count, size, trigger
-                        );
-                    }
-                    println!("\n{} checkpoint(s)", entries.len());
                 }
+                println!("\n{} checkpoint(s)", entries.len());
             }
             0
         }

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -2239,7 +2239,7 @@ fn print_human(info: &DoctorInfo) {
             );
         } else if tdb.stale {
             let age_str = match tdb.age_hours {
-                Some(h) if h < 48.0 => format!("{:.0}h old", h),
+                Some(h) if h < 48.0 => format!("{h:.0}h old"),
                 Some(h) => format!("{:.0}d old", h / 24.0),
                 None => "unknown age".to_string(),
             };
@@ -2248,7 +2248,7 @@ fn print_human(info: &DoctorInfo) {
             let path = tdb.path.as_deref().unwrap_or("unknown");
             let age_str = match tdb.age_hours {
                 Some(h) if h < 1.0 => format!("{:.0}m old", h * 60.0),
-                Some(h) if h < 48.0 => format!("{:.0}h old", h),
+                Some(h) if h < 48.0 => format!("{h:.0}h old"),
                 Some(h) => format!("{:.0}d old", h / 24.0),
                 None => "unknown age".to_string(),
             };
@@ -2358,8 +2358,7 @@ fn print_human(info: &DoctorInfo) {
             println!();
             if next_level > gaps.current_paranoia {
                 println!(
-                    "  \u{2192} Set 'paranoia: {}' in .tirith/policy.yaml to surface these detections",
-                    next_level
+                    "  \u{2192} Set 'paranoia: {next_level}' in .tirith/policy.yaml to surface these detections"
                 );
             }
         }

--- a/crates/tirith/src/cli/ecosystem.rs
+++ b/crates/tirith/src/cli/ecosystem.rs
@@ -233,7 +233,7 @@ fn exit_code(action: Action) -> i32 {
 /// silence every longer name containing it.
 fn package_allowlisted(policy: &Policy, eco: Ecosystem, name: &str) -> bool {
     let bare = name.to_lowercase();
-    let qualified = format!("{}:{}", eco, bare);
+    let qualified = format!("{eco}:{bare}");
 
     let matches_entry = |entry: &str| {
         let e = entry.trim().to_lowercase();

--- a/crates/tirith/src/cli/iac.rs
+++ b/crates/tirith/src/cli/iac.rs
@@ -274,7 +274,7 @@ fn emit_check_plan_human(plan_path: &Path, sha: &str, summary: &PlanSummary, pur
     eprintln!("tirith iac check-plan:");
     eprintln!("  plan:        {}", plan_path.display());
     eprintln!("  tool:        {}", summary.tool.as_str());
-    eprintln!("  sha256:      {}", sha);
+    eprintln!("  sha256:      {sha}");
     eprintln!(
         "  changes:     create={} update={} destroy={} (total={})",
         summary.create, summary.update, summary.destroy, summary.total_changes,
@@ -304,7 +304,7 @@ fn emit_check_plan_human(plan_path: &Path, sha: &str, summary: &PlanSummary, pur
         }
     }
     if purged > 0 {
-        eprintln!("  purged {} old plan(s) from the cache", purged);
+        eprintln!("  purged {purged} old plan(s) from the cache");
     }
     eprintln!("  recorded in: {}", iac_plan::iac_plans_dir_display(),);
 }

--- a/crates/tirith/src/cli/install.rs
+++ b/crates/tirith/src/cli/install.rs
@@ -674,7 +674,7 @@ fn emit_combined_json(plan: &InstallPlan, online: bool, outcome: Option<OutcomeR
         .map(|p| PackageOut {
             ecosystem: p.reference.ecosystem.to_string(),
             name: &p.reference.name,
-            version: p.reference.version.as_deref(),
+            version: p.reference.version.as_version_str(),
             risk_score: p.risk.score,
             risk_level: p.risk.risk_level,
         })

--- a/crates/tirith/src/cli/output_guard.rs
+++ b/crates/tirith/src/cli/output_guard.rs
@@ -176,25 +176,17 @@ fn strip_block(content: &str) -> String {
 fn build_snippet(shell: &str) -> String {
     match shell {
         "fish" => format!(
-            "{begin}\nfunction tirith-output-guard-wrap\n    if test (count $argv) -eq 0\n        echo 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]' >&2\n        return 2\n    end\n    $argv 2>&1 | tirith view --max-bytes 16777216 -\nend\nalias tirith-out 'tirith-output-guard-wrap'\n{end}\n",
-            begin = BEGIN_MARKER,
-            end = END_MARKER,
+            "{BEGIN_MARKER}\nfunction tirith-output-guard-wrap\n    if test (count $argv) -eq 0\n        echo 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]' >&2\n        return 2\n    end\n    $argv 2>&1 | tirith view --max-bytes 16777216 -\nend\nalias tirith-out 'tirith-output-guard-wrap'\n{END_MARKER}\n",
         ),
         "nushell" => format!(
-            "{begin}\ndef tirith-output-guard-wrap [...cmd] {{\n    if ($cmd | length) == 0 {{\n        print --stderr 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]'\n        return 2\n    }}\n    run-external $cmd.0 ...($cmd | skip 1) | tirith view --max-bytes 16777216 -\n}}\nalias tirith-out = tirith-output-guard-wrap\n{end}\n",
-            begin = BEGIN_MARKER,
-            end = END_MARKER,
+            "{BEGIN_MARKER}\ndef tirith-output-guard-wrap [...cmd] {{\n    if ($cmd | length) == 0 {{\n        print --stderr 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]'\n        return 2\n    }}\n    run-external $cmd.0 ...($cmd | skip 1) | tirith view --max-bytes 16777216 -\n}}\nalias tirith-out = tirith-output-guard-wrap\n{END_MARKER}\n",
         ),
         "powershell" => format!(
-            "{begin}\nfunction tirith-output-guard-wrap {{\n    param([Parameter(ValueFromRemainingArguments=$true)]$Args)\n    if ($Args.Count -eq 0) {{\n        Write-Error 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]'\n        return\n    }}\n    & $Args[0] $Args[1..($Args.Count-1)] 2>&1 | & tirith view --max-bytes 16777216 -\n}}\nSet-Alias tirith-out tirith-output-guard-wrap\n{end}\n",
-            begin = BEGIN_MARKER,
-            end = END_MARKER,
+            "{BEGIN_MARKER}\nfunction tirith-output-guard-wrap {{\n    param([Parameter(ValueFromRemainingArguments=$true)]$Args)\n    if ($Args.Count -eq 0) {{\n        Write-Error 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]'\n        return\n    }}\n    & $Args[0] $Args[1..($Args.Count-1)] 2>&1 | & tirith view --max-bytes 16777216 -\n}}\nSet-Alias tirith-out tirith-output-guard-wrap\n{END_MARKER}\n",
         ),
         // zsh / bash / posix sh share one snippet.
         _ => format!(
-            "{begin}\ntirith-output-guard-wrap() {{\n    if [ \"$#\" -eq 0 ]; then\n        echo 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]' >&2\n        return 2\n    fi\n    \"$@\" 2>&1 | command tirith view --max-bytes 16777216 -\n}}\nalias tirith-out='tirith-output-guard-wrap'\n{end}\n",
-            begin = BEGIN_MARKER,
-            end = END_MARKER,
+            "{BEGIN_MARKER}\ntirith-output-guard-wrap() {{\n    if [ \"$#\" -eq 0 ]; then\n        echo 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]' >&2\n        return 2\n    fi\n    \"$@\" 2>&1 | command tirith view --max-bytes 16777216 -\n}}\nalias tirith-out='tirith-output-guard-wrap'\n{END_MARKER}\n",
         ),
     }
 }
@@ -232,11 +224,7 @@ mod tests {
 
     #[test]
     fn strip_block_removes_inserted_section() {
-        let content = format!(
-            "before line\n{begin}\nfunc def\n{end}\nafter line\n",
-            begin = BEGIN_MARKER,
-            end = END_MARKER,
-        );
+        let content = format!("before line\n{BEGIN_MARKER}\nfunc def\n{END_MARKER}\nafter line\n",);
         let out = strip_block(&content);
         assert!(out.contains("before line"));
         assert!(out.contains("after line"));

--- a/crates/tirith/src/cli/policy.rs
+++ b/crates/tirith/src/cli/policy.rs
@@ -912,7 +912,7 @@ fn print_test_command_human(
     _policy: &Policy,
     trace: &PolicyTrace,
 ) {
-    eprintln!("tirith policy test: command = {:?}", command);
+    eprintln!("tirith policy test: command = {command:?}");
     eprintln!(
         "  policy: {}",
         trace
@@ -947,7 +947,7 @@ fn print_test_command_human(
 
 fn print_test_file_human(file_path: &str, result: &scan::FileScanResult, _policy: &Policy) {
     if result.findings.is_empty() {
-        eprintln!("tirith policy test: {} — no findings", file_path);
+        eprintln!("tirith policy test: {file_path} — no findings");
         return;
     }
 

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -661,7 +661,7 @@ fn print_status_human(info: &ThreatDbStatus) {
     let path = info.path.as_deref().unwrap_or("unknown");
     let age_str = match info.age_hours {
         Some(h) if h < 1.0 => format!("{:.0}m old", h * 60.0),
-        Some(h) if h < 48.0 => format!("{:.0}h old", h),
+        Some(h) if h < 48.0 => format!("{h:.0}h old"),
         Some(h) => format!("{:.0}d old", h / 24.0),
         None => "unknown age".to_string(),
     };
@@ -902,8 +902,7 @@ fn fetch_manifest_from_with_state(
         let content_len = resp.content_length().unwrap_or(0);
         if content_len > MAX_MANIFEST_SIZE {
             return Err(format!(
-                "manifest too large: {} bytes (max {})",
-                content_len, MAX_MANIFEST_SIZE
+                "manifest too large: {content_len} bytes (max {MAX_MANIFEST_SIZE})"
             ));
         }
         let body = resp
@@ -970,8 +969,7 @@ fn fetch_manifest_from_with_state(
             let retry_content_len = retry_resp.content_length().unwrap_or(0);
             if retry_content_len > MAX_MANIFEST_SIZE {
                 return Err(format!(
-                    "manifest too large on retry: {} bytes (max {})",
-                    retry_content_len, MAX_MANIFEST_SIZE
+                    "manifest too large on retry: {retry_content_len} bytes (max {MAX_MANIFEST_SIZE})"
                 ));
             }
             let retry_etag = retry_resp
@@ -1528,9 +1526,8 @@ fn explain_package(
             source_label: None,
             confidence: None,
             detail: format!(
-                "{} package '{}' is edit-distance {} from the popular package '{}' \
-                 — a possible slopsquat/typo. Not itself listed as malicious.",
-                eco, name, distance, popular
+                "{eco} package '{name}' is edit-distance {distance} from the popular package '{popular}' \
+                 — a possible slopsquat/typo. Not itself listed as malicious."
             ),
             reference_url: None,
         });
@@ -1977,7 +1974,7 @@ const MONTH_DAYS: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 /// Proleptic Gregorian leap-year test, shared by the date parser and formatter.
 fn is_leap_year(y: i64) -> bool {
-    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+    (y.rem_euclid(4) == 0 && y.rem_euclid(100) != 0) || y.rem_euclid(400) == 0
 }
 
 /// Parse `YYYY-MM-DD` (or `...THH:MM:SS`) to a Unix epoch. Dependency-free;
@@ -2504,8 +2501,7 @@ mod tests {
         let diff = written_ts.saturating_sub(now);
         assert_eq!(
             diff, BACKOFF_SECS,
-            "backoff should set next-check-at to now + {} seconds, got diff={}",
-            BACKOFF_SECS, diff
+            "backoff should set next-check-at to now + {BACKOFF_SECS} seconds, got diff={diff}"
         );
         assert_eq!(
             BACKOFF_SECS, 3600,

--- a/crates/tirith/src/cli/warnings.rs
+++ b/crates/tirith/src/cli/warnings.rs
@@ -136,8 +136,7 @@ fn print_summary(w: &SessionWarnings, top_rules: &[(String, u32)]) {
         let next_level = next_paranoia_for_hidden(w.hidden_low, w.hidden_info);
         if let Some(next) = next_level {
             eprintln!(
-                "  \u{21b3} {} findings hidden ({hidden_desc}). Set 'paranoia: {next}' in .tirith/policy.yaml to see them.",
-                hidden,
+                "  \u{21b3} {hidden} findings hidden ({hidden_desc}). Set 'paranoia: {next}' in .tirith/policy.yaml to see them.",
             );
         }
     } else {

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -1120,7 +1120,18 @@ fn embedded_shell_hooks_match_repo_hooks() {
 
 #[test]
 fn tier1_exit_fast_for_ls() {
-    let out = tirith()
+    let tmpdir = tempfile::tempdir().expect("tempdir");
+    let project = tmpdir.path().join("project");
+    let home = tmpdir.path().join("home");
+    fs::create_dir_all(project.join(".git")).expect("create isolated project");
+    fs::create_dir_all(&home).expect("create isolated home");
+
+    let mut command = tirith_isolated("tier1-exit-fast", &tmpdir.path().join("state"), &project);
+    scrub_ambient_env(&mut command);
+    let out = command
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("XDG_CONFIG_HOME", tmpdir.path().join("config"))
         .args(["check", "--json", "--shell", "posix", "--", "ls -la /tmp"])
         .output()
         .expect("failed to run tirith");

--- a/deny.toml
+++ b/deny.toml
@@ -1,25 +1,6 @@
 [advisories]
 version = 2
-ignore = [
-    # time RFC 2822 parsing DoS (stack exhaustion). Cargo.toml pins time to
-    # <0.3.38 (0.3.38+ needs time-core >=0.1.3 / Rust 1.85, above our MSRV 1.83),
-    # so the version we build predates the advisory's 0.3.47 fix and stays in the
-    # affected range. Ignored regardless: that fix requires Rust 1.88 (far above
-    # MSRV 1.83), and tirith never parses user-controlled RFC 2822 dates (the only
-    # trigger). Transitive dep via lopdf/rust-s3. See the time pin note in Cargo.toml.
-    "RUSTSEC-2026-0009",
-    # rustls-pemfile unmaintained — transitive dep of rust-s3 (license server).
-    # No replacement available; rust-s3 hasn't migrated yet.
-    "RUSTSEC-2025-0134",
-    # rustls-webpki CRL / name-constraint advisories — affect 0.101.7 via
-    # rust-s3 → aws-creds → attohttpc → rustls → rustls-webpki. Transitive
-    # chain pinned until rust-s3 moves forward. tirith does not use CRL
-    # revocation checking or name-constraint validation on this path. The
-    # current 0.103.x copy is kept up to date separately.
-    "RUSTSEC-2026-0098",
-    "RUSTSEC-2026-0099",
-    "RUSTSEC-2026-0104",
-]
+ignore = []
 
 [licenses]
 version = 2

--- a/tests/fixtures/ecosystem.toml
+++ b/tests/fixtures/ecosystem.toml
@@ -608,10 +608,14 @@ context = "exec"
 expected_action = "allow"
 expected_rules = []
 
+# Uses a synthetic package name (not `react`/etc): the engine consults the
+# locally-installed threat DB via `ThreatDb::cached()`, and a real popular name
+# can now carry a version-specific malicious record (A1 unresolved-warn), which
+# would make this static-path fixture environment-dependent.
 [[fixture]]
 name = "m6_ch6_package_maintainer_change_static_path_does_not_fire"
 min_milestone = 6
-input = "npm install react"
+input = "npm install maintainer-change-test-pkg"
 context = "exec"
 expected_action = "allow"
 expected_rules = []

--- a/tests/fixtures/threatintel.toml
+++ b/tests/fixtures/threatintel.toml
@@ -69,6 +69,40 @@ context = "exec"
 expected_action = "allow"
 expected_rules = []
 
+# A1 — an unpinned install of a version-specific malicious record cannot be
+# resolved, so it warns (not blocks) and must NOT claim a confirmed exact match.
+[[fixture]]
+name = "npm_install_unpinned_malicious_warns_unresolved"
+min_milestone = 1
+input = "npm install evil-package"
+context = "exec"
+expected_action = "warn"
+expected_rules = ["threat_unresolved_malicious_package"]
+forbidden_rules = ["threat_malicious_package"]
+
+# A1 — an npm range constraint is not in the parsed subset, so it stays
+# unresolved (warn), never a false exact match.
+[[fixture]]
+name = "npm_install_range_malicious_warns_unresolved"
+min_milestone = 1
+input = "npm install evil-package@^1.0"
+context = "exec"
+expected_action = "warn"
+expected_rules = ["threat_unresolved_malicious_package"]
+forbidden_rules = ["threat_malicious_package"]
+
+# A1 — the unresolved warning does NOT short-circuit other signals: a co-present
+# typosquat (reacct -> react) still fires. The typosquat is High, so the verdict
+# blocks, but both rules must be present and there must be no false exact match.
+[[fixture]]
+name = "npm_install_unresolved_plus_typosquat_both_fire"
+min_milestone = 1
+input = "npm install evil-package reacct"
+context = "exec"
+expected_action = "block"
+expected_rules = ["threat_unresolved_malicious_package", "threat_package_typosquat"]
+forbidden_rules = ["threat_malicious_package"]
+
 [[fixture]]
 name = "pip_install_all_versions_malicious"
 min_milestone = 1

--- a/tools/license-server/Cargo.toml
+++ b/tools/license-server/Cargo.toml
@@ -38,5 +38,6 @@ uuid = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-# Backup (optional R2/S3)
-rust-s3 = { version = "0.35", default-features = false, features = ["tokio-rustls-tls"] }
+# R2 backup uses the existing reqwest/HMAC/SHA-256 stack and a small,
+# deterministic AWS SigV4 signer in `main.rs`. Keeping the one PUT operation
+# in-tree avoids pulling the vulnerable rust-s3 -> aws-creds -> quick-xml chain.

--- a/tools/license-server/src/main.rs
+++ b/tools/license-server/src/main.rs
@@ -352,26 +352,15 @@ async fn upload_to_r2(
     backup_path: &str,
     date_str: &str,
 ) {
-    use s3::creds::Credentials;
-    use s3::Bucket;
-    use s3::Region;
-
-    let region = Region::Custom {
-        region: "auto".to_string(),
-        endpoint: endpoint.to_string(),
-    };
-    let credentials = match Credentials::new(Some(access_key), Some(secret_key), None, None, None) {
-        Ok(c) => c,
+    let client = match reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(client) => client,
         Err(e) => {
-            error!("R2 credentials error: {e}");
-            return;
-        }
-    };
-
-    let bucket = match Bucket::new(bucket_name, region, credentials) {
-        Ok(b) => b,
-        Err(e) => {
-            error!("R2 bucket init error: {e}");
+            error!("failed to build R2 HTTP client: {e}");
             return;
         }
     };
@@ -385,12 +374,22 @@ async fn upload_to_r2(
     };
 
     let key = format!("backups/tirith-license-{date_str}.db");
-    match bucket.put_object(&key, &data).await {
-        Ok(resp) if resp.status_code() < 300 => {
+    match put_r2_object(
+        &client,
+        endpoint,
+        bucket_name,
+        access_key,
+        secret_key,
+        &key,
+        data,
+    )
+    .await
+    {
+        Ok(status) if status.is_success() => {
             info!(key = %key, "backup uploaded to R2");
         }
-        Ok(resp) => {
-            error!(status = resp.status_code(), "R2 upload returned error");
+        Ok(status) => {
+            error!(%status, "R2 upload returned error");
         }
         Err(e) => {
             error!("R2 upload failed: {e}");
@@ -400,8 +399,255 @@ async fn upload_to_r2(
     let checksum_path = format!("{backup_path}.sha256");
     if let Ok(checksum_data) = tokio::fs::read(&checksum_path).await {
         let checksum_key = format!("backups/tirith-license-{date_str}.db.sha256");
-        if let Err(e) = bucket.put_object(&checksum_key, &checksum_data).await {
-            error!("R2 checksum upload failed: {e}");
+        match put_r2_object(
+            &client,
+            endpoint,
+            bucket_name,
+            access_key,
+            secret_key,
+            &checksum_key,
+            checksum_data,
+        )
+        .await
+        {
+            Ok(status) if status.is_success() => {}
+            Ok(status) => error!(%status, "R2 checksum upload returned error"),
+            Err(e) => error!("R2 checksum upload failed: {e}"),
         }
+    }
+}
+
+const R2_REGION: &str = "auto";
+const S3_SERVICE: &str = "s3";
+const SIGV4_ALGORITHM: &str = "AWS4-HMAC-SHA256";
+const SIGV4_SIGNED_HEADERS: &str = "host;x-amz-content-sha256;x-amz-date";
+
+struct SignedR2Put {
+    url: reqwest::Url,
+    host: String,
+    amz_date: String,
+    payload_hash: String,
+    authorization: String,
+}
+
+fn hmac_sha256(key: &[u8], input: &[u8]) -> [u8; 32] {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(key)
+        .expect("HMAC-SHA256 accepts keys of every length");
+    mac.update(input);
+    let bytes = mac.finalize().into_bytes();
+    let mut output = [0_u8; 32];
+    output.copy_from_slice(&bytes);
+    output
+}
+
+/// Build a path-style R2 PUT request signed with AWS Signature Version 4.
+///
+/// R2 uses the standard S3 SigV4 protocol with the fixed `auto` region. The
+/// endpoint is deployment configuration, but it still has to be an HTTPS origin
+/// with no credentials, query, or fragment so Authorization can never be sent to
+/// a redirected or ambiguous target.
+fn sign_r2_put(
+    endpoint: &str,
+    bucket_name: &str,
+    access_key: &str,
+    secret_key: &str,
+    key: &str,
+    body: &[u8],
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<SignedR2Put, &'static str> {
+    use sha2::{Digest, Sha256};
+
+    if bucket_name.is_empty()
+        || access_key.is_empty()
+        || secret_key.is_empty()
+        || key.is_empty()
+        || key.split('/').any(str::is_empty)
+    {
+        return Err("R2 signing inputs are incomplete");
+    }
+
+    let mut url = reqwest::Url::parse(endpoint).map_err(|_| "R2 endpoint is not a valid URL")?;
+    if url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.path() != "/"
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err("R2 endpoint must be a credential-free HTTPS origin");
+    }
+
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|_| "R2 endpoint cannot be used as a URL base")?;
+        segments.pop_if_empty().push(bucket_name);
+        for segment in key.split('/') {
+            segments.push(segment);
+        }
+    }
+
+    let hostname = url.host_str().ok_or("R2 endpoint has no host")?;
+    let host = match url.port() {
+        Some(port) => format!("{hostname}:{port}"),
+        None => hostname.to_string(),
+    };
+    let canonical_uri = url.path();
+    let payload_hash = hex::encode(Sha256::digest(body));
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let date = now.format("%Y%m%d").to_string();
+    let canonical_headers =
+        format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n");
+    let canonical_request = format!(
+        "PUT\n{canonical_uri}\n\n{canonical_headers}\n{SIGV4_SIGNED_HEADERS}\n{payload_hash}"
+    );
+    let scope = format!("{date}/{R2_REGION}/{S3_SERVICE}/aws4_request");
+    let string_to_sign = format!(
+        "{SIGV4_ALGORITHM}\n{amz_date}\n{scope}\n{}",
+        hex::encode(Sha256::digest(canonical_request.as_bytes()))
+    );
+
+    let date_key = hmac_sha256(format!("AWS4{secret_key}").as_bytes(), date.as_bytes());
+    let region_key = hmac_sha256(&date_key, R2_REGION.as_bytes());
+    let service_key = hmac_sha256(&region_key, S3_SERVICE.as_bytes());
+    let signing_key = hmac_sha256(&service_key, b"aws4_request");
+    let signature = hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+    let authorization = format!(
+        "{SIGV4_ALGORITHM} Credential={access_key}/{scope}, SignedHeaders={SIGV4_SIGNED_HEADERS}, Signature={signature}"
+    );
+
+    Ok(SignedR2Put {
+        url,
+        host,
+        amz_date,
+        payload_hash,
+        authorization,
+    })
+}
+
+async fn put_r2_object(
+    client: &reqwest::Client,
+    endpoint: &str,
+    bucket_name: &str,
+    access_key: &str,
+    secret_key: &str,
+    key: &str,
+    body: Vec<u8>,
+) -> Result<reqwest::StatusCode, &'static str> {
+    use reqwest::header::{AUTHORIZATION, HOST};
+
+    let signed = sign_r2_put(
+        endpoint,
+        bucket_name,
+        access_key,
+        secret_key,
+        key,
+        &body,
+        chrono::Utc::now(),
+    )?;
+    client
+        .put(signed.url)
+        .header(HOST, signed.host)
+        .header("x-amz-content-sha256", signed.payload_hash)
+        .header("x-amz-date", signed.amz_date)
+        .header(AUTHORIZATION, signed.authorization)
+        .body(body)
+        .send()
+        .await
+        .map(|response| response.status())
+        .map_err(|_| "R2 upload request failed")
+}
+
+#[cfg(test)]
+mod r2_signing_tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn test_time() -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc
+            .with_ymd_and_hms(2026, 8, 12, 3, 4, 5)
+            .single()
+            .unwrap()
+    }
+
+    #[test]
+    fn r2_signature_matches_fixed_independent_vector() {
+        let signed = sign_r2_put(
+            "https://account.r2.cloudflarestorage.com",
+            "tirith-backups",
+            "AKIAEXAMPLE",
+            "very-secret-test-key",
+            "backups/tirith-license-2026-08-12.db",
+            b"abc",
+            test_time(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            signed.url.as_str(),
+            "https://account.r2.cloudflarestorage.com/tirith-backups/backups/tirith-license-2026-08-12.db"
+        );
+        assert_eq!(
+            signed.payload_hash,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            signed.authorization,
+            "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/20260812/auto/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=8640f3028fe5b7c57a6d90c4da75539c28984c62d1a593b334d90f5a96cf8ab9"
+        );
+        assert!(!signed.authorization.contains("very-secret-test-key"));
+    }
+
+    #[test]
+    fn r2_signer_rejects_ambiguous_or_insecure_endpoints() {
+        for endpoint in [
+            "http://account.r2.cloudflarestorage.com",
+            "https://user@account.r2.cloudflarestorage.com",
+            "https://account.r2.cloudflarestorage.com/api/",
+            "https://account.r2.cloudflarestorage.com?redirect=1",
+            "https://account.r2.cloudflarestorage.com#fragment",
+        ] {
+            assert!(sign_r2_put(
+                endpoint,
+                "bucket",
+                "key",
+                "secret",
+                "backup.db",
+                b"x",
+                test_time()
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn r2_signature_binds_payload_and_percent_encoded_path() {
+        let first = sign_r2_put(
+            "https://account.r2.cloudflarestorage.com",
+            "backup bucket",
+            "key",
+            "secret",
+            "daily/backup file.db",
+            b"first",
+            test_time(),
+        )
+        .unwrap();
+        let second = sign_r2_put(
+            "https://account.r2.cloudflarestorage.com",
+            "backup bucket",
+            "key",
+            "secret",
+            "daily/backup file.db",
+            b"second",
+            test_time(),
+        )
+        .unwrap();
+
+        assert_eq!(first.url.path(), "/backup%20bucket/daily/backup%20file.db");
+        assert_ne!(first.payload_hash, second.payload_hash);
+        assert_ne!(first.authorization, second.authorization);
     }
 }

--- a/tools/sign-license/src/main.rs
+++ b/tools/sign-license/src/main.rs
@@ -181,7 +181,7 @@ fn cmd_keygen(output: &PathBuf, kid: &str) -> Result<(), String> {
     println!("    kid: \"{kid}\",");
     print!("    key: [");
     for (i, b) in pk_bytes.iter().enumerate() {
-        if i % 20 == 0 {
+        if i.is_multiple_of(20) {
             print!("\n        ");
         }
         print!("{b}");
@@ -411,7 +411,7 @@ fn parse_timestamp(s: &str) -> Result<i64, String> {
 }
 
 fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, String> {
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         return Err("hex string has odd length".to_string());
     }
     (0..hex.len())


### PR DESCRIPTION
Part of the artifact-firewall hardening train (Stack A, PR 1 of 4). Bases on `main`. The rest of Stack A (A2 to A4) and Stack B will stack on this branch.

## What

Replace the lossy `version: Option<String>` on package references with a `VersionIntent` enum (Unspecified / Exact / Constraint{raw, parsed} / Resolved) at both the command-path `PackageRef` and the ecosystem dependency model, so an unpinned or constrained install is no longer flattened to "no version" and silently treated as unpinned-clean. An unparsed or only partially understood constraint is preserved verbatim and treated as unresolved, never an exact pin.

Add a constraint-aware, serializable `assess_package` to the threat DB returning a tagged `PackageThreatAssessment` (NoRecord / ExactMatch / ConstraintIntersectsAffected / ConstraintExcludesAffected / Unresolved), built from wire strings (`ThreatMatchSummary`) since neither `ThreatMatch` nor `ThreatSource` derive Serialize. `check_package` stays as a shim. An all-versions record hard-matches even when Unspecified; `ConstraintExcludesAffected` is returned only on proven exclusion (whole requirement parsed, every affected version parsed, all evaluate false); any unsupported PEP 440 form (marker, epoch, local, `~=`, `===`, wildcard, parse failure) becomes Unresolved. PEP 440 parsing is PyPI only for now; other ecosystems stay unresolved.

New Medium / Warn RuleId `ThreatUnresolvedMaliciousPackage`, fired for the Unresolved and ConstraintIntersectsAffected paths on both the command path and the manifest/installed path. It does not short-circuit other signals: a co-present typosquat still fires, and only an ExactMatch suppresses weaker name-similarity findings.

Introduce `escalation::finalize_static_verdict` and use it in `ecosystem_scan`, which previously built its verdict via `Verdict::from_findings` and so ignored `action_overrides`. It applies severity overrides, action derivation, action overrides, then paranoia filtering without downgrading an override-forced Block.

## Notes

- Tests for the malicious-package paths build throwaway in-memory signed DBs rather than regenerating the shared `test-threatdb.dat`, because the generator also rotates the production Ed25519 verify key.
- The new threat fixtures use existing hermetic `test-threatdb.dat` content (synthetic `evil-package` / `reacct`), not real package names.

## Gate

fmt clean, clippy `-D warnings` clean, full workspace builds, 2961 tirith-core tests pass. The known parallel-env-race flakes (checkpoint-restore, clipboard-sidecar, url_validate documentation-range) pass single-threaded and touch no A1 code.

## Stack

A2 (typed scan outcomes, coverage, file classification) will base on this branch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a Threat Intel **Medium** warning: `threat_unresolved_malicious_package` when a malicious package name is known but the requested version is **unpinned or overlaps affected versions**, with remediation guidance.

- **Bug Fixes**
  - Made threat assessment **constraint-aware**, distinguishing confirmed malicious vs **unresolved** cases.
  - Improved verdict handling so **block overrides** remain consistent after filtering.
  - Excluded this rule from injection-seed downgrade flows.
  - Updated per-package JSON to report the **analyzed version intent**.

- **Refactor**
  - Introduced lossless **version-intent** handling across scans and installs.

- **Tests**
  - Extended golden fixtures and added new threat-intel unresolved fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the lossy `version: Option<String>` on package references with a `VersionIntent` enum (`Unspecified / Exact / Constraint / Resolved`), adds a constraint-aware `assess_package` to the threat DB returning a tagged `PackageThreatAssessment`, and introduces `finalize_static_verdict` to ensure `ecosystem_scan` honours `action_overrides` and paranoia policy levers that the bare `Verdict::from_findings` constructor ignored.

- **`VersionIntent` + PEP 440 constraint evaluator** (`version_intent.rs`): lossless representation of pip specifiers, Cargo caret requirements, npm X-ranges, and Gem version strings; conservatively rejects unsupported forms (markers, epochs, `~=`, wildcards) as `Unresolved`.
- **`assess_package` / `merge_assessments`** (`threatdb.rs`): constraint-aware assessment returning `NoRecord / ExactMatch / ConstraintIntersectsAffected / ConstraintExcludesAffected / Unresolved`; raw-token exact fallback handles non-semver identifiers (Docker digests, dist-tags); `ConstraintExcludesAffected` requires proven exclusion of every affected version.
- **`finalize_static_verdict`** (`escalation.rs`) + **manifest parsers** (`ecosystem_scan.rs`): all manifest paths now carry version intent; Python `python_requirement_spec` strips extras brackets and inline comments; `npm_partial_xrange` uses `checked_add` to prevent overflow; `ecosystem_scan` now applies action and severity overrides via the new finalizer.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one known cosmetic gap: the ecosystem-scan path's warning for a constraint that provably overlaps malicious versions uses the same imprecise 'could not be resolved' message as a fully-unresolvable constraint, where the command path correctly says 'overlaps the affected versions'. No security bypasses or missed detections were found.

The new `assess_package` logic, the `VersionIntent` constructors, `python_requirement_spec` inline-comment stripping, `npm_partial_xrange` overflow guard, and `finalize_static_verdict` are all correct and well-tested. The one remaining gap — `unresolved_dependency_finding` emitting a generic message for `ConstraintIntersectsAffected` while the command path generates a more specific one — is a UX inconsistency, not a missed detection or false negative. Prior-cycle findings (gem CLI `from_explicit_version` instead of `from_gem_version`, Gemfile multi-constraint second-spec dropped, Poetry version specs as Unspecified) are acknowledged deferred work and stay conservative (warn rather than silently pass).

`crates/tirith-core/src/ecosystem_scan.rs` — the `unresolved_dependency_finding` function and the `findings_for` block that calls it for both `ConstraintIntersectsAffected` and `Unresolved`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/version_intent.rs | New file introducing `VersionIntent` enum and PEP 440 constraint parser; handles edge cases (local versions, markers, wildcards, overflow) conservatively and is well-tested. |
| crates/tirith-core/src/threatdb.rs | Adds `assess_package` / `assess_package_self` with constraint-aware assessment and `merge_assessments` for supplemental overlay; all precedence rules and edge cases (empty-versions, local-version base-match, raw-token fallback) are well-tested. |
| crates/tirith-core/src/ecosystem_scan.rs | Extensive manifest-parser upgrades carrying `VersionIntent` through every ecosystem; `python_requirement_spec` correctly strips extras and inline comments; `npm_partial_xrange` uses `checked_add` for overflow safety. Minor: `unresolved_dependency_finding` uses a generic 'could not be resolved' message for `ConstraintIntersectsAffected` where a more specific description is warranted. |
| crates/tirith-core/src/rules/threatintel.rs | Command-path assessment migrated to `assess_package`; correct ecosystem-specific helpers used (e.g., `from_cargo_version`, `from_pep440_specifier`). Gem CLI `--version` flag still calls `from_explicit_version` rather than `from_gem_version`, which was flagged in a previous review cycle. |
| crates/tirith-core/src/escalation.rs | New `finalize_static_verdict` closes the gap where `ecosystem_scan` ignored `action_overrides`; paranoia never downgrades an override-forced Block; causal findings are re-exposed post-paranoia so a restored Block still has an explanation. Four dedicated tests cover the critical code paths. |
| crates/tirith-core/src/install_txn.rs | Docker/Go version parsing migrated to `VersionIntent`; OSV enrichment correctly restricts `effective_version` to `exact_version()` only, preventing range text from being sent as a literal version to the OSV API. |
| crates/tirith-core/src/threatdb_api.rs | Uses `exact_version()` instead of `version.clone()` for the OSV lookup, correctly preventing constraint text from being sent as a literal version string. |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Package reference\n(name + raw version string)"] --> B["VersionIntent\nconstructor"]
    B --> |"pip ==1.2.3"| C["Exact('1.2.3')"]
    B --> |"pip >=1.0,<2.0\n(parsed PEP 440)"| D["Constraint{parsed:Some}"]
    B --> |"cargo ^1.0\n(unparsed)"| E["Constraint{parsed:None}"]
    B --> |"pip install foo\n(no version)"| F["Unspecified"]
    B --> |"lockfile pin"| G["Resolved('1.2.3')"]
    C --> H["assess_package_self"]
    D --> H
    E --> H
    F --> H
    G --> H
    H --> |"all_versions_malicious"| I["ExactMatch → Critical/Block"]
    H --> |"Exact/Resolved matches DB"| I
    H --> |"Exact/Resolved misses DB"| J["NoRecord → no finding"]
    H --> |"Unspecified"| K["Unresolved → Medium/Warn"]
    H --> |"Constraint parsed,\noverlaps affected"| L["ConstraintIntersects → Medium/Warn"]
    H --> |"Constraint parsed,\nexcludes all affected"| M["ConstraintExcludes → no finding"]
    H --> |"Constraint unparsed,\nraw token literal match"| I
    H --> |"Constraint unparsed,\nno literal match"| K
    I --> N["finalize_static_verdict\n(overrides + paranoia)"]
    K --> N
    L --> N
    N --> O["EcosystemScanReport / InstallVerdict"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Package reference\n(name + raw version string)"] --> B["VersionIntent\nconstructor"]
    B --> |"pip ==1.2.3"| C["Exact('1.2.3')"]
    B --> |"pip >=1.0,<2.0\n(parsed PEP 440)"| D["Constraint{parsed:Some}"]
    B --> |"cargo ^1.0\n(unparsed)"| E["Constraint{parsed:None}"]
    B --> |"pip install foo\n(no version)"| F["Unspecified"]
    B --> |"lockfile pin"| G["Resolved('1.2.3')"]
    C --> H["assess_package_self"]
    D --> H
    E --> H
    F --> H
    G --> H
    H --> |"all_versions_malicious"| I["ExactMatch → Critical/Block"]
    H --> |"Exact/Resolved matches DB"| I
    H --> |"Exact/Resolved misses DB"| J["NoRecord → no finding"]
    H --> |"Unspecified"| K["Unresolved → Medium/Warn"]
    H --> |"Constraint parsed,\noverlaps affected"| L["ConstraintIntersects → Medium/Warn"]
    H --> |"Constraint parsed,\nexcludes all affected"| M["ConstraintExcludes → no finding"]
    H --> |"Constraint unparsed,\nraw token literal match"| I
    H --> |"Constraint unparsed,\nno literal match"| K
    I --> N["finalize_static_verdict\n(overrides + paranoia)"]
    K --> N
    L --> N
    N --> O["EcosystemScanReport / InstallVerdict"]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `crates/tirith-core/src/threatdb.rs`, line 853-860 ([link](https://github.com/sheeki03/tirith/blob/ee8751966b39df4f40616c556c6beba9f719559e/crates/tirith-core/src/threatdb.rs#L853-L860)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Non-semver exact strings silently downgraded from ExactMatch to Unresolved**

   The command path now calls `assess_package` instead of `check_package`. For version strings that `looks_like_plain_version` rejects — Docker digests (`sha256:abcdef…`), the implicit-`"latest"` token from `parse_docker_specs`/`parse_go_specs`, and any other non-semver specifier — `from_explicit_version` produces `Constraint { raw, parsed: None }`. This arm returns `Unresolved { ConstraintUnsupported }` without attempting a verbatim string comparison against `rec.versions`.

   The old `check_package` path used `rv == version` directly. For a threat DB record that is **not** `all_versions_malicious` and whose affected version strings are non-semver (e.g., a specific Docker tag `"3.15.0-alpine"` or a digest), the assessment silently changes from `ExactMatch` → `ThreatMaliciousPackage` (Block/Critical) to `Unresolved` → `ThreatUnresolvedMaliciousPackage` (Warn/Medium).

   A minimal fix is to do a verbatim fallback before the `ConstraintUnsupported` bail-out:
   ```rust
   VersionIntent::Constraint { parsed, raw } => {
       // Fallback: verbatim match preserves pre-existing behaviour for
       // non-semver exact specifiers (Docker digests, dist-tags stored
       // literally in the DB).
       if rec.versions.iter().any(|rv| rv == raw) {
           return PackageThreatAssessment::ExactMatch(summary);
       }
       let Some(constraint) = parsed else {
           return PackageThreatAssessment::Unresolved { … };
       };
   ```
   The existing `check_package_shim_still_matches` test validates the shim, not the new `assess_package` path, so a regression here would not be caught by the current test suite.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftirith-core%2Fsrc%2Fthreatdb.rs%0ALine%3A%20853-860%0A%0AComment%3A%0A**Non-semver%20exact%20strings%20silently%20downgraded%20from%20ExactMatch%20to%20Unresolved**%0A%0AThe%20command%20path%20now%20calls%20%60assess_package%60%20instead%20of%20%60check_package%60.%20For%20version%20strings%20that%20%60looks_like_plain_version%60%20rejects%20%E2%80%94%20Docker%20digests%20%28%60sha256%3Aabcdef%E2%80%A6%60%29%2C%20the%20implicit-%60%22latest%22%60%20token%20from%20%60parse_docker_specs%60%2F%60parse_go_specs%60%2C%20and%20any%20other%20non-semver%20specifier%20%E2%80%94%20%60from_explicit_version%60%20produces%20%60Constraint%20%7B%20raw%2C%20parsed%3A%20None%20%7D%60.%20This%20arm%20returns%20%60Unresolved%20%7B%20ConstraintUnsupported%20%7D%60%20without%20attempting%20a%20verbatim%20string%20comparison%20against%20%60rec.versions%60.%0A%0AThe%20old%20%60check_package%60%20path%20used%20%60rv%20%3D%3D%20version%60%20directly.%20For%20a%20threat%20DB%20record%20that%20is%20**not**%20%60all_versions_malicious%60%20and%20whose%20affected%20version%20strings%20are%20non-semver%20%28e.g.%2C%20a%20specific%20Docker%20tag%20%60%223.15.0-alpine%22%60%20or%20a%20digest%29%2C%20the%20assessment%20silently%20changes%20from%20%60ExactMatch%60%20%E2%86%92%20%60ThreatMaliciousPackage%60%20%28Block%2FCritical%29%20to%20%60Unresolved%60%20%E2%86%92%20%60ThreatUnresolvedMaliciousPackage%60%20%28Warn%2FMedium%29.%0A%0AA%20minimal%20fix%20is%20to%20do%20a%20verbatim%20fallback%20before%20the%20%60ConstraintUnsupported%60%20bail-out%3A%0A%60%60%60rust%0AVersionIntent%3A%3AConstraint%20%7B%20parsed%2C%20raw%20%7D%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20Fallback%3A%20verbatim%20match%20preserves%20pre-existing%20behaviour%20for%0A%20%20%20%20%2F%2F%20non-semver%20exact%20specifiers%20%28Docker%20digests%2C%20dist-tags%20stored%0A%20%20%20%20%2F%2F%20literally%20in%20the%20DB%29.%0A%20%20%20%20if%20rec.versions.iter%28%29.any%28%7Crv%7C%20rv%20%3D%3D%20raw%29%20%7B%0A%20%20%20%20%20%20%20%20return%20PackageThreatAssessment%3A%3AExactMatch%28summary%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20let%20Some%28constraint%29%20%3D%20parsed%20else%20%7B%0A%20%20%20%20%20%20%20%20return%20PackageThreatAssessment%3A%3AUnresolved%20%7B%20%E2%80%A6%20%7D%3B%0A%20%20%20%20%7D%3B%0A%60%60%60%0AThe%20existing%20%60check_package_shim_still_matches%60%20test%20validates%20the%20shim%2C%20not%20the%20new%20%60assess_package%60%20path%2C%20so%20a%20regression%20here%20would%20not%20be%20caught%20by%20the%20current%20test%20suite.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `crates/tirith-core/src/version_intent.rs`, line 1409-1424 ([link](https://github.com/sheeki03/tirith/blob/ee8751966b39df4f40616c556c6beba9f719559e/crates/tirith-core/src/version_intent.rs#L1409-L1424)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`from_explicit_version` accepts pre-release tails as Exact but `from_pep440_specifier("==...")` does not**

   `looks_like_plain_version` allows `-`/`+` tails, so `from_explicit_version("1.2.3-beta.1")` → `Exact("1.2.3-beta.1")` (string-matched against the DB). But `from_pep440_specifier("==1.2.3-beta.1")` fails `ReleaseVersion::parse` on the hyphen and falls through to `Constraint { parsed: None }` → `Unresolved` in `assess_package_self`, meaning the exact string `"1.2.3-beta.1"` is never compared against DB records.

   If a malicious PyPI package's affected version is stored as `"1.2.3-beta.1"` (a normalized PEP 440 pre-release would be `1.2.3b1`, but threat feeds occasionally store the pip-style form), a user running `pip install pkg==1.2.3-beta.1` would get `Unresolved` (false-positive warn) when the version is not in the DB, or `Unresolved` instead of `ExactMatch` when it is — either way the string comparison is skipped. The verbatim fallback suggested on `assess_package_self` would close this gap at the same time.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftirith-core%2Fsrc%2Fversion_intent.rs%0ALine%3A%201409-1424%0A%0AComment%3A%0A**%60from_explicit_version%60%20accepts%20pre-release%20tails%20as%20Exact%20but%20%60from_pep440_specifier%28%22%3D%3D...%22%29%60%20does%20not**%0A%0A%60looks_like_plain_version%60%20allows%20%60-%60%2F%60%2B%60%20tails%2C%20so%20%60from_explicit_version%28%221.2.3-beta.1%22%29%60%20%E2%86%92%20%60Exact%28%221.2.3-beta.1%22%29%60%20%28string-matched%20against%20the%20DB%29.%20But%20%60from_pep440_specifier%28%22%3D%3D1.2.3-beta.1%22%29%60%20fails%20%60ReleaseVersion%3A%3Aparse%60%20on%20the%20hyphen%20and%20falls%20through%20to%20%60Constraint%20%7B%20parsed%3A%20None%20%7D%60%20%E2%86%92%20%60Unresolved%60%20in%20%60assess_package_self%60%2C%20meaning%20the%20exact%20string%20%60%221.2.3-beta.1%22%60%20is%20never%20compared%20against%20DB%20records.%0A%0AIf%20a%20malicious%20PyPI%20package's%20affected%20version%20is%20stored%20as%20%60%221.2.3-beta.1%22%60%20%28a%20normalized%20PEP%20440%20pre-release%20would%20be%20%601.2.3b1%60%2C%20but%20threat%20feeds%20occasionally%20store%20the%20pip-style%20form%29%2C%20a%20user%20running%20%60pip%20install%20pkg%3D%3D1.2.3-beta.1%60%20would%20get%20%60Unresolved%60%20%28false-positive%20warn%29%20when%20the%20version%20is%20not%20in%20the%20DB%2C%20or%20%60Unresolved%60%20instead%20of%20%60ExactMatch%60%20when%20it%20is%20%E2%80%94%20either%20way%20the%20string%20comparison%20is%20skipped.%20The%20verbatim%20fallback%20suggested%20on%20%60assess_package_self%60%20would%20close%20this%20gap%20at%20the%20same%20time.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

3. `crates/tirith-core/src/ecosystem_scan.rs`, line 104-118 ([link](https://github.com/sheeki03/tirith/blob/b06bd84b363fdd138bf7c7b1232ae3ef61eb43be/crates/tirith-core/src/ecosystem_scan.rs#L104-L118)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Integer overflow in `npm_partial_xrange` — security bypass in release mode / panic in debug mode**

   `major + 1` and `minor + 1` are plain `u64` arithmetic. If a `package.json` contains a dependency version like `"18446744073709551615"` (a string that parses cleanly as a single numeric segment), `npm_partial_xrange` overflows:
   - **Debug build**: panics with "attempt to add with overflow" — attackers can crash tirith by planting a crafted manifest.
   - **Release build** (default, no overflow-checks): wraps to 0, producing `">=18446744073709551615.0.0,<0.0.0"`. `<0.0.0` never matches any real version, so `VersionConstraint::matches` returns `false` for every affected version, `intersecting.is_empty()` is `true`, and `assess_package_self` returns `ConstraintExcludesAffected` — a **proven-safe verdict** — for a package that is actually malicious. The threat warning is completely suppressed.

   Use `checked_add(1)` and return `None` on overflow so the version falls back to an `Exact` pin (which performs a correct literal/numeric string compare against the DB) rather than generating a malformed exclusion constraint.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftirith-core%2Fsrc%2Fecosystem_scan.rs%0ALine%3A%20104-118%0A%0AComment%3A%0A**Integer%20overflow%20in%20%60npm_partial_xrange%60%20%E2%80%94%20security%20bypass%20in%20release%20mode%20%2F%20panic%20in%20debug%20mode**%0A%0A%60major%20%2B%201%60%20and%20%60minor%20%2B%201%60%20are%20plain%20%60u64%60%20arithmetic.%20If%20a%20%60package.json%60%20contains%20a%20dependency%20version%20like%20%60%2218446744073709551615%22%60%20%28a%20string%20that%20parses%20cleanly%20as%20a%20single%20numeric%20segment%29%2C%20%60npm_partial_xrange%60%20overflows%3A%0A-%20**Debug%20build**%3A%20panics%20with%20%22attempt%20to%20add%20with%20overflow%22%20%E2%80%94%20attackers%20can%20crash%20tirith%20by%20planting%20a%20crafted%20manifest.%0A-%20**Release%20build**%20%28default%2C%20no%20overflow-checks%29%3A%20wraps%20to%200%2C%20producing%20%60%22%3E%3D18446744073709551615.0.0%2C%3C0.0.0%22%60.%20%60%3C0.0.0%60%20never%20matches%20any%20real%20version%2C%20so%20%60VersionConstraint%3A%3Amatches%60%20returns%20%60false%60%20for%20every%20affected%20version%2C%20%60intersecting.is_empty%28%29%60%20is%20%60true%60%2C%20and%20%60assess_package_self%60%20returns%20%60ConstraintExcludesAffected%60%20%E2%80%94%20a%20**proven-safe%20verdict**%20%E2%80%94%20for%20a%20package%20that%20is%20actually%20malicious.%20The%20threat%20warning%20is%20completely%20suppressed.%0A%0AUse%20%60checked_add%281%29%60%20and%20return%20%60None%60%20on%20overflow%20so%20the%20version%20falls%20back%20to%20an%20%60Exact%60%20pin%20%28which%20performs%20a%20correct%20literal%2Fnumeric%20string%20compare%20against%20the%20DB%29%20rather%20than%20generating%20a%20malformed%20exclusion%20constraint.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (29): Last reviewed commit: ["fix(ecosystem): strip inline \`#\` comment..."](https://github.com/sheeki03/tirith/commit/9d68a19c8ee98c318a973997e5876b341d2a8609) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38633614)</sub>

<!-- /greptile_comment -->