### PR TITLE
fix: recognize operational policy fields in validator

### DIFF
--- a/crates/tirith-core/src/policy_validate.rs
+++ b/crates/tirith-core/src/policy_validate.rs
@@ -791,6 +791,18 @@ fn validate_unknown_fields(yaml: &str, issues: &mut Vec<PolicyIssue>) {
         "threat_intel",
         "agent_rules",
         "package_policy",
+        "share",
+        "context_guard_enabled",
+        "context_destructive_verbs",
+        "iac_require_plan_before_apply",
+        "sudo_require_reason",
+        "sudo_session_ttl",
+        "env_guard_enabled",
+        "env_guard_sensitive_vars",
+        "exec_guard_enabled",
+        "hooks_guard_enabled",
+        "baseline_enabled",
+        "allowed_install_domains",
     ];
 
     // A typo here is load-bearing — a misspelled `block_newr_than_days` silently
@@ -1288,6 +1300,29 @@ custom_rules:
         let yaml = "not_a_real_field: true\n";
         let issues = validate(yaml);
         assert!(issues.iter().any(|i| i.message.contains("unknown field")));
+    }
+
+    #[test]
+    fn test_operational_guard_fields_are_known() {
+        let yaml = r#"
+share: {}
+context_guard_enabled: true
+context_destructive_verbs: {}
+iac_require_plan_before_apply: true
+sudo_require_reason: false
+sudo_session_ttl: 1800
+env_guard_enabled: true
+env_guard_sensitive_vars: [EXAMPLE_TOKEN]
+exec_guard_enabled: true
+hooks_guard_enabled: true
+baseline_enabled: true
+allowed_install_domains: [example.com]
+"#;
+        let issues = validate(yaml);
+        assert!(
+            !issues.iter().any(|i| i.message.contains("unknown field")),
+            "serialized Policy fields must be accepted by the typo guard: {issues:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep `policy validate`'s top-level typo guard aligned with every serializable `Policy` field
- stop false `unknown field` warnings for CLI-generated operational guard settings
- add a regression test covering share, context, IaC, sudo, env, exec, hooks, baseline, and install-domain fields

## Motivation

`tirith context guard on` and `tirith iac require-plan-before-apply on` write valid fields that the runtime deserializes and enforces, but Tirith 0.3.3's validator still reports those fields as unknown. The validator allowlist was missing 12 serializable fields from `Policy`.

## Verification

- `cargo fmt --check`
- `cargo test -p tirith-core policy_validate::tests`
- Result: 42 passed, 0 failed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns policy validation with operational policy fields. The main changes are:

- Adds operational guard fields to the top-level validator allowlist.
- Covers context, IaC, sudo, env, exec, hooks, baseline, install-domain, and share fields.
- Adds a regression test for those serialized policy keys.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/policy_validate.rs | Updates the validator allowlist for existing serialized policy fields and adds focused regression coverage. |

<sub>Reviews (1): Last reviewed commit: ["fix: recognize operational policy fields..."](https://github.com/sheeki03/tirith/commit/02402a4ecc13dac0c1bd4dd36f43b43613d17e6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44193221)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy validation now recognizes additional operational and security guard settings.
  * Prevented valid policy fields from being incorrectly reported as unknown.
  * Added regression coverage to help ensure these settings remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->