### PR TITLE
feat(output): sanitize untrusted fields in human CLI output (terminal control + deceptive Unicode)

### DIFF
--- a/crates/tirith-core/src/extract.rs
+++ b/crates/tirith-core/src/extract.rs
@@ -949,7 +949,7 @@ mod output_scan_tests {
 }
 
 /// Check if a character is a bidi control.
-fn is_bidi_control(ch: char) -> bool {
+pub(crate) fn is_bidi_control(ch: char) -> bool {
     matches!(
         ch,
         '\u{200E}' // LRM
@@ -967,7 +967,7 @@ fn is_bidi_control(ch: char) -> bool {
 }
 
 /// Check if a character is zero-width.
-fn is_zero_width(ch: char) -> bool {
+pub(crate) fn is_zero_width(ch: char) -> bool {
     matches!(
         ch,
         '\u{180E}' // Mongolian Vowel Separator
@@ -982,17 +982,17 @@ fn is_zero_width(ch: char) -> bool {
 }
 
 /// Check if a character is a Unicode Tag (hidden ASCII encoding).
-fn is_unicode_tag(ch: char) -> bool {
+pub(crate) fn is_unicode_tag(ch: char) -> bool {
     ('\u{E0000}'..='\u{E007F}').contains(&ch)
 }
 
 /// Check if a character is a variation selector (VS1-16 or VS17-256).
-fn is_variation_selector(ch: char) -> bool {
+pub(crate) fn is_variation_selector(ch: char) -> bool {
     ('\u{FE00}'..='\u{FE0F}').contains(&ch) || ('\u{E0100}'..='\u{E01EF}').contains(&ch)
 }
 
 /// Check if a character is a Hangul Filler (invisible Korean character).
-fn is_hangul_filler(ch: char) -> bool {
+pub(crate) fn is_hangul_filler(ch: char) -> bool {
     matches!(
         ch,
         '\u{3164}' // Hangul Filler
@@ -1003,14 +1003,14 @@ fn is_hangul_filler(ch: char) -> bool {
 
 /// Check if a character is an invisible math operator (Function Application,
 /// Invisible Times, Invisible Separator, Invisible Plus).
-fn is_invisible_math_operator(ch: char) -> bool {
+pub(crate) fn is_invisible_math_operator(ch: char) -> bool {
     ('\u{2061}'..='\u{2064}').contains(&ch)
 }
 
 /// Stealth-encoding whitespace variant (steganographic spaces). Layout spaces
 /// (U+00A0 NBSP, U+202F Narrow NBSP, U+3000 Ideographic) are excluded — they
 /// appear legitimately in localized prose.
-fn is_invisible_whitespace(ch: char) -> bool {
+pub(crate) fn is_invisible_whitespace(ch: char) -> bool {
     matches!(
         ch,
         '\u{2000}' // En Quad

--- a/crates/tirith-core/src/mcp/output_filter.rs
+++ b/crates/tirith-core/src/mcp/output_filter.rs
@@ -775,6 +775,42 @@ pub fn sanitize_text_str(s: &str) -> String {
     String::from_utf8(out).unwrap_or_else(|_| s.to_string())
 }
 
+/// Sanitize untrusted text for HUMAN terminal DISPLAY: a strict superset of the
+/// terminal-control scrub that ALSO drops the deceptive / invisible Unicode
+/// classes the terminal scrub leaves intact.
+///
+/// Two passes:
+/// 1. [`sanitize_text_str`] strips ESC/CSI/OSC/APC/DCS escapes, bare CR, C0
+///    controls (except `\t`/`\n`), DEL, the strippable zero-width set, and Unicode
+///    Tags: everything that corrupts a terminal.
+/// 2. The display-DECEPTION codepoints that survive (1) are dropped: bidi
+///    controls, variation selectors, Hangul fillers, invisible math operators, and
+///    stealth whitespace, plus the full zero-width / Unicode-Tag predicate sets.
+///    The latter two are defensive: they also catch the zero-width chars (1) does
+///    not strip, e.g. U+180E, U+034F, U+00AD. A bidi override or Hangul filler in
+///    a finding title would otherwise render deceptively.
+///
+/// This is DISPLAY sanitization ONLY: it strips deceptive / invisible codepoints
+/// but does NOT normalize (no confusable fold, leetspeak, or base64 / hex decode).
+/// Those detection-only transforms live in [`crate::deobfuscate`] and must stay
+/// separate (CLAUDE.md: "do not consolidate the two normalizers"). `\t` / `\n` /
+/// CRLF are kept (the CLI wrapper applies per-field newline policy). The result is
+/// always valid UTF-8 (whole chars are dropped, never split).
+pub fn sanitize_for_display(s: &str) -> String {
+    sanitize_text_str(s)
+        .chars()
+        .filter(|&ch| {
+            !(crate::extract::is_bidi_control(ch)
+                || crate::extract::is_zero_width(ch)
+                || crate::extract::is_unicode_tag(ch)
+                || crate::extract::is_variation_selector(ch)
+                || crate::extract::is_hangul_filler(ch)
+                || crate::extract::is_invisible_math_operator(ch)
+                || crate::extract::is_invisible_whitespace(ch))
+        })
+        .collect()
+}
+
 /// Strip ANSI/OSC/APC/DCS escapes and zero-width chars from `chunk` into `out`.
 /// Mirrors `tirith view` so both surfaces sanitize identically. Keeps `\t`/`\n`
 /// and CRLF; drops bare CR (display-overwriting), other C0 controls, and DEL.
@@ -903,6 +939,26 @@ mod tests {
     fn osc52_text() -> String {
         // A complete OSC 52 (clipboard-write) sequence.
         "before-payload-\x1B]52;c;aGVsbG8=\x07-after-payload".to_string()
+    }
+
+    #[test]
+    fn sanitize_for_display_strips_terminal_and_deceptive_unicode() {
+        // Terminal-control: CSI screen-clear and OSC52 clipboard-write are gone.
+        assert_eq!(sanitize_for_display("a\x1b[2Jb"), "ab");
+        assert_eq!(sanitize_for_display("x\x1b]52;c;aGk=\x07y"), "xy");
+        // Zero-width (U+200B) and Unicode Tag (U+E0001).
+        assert_eq!(sanitize_for_display("a\u{200B}b"), "ab");
+        assert_eq!(sanitize_for_display("a\u{E0001}b"), "ab");
+        // Deceptive classes the terminal scrub does NOT strip: bidi override
+        // (U+202E), variation selector (U+FE0F), Hangul filler (U+3164), invisible
+        // math operator (U+2061).
+        assert_eq!(sanitize_for_display("a\u{202E}b"), "ab");
+        assert_eq!(sanitize_for_display("a\u{FE0F}b"), "ab");
+        assert_eq!(sanitize_for_display("a\u{3164}b"), "ab");
+        assert_eq!(sanitize_for_display("a\u{2061}b"), "ab");
+        // Plain ASCII plus \n / \t are preserved (newline policy is the CLI
+        // wrapper's job, not the core display scrub's).
+        assert_eq!(sanitize_for_display("hello\tworld\nok"), "hello\tworld\nok");
     }
 
     #[test]

--- a/crates/tirith/src/cli/ai.rs
+++ b/crates/tirith/src/cli/ai.rs
@@ -410,15 +410,14 @@ fn truncate_line(s: &str) -> String {
 }
 
 /// Neutralize one untrusted, AI-config-derived string before printing it in HUMAN
-/// mode (CodeRabbit M13 PR #132 R20). Runs it through tirith's own
-/// `output_filter` (strips ANSI/OSC/APC/DCS, bare CR, C0 controls except `\t`,
-/// DEL, zero-width), then flattens kept tabs/newlines to spaces so one display
-/// field stays on a single line.
+/// mode (CodeRabbit M13 PR #132 R20). Routes through the shared
+/// [`tirith_core::mcp::output_filter::sanitize_for_display`] (strips ANSI/OSC/APC/DCS,
+/// bare CR, C0 controls except `\t`/`\n`, DEL, AND the deceptive/invisible Unicode
+/// classes: bidi controls, variation selectors, Hangul fillers, invisible math
+/// operators, zero-width / Unicode-Tag sets), then flattens any kept tabs/newlines
+/// to spaces so one display field stays on a single line.
 fn sanitize_display(s: &str) -> String {
-    let mut out = Vec::with_capacity(s.len());
-    tirith_core::mcp::output_filter::sanitize_text_into(s.as_bytes(), &mut out);
-    let cleaned = String::from_utf8(out).unwrap_or_default();
-    cleaned
+    tirith_core::mcp::output_filter::sanitize_for_display(s)
         .chars()
         .map(|c| if c.is_whitespace() { ' ' } else { c })
         .collect()

--- a/crates/tirith/src/cli/aliases.rs
+++ b/crates/tirith/src/cli/aliases.rs
@@ -159,14 +159,16 @@ fn print_human_explain(name: &str, ex: &aliases::AliasExplain) {
 }
 
 fn print_one_finding(f: &AliasFinding) {
+    // name/location/detail come from the user's shell-config aliases, an attacker
+    // persistence surface; sanitize each before display.
     eprintln!(
         "  [{}] {}\n      name:     {} ({})\n      location: {}\n      detail:   {}\n",
         severity_label(f.severity),
         f.rule_id,
-        f.name,
+        super::sanitize_for_human_output(&f.name, false),
         f.kind.as_str(),
-        f.location,
-        f.detail,
+        super::sanitize_for_human_output(&f.location, false),
+        super::sanitize_for_human_output(&f.detail, false),
     );
 }
 

--- a/crates/tirith/src/cli/checkpoint.rs
+++ b/crates/tirith/src/cli/checkpoint.rs
@@ -601,8 +601,14 @@ fn print_watch_human(
         println!();
         for f in findings {
             let sev = tirith_core::style::severity_label(&f.severity, s);
-            println!("  [{sev}] {}", f.title);
-            println!("        {}", f.description);
+            println!(
+                "  [{sev}] {}",
+                super::sanitize_for_human_output(&f.title, false)
+            );
+            println!(
+                "        {}",
+                super::sanitize_for_human_output(&f.description, true)
+            );
         }
     }
 }

--- a/crates/tirith/src/cli/ecosystem.rs
+++ b/crates/tirith/src/cli/ecosystem.rs
@@ -281,15 +281,14 @@ fn print_json(report: &EcosystemScanReport) -> bool {
 fn print_human(report: &EcosystemScanReport) {
     let finding_count = report.verdict.findings.len();
 
+    // scan_root and the discovered manifest paths/names are untrusted (the scanned
+    // tree can hold attacker-named files); sanitize each before display.
+    let scan_root = super::sanitize_for_human_output(&report.scan_root, false);
     if report.manifests.is_empty() {
-        eprintln!(
-            "tirith ecosystem scan: {} — no dependency manifests found",
-            report.scan_root
-        );
+        eprintln!("tirith ecosystem scan: {scan_root} — no dependency manifests found");
     } else {
         eprintln!(
-            "tirith ecosystem scan: {} — {} manifest(s), {} dependencies, {} finding(s)",
-            report.scan_root,
+            "tirith ecosystem scan: {scan_root} — {} manifest(s), {} dependencies, {} finding(s)",
             report.manifests.len(),
             report.dependency_count,
             finding_count,
@@ -300,7 +299,7 @@ fn print_human(report: &EcosystemScanReport) {
         eprintln!();
         eprintln!("  manifests:");
         for m in &report.manifests {
-            eprintln!("    - {m}");
+            eprintln!("    - {}", super::sanitize_for_human_output(m, false));
         }
     }
 
@@ -308,9 +307,13 @@ fn print_human(report: &EcosystemScanReport) {
         eprintln!();
         eprintln!("  notes:");
         for note in &report.notes {
+            let note_text = super::sanitize_for_human_output(&note.note, false);
             match &note.manifest {
-                Some(m) => eprintln!("    - [{m}] {}", note.note),
-                None => eprintln!("    - {}", note.note),
+                Some(m) => eprintln!(
+                    "    - [{}] {note_text}",
+                    super::sanitize_for_human_output(m, false)
+                ),
+                None => eprintln!("    - {note_text}"),
             }
         }
     }
@@ -341,8 +344,16 @@ fn print_human(report: &EcosystemScanReport) {
                 &finding.severity,
                 tirith_core::style::Stream::Stdout,
             );
-            println!("  {} {} — {}", sev, finding.rule_id, finding.title);
-            println!("    {}", finding.description);
+            println!(
+                "  {} {} — {}",
+                sev,
+                finding.rule_id,
+                super::sanitize_for_human_output(&finding.title, false)
+            );
+            println!(
+                "    {}",
+                super::sanitize_for_human_output(&finding.description, true)
+            );
         }
     }
 

--- a/crates/tirith/src/cli/env_guard.rs
+++ b/crates/tirith/src/cli/env_guard.rs
@@ -102,7 +102,8 @@ fn guard_status(json: bool) -> i32 {
             );
             for f in &rc_findings {
                 if let Some(tirith_core::verdict::Evidence::Text { detail }) = f.evidence.first() {
-                    eprintln!("    {detail}");
+                    // detail embeds the rc-file-derived var name (attacker-influenced).
+                    eprintln!("    {}", super::sanitize_for_human_output(detail, false));
                 }
             }
             eprintln!(

--- a/crates/tirith/src/cli/exec.rs
+++ b/crates/tirith/src/cli/exec.rs
@@ -333,11 +333,17 @@ fn print_human_check(
     findings: &[Finding],
 ) {
     eprintln!("tirith exec check `{bin}`:");
-    eprintln!("  resolves to: {}", resolved.display());
+    eprintln!(
+        "  resolves to: {}",
+        super::sanitize_for_human_output(&resolved.display().to_string(), false)
+    );
     if hits.len() > 1 {
         eprintln!("  also on PATH ({} total):", hits.len());
         for h in hits.iter().skip(1) {
-            eprintln!("    {}", h.display());
+            eprintln!(
+                "    {}",
+                super::sanitize_for_human_output(&h.display().to_string(), false)
+            );
         }
     }
     print_provenance_body(prov);
@@ -345,7 +351,10 @@ fn print_human_check(
 }
 
 fn print_human_provenance(prov: &Provenance, findings: &[Finding]) {
-    eprintln!("tirith exec provenance `{}`:", prov.path);
+    eprintln!(
+        "tirith exec provenance `{}`:",
+        super::sanitize_for_human_output(&prov.path, false)
+    );
     print_provenance_body(prov);
     print_findings(findings);
 }
@@ -392,7 +401,12 @@ fn print_findings(findings: &[Finding]) {
     }
     eprintln!("\n  {} finding(s):", findings.len());
     for f in findings {
-        eprintln!("    [{}] {} — {}", f.severity, f.rule_id, f.title);
+        eprintln!(
+            "    [{}] {} — {}",
+            f.severity,
+            f.rule_id,
+            super::sanitize_for_human_output(&f.title, false)
+        );
     }
 }
 

--- a/crates/tirith/src/cli/hooks.rs
+++ b/crates/tirith/src/cli/hooks.rs
@@ -100,9 +100,9 @@ fn print_category(scan: &RepoHookScan, category: HookCategory, header: &str) {
         eprintln!(
             "  {:<10} {:<22} {:<8} {}",
             e.provider.as_str(),
-            e.name,
+            super::sanitize_for_human_output(&e.name, false),
             risk,
-            e.source_path.display(),
+            super::sanitize_for_human_output(&e.source_path.display().to_string(), false),
         );
     }
     eprintln!();
@@ -366,14 +366,16 @@ fn print_human_explain(name: &str, matches: &[RepoHookEntry]) {
 }
 
 fn print_one_finding(f: &RepoHookFinding) {
+    // name/location/detail describe an attacker-controllable repo hook/automation
+    // entry; sanitize each before display.
     eprintln!(
         "  [{}] {}\n      surface:  {} ({})\n      location: {}\n      detail:   {}\n",
         severity_label(f.severity),
         f.rule_id,
-        f.name,
+        super::sanitize_for_human_output(&f.name, false),
         f.provider.as_str(),
-        f.location,
-        f.detail,
+        super::sanitize_for_human_output(&f.location, false),
+        super::sanitize_for_human_output(&f.detail, false),
     );
 }
 

--- a/crates/tirith/src/cli/hygiene.rs
+++ b/crates/tirith/src/cli/hygiene.rs
@@ -81,15 +81,17 @@ pub fn fix(dry_run: bool, yes: bool, json: bool) -> i32 {
             continue;
         };
 
+        // The scanned path is untrusted (a repo-root stray file can be
+        // attacker-named); sanitize the DISPLAY copy. `apply_chmod` still uses the
+        // real `f.path`.
+        let path = super::sanitize_for_human_output(&f.path.display().to_string(), false);
+
         if dry_run {
             results.push(FixResult::would_chmod(f, mode));
             if !json {
                 eprintln!(
                     "would chmod {:04o} {}  ({} → {})",
-                    mode,
-                    f.path.display(),
-                    f.actual,
-                    f.expected
+                    mode, path, f.actual, f.expected
                 );
             }
             continue;
@@ -97,11 +99,11 @@ pub fn fix(dry_run: bool, yes: bool, json: bool) -> i32 {
 
         // Per-finding confirmation unless --yes. `confirm` is TTY-gated and
         // returns false in a non-interactive context without --yes.
-        let prompt = format!("chmod {:04o} {}?", mode, f.path.display());
+        let prompt = format!("chmod {mode:04o} {path}?");
         if !confirm(&prompt, yes) {
             results.push(FixResult::skipped(f, mode));
             if !json {
-                eprintln!("skipped {}", f.path.display());
+                eprintln!("skipped {path}");
             }
             continue;
         }
@@ -110,14 +112,14 @@ pub fn fix(dry_run: bool, yes: bool, json: bool) -> i32 {
             Ok(()) => {
                 results.push(FixResult::applied(f, mode));
                 if !json {
-                    eprintln!("chmod {:04o} {}", mode, f.path.display());
+                    eprintln!("chmod {mode:04o} {path}");
                 }
             }
             Err(e) => {
                 had_error = true;
                 results.push(FixResult::failed(f, mode, &e.to_string()));
                 if !json {
-                    eprintln!("FAILED chmod {:04o} {}: {e}", mode, f.path.display());
+                    eprintln!("FAILED chmod {mode:04o} {path}: {e}");
                 }
             }
         }
@@ -177,7 +179,7 @@ fn print_human_scan(findings: &[HygieneFinding]) {
             severity_label(f.severity),
             f.rule_id,
             f.category.as_str(),
-            f.path.display(),
+            super::sanitize_for_human_output(&f.path.display().to_string(), false),
             f.expected,
             f.actual,
             f.fix_suggestion,
@@ -214,7 +216,7 @@ fn print_human_fix_summary(dry_run: bool, results: &[FixResult], manual: &[&Hygi
             eprintln!(
                 "  [{}] {}\n      {}",
                 severity_label(f.severity),
-                f.path.display(),
+                super::sanitize_for_human_output(&f.path.display().to_string(), false),
                 f.fix_suggestion
             );
         }

--- a/crates/tirith/src/cli/hygiene.rs
+++ b/crates/tirith/src/cli/hygiene.rs
@@ -99,7 +99,12 @@ pub fn fix(dry_run: bool, yes: bool, json: bool) -> i32 {
 
         // Per-finding confirmation unless --yes. `confirm` is TTY-gated and
         // returns false in a non-interactive context without --yes.
-        let prompt = format!("chmod {mode:04o} {path}?");
+        // The confirmation target must be injective: a display sanitizer can
+        // intentionally collapse controls/deceptive Unicode, which could make
+        // two different filesystem paths look identical. Present an exact,
+        // printable byte/code-unit escape before mutating the original path.
+        let prompt_path = confirmation_path(&f.path);
+        let prompt = format!("chmod {mode:04o} {prompt_path}?");
         if !confirm(&prompt, yes) {
             results.push(FixResult::skipped(f, mode));
             if !json {
@@ -155,6 +160,60 @@ fn apply_chmod(path: &std::path::Path, mode: u32) -> std::io::Result<()> {
 #[cfg(not(unix))]
 fn apply_chmod(_path: &std::path::Path, _mode: u32) -> std::io::Result<()> {
     Ok(())
+}
+
+/// Render the exact path selected for a destructive confirmation without
+/// emitting terminal controls or deceptive Unicode. Unlike the ordinary human
+/// display sanitizer, this representation is injective over the platform path
+/// encoding, so approval cannot be transferred to a different raw path that
+/// happens to sanitize to the same text.
+#[cfg(unix)]
+fn confirmation_path(path: &std::path::Path) -> String {
+    use std::fmt::Write as _;
+    use std::os::unix::ffi::OsStrExt;
+
+    let mut rendered = String::from("b\"");
+    for byte in path.as_os_str().as_bytes() {
+        match *byte {
+            b' '..=b'~' if !matches!(*byte, b'\\' | b'\"') => rendered.push(*byte as char),
+            b'\\' => rendered.push_str("\\\\"),
+            b'\"' => rendered.push_str("\\\""),
+            value => write!(rendered, "\\x{value:02x}").expect("write to String"),
+        }
+    }
+    rendered.push('\"');
+    rendered
+}
+
+#[cfg(windows)]
+fn confirmation_path(path: &std::path::Path) -> String {
+    use std::fmt::Write as _;
+    use std::os::windows::ffi::OsStrExt;
+
+    let mut rendered = String::from("u\"");
+    for unit in path.as_os_str().encode_wide() {
+        match unit {
+            0x20..=0x7e if !matches!(unit, 0x5c | 0x22) => {
+                rendered.push(char::from_u32(u32::from(unit)).expect("ASCII code unit"));
+            }
+            0x5c => rendered.push_str("\\\\"),
+            0x22 => rendered.push_str("\\\""),
+            value => write!(rendered, "\\u{value:04x}").expect("write to String"),
+        }
+    }
+    rendered.push('\"');
+    rendered
+}
+
+#[cfg(not(any(unix, windows)))]
+fn confirmation_path(path: &std::path::Path) -> String {
+    let escaped: String = path
+        .as_os_str()
+        .to_string_lossy()
+        .chars()
+        .flat_map(char::escape_default)
+        .collect();
+    format!("u\"{escaped}\"")
 }
 
 // ─── human output ────────────────────────────────────────────────────────────
@@ -314,6 +373,30 @@ mod tests {
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confirmation_path_is_exact_printable_and_collision_free() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let ordinary = std::path::Path::new("/tmp/key with spaces");
+        assert_eq!(confirmation_path(ordinary), "b\"/tmp/key with spaces\"");
+
+        let hostile =
+            std::path::PathBuf::from(OsString::from_vec(b"/tmp/key\n\x1b\xe2\x80\xae".to_vec()));
+        let escaped = confirmation_path(&hostile);
+        assert_eq!(escaped, "b\"/tmp/key\\x0a\\x1b\\xe2\\x80\\xae\"");
+        assert!(!escaped.contains('\n'));
+        assert!(!escaped.contains('\u{1b}'));
+
+        let collapsed_peer = std::path::Path::new("/tmp/key");
+        assert_ne!(
+            escaped,
+            confirmation_path(collapsed_peer),
+            "distinct raw mutation targets must never share a confirmation label"
+        );
     }
 
     #[test]

--- a/crates/tirith/src/cli/iac.rs
+++ b/crates/tirith/src/cli/iac.rs
@@ -272,7 +272,10 @@ pub fn check_plan(plan_path: &Path, forced_tool: Option<&str>, json: bool) -> i3
 
 fn emit_check_plan_human(plan_path: &Path, sha: &str, summary: &PlanSummary, purged: usize) {
     eprintln!("tirith iac check-plan:");
-    eprintln!("  plan:        {}", plan_path.display());
+    eprintln!(
+        "  plan:        {}",
+        super::sanitize_for_human_output(&plan_path.display().to_string(), false)
+    );
     eprintln!("  tool:        {}", summary.tool.as_str());
     eprintln!("  sha256:      {sha}");
     eprintln!(
@@ -280,27 +283,38 @@ fn emit_check_plan_human(plan_path: &Path, sha: &str, summary: &PlanSummary, pur
         summary.create, summary.update, summary.destroy, summary.total_changes,
     );
     if summary.has_high_risk_changes() {
+        // Resource addresses are parsed from the (untrusted) plan file, so a crafted
+        // module/resource name could carry escapes; sanitize each joined list.
         eprintln!("  high-risk categories:");
         if !summary.iam_changes.is_empty() {
-            eprintln!("    iam:                {}", summary.iam_changes.join(", "));
+            eprintln!(
+                "    iam:                {}",
+                super::sanitize_for_human_output(&summary.iam_changes.join(", "), false)
+            );
         }
         if !summary.security_group_changes.is_empty() {
             eprintln!(
                 "    security_groups:    {}",
-                summary.security_group_changes.join(", ")
+                super::sanitize_for_human_output(&summary.security_group_changes.join(", "), false)
             );
         }
         if !summary.public_bucket_changes.is_empty() {
             eprintln!(
                 "    public_buckets:     {}",
-                summary.public_bucket_changes.join(", ")
+                super::sanitize_for_human_output(&summary.public_bucket_changes.join(", "), false)
             );
         }
         if !summary.db_changes.is_empty() {
-            eprintln!("    db_instances:       {}", summary.db_changes.join(", "));
+            eprintln!(
+                "    db_instances:       {}",
+                super::sanitize_for_human_output(&summary.db_changes.join(", "), false)
+            );
         }
         if !summary.lb_changes.is_empty() {
-            eprintln!("    load_balancers:     {}", summary.lb_changes.join(", "));
+            eprintln!(
+                "    load_balancers:     {}",
+                super::sanitize_for_human_output(&summary.lb_changes.join(", "), false)
+            );
         }
     }
     if purged > 0 {

--- a/crates/tirith/src/cli/install.rs
+++ b/crates/tirith/src/cli/install.rs
@@ -1043,8 +1043,16 @@ fn print_plan_human(plan: &InstallPlan, online: bool) {
     }
     for finding in &plan.verdict.findings {
         let sev = tirith_core::style::severity_label(&finding.severity, s);
-        eprintln!("    {} {} — {}", sev, finding.rule_id, finding.title);
-        eprintln!("      {}", finding.description);
+        eprintln!(
+            "    {} {} — {}",
+            sev,
+            finding.rule_id,
+            super::sanitize_for_human_output(&finding.title, false)
+        );
+        eprintln!(
+            "      {}",
+            super::sanitize_for_human_output(&finding.description, true)
+        );
     }
 
     if !plan.notes.is_empty() {
@@ -1102,8 +1110,16 @@ fn print_url_preflight_human(url: &str, verdict: &Verdict) {
     }
     for finding in &verdict.findings {
         let sev = tirith_core::style::severity_label(&finding.severity, s);
-        eprintln!("    {} {} — {}", sev, finding.rule_id, finding.title);
-        eprintln!("      {}", finding.description);
+        eprintln!(
+            "    {} {} — {}",
+            sev,
+            finding.rule_id,
+            super::sanitize_for_human_output(&finding.title, false)
+        );
+        eprintln!(
+            "      {}",
+            super::sanitize_for_human_output(&finding.description, true)
+        );
     }
 }
 

--- a/crates/tirith/src/cli/lab.rs
+++ b/crates/tirith/src/cli/lab.rs
@@ -287,7 +287,12 @@ pub fn run(interactive: bool, filter: Option<&str>, json: bool, score: bool) -> 
                 if pass { "PASS" } else { "FAIL" }
             );
             for f in &verdict.findings {
-                println!("    [{}] {} — {}", f.severity, f.rule_id, f.title);
+                println!(
+                    "    [{}] {} — {}",
+                    f.severity,
+                    f.rule_id,
+                    super::sanitize_for_human_output(&f.title, false)
+                );
             }
         }
 

--- a/crates/tirith/src/cli/logs.rs
+++ b/crates/tirith/src/cli/logs.rs
@@ -111,7 +111,12 @@ fn print_scan_human(path: &Path, verdict: &tirith_core::verdict::Verdict) {
         if verdict.findings.len() == 1 { "" } else { "s" }
     );
     for f in &verdict.findings {
-        eprintln!("  [{}] {} — {}", f.severity, f.rule_id, f.title);
+        eprintln!(
+            "  [{}] {} — {}",
+            f.severity,
+            f.rule_id,
+            super::sanitize_for_human_output(&f.title, false)
+        );
     }
     eprintln!(
         "  note: prompt-injection seeds are heuristics — treat all agent output as untrusted regardless."

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -98,11 +98,6 @@ fn write_json_to<W: Write, T: serde::Serialize>(out: &mut W, value: &T) -> bool 
 ///
 /// Callers MUST pass only the untrusted VALUE, never a whole formatted line: the
 /// display scrub removes ALL ANSI, including tirith's own severity colors.
-///
-/// Not yet wired into the CLI renderers; that lands in the next checkpoint of this
-/// PR. `#[allow(dead_code)]` bridges the gap in this binary crate until those call
-/// sites arrive.
-#[allow(dead_code)]
 pub fn sanitize_for_human_output(s: &str, allow_multiline: bool) -> String {
     let cleaned = tirith_core::mcp::output_filter::sanitize_for_display(s);
     if allow_multiline {

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -82,6 +82,48 @@ fn write_json_to<W: Write, T: serde::Serialize>(out: &mut W, value: &T) -> bool 
     serde_json::to_writer_pretty(&mut *out, value).is_ok() && writeln!(out).is_ok()
 }
 
+/// Sanitize untrusted text for human terminal output.
+///
+/// Wraps [`tirith_core::mcp::output_filter::sanitize_for_display`] (which strips
+/// terminal-control escapes AND deceptive / invisible Unicode), then applies the
+/// newline policy for the field kind:
+///
+/// - `allow_multiline == false`: also strip `\n` and `\r`, so a single-line label
+///   (finding title, path, manifest name) cannot break onto extra terminal rows.
+/// - `allow_multiline == true`: KEEP `\n`, but RE-INDENT every continuation line
+///   with a two-space prefix so an injected newline cannot forge a fake top-level
+///   row that impersonates tirith's own output. The display scrub already dropped
+///   any bare `\r` and kept only CRLF, so each line's trailing `\r` is trimmed and
+///   the row re-joined with `\n` + indent.
+///
+/// Callers MUST pass only the untrusted VALUE, never a whole formatted line: the
+/// display scrub removes ALL ANSI, including tirith's own severity colors.
+///
+/// Not yet wired into the CLI renderers; that lands in the next checkpoint of this
+/// PR. `#[allow(dead_code)]` bridges the gap in this binary crate until those call
+/// sites arrive.
+#[allow(dead_code)]
+pub fn sanitize_for_human_output(s: &str, allow_multiline: bool) -> String {
+    let cleaned = tirith_core::mcp::output_filter::sanitize_for_display(s);
+    if allow_multiline {
+        // Keep newlines but re-indent every continuation line so an injected `\n`
+        // cannot fabricate a new top-level row. The display scrub already reduced
+        // any `\r` to CRLF form, so trim a trailing `\r` per line before re-joining
+        // with `\n` + a two-space indent.
+        cleaned
+            .split('\n')
+            .map(|line| line.strip_suffix('\r').unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    } else {
+        // Single-line label: drop every newline / carriage return outright.
+        cleaned
+            .chars()
+            .filter(|&c| c != '\n' && c != '\r')
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod write_json_tests {
     use super::write_json_to;
@@ -819,7 +861,8 @@ pub fn warn_repo_policy_neutralized(policy: &tirith_core::policy::Policy) {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_shim_target, quiet_from_env, resolve_shim_target, shell_join, should_warn_neutralized,
+        parse_shim_target, quiet_from_env, resolve_shim_target, sanitize_for_human_output,
+        shell_join, should_warn_neutralized,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -845,6 +888,43 @@ mod tests {
         // Embedded single quotes escaped as '\''; empty arg shown as ''.
         assert_eq!(q(&["echo", "it's"]), "echo 'it'\\''s'");
         assert_eq!(q(&["x", ""]), "x ''");
+    }
+
+    #[test]
+    fn sanitize_for_human_output_single_line_strips_newlines_and_deception() {
+        // allow_multiline=false strips \n and \r entirely (single-line label).
+        assert_eq!(sanitize_for_human_output("a\nb\r\nc", false), "abc");
+        // The deceptive / invisible set is stripped: bidi override (U+202E),
+        // zero-width (U+200B), Hangul filler (U+3164).
+        assert_eq!(
+            sanitize_for_human_output("a\u{202E}b\u{200B}c\u{3164}d", false),
+            "abcd"
+        );
+        // An embedded ANSI/CSI escape is scrubbed. Callers pass only the untrusted
+        // field, never tirith's own styled line, so stripping all ANSI is correct.
+        assert_eq!(
+            sanitize_for_human_output("a\x1b[31mred\x1b[0mb", false),
+            "aredb"
+        );
+        assert_eq!(sanitize_for_human_output("a\x1b[2Jb", false), "ab");
+    }
+
+    #[test]
+    fn sanitize_for_human_output_multiline_keeps_newline_but_reindents() {
+        // A forged top-level row cannot be fabricated: the injected newline is
+        // kept, but the continuation line is indented so it cannot impersonate a
+        // new tirith output row.
+        assert_eq!(
+            sanitize_for_human_output("real title\nFORGED ROW", true),
+            "real title\n  FORGED ROW"
+        );
+        // CRLF is normalized to \n + indent (the scrub keeps CRLF; the wrapper
+        // trims the trailing CR before re-joining).
+        assert_eq!(sanitize_for_human_output("a\r\nb", true), "a\n  b");
+        // The deceptive set is still stripped in multiline mode.
+        assert_eq!(sanitize_for_human_output("a\u{202E}b", true), "ab");
+        // An embedded ESC sequence is scrubbed here too.
+        assert_eq!(sanitize_for_human_output("x\x1b[2Jy\nz", true), "xy\n  z");
     }
 
     #[test]

--- a/crates/tirith/src/cli/package.rs
+++ b/crates/tirith/src/cli/package.rs
@@ -374,13 +374,22 @@ fn print_inspect_human(
         } else {
             ""
         };
-        eprintln!("  {}{status}", m.path.display());
+        // Member paths and violation details are attacker-controlled artifact
+        // content (a crafted wheel member can carry escapes/newlines).
+        eprintln!(
+            "  {}{status}",
+            super::sanitize_for_human_output(&m.path.display().to_string(), false)
+        );
         for v in &m.inspected.violation_details {
-            eprintln!("    - {v}");
+            eprintln!("    - {}", super::sanitize_for_human_output(v, false));
         }
     }
     for gap in &set.gaps {
-        eprintln!("  not inspected: {} ({})", gap.location, gap.kind.as_str());
+        eprintln!(
+            "  not inspected: {} ({})",
+            super::sanitize_for_human_output(&gap.location.to_string(), false),
+            gap.kind.as_str()
+        );
     }
 
     if verdict.findings.is_empty() {
@@ -396,13 +405,18 @@ fn print_inspect_human(
             &finding.severity,
             tirith_core::style::Stream::Stdout,
         );
-        println!("  {} {} — {}", sev, finding.rule_id, finding.title);
+        println!(
+            "  {} {} — {}",
+            sev,
+            finding.rule_id,
+            super::sanitize_for_human_output(&finding.title, false)
+        );
         // Surface the member-qualified location lines from the evidence so a
         // reviewer sees `foo.whl!/member`, not just the outer wheel.
         for ev in &finding.evidence {
             if let tirith_core::verdict::Evidence::Text { detail } = ev {
                 if detail.starts_with("location:") || detail.contains("!/") {
-                    println!("    {detail}");
+                    println!("    {}", super::sanitize_for_human_output(detail, true));
                 }
             }
         }

--- a/crates/tirith/src/cli/paste.rs
+++ b/crates/tirith/src/cli/paste.rs
@@ -213,13 +213,14 @@ fn resolve_source_attribution(
 /// (potentially sensitive) page title or path can leak into logs / JSON.
 const PROVENANCE_MAX_CHARS: usize = 256;
 
-/// Neutralize one untrusted provenance string before display/logging. Runs through the
-/// shared `output_filter` (strips ANSI/OSC/APC/DCS, bare CR, C0 controls, DEL, zero-width),
-/// then flattens tabs/newlines to spaces and length-caps.
+/// Neutralize one untrusted provenance string before display/logging. Routes through
+/// the shared [`tirith_core::mcp::output_filter::sanitize_for_display`] (strips
+/// ANSI/OSC/APC/DCS, bare CR, C0 controls, DEL, AND the deceptive/invisible Unicode
+/// classes: bidi controls, variation selectors, Hangul fillers, invisible math
+/// operators, zero-width / Unicode-Tag sets), then flattens tabs/newlines to spaces
+/// and length-caps.
 fn sanitize_provenance_text(s: &str) -> String {
-    let mut out = Vec::with_capacity(s.len());
-    tirith_core::mcp::output_filter::sanitize_text_into(s.as_bytes(), &mut out);
-    let cleaned = String::from_utf8(out).unwrap_or_default();
+    let cleaned = tirith_core::mcp::output_filter::sanitize_for_display(s);
     let flattened: String = cleaned
         .chars()
         .map(|c| if c.is_whitespace() { ' ' } else { c })

--- a/crates/tirith/src/cli/persistence.rs
+++ b/crates/tirith/src/cli/persistence.rs
@@ -208,10 +208,12 @@ fn print_human_scan(entries: &[PersistenceEntry], snapshot_note: &str) {
     );
     for e in entries {
         let state = if e.present { "present" } else { "absent " };
+        // `location` can be a DISCOVERED launch-agent / systemd-unit filename
+        // (attacker-named via read_dir), so sanitize it like the diff path does.
         eprintln!(
             "  [{state}] {:<16} {}\n             sha256: {}",
             e.kind.as_str(),
-            e.location,
+            super::sanitize_for_human_output(&e.location, false),
             e.sha256,
         );
     }
@@ -252,20 +254,26 @@ fn print_human_watch_poll(poll: u64, findings: &[PersistenceFinding]) {
 }
 
 fn print_one_finding(f: &PersistenceFinding) {
+    // location/change/added-lines are attacker-controlled file content (a persisted
+    // change diff); credential-redaction is not terminal-sanitization, so each is
+    // also routed through the display scrub.
     eprintln!(
         "  [{}] {}  ({})\n      surface: {}\n      change:  {}",
         severity_label(f.severity),
         f.rule_id,
         f.kind.as_str(),
-        f.location,
-        f.change,
+        super::sanitize_for_human_output(&f.location, false),
+        super::sanitize_for_human_output(&f.change, false),
     );
     if f.added_lines.is_empty() {
         eprintln!("      added:   (no line content — tracked by hash)\n");
     } else {
         eprintln!("      added lines (credential-redacted):");
         for line in &f.added_lines {
-            eprintln!("        + {line}");
+            eprintln!(
+                "        + {}",
+                super::sanitize_for_human_output(line, false)
+            );
         }
         eprintln!();
     }

--- a/crates/tirith/src/cli/policy.rs
+++ b/crates/tirith/src/cli/policy.rs
@@ -932,7 +932,12 @@ fn print_test_command_human(
             &finding.severity,
             tirith_core::style::Stream::Stderr,
         );
-        eprintln!("    {} {} — {}", sev, finding.rule_id, finding.title);
+        eprintln!(
+            "    {} {} — {}",
+            sev,
+            finding.rule_id,
+            super::sanitize_for_human_output(&finding.title, false)
+        );
     }
 
     if !trace.allowlist_checked.is_empty() || !trace.blocklist_checked.is_empty() {
@@ -950,14 +955,16 @@ fn print_test_command_human(
 }
 
 fn print_test_file_human(file_path: &str, result: &scan::FileScanResult, _policy: &Policy) {
+    // The tested file path is the untrusted scan subject; a crafted name could
+    // carry escapes/newlines into this label.
+    let file_path = super::sanitize_for_human_output(file_path, false);
     if result.findings.is_empty() {
         eprintln!("tirith policy test: {file_path} — no findings");
         return;
     }
 
     eprintln!(
-        "tirith policy test: {} — {} finding(s)",
-        file_path,
+        "tirith policy test: {file_path} — {} finding(s)",
         result.findings.len()
     );
 
@@ -966,8 +973,16 @@ fn print_test_file_human(file_path: &str, result: &scan::FileScanResult, _policy
             &finding.severity,
             tirith_core::style::Stream::Stderr,
         );
-        eprintln!("  {} {} — {}", sev, finding.rule_id, finding.title);
-        eprintln!("    {}", finding.description);
+        eprintln!(
+            "  {} {} — {}",
+            sev,
+            finding.rule_id,
+            super::sanitize_for_human_output(&finding.title, false)
+        );
+        eprintln!(
+            "    {}",
+            super::sanitize_for_human_output(&finding.description, true)
+        );
     }
 }
 

--- a/crates/tirith/src/cli/preview.rs
+++ b/crates/tirith/src/cli/preview.rs
@@ -140,8 +140,16 @@ fn print_human(
     if !findings.is_empty() {
         println!();
         for f in findings {
-            println!("  [{}] {} — {}", f.severity, f.rule_id, f.title);
-            println!("    {}", f.description);
+            println!(
+                "  [{}] {} — {}",
+                f.severity,
+                f.rule_id,
+                super::sanitize_for_human_output(&f.title, false)
+            );
+            println!(
+                "    {}",
+                super::sanitize_for_human_output(&f.description, true)
+            );
         }
     }
 

--- a/crates/tirith/src/cli/scan.rs
+++ b/crates/tirith/src/cli/scan.rs
@@ -680,13 +680,21 @@ fn print_human_result(result: &scan::ScanResult) {
         } else {
             ""
         };
-        eprintln!("  {}{label}", file_result.path.display());
+        eprintln!(
+            "  {}{label}",
+            super::sanitize_for_human_output(&file_result.path.display().to_string(), false)
+        );
         for finding in &file_result.findings {
             let sev = tirith_core::style::severity_label(
                 &finding.severity,
                 tirith_core::style::Stream::Stderr,
             );
-            eprintln!("    {} {} — {}", sev, finding.rule_id, finding.title);
+            eprintln!(
+                "    {} {} — {}",
+                sev,
+                finding.rule_id,
+                super::sanitize_for_human_output(&finding.title, false)
+            );
         }
     }
 
@@ -767,14 +775,14 @@ fn sarif_location_for_finding(
 }
 
 fn print_human_file_result(result: &scan::FileScanResult) {
+    let path_display = super::sanitize_for_human_output(&result.path.display().to_string(), false);
     if result.findings.is_empty() {
-        eprintln!("tirith scan: {} — no issues found", result.path.display());
+        eprintln!("tirith scan: {path_display} — no issues found");
         return;
     }
 
     eprintln!(
-        "tirith scan: {} — {} finding(s)",
-        result.path.display(),
+        "tirith scan: {path_display} — {} finding(s)",
         result.findings.len()
     );
 
@@ -783,8 +791,16 @@ fn print_human_file_result(result: &scan::FileScanResult) {
             &finding.severity,
             tirith_core::style::Stream::Stderr,
         );
-        eprintln!("  {} {} — {}", sev, finding.rule_id, finding.title);
-        eprintln!("    {}", finding.description);
+        eprintln!(
+            "  {} {} — {}",
+            sev,
+            finding.rule_id,
+            super::sanitize_for_human_output(&finding.title, false)
+        );
+        eprintln!(
+            "    {}",
+            super::sanitize_for_human_output(&finding.description, true)
+        );
     }
 }
 

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -347,8 +347,7 @@ fn try_v2_index_update(force: bool) -> Result<UpdateOutcome, String> {
         Some(a) => a,
         None => {
             eprintln!(
-                "tirith: v2 index has no asset compatible with this build (max format {}, tirith {}); using legacy manifest",
-                MAX_FORMAT_VERSION, current_tirith_version
+                "tirith: v2 index has no asset compatible with this build (max format {MAX_FORMAT_VERSION}, tirith {current_tirith_version}); using legacy manifest"
             );
             return Ok(UpdateOutcome::NoCompatibleAsset);
         }
@@ -1346,8 +1345,7 @@ fn download_db(manifest: &Manifest) -> Result<Vec<u8>, String> {
 fn download_url(url: &str, declared_size: u64) -> Result<Vec<u8>, String> {
     if declared_size > MAX_DB_SIZE {
         return Err(format!(
-            "DB file too large: {} bytes (max {})",
-            declared_size, MAX_DB_SIZE
+            "DB file too large: {declared_size} bytes (max {MAX_DB_SIZE})"
         ));
     }
 
@@ -1438,8 +1436,7 @@ fn fetch_index_v2_from(url: &str) -> Result<IndexV2, String> {
     let content_len = resp.content_length().unwrap_or(0);
     if content_len > MAX_MANIFEST_SIZE {
         return Err(format!(
-            "v2 index too large: {} bytes (max {})",
-            content_len, MAX_MANIFEST_SIZE
+            "v2 index too large: {content_len} bytes (max {MAX_MANIFEST_SIZE})"
         ));
     }
     let body = resp

--- a/crates/tirith/src/cli/view.rs
+++ b/crates/tirith/src/cli/view.rs
@@ -232,7 +232,7 @@ fn is_strippable_zero_width(ch: char) -> bool {
 
 fn print_findings_human(verdict: &Verdict, path: Option<&Path>, total_bytes: u64, truncated: bool) {
     let label = path
-        .map(|p| p.display().to_string())
+        .map(|p| super::sanitize_for_human_output(&p.display().to_string(), false))
         .unwrap_or_else(|| "<stdin>".to_string());
 
     let banner = match verdict.action {
@@ -248,8 +248,16 @@ fn print_findings_human(verdict: &Verdict, path: Option<&Path>, total_bytes: u64
     }
 
     for f in &verdict.findings {
-        eprintln!("  [{}] {} — {}", f.severity, f.rule_id, f.title);
-        eprintln!("    {}", f.description);
+        eprintln!(
+            "  [{}] {} — {}",
+            f.severity,
+            f.rule_id,
+            super::sanitize_for_human_output(&f.title, false)
+        );
+        eprintln!(
+            "    {}",
+            super::sanitize_for_human_output(&f.description, true)
+        );
     }
 }
 

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -16643,3 +16643,249 @@ fn pkg_receipt_show_accepts_an_untampered_receipt() {
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR1: human-output sanitization sweep.
+//
+// These drive REAL attacker bytes into the CLI human renderers (paths, finding
+// descriptions, scan roots) and assert the display scrub neutralizes them, while
+// machine (JSON) output is intentionally left intact. The unit tests beside the
+// helper cover the per-codepoint matrix; these prove the WIRING end-to-end.
+// ───────────────────────────────────────────────────────────────────────────
+
+/// One representative of every class the display scrub must drop, bracketed by
+/// visible ASCII anchors so we can prove the readable text survives and that the
+/// embedded newline cannot forge a fresh top-level row: CSI, OSC52 (+BEL),
+/// zero-width, bidi override, Unicode tag, variation selector, Hangul filler,
+/// invisible math operator, and an embedded `\n`. The source is pure ASCII (escape
+/// notation); the bytes only materialize at runtime.
+const ATTACK_PAYLOAD: &str = concat!(
+    "evilSTART",
+    "\x1b[2J",                // CSI: clear screen
+    "\x1b]52;c;aGVsbG8=\x07", // OSC 52: clipboard write, BEL-terminated
+    "\u{200b}",               // zero-width space
+    "\u{202e}",               // right-to-left override (bidi)
+    "\u{e0001}",              // Unicode tag
+    "\u{fe0f}",               // variation selector
+    "\u{3164}",               // Hangul filler
+    "\u{2061}",               // function application (invisible math)
+    "\n",                     // would forge a new terminal row
+    "ENDvis",
+);
+
+/// Assert no attacker-class byte/codepoint reached `human` (raw output bytes) and
+/// that both visible anchors survived the scrub.
+fn assert_attack_codepoints_stripped(human: &[u8]) {
+    assert!(
+        !human.contains(&0x1b),
+        "raw ESC (0x1b) must never reach human output"
+    );
+    assert!(
+        !human.contains(&0x07),
+        "raw BEL (0x07) must never reach human output"
+    );
+    let s = String::from_utf8_lossy(human);
+    for (cp, name) in [
+        ('\u{200b}', "zero-width space"),
+        ('\u{202e}', "bidi override"),
+        ('\u{e0001}', "Unicode tag"),
+        ('\u{fe0f}', "variation selector"),
+        ('\u{3164}', "Hangul filler"),
+        ('\u{2061}', "invisible math operator"),
+    ] {
+        assert!(
+            !s.contains(cp),
+            "{name} (U+{:04X}) must be stripped from human output",
+            cp as u32
+        );
+    }
+    assert!(
+        s.contains("evilSTART"),
+        "leading visible anchor must survive the scrub; got: {s:?}"
+    );
+    assert!(
+        s.contains("ENDvis"),
+        "trailing visible anchor must survive the scrub; got: {s:?}"
+    );
+}
+
+/// Build a `.mcp.json` under `dir` whose single server NAME is `ATTACK_PAYLOAD`
+/// and whose URL is plain HTTP, so a scan fires `McpInsecureServer` with the name
+/// echoed verbatim into the finding DESCRIPTION. serde_json escapes every control
+/// byte, so the file on disk is valid JSON; tirith decodes the name back to the
+/// raw bytes in memory. Returns the file path.
+fn write_attacker_mcp_config(dir: &std::path::Path) -> PathBuf {
+    let mut servers = serde_json::Map::new();
+    servers.insert(
+        ATTACK_PAYLOAD.to_string(),
+        serde_json::json!({ "url": "http://example.test/mcp" }),
+    );
+    let config = serde_json::json!({ "mcpServers": servers });
+    let path = dir.join(".mcp.json");
+    fs::write(
+        &path,
+        serde_json::to_string(&config).expect("serialize mcp config"),
+    )
+    .expect("write .mcp.json");
+    path
+}
+
+#[test]
+fn scan_human_output_neutralizes_attacker_finding_description() {
+    let dir = tempfile::tempdir().unwrap();
+    let mcp = write_attacker_mcp_config(dir.path());
+
+    let out = tirith_in_proj(dir.path())
+        .arg("scan")
+        .arg(&mcp)
+        .output()
+        .expect("failed to run tirith scan");
+
+    // The MCP insecure-HTTP finding is Critical, so the scan exits non-zero.
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "an insecure-HTTP MCP server must be flagged (non-zero exit); stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Human findings render to stderr; the description echoed the server name.
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("connects over unencrypted HTTP"),
+        "the MCP finding description must be present in human output; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_attack_codepoints_stripped(&out.stderr);
+
+    // The description is a multi-line field (allow_multiline=true): the injected
+    // newline is KEPT but re-indented, so the continuation never starts at column 0
+    // where it could impersonate a fresh tirith output row.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.lines().any(|l| l.starts_with("ENDvis")),
+        "an injected newline must be re-indented, not forge a column-0 row; stderr: {stderr}"
+    );
+    let end_line = stderr
+        .lines()
+        .find(|l| l.contains("ENDvis"))
+        .expect("trailing anchor line");
+    assert!(
+        end_line.starts_with(char::is_whitespace),
+        "the continuation row must be indented; got: {end_line:?}"
+    );
+}
+
+#[test]
+fn scan_machine_json_is_not_display_sanitized() {
+    let dir = tempfile::tempdir().unwrap();
+    let mcp = write_attacker_mcp_config(dir.path());
+
+    let out = tirith_in_proj(dir.path())
+        .arg("scan")
+        .arg(&mcp)
+        .args(["--format", "json"])
+        .output()
+        .expect("failed to run tirith scan --format json");
+
+    // Machine output must stay VALID JSON ...
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("scan --format json must emit valid JSON");
+    assert!(parsed.is_object(), "scan JSON root should be an object");
+
+    // ... and must NOT be display-sanitized: the control byte survives JSON-escaped
+    // and the bidi override survives as a raw codepoint (serde only escapes C0).
+    let raw = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        raw.contains("\\u001b"),
+        "machine JSON must PRESERVE the ESC byte (JSON-escaped), not strip it"
+    );
+    assert!(
+        raw.contains('\u{202e}'),
+        "machine JSON must PRESERVE the bidi override codepoint (it is not a terminal)"
+    );
+}
+
+#[test]
+fn policy_test_file_human_output_neutralizes_attacker_description() {
+    let dir = tempfile::tempdir().unwrap();
+    let mcp = write_attacker_mcp_config(dir.path());
+
+    let out = tirith_in_proj(dir.path())
+        .args(["policy", "test", "--file"])
+        .arg(&mcp)
+        .output()
+        .expect("failed to run tirith policy test --file");
+
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("connects over unencrypted HTTP"),
+        "policy test --file must render the MCP finding; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_attack_codepoints_stripped(&out.stderr);
+}
+
+// File names can carry control bytes / newlines on Unix; Windows rejects them, so
+// the attacker-named-path vectors are Unix-only.
+
+#[cfg(unix)]
+#[test]
+fn scan_single_file_human_output_neutralizes_attacker_path() {
+    let dir = tempfile::tempdir().unwrap();
+    // The scanned file's NAME carries the full attack matrix; benign content so the
+    // "no issues found" branch prints (and sanitizes) the path label.
+    let path = dir.path().join(ATTACK_PAYLOAD);
+    fs::write(&path, b"clean content\n").expect("write attacker-named file");
+
+    let out = tirith_in_proj(dir.path())
+        .arg("scan")
+        .arg(&path)
+        .output()
+        .expect("failed to run tirith scan on attacker-named file");
+
+    assert_attack_codepoints_stripped(&out.stderr);
+    // Single-line label (allow_multiline=false): the newline is dropped outright,
+    // so both anchors land on ONE line — no forged row.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let line = stderr
+        .lines()
+        .find(|l| l.contains("evilSTART"))
+        .expect("path label line");
+    assert!(
+        line.contains("ENDvis"),
+        "an embedded newline in the path must be stripped (one line), not forge a row; got: {line:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn view_human_output_neutralizes_attacker_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join(ATTACK_PAYLOAD);
+    fs::write(&path, b"clean content\n").expect("write attacker-named file");
+
+    let out = tirith_in_proj(dir.path())
+        .arg("view")
+        .arg(&path)
+        .output()
+        .expect("failed to run tirith view on attacker-named file");
+
+    // `tirith view` prints the banner + path label to stderr regardless of findings.
+    assert_attack_codepoints_stripped(&out.stderr);
+}
+
+#[cfg(unix)]
+#[test]
+fn ecosystem_scan_human_output_neutralizes_attacker_scan_root() {
+    let parent = tempfile::tempdir().unwrap();
+    // An attacker-named directory with no manifests: scan_root is echoed into the
+    // "no dependency manifests found" line and must be sanitized.
+    let target = parent.path().join(ATTACK_PAYLOAD);
+    fs::create_dir(&target).expect("create attacker-named dir");
+
+    let out = tirith_in_proj(parent.path())
+        .args(["ecosystem", "scan"])
+        .arg(&target)
+        .output()
+        .expect("failed to run tirith ecosystem scan");
+
+    assert_attack_codepoints_stripped(&out.stderr);
+}


### PR DESCRIPTION
## What this is

Several CLI human renderers printed attacker-controlled fields (scanned paths, finding titles and descriptions, evidence, manifest names, scan roots) raw to the terminal. A crafted wheel member path or finding title carrying ANSI/OSC/zero-width/bidi/newline content could repaint or spoof the analyst's terminal - the exact class tirith exists to stop (compare GuardDog CVE-2026-44972). After this PR, tirith's own output is not an injection vector.

## Changes

- Core: `pub fn sanitize_for_display` in tirith-core composes the existing terminal scrub (ESC/CSI/OSC/APC/DCS, bare CR, C0, DEL) with the deceptive-Unicode classes that previously passed through display output: bidi controls, zero-width, Unicode tags, variation selectors, hangul fillers, invisible math operators, invisible whitespace. The codepoint predicates in extract.rs are the single source of truth (exposed pub(crate)); the detection-vs-display normalizer split documented in CLAUDE.md is preserved.
- CLI: `sanitize_for_human_output(s, allow_multiline)`; single-line fields (titles, paths, manifest names) also strip newlines and CR, multi-line fields (descriptions, evidence) are re-indented per line so an injected line cannot forge a terminal row that impersonates tirith output.
- 21 renderers routed per untrusted FIELD, never per formatted line, so tirith's own severity colors survive: scan, view, ecosystem, policy, exec, checkpoint, install, lab, preview, logs, package, plus aliases/hooks/persistence/env_guard. The two pre-existing local sanitizers (ai.rs, paste.rs) migrated to the shared helper to remove drift.
- Machine output (JSON/SARIF) is intentionally NOT display-sanitized; it must stay valid for downstream consumers. A contrast test pins that behavior.

## Tests

Unit tests beside both helpers plus 6 subprocess integration tests in cli_integration.rs driving `tirith scan`, `tirith view`, `tirith ecosystem scan`, and `tirith policy test` against an attack matrix: CSI, OSC52, zero-width, bidi override, Unicode tags, variation selectors, hangul filler, invisible math operators, embedded newlines. Asserts no raw control bytes and no forged lines reach the terminal.

Known follow-up (tracked, not blocking): the incident.rs markdown-report builder does not strip ANSI/deceptive Unicode (residual only if a report file is cat'd to a terminal); deferred to avoid risking its markdown-escaping tests.

## Stack

PR1 of the series, stacked on #169 (base: `security/pdf-lopdf-dos-mitigation`). Full gate green: fmt --check, clippy -D warnings (stable and 1.83), test --workspace (1.83), cargo deny check. Remaining test failures are only the documented pre-existing environmental flakes that fail identically on the untouched base.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR sanitizes untrusted values in human CLI output. The main changes are:

- Adds a shared terminal-control and deceptive-Unicode scrubber.
- Applies single-line and multiline policies across CLI renderers.
- Preserves original values in JSON and SARIF output.
- Adds unit and subprocess coverage for terminal-injection payloads.

<h3>Confidence Score: 4/5</h3>

The hygiene permission-change prompt needs a fix before merging.

- The shared sanitizer and renderer wiring cover the main terminal-injection paths.
- The interactive hygiene flow can display a different filename from the entry it modifies.

crates/tirith/src/cli/hygiene.rs

<details open><summary><h3>Security Review</h3></summary>

The terminal-injection protections improve human output across the CLI. The hygiene fix prompt still uses a lossy path label to authorize an operation on the original path, which can misidentify an attacker-named filesystem entry.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/mcp/output_filter.rs | Adds the shared display sanitizer by combining terminal-control removal with deceptive-Unicode filtering. |
| crates/tirith-core/src/extract.rs | Exposes existing Unicode predicates within the crate for reuse by display sanitization. |
| crates/tirith/src/cli/mod.rs | Adds centralized single-line stripping and multiline continuation indentation. |
| crates/tirith/src/cli/hygiene.rs | Sanitizes displayed paths but uses the lossy result in a confirmation for an operation on the original path. |
| crates/tirith/tests/cli_integration.rs | Adds end-to-end tests for terminal controls, deceptive Unicode, forged newlines, and unchanged machine output. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftirith%2Fsrc%2Fcli%2Fhygiene.rs%3A102%0A**Prompt%20Names%20A%20Different%20Path**%0A%0AThe%20confirmation%20displays%20the%20lossy%20sanitized%20%60path%60%2C%20but%20%60apply_chmod%60%20later%20modifies%20the%20original%20%60f.path%60.%20On%20Unix%2C%20a%20filename%20such%20as%20%60con%5Cu%7B200b%7Dfig%60%20is%20shown%20as%20%60config%60%2C%20so%20the%20user%20can%20approve%20a%20permission%20change%20for%20a%20different%20filesystem%20entry%20than%20the%20prompt%20appears%20to%20name.%20Use%20an%20unambiguous%20escaped%20path%20representation%20for%20destructive%20confirmations%20instead%20of%20deleting%20characters.%0A%0A&repo=sheeki03%2Ftirith&pr=170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(output): route untrusted fields thr..."](https://github.com/sheeki03/tirith/commit/d44f3b73ee343be6bf17981eec5a32a091d31e20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44742361)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->