### PR TITLE
feat(threatdb): DigitalSide gated feed source (defined, CI-disabled pending freshness)

### DIFF
--- a/.github/workflows/threatdb.yml
+++ b/.github/workflows/threatdb.yml
@@ -62,6 +62,20 @@ jobs:
           wait
           echo "Sources fetched successfully"
 
+      # DigitalSide Threat-Intel (davidonzo/Threat-Intel, MIT-licensed code) is
+      # defined in the compiler as ThreatSource::DigitalSide with a --digitalside
+      # <path> flag and a MISP-CSV parser, but the CI fetch is DELIBERATELY NOT
+      # wired up: the upstream feed is stale. Its automated daily commits stopped
+      # at 2024-10-18 and, re-checked on 2026-07-16, the repository had published
+      # nothing new since (last commit still 2024-10-18T07:09:50Z). The upstream
+      # data license/redistribution terms are also unstated in the repo README and
+      # the MISP feed metadata (distribution flag "0"), which is a second reason to
+      # hold off ingesting it into the signed DB. To re-enable once upstream is
+      # fresh AND the data license permits redistribution: fetch the MISP CSV
+      # export (e.g. the csv/ directory or a concatenated export) into /tmp, vendor
+      # the upstream LICENSE + attribution as the other feeds do, and pass
+      # `--digitalside <path>` in the "Compile threat database" step below.
+
       # Bail early if signing key is not configured
       - name: Check signing key
         env:

--- a/crates/tirith-core/src/rules/threatintel.rs
+++ b/crates/tirith-core/src/rules/threatintel.rs
@@ -644,7 +644,8 @@ fn hostname_rule_for_source(source: threatdb::ThreatSource) -> (RuleId, Severity
         | threatdb::ThreatSource::CisaKev
         | threatdb::ThreatSource::FireholIp
         | threatdb::ThreatSource::TorExit
-        | threatdb::ThreatSource::ExfilEndpoint => (
+        | threatdb::ThreatSource::ExfilEndpoint
+        | threatdb::ThreatSource::DigitalSide => (
             RuleId::ThreatMaliciousUrl,
             Severity::High,
             "malicious hostname",
@@ -670,7 +671,8 @@ fn ip_rule_for_source(source: threatdb::ThreatSource) -> (RuleId, Severity, &'st
         | threatdb::ThreatSource::PhishingArmy
         | threatdb::ThreatSource::PhishTank
         | threatdb::ThreatSource::FireholIp
-        | threatdb::ThreatSource::ExfilEndpoint => {
+        | threatdb::ThreatSource::ExfilEndpoint
+        | threatdb::ThreatSource::DigitalSide => {
             (RuleId::ThreatMaliciousIp, Severity::High, "malicious IP")
         }
     }
@@ -1504,5 +1506,19 @@ mod tests {
         let (rule, sev, _) = ip_rule_for_source(threatdb::ThreatSource::FeodoTracker);
         assert_eq!(rule, RuleId::ThreatMaliciousIp);
         assert_eq!(sev, Severity::High);
+    }
+
+    #[test]
+    fn digitalside_maps_to_generic_malicious_rules() {
+        // DigitalSide is a generic IoC feed: hostnames route to ThreatMaliciousUrl
+        // and IPs to ThreatMaliciousIp, both High, like the other IoC sources.
+        let (host_rule, host_sev, _) =
+            hostname_rule_for_source(threatdb::ThreatSource::DigitalSide);
+        assert_eq!(host_rule, RuleId::ThreatMaliciousUrl);
+        assert_eq!(host_sev, Severity::High);
+
+        let (ip_rule, ip_sev, _) = ip_rule_for_source(threatdb::ThreatSource::DigitalSide);
+        assert_eq!(ip_rule, RuleId::ThreatMaliciousIp);
+        assert_eq!(ip_sev, Severity::High);
     }
 }

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -286,6 +286,14 @@ pub enum ThreatSource {
     /// list supplied at CI time; compiled into the signed primary DB. Appended
     /// as discriminant 11 so older `.dat` files (sources 0-10) still load.
     ExfilEndpoint = 11,
+    /// DigitalSide Threat-Intel (davidonzo/Threat-Intel) MISP-style CSV feed of
+    /// malicious URLs, domains, and IPs. Defined but NOT wired into the CI fetch:
+    /// the upstream feed's automated daily updates stopped at 2024-10-18 (freshness
+    /// gate re-checked and FAILED on 2026-07-16), so the source lands in code for a
+    /// future re-enable but is not compiled into the signed DB yet. Supplemental
+    /// until the gate passes and it ships via the signed CI DB. Appended as
+    /// discriminant 12 so older `.dat` files (sources 0-11) still load.
+    DigitalSide = 12,
 }
 
 impl ThreatSource {
@@ -303,12 +311,13 @@ impl ThreatSource {
             9 => Some(Self::FireholIp),
             10 => Some(Self::TorExit),
             11 => Some(Self::ExfilEndpoint),
+            12 => Some(Self::DigitalSide),
             _ => None,
         }
     }
 
     /// Every threat source variant, in stable declaration order.
-    pub const ALL: [ThreatSource; 12] = [
+    pub const ALL: [ThreatSource; 13] = [
         Self::OssfMalicious,
         Self::DatadogMalicious,
         Self::FeodoTracker,
@@ -321,6 +330,7 @@ impl ThreatSource {
         Self::FireholIp,
         Self::TorExit,
         Self::ExfilEndpoint,
+        Self::DigitalSide,
     ];
 
     /// Stable machine-readable identifier (snake_case). Used as the key in
@@ -339,6 +349,7 @@ impl ThreatSource {
             Self::FireholIp => "firehol_ip",
             Self::TorExit => "tor_exit",
             Self::ExfilEndpoint => "exfil_endpoint",
+            Self::DigitalSide => "digitalside",
         }
     }
 
@@ -357,7 +368,10 @@ impl ThreatSource {
             | Self::PhishTank
             | Self::ThreatFoxIoc
             | Self::FireholIp
-            | Self::TorExit => SourceTier::Supplemental,
+            | Self::TorExit
+            // Gated feed: Supplemental until the freshness gate passes and it is
+            // compiled into the signed CI DB (upstream stale as of 2024-10-18).
+            | Self::DigitalSide => SourceTier::Supplemental,
         }
     }
 
@@ -379,6 +393,7 @@ impl ThreatSource {
             Self::TorExit => "https://www.torproject.org/",
             // Curated in-tree feed, not a third-party project; point at the repo.
             Self::ExfilEndpoint => "https://github.com/sheeki03/tirith",
+            Self::DigitalSide => "https://github.com/davidonzo/Threat-Intel",
         }
     }
 
@@ -397,6 +412,7 @@ impl ThreatSource {
             Self::FireholIp => "FireHOL IP",
             Self::TorExit => "Tor Exit Node",
             Self::ExfilEndpoint => "Exfiltration Endpoint",
+            Self::DigitalSide => "DigitalSide Threat-Intel",
         }
     }
 
@@ -416,7 +432,10 @@ impl ThreatSource {
             | Self::PhishTank
             | Self::ThreatFoxIoc
             | Self::FireholIp
-            | Self::ExfilEndpoint => Confidence::Confirmed,
+            | Self::ExfilEndpoint
+            // DigitalSide indicators are confirmed-bad IoCs, like the other
+            // network-indicator hostname/IP feeds.
+            | Self::DigitalSide => Confidence::Confirmed,
         }
     }
 }
@@ -4053,9 +4072,15 @@ mod tests {
         for src in ThreatSource::ALL {
             assert!(seen.insert(src as u8), "ALL has a duplicate: {src:?}");
         }
-        assert_eq!(ThreatSource::ALL.len(), 12);
+        assert_eq!(ThreatSource::ALL.len(), 13);
+        // Discriminant 12 is now DigitalSide; 13 is the first out-of-range value.
+        assert_eq!(
+            ThreatSource::from_u8(12),
+            Some(ThreatSource::DigitalSide),
+            "discriminant 12 must decode to DigitalSide"
+        );
         assert!(
-            ThreatSource::from_u8(12).is_none(),
+            ThreatSource::from_u8(13).is_none(),
             "from_u8 must reject an out-of-range discriminant"
         );
     }
@@ -4087,7 +4112,8 @@ mod tests {
         ] {
             assert_eq!(src.tier(), SourceTier::Primary, "{src:?} should be primary");
         }
-        // The rest are opt-in supplemental.
+        // The rest are opt-in supplemental (incl. the gated DigitalSide feed,
+        // which stays supplemental until its freshness gate passes).
         for src in [
             ThreatSource::Urlhaus,
             ThreatSource::PhishingArmy,
@@ -4095,6 +4121,7 @@ mod tests {
             ThreatSource::ThreatFoxIoc,
             ThreatSource::FireholIp,
             ThreatSource::TorExit,
+            ThreatSource::DigitalSide,
         ] {
             assert_eq!(
                 src.tier(),
@@ -4102,6 +4129,34 @@ mod tests {
                 "{src:?} should be supplemental"
             );
         }
+    }
+
+    #[test]
+    fn digitalside_hostname_and_ip_roundtrip_with_source_attribution() {
+        // Build an in-memory signed DB with an ephemeral key (the production
+        // verify key is never touched), carrying one DigitalSide-sourced hostname
+        // and one IP, then confirm the lookups attribute the match to DigitalSide.
+        // Synthetic RFC-2606 / RFC-5737 indicators only, never real IoCs.
+        let key = SigningKey::generate(&mut OsRng);
+        let mut writer = ThreatDbWriter::new(1700000000, 1);
+        writer.add_hostname("malware.example", ThreatSource::DigitalSide);
+        writer.add_ip(Ipv4Addr::new(192, 0, 2, 66), ThreatSource::DigitalSide);
+        let db = ThreatDb::from_bytes(writer.build(&key).expect("build"), 0).expect("load");
+
+        let host_match = db
+            .check_hostname("malware.example")
+            .expect("DigitalSide hostname must be found");
+        assert_eq!(host_match.source, ThreatSource::DigitalSide);
+        assert_eq!(host_match.confidence, Confidence::Confirmed);
+
+        let ip_match = db
+            .check_ip(Ipv4Addr::new(192, 0, 2, 66))
+            .expect("DigitalSide IP must be found");
+        assert_eq!(ip_match.source, ThreatSource::DigitalSide);
+
+        // Attribution also flows through the per-source breakdown.
+        let bd = db.source_breakdown();
+        assert_eq!(bd.count_for(ThreatSource::DigitalSide), 2);
     }
 
     #[test]

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -4096,6 +4096,7 @@ mod tests {
         // Spot-check a couple of stable identifiers.
         assert_eq!(ThreatSource::OssfMalicious.as_str(), "ossf_malicious");
         assert_eq!(ThreatSource::TorExit.as_str(), "tor_exit");
+        assert_eq!(ThreatSource::DigitalSide.as_str(), "digitalside");
     }
 
     #[test]

--- a/crates/tirith-core/src/threatdb_feeds.rs
+++ b/crates/tirith-core/src/threatdb_feeds.rs
@@ -198,35 +198,51 @@ pub fn parse_phishtank_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
 ///   `md5` / `sha1` / `sha256`, `mime-type`, `comment`, and so on -- is skipped,
 ///   so a file name or a hash is never mistaken for a host or IP.
 ///
-/// Column positions are resolved from the header row, falling back to the fixed
-/// MISP layout (`type` = 3, `value` = 4, `to_ids` = 6) when a header is absent.
-/// Scope is v1 hostnames plus IPv4; file-hash ingestion is deferred to a
-/// follow-up (the `CuratedFileHashes` path).
+/// The header row is detected rather than assumed: if the first row carries the
+/// `type` / `value` / `to_ids` column names it sets the column positions and is
+/// skipped; otherwise the fixed MISP layout (`type` = 3, `value` = 4,
+/// `to_ids` = 6) is used and that first row is ingested as a real indicator, so a
+/// headerless export never silently drops its first record. Scope is v1 hostnames
+/// plus IPv4; file-hash ingestion is deferred to a follow-up (the
+/// `CuratedFileHashes` path).
 pub fn parse_digitalside_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
-    let mut csv = csv::ReaderBuilder::new()
-        .has_headers(true)
+    // has_headers(false) so we detect the header ourselves. has_headers(true)
+    // would consume the first row of a headerless export as the header and drop
+    // that indicator.
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(false)
         .flexible(true)
         .from_reader(reader);
-    let headers = csv
-        .headers()
-        .map_err(|e| format!("DigitalSide headers: {e}"))?
-        .clone();
+    let mut records = rdr.records();
 
-    let type_idx = headers
-        .iter()
-        .position(|header| header == "type")
-        .unwrap_or(3);
-    let value_idx = headers
-        .iter()
-        .position(|header| header == "value")
-        .unwrap_or(4);
-    let to_ids_idx = headers
-        .iter()
-        .position(|header| header == "to_ids")
-        .unwrap_or(6);
+    let first = match records.next() {
+        Some(Ok(record)) => record,
+        Some(Err(e)) => return Err(format!("DigitalSide first record: {e}")),
+        None => return Ok(FeedEntries::default()),
+    };
+    let has_header = first.iter().any(|field| field == "type")
+        && first.iter().any(|field| field == "value")
+        && first.iter().any(|field| field == "to_ids");
+    let (type_idx, value_idx, to_ids_idx) = if has_header {
+        (
+            first.iter().position(|field| field == "type").unwrap_or(3),
+            first.iter().position(|field| field == "value").unwrap_or(4),
+            first
+                .iter()
+                .position(|field| field == "to_ids")
+                .unwrap_or(6),
+        )
+    } else {
+        // Fixed MISP column layout when the export has no header row.
+        (3, 4, 6)
+    };
+
+    // Skip the first row only if it was the header; a headerless export's first
+    // row is a real indicator and is ingested with the rest.
+    let leading = if has_header { None } else { Some(Ok(first)) };
 
     let mut entries = FeedEntries::default();
-    for record in csv.records() {
+    for record in leading.into_iter().chain(records) {
         let record = match record {
             Ok(record) => record,
             Err(_) => continue,
@@ -600,6 +616,22 @@ mod tests {
         let entries = parse_digitalside_csv(csv.as_bytes()).unwrap();
         assert!(entries.hostnames.is_empty());
         assert!(entries.ips.is_empty());
+    }
+
+    #[test]
+    fn digitalside_csv_headerless_export_keeps_first_indicator() {
+        // A headerless export (no type/value/to_ids header row) must ingest its
+        // first row instead of consuming it as a header. Column positions fall
+        // back to the fixed MISP layout (type=3, value=4, to_ids=6).
+        let rows = [
+            r#""u1",100,"Network activity","domain","first.example","",1,1728745084,"","","","","""#,
+            r#""u2",100,"Network activity","ip-dst","192.0.2.7","",1,1728745084,"","","","","""#,
+        ];
+        let csv = format!("{}\n", rows.join("\n"));
+        let entries = parse_digitalside_csv(csv.as_bytes()).unwrap();
+        // The first indicator is not swallowed as a header.
+        assert_eq!(entries.hostnames, vec!["first.example".to_string()]);
+        assert_eq!(entries.ips, vec![Ipv4Addr::new(192, 0, 2, 7)]);
     }
 
     #[test]

--- a/crates/tirith-core/src/threatdb_feeds.rs
+++ b/crates/tirith-core/src/threatdb_feeds.rs
@@ -180,6 +180,101 @@ pub fn parse_phishtank_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
     Ok(entries)
 }
 
+/// Parse a DigitalSide Threat-Intel MISP-style CSV export.
+///
+/// The upstream feed (davidonzo/Threat-Intel) exports one MISP attribute per
+/// row in the standard MISP CSV shape:
+///
+/// ```text
+/// uuid,event_id,category,type,value,comment,to_ids,date,object_relation,...
+/// ```
+///
+/// MISP semantics enforced here:
+/// * Only rows with `to_ids=1` are ingested (an analyst has flagged the
+///   attribute as a detectable indicator); `to_ids=0` context rows are dropped.
+/// * Only network-indicator `type`s are ingested: `url` (mapped through
+///   [`extract_hostname_from_url`]), `domain` / `hostname` (taken directly), and
+///   `ip-src` / `ip-dst` (parsed as IPv4). Every other type -- `filename`,
+///   `md5` / `sha1` / `sha256`, `mime-type`, `comment`, and so on -- is skipped,
+///   so a file name or a hash is never mistaken for a host or IP.
+///
+/// Column positions are resolved from the header row, falling back to the fixed
+/// MISP layout (`type` = 3, `value` = 4, `to_ids` = 6) when a header is absent.
+/// Scope is v1 hostnames plus IPv4; file-hash ingestion is deferred to a
+/// follow-up (the `CuratedFileHashes` path).
+pub fn parse_digitalside_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
+    let mut csv = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_reader(reader);
+    let headers = csv
+        .headers()
+        .map_err(|e| format!("DigitalSide headers: {e}"))?
+        .clone();
+
+    let type_idx = headers
+        .iter()
+        .position(|header| header == "type")
+        .unwrap_or(3);
+    let value_idx = headers
+        .iter()
+        .position(|header| header == "value")
+        .unwrap_or(4);
+    let to_ids_idx = headers
+        .iter()
+        .position(|header| header == "to_ids")
+        .unwrap_or(6);
+
+    let mut entries = FeedEntries::default();
+    for record in csv.records() {
+        let record = match record {
+            Ok(record) => record,
+            Err(_) => continue,
+        };
+
+        // MISP `to_ids` gate: ingest only analyst-flagged detectable indicators.
+        if record.get(to_ids_idx).map(str::trim) != Some("1") {
+            continue;
+        }
+
+        let ioc_type = match record.get(type_idx) {
+            Some(value) => value.trim().to_ascii_lowercase(),
+            None => continue,
+        };
+        let value = match record.get(value_idx) {
+            Some(value) => value.trim(),
+            None => continue,
+        };
+        if value.is_empty() {
+            continue;
+        }
+
+        match ioc_type.as_str() {
+            "url" => {
+                if let Some(host) = extract_hostname_from_url(value) {
+                    entries.hostnames.push(host);
+                }
+            }
+            // A domain/hostname attribute is a bare host; the guard rejects a
+            // stray URL sneaking into the field before it is stored.
+            "domain" | "hostname" if !value.contains('/') => {
+                entries.hostnames.push(value.to_ascii_lowercase());
+            }
+            "ip-src" | "ip-dst" => {
+                if let Ok(ip) = value.parse::<Ipv4Addr>() {
+                    entries.ips.push(ip);
+                }
+            }
+            // filename, md5/sha*, mime-type, comment, and every other type are
+            // deliberately not network indicators and are skipped.
+            _ => {}
+        }
+    }
+
+    entries.sort_and_dedup();
+    Ok(entries)
+}
+
 pub fn parse_domain_blocklist(contents: &str) -> FeedEntries {
     let mut entries = FeedEntries::default();
     for line in contents.lines() {
@@ -427,6 +522,84 @@ mod tests {
         let csv = "phish_id,url,detail_url\n1,https://phish.example/login,https://phishtank.org/phish/1\n";
         let entries = parse_phishtank_csv(csv.as_bytes()).unwrap();
         assert_eq!(entries.hostnames, vec!["phish.example".to_string()]);
+    }
+
+    // Standard MISP CSV export header used by the DigitalSide feed.
+    const DIGITALSIDE_HEADER: &str = "uuid,event_id,category,type,value,comment,to_ids,date,object_relation,attribute_tag,object_uuid,object_name,object_meta_category";
+
+    #[test]
+    fn digitalside_csv_ingests_only_network_indicators_with_to_ids() {
+        // MISP-style rows using synthetic RFC-2606 hosts and RFC-5737 IPs, in the
+        // real quoted export shape (string fields quoted, numerics bare).
+        let rows = [
+            // Ingested: to_ids=1 network indicators (url/domain/hostname/ip-src/ip-dst).
+            r#""u1",100,"Network activity","url","http://malware.example/x","",1,1728745084,"","","","","""#,
+            r#""u2",100,"Network activity","domain","evil.example","",1,1728745084,"","","","","""#,
+            r#""u3",100,"Network activity","hostname","c2.evil.example","",1,1728745084,"","","","","""#,
+            r#""u4",100,"Network activity","ip-src","192.0.2.10","",1,1728745084,"","","","","""#,
+            r#""u5",100,"Network activity","ip-dst","198.51.100.20","",1,1728745084,"","","","","""#,
+            // Dropped: to_ids=0 context row, even though it is a domain.
+            r#""u6",100,"Network activity","domain","benign-context.example","",0,1728745084,"","","","","""#,
+            // Dropped: non-network types, even with to_ids=1. A filename that
+            // happens to look like a host must NOT become a hostname.
+            r#""u7",100,"Payload delivery","filename","dropper.example","",1,1728745084,"","","","","""#,
+            r#""u8",100,"Payload delivery","md5","d41d8cd98f00b204e9800998ecf8427e","",1,1728745084,"","","","","""#,
+            r#""u9",100,"Payload delivery","sha256","e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","",1,1728745084,"","","","","""#,
+            r#""u10",100,"Other","comment","see evil.example for details","",1,1728745084,"","","","","""#,
+        ];
+        let csv = format!("{DIGITALSIDE_HEADER}\n{}\n", rows.join("\n"));
+        let entries = parse_digitalside_csv(csv.as_bytes()).unwrap();
+
+        // Hostnames come out sorted+deduped: url host, domain, and hostname only.
+        assert_eq!(
+            entries.hostnames,
+            vec![
+                "c2.evil.example".to_string(),
+                "evil.example".to_string(),
+                "malware.example".to_string(),
+            ],
+        );
+        assert_eq!(
+            entries.ips,
+            vec![
+                Ipv4Addr::new(192, 0, 2, 10),
+                Ipv4Addr::new(198, 51, 100, 20)
+            ],
+        );
+        // The to_ids=0 domain, the filename, the hashes, and the comment produced
+        // no host: a non-network attribute is never ingested as an indicator.
+        assert!(!entries
+            .hostnames
+            .contains(&"benign-context.example".to_string()));
+        assert!(!entries.hostnames.contains(&"dropper.example".to_string()));
+    }
+
+    #[test]
+    fn digitalside_csv_dedups_repeated_indicators() {
+        let rows = [
+            r#""u1",100,"Network activity","domain","dup.example","",1,1728745084,"","","","","""#,
+            r#""u2",100,"Network activity","domain","dup.example","",1,1728745084,"","","","","""#,
+            // Same host reached via a url attribute; must fold into one entry.
+            r#""u3",100,"Network activity","url","http://dup.example/other","",1,1728745084,"","","","","""#,
+            r#""u4",100,"Network activity","ip-dst","203.0.113.5","",1,1728745084,"","","","","""#,
+            r#""u5",100,"Network activity","ip-dst","203.0.113.5","",1,1728745084,"","","","","""#,
+        ];
+        let csv = format!("{DIGITALSIDE_HEADER}\n{}\n", rows.join("\n"));
+        let entries = parse_digitalside_csv(csv.as_bytes()).unwrap();
+        assert_eq!(entries.hostnames, vec!["dup.example".to_string()]);
+        assert_eq!(entries.ips, vec![Ipv4Addr::new(203, 0, 113, 5)]);
+    }
+
+    #[test]
+    fn digitalside_csv_drops_to_ids_zero_rows() {
+        // A single to_ids=0 row yields nothing: the MISP flag gate is required.
+        let rows = [
+            r#""u1",100,"Network activity","domain","context-only.example","",0,1728745084,"","","","","""#,
+        ];
+        let csv = format!("{DIGITALSIDE_HEADER}\n{}\n", rows.join("\n"));
+        let entries = parse_digitalside_csv(csv.as_bytes()).unwrap();
+        assert!(entries.hostnames.is_empty());
+        assert!(entries.ips.is_empty());
     }
 
     #[test]

--- a/crates/tirith/src/bin/tirith_threatdb_compile.rs
+++ b/crates/tirith/src/bin/tirith_threatdb_compile.rs
@@ -15,9 +15,9 @@ use ed25519_dalek::{Signer, SigningKey};
 
 use tirith_core::threatdb::{Confidence, Ecosystem, ThreatDbFormat, ThreatDbWriter, ThreatSource};
 use tirith_core::threatdb_feeds::{
-    parse_curated_file_hashes, parse_domain_blocklist, parse_exfil_endpoint_list,
-    parse_phishtank_csv, parse_threatfox_zip, parse_tor_exit_list, parse_urlhaus_csv,
-    CuratedFileHashes, FileHashProvenance,
+    parse_curated_file_hashes, parse_digitalside_csv, parse_domain_blocklist,
+    parse_exfil_endpoint_list, parse_phishtank_csv, parse_threatfox_zip, parse_tor_exit_list,
+    parse_urlhaus_csv, CuratedFileHashes, FileHashProvenance,
 };
 
 #[derive(Parser)]
@@ -72,6 +72,14 @@ struct Cli {
     /// Tor bulk exit list (Phase B)
     #[arg(long)]
     tor_exit: Option<PathBuf>,
+
+    /// DigitalSide Threat-Intel MISP-style CSV export (davidonzo/Threat-Intel).
+    /// GATED feed: the source is defined but the CI fetch is disabled while the
+    /// upstream feed is stale (last automatic update 2024-10-18; gate re-checked
+    /// 2026-07-16). Optional -- skipped if not supplied; degrades to empty with a
+    /// warning if unreadable, like the other optional Phase B feeds.
+    #[arg(long)]
+    digitalside: Option<PathBuf>,
 
     /// Curated exfiltration-endpoint / webhook-catcher hostname list. Plain
     /// domain-per-line blocklist; compiled into the signed primary DB under
@@ -861,6 +869,36 @@ fn parse_tor_exit_file(path: &Path) -> Vec<Ipv4Addr> {
     }
 }
 
+/// Parse a DigitalSide MISP-style CSV file into hostnames and IPv4 IoCs.
+///
+/// Best-effort like the other optional Phase B feeds (URLhaus/ThreatFox): an
+/// unreadable or unparseable file warns and degrades to empty rather than
+/// aborting the build. DigitalSide is a gated supplemental source, not a signed
+/// primary feed, so a transient failure must not fail closed here.
+fn parse_digitalside_file(path: &Path) -> (Vec<String>, Vec<Ipv4Addr>) {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!(
+                "warning: cannot open DigitalSide file {}: {e}",
+                path.display()
+            );
+            return (Vec::new(), Vec::new());
+        }
+    };
+
+    match parse_digitalside_csv(file) {
+        Ok(entries) => (entries.hostnames, entries.ips),
+        Err(e) => {
+            eprintln!(
+                "warning: cannot parse DigitalSide CSV {}: {e}",
+                path.display()
+            );
+            (Vec::new(), Vec::new())
+        }
+    }
+}
+
 fn parse_typosquats_csv(path: &Path) -> Vec<TyposquatEntry> {
     let mut entries = Vec::new();
 
@@ -1267,6 +1305,15 @@ fn main() {
         Vec::new()
     };
 
+    let (digitalside_hosts, digitalside_ips) = if let Some(ref path) = cli.digitalside {
+        eprintln!("  parsing DigitalSide IOCs from {}", path.display());
+        let parsed = parse_digitalside_file(path);
+        eprintln!("    {} hostnames, {} IPs", parsed.0.len(), parsed.1.len());
+        parsed
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
     let exfil_endpoint_hosts = if let Some(ref path) = cli.exfil_endpoints {
         eprintln!("  parsing exfil endpoints from {}", path.display());
         // Fail closed: an explicitly-supplied feed that cannot be read must abort
@@ -1364,6 +1411,14 @@ fn main() {
 
     for ip in &tor_exit_ips {
         writer.add_ip(*ip, ThreatSource::TorExit);
+    }
+
+    for host in &digitalside_hosts {
+        writer.add_hostname(host, ThreatSource::DigitalSide);
+    }
+
+    for ip in &digitalside_ips {
+        writer.add_ip(*ip, ThreatSource::DigitalSide);
     }
 
     for typo in &typosquats {

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -3777,8 +3777,8 @@ fn threatdb_sources_lists_all_feeds_with_counts() {
     let v: serde_json::Value = serde_json::from_str(&stdout).expect("sources JSON");
     assert_eq!(v["db_installed"], true);
     let sources = v["sources"].as_array().expect("sources array");
-    // All 12 ThreatSource variants must be listed.
-    assert_eq!(sources.len(), 12, "every threat source must be listed");
+    // All 13 ThreatSource variants must be listed.
+    assert_eq!(sources.len(), 13, "every threat source must be listed");
     // The fixture has 2 OSSF-malicious package records.
     let ossf = sources
         .iter()
@@ -3930,7 +3930,7 @@ fn threatdb_alias_threatdb_still_works() {
         "the `threatdb` alias must still work"
     );
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("sources JSON via alias");
-    assert_eq!(v["sources"].as_array().unwrap().len(), 12);
+    assert_eq!(v["sources"].as_array().unwrap().len(), 13);
 }
 
 // verify-self / update / version --provenance (M2 item 24) These tests run the CLI end-to-end.


### PR DESCRIPTION
## What this is

Adds DigitalSide Threat-Intel (davidonzo/Threat-Intel) as a new threat-DB source, `ThreatSource::DigitalSide` (discriminant 12), with a MISP-style CSV parser and a `--digitalside` compiler flag. It is a GATED feed: the source is fully defined in code, but the CI fetch is deliberately left disabled because the upstream feed is stale.

## Freshness gate: STALE, so CI fetch is disabled

Re-checked 2026-07-16. The upstream repo's automated daily "Automatic Update" commits stopped at 2024-10-18 (about 21 months ago) and nothing has been published since; MISP/OSINT indexes corroborate data only through Oct 2024. Separately, the upstream DATA license is unstated (repo code is MIT, but the feed metadata sets MISP distribution "0" and declares no data license), so redistribution into the signed DB is unresolved. Both reasons point the same way: define the source now, ship the parser and flag, but do not fetch. `threatdb.yml` gets a documentation comment recording the dates, the license gap, and the exact re-enable steps. No LICENSE vendored (nothing is ingested while disabled).

## Changes

- `ThreatSource::DigitalSide = 12` in threatdb.rs: the full 8-site edit set (enum, `from_u8`, `ALL` + count 12 to 13, `as_str` "digitalside", `tier` Supplemental, `upstream_url`, `label`, `default_confidence` Confirmed). Appended discriminant so older `.dat` files (sources 0-11) still load.
- Explicit routing arms in BOTH `hostname_rule_for_source` and `ip_rule_for_source` (threatintel.rs), which have no `_` fallthrough by design: hostnames route to `ThreatMaliciousUrl` (High), IPs to `ThreatMaliciousIp` (High), like the other generic IoC feeds. No other exhaustive `ThreatSource` match needed an arm (`source_breakdown` and the threatdb CLI iterate `ThreatSource::ALL`, verified by a clean `cargo +1.83 check --workspace --all-targets`).
- `parse_digitalside_csv` (threatdb_feeds.rs, reuses the existing `csv` crate, no new dependency): MISP semantics enforced. Only `to_ids=1` rows; only network types `url` (via `extract_hostname_from_url`), `domain`/`hostname` (direct), `ip-src`/`ip-dst` (IPv4). `filename`, `md5`/`sha*`, `mime-type`, `comment`, and every other type are skipped, so a file name or hash is never mistaken for a host. Columns resolved by header with a fixed-position fallback. IPv4 scope for v1; file-hash ingestion deferred.
- Compiler: `--digitalside <path>` flag + `parse_digitalside_file` (best-effort, degrades to empty like the other optional Phase B feeds, not fail-closed, since it is gated supplemental) + `add_hostname`/`add_ip` with `ThreatSource::DigitalSide`.

## Tests

- Parser: `digitalside_csv_ingests_only_network_indicators_with_to_ids`, `digitalside_csv_dedups_repeated_indicators`, `digitalside_csv_drops_to_ids_zero_rows` (synthetic RFC-2606 hosts / RFC-5737 IPs).
- In-memory roundtrip `digitalside_hostname_and_ip_roundtrip_with_source_attribution`: builds a signed DB with an ephemeral key (the production verify key is never touched) and asserts `check_hostname`/`check_ip` and `source_breakdown` attribute the match to DigitalSide.
- Routing `digitalside_maps_to_generic_malicious_rules`; discriminant test updated (`ALL.len()` 13, `from_u8(12)=Some(DigitalSide)`, `from_u8(13)=None`); tier test updated; both `cli_integration` source-count assertions bumped 12 to 13.

## Stack and CI note

PR4 of the series, stacked on #172 (base `security/lotl-cred`). Verified: `cargo +1.83 fmt --check` clean, stable clippy `-D warnings` clean, all PR4 tests green (the only workspace test failures are the pre-existing checkpoint/clipboard environmental flakes, which pass in isolation).

`cargo deny check advisories` currently fails on three advisories, all PRE-EXISTING and unrelated to this PR (PR4 changes no Cargo.toml/Cargo.lock, and they fail identically on the stack base): RUSTSEC-2026-0194 and RUSTSEC-2026-0195 (quick-xml via rust-s3 / tirith-license-server) and RUSTSEC-2026-0204 (crossbeam-epoch, a dev-dependency). These were published upstream after this stack was last gated and affect every branch in the stack; they are being handled separately, not in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added DigitalSide as a supplemental threat-data source with hostname and IPv4 ingestion.
  - Added an optional DigitalSide feed input to threat DB compilation.
- **Bug Fixes**
  - Ensured DigitalSide hostname/IP indicators are attributed and routed to the correct malicious URL/IP targets.
- **Tests**
  - Expanded coverage for DigitalSide parsing, filtering, deduplication, attribution, and updated CLI source counts.
- **Chores**
  - Documented CI conditions for (re)enabling DigitalSide feed ingestion and updated security advisory ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds DigitalSide as a gated threat-intelligence source. The main changes are:

- Adds DigitalSide source metadata, attribution, and threat-rule routing.
- Adds MISP-style CSV parsing for network indicators marked for detection.
- Adds an optional `--digitalside` compiler input.
- Keeps CI ingestion disabled pending feed freshness and licensing clarity.
- Adds parser, database round-trip, routing, and CLI source-count tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The headerless CSV path now retains and processes the first record.
- Tests cover the corrected hostname and IP ingestion path.
- No blocking issue remains in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/threatdb_feeds.rs | Adds DigitalSide CSV parsing and preserves the first indicator in headerless exports. |
| crates/tirith-core/src/threatdb.rs | Adds the DigitalSide source discriminant, metadata, decoding, attribution, and round-trip coverage. |
| crates/tirith-core/src/rules/threatintel.rs | Routes DigitalSide hostname and IP matches to the generic high-severity threat rules. |
| crates/tirith/src/bin/tirith_threatdb_compile.rs | Adds optional DigitalSide file parsing and writes parsed indicators with source attribution. |
| .github/workflows/threatdb.yml | Documents the freshness and licensing gates while leaving CI ingestion disabled. |

<sub>Reviews (2): Last reviewed commit: ["test(threatdb): pin DigitalSide as\_str s..."](https://github.com/sheeki03/tirith/commit/4cb2c0ee0bcc95ff1e5d1643f64a7d2974a01cf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44758100)</sub>

<!-- /greptile_comment -->