### PR TITLE
fix: ignore Hermes transient cleanup in deletion correlation

### DIFF
--- a/crates/tirith-core/src/escalation.rs
+++ b/crates/tirith-core/src/escalation.rs
@@ -951,6 +951,13 @@ fn delete_path_args<'a>(tool: &str, args: &'a [String]) -> Vec<&'a String> {
             }
             continue;
         }
+        // The command-string tokenizer can retain a shell redirection as an
+        // argument (for example `2>/dev/null`). It is syntax, not a deleted path.
+        // Strip leading file-descriptor digits before testing the operator.
+        let redirection = a.trim_start_matches(|c: char| c.is_ascii_digit());
+        if redirection.starts_with('>') || redirection.starts_with('<') {
+            continue;
+        }
         paths.push(a);
     }
     paths
@@ -3389,6 +3396,32 @@ mod tests {
                 .get(crate::event_buffer::NON_BUILD_DELETE_COUNT_KEY)
                 .map(String::as_str),
             Some("2")
+        );
+    }
+
+    #[test]
+    fn derive_file_delete_ignores_shell_redirection_tokens() {
+        let v = raw_verdict_with(Action::Allow, vec![], None);
+        let del = derive_typed_events(
+            "rm -f /tmp/hermes-snap-deadbeef.sh.tmp.$BASHPID 2>/dev/null",
+            &v,
+        )
+        .into_iter()
+        .find(|e| e.kind == EventKind::FileDelete)
+        .expect("snapshot cleanup must record a FileDelete");
+        assert_eq!(
+            del.metadata
+                .get(crate::event_buffer::DELETE_COUNT_KEY)
+                .map(String::as_str),
+            Some("1"),
+            "the stderr redirection is syntax, not a second path"
+        );
+        assert_eq!(
+            del.metadata
+                .get(crate::event_buffer::NON_BUILD_DELETE_COUNT_KEY)
+                .map(String::as_str),
+            Some("0"),
+            "Hermes' generated environment snapshot temp is not authored source"
         );
     }
 

--- a/crates/tirith-core/src/escalation.rs
+++ b/crates/tirith-core/src/escalation.rs
@@ -702,6 +702,7 @@ fn derive_typed_events(cmd: &str, verdict: &Verdict) -> Vec<TypedEvent> {
 
     // --- Command-shape signals ---------------------------------------------
     let segments = tokenize::tokenize(cmd, ShellType::Posix);
+    let hermes_snapshot_cleanup_segment = generated_hermes_snapshot_cleanup_segment(&segments);
     let mut leader_is_network = false;
     let mut delete_path: Option<String> = None;
     // Path-operand counts accumulated across ALL rm/unlink/shred segments in this
@@ -721,7 +722,7 @@ fn derive_typed_events(cmd: &str, verdict: &Verdict) -> Vec<TypedEvent> {
     let mut secret_write_path: Option<String> = None;
     let mut manifest_write_path: Option<String> = None;
 
-    for seg in &segments {
+    for (segment_index, seg) in segments.iter().enumerate() {
         let (leader, args) = resolve_leader_and_args(seg);
         let leader_base = command_base(&leader);
 
@@ -748,7 +749,11 @@ fn derive_typed_events(cmd: &str, verdict: &Verdict) -> Vec<TypedEvent> {
                 // is three deletions, and split the total into non-build paths so
                 // the mass-delete correlation never counts `dist/`/`node_modules/`.
                 delete_path_count += count_path_args(leader_base.as_str(), &args);
-                delete_non_build_count += count_non_build_path_args(leader_base.as_str(), &args);
+                delete_non_build_count += count_non_build_path_args(
+                    leader_base.as_str(),
+                    &args,
+                    hermes_snapshot_cleanup_segment == Some(segment_index),
+                );
             }
             "git" if git_is_force_push(&args) => is_force_push = true,
             "npm" | "pnpm" | "yarn" | "pip" | "pip3" | "cargo" | "brew" | "gem" | "go" | "apt"
@@ -986,11 +991,108 @@ fn count_path_args(tool: &str, args: &[String]) -> usize {
 /// `rm -rf src x` -> 2. This is what the mass-deletion correlation sums, so a mixed
 /// delete contributes exactly its real non-build paths instead of all-or-nothing on
 /// one sampled path.
-fn count_non_build_path_args(tool: &str, args: &[String]) -> usize {
+fn count_non_build_path_args(
+    tool: &str,
+    args: &[String],
+    generated_hermes_snapshot_cleanup: bool,
+) -> usize {
     delete_path_args(tool, args)
         .into_iter()
-        .filter(|a| !crate::util_build_dirs::is_build_artifact_path(a))
+        .filter(|a| {
+            !(crate::util_build_dirs::is_build_artifact_path(a)
+                || (generated_hermes_snapshot_cleanup && is_hermes_snapshot_tmp_operand(a)))
+        })
         .count()
+}
+
+fn is_hermes_snapshot_tmp_operand(path: &str) -> bool {
+    path == "\"$__hermes_snap_tmp\""
+}
+
+/// Locate Hermes Agent's generated atomic environment-snapshot fallback.
+///
+/// The exemption is bound to one parsed `|| rm -f "$__hermes_snap_tmp"` segment, not
+/// inferred from substrings elsewhere in the command. The same segment sequence must contain
+/// the exact temp-root `mktemp` assignment, a redirect into that variable, and a matching
+/// atomic rename in that order. Any additional fallback-like segment or unexpected use of the
+/// private variable between assignment and cleanup fails closed.
+fn generated_hermes_snapshot_cleanup_segment(segments: &[tokenize::Segment]) -> Option<usize> {
+    const ASSIGNMENT_PREFIX: &str = "__hermes_snap_tmp=$(mktemp ";
+    const VARIABLE: &str = "\"$__hermes_snap_tmp\"";
+    const CLEANUP: &str = "rm -f \"$__hermes_snap_tmp\" 2>/dev/null";
+
+    let assignments: Vec<(usize, &str)> = segments
+        .iter()
+        .enumerate()
+        .filter_map(|(index, segment)| {
+            let template = segment
+                .raw
+                .strip_prefix(ASSIGNMENT_PREFIX)?
+                .strip_suffix(')')?
+                .trim()
+                .trim_matches(['\'', '"']);
+            if template.split_whitespace().count() == 1
+                && template.ends_with(".sh.tmp.XXXXXXXXXX")
+                && crate::util_build_dirs::is_hermes_temp_artifact_path(template)
+            {
+                Some((index, template))
+            } else {
+                None
+            }
+        })
+        .collect();
+    let [(assignment_index, template)] = assignments.as_slice() else {
+        return None;
+    };
+    let (snapshot_path, _) = template.split_once(".tmp.")?;
+    if !snapshot_path.ends_with(".sh") {
+        return None;
+    }
+
+    let cleanup_candidates: Vec<usize> = segments
+        .iter()
+        .enumerate()
+        .filter_map(|(index, segment)| {
+            (segment.preceding_separator.as_deref() == Some("||") && segment.raw == CLEANUP)
+                .then_some(index)
+        })
+        .collect();
+    let [cleanup_index] = cleanup_candidates.as_slice() else {
+        return None;
+    };
+    if assignment_index >= cleanup_index {
+        return None;
+    }
+
+    let expected_redirect = format!("}} > {VARIABLE}");
+    let redirect_index = segments
+        .iter()
+        .enumerate()
+        .skip(assignment_index + 1)
+        .take(cleanup_index - assignment_index - 1)
+        .find_map(|(index, segment)| (segment.raw == expected_redirect).then_some(index))?;
+
+    let expected_mv = format!("mv -f {VARIABLE} {snapshot_path}");
+    let mv_index = segments
+        .iter()
+        .enumerate()
+        .skip(redirect_index + 1)
+        .take(cleanup_index - redirect_index - 1)
+        .find_map(|(index, segment)| (segment.raw == expected_mv).then_some(index))?;
+
+    for (index, segment) in segments
+        .iter()
+        .enumerate()
+        .skip(assignment_index + 1)
+        .take(cleanup_index - assignment_index - 1)
+    {
+        if segment.raw.contains("__hermes_snap_tmp") && index != redirect_index && index != mv_index
+        {
+            return None;
+        }
+    }
+
+    Some(*cleanup_index)
 }
 
 /// Split a `scheme://rest` argument into its lowercased scheme and the raw host
@@ -3423,6 +3525,174 @@ mod tests {
             Some("0"),
             "Hermes' generated environment snapshot temp is not authored source"
         );
+    }
+
+    const HERMES_SNAPSHOT_WRAPPER: &str = concat!(
+        "true; __hermes_ec=$?; umask 077; ",
+        "__hermes_snap_tmp=$(mktemp ",
+        "/var/folders/ab/cd/T/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+        "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+        "mv -f \"$__hermes_snap_tmp\" ",
+        "/var/folders/ab/cd/T/hermes-snap-deadbeef.sh; } ",
+        "2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+    );
+
+    #[test]
+    fn derive_file_delete_ignores_hermes_snapshot_variable_cleanup() {
+        let v = raw_verdict_with(Action::Allow, vec![], None);
+        let command = HERMES_SNAPSHOT_WRAPPER;
+        let segments = tokenize::tokenize(command, ShellType::Posix);
+        assert!(generated_hermes_snapshot_cleanup_segment(&segments).is_some());
+        let del = derive_typed_events(command, &v)
+            .into_iter()
+            .find(|e| e.kind == EventKind::FileDelete)
+            .expect("snapshot fallback cleanup must record a FileDelete");
+        assert_eq!(
+            del.metadata
+                .get(crate::event_buffer::DELETE_COUNT_KEY)
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            del.metadata
+                .get(crate::event_buffer::NON_BUILD_DELETE_COUNT_KEY)
+                .map(String::as_str),
+            Some("0"),
+            "the generated Hermes snapshot variable resolves only to a temp artifact"
+        );
+    }
+
+    #[test]
+    fn derive_file_delete_counts_authored_private_variable_deletes_before_wrapper() {
+        let v = raw_verdict_with(Action::Allow, vec![], None);
+        for (prefix, expected_total, expected_non_build) in [
+            (
+                concat!(
+                    "printf -v __hermes_snap_tmp /important/a; ",
+                    "rm -f \"$__hermes_snap_tmp\"; ",
+                    "printf -v __hermes_snap_tmp /important/b; ",
+                    "rm -f \"$__hermes_snap_tmp\"",
+                ),
+                "3",
+                "2",
+            ),
+            ("false || rm -f \"$__hermes_snap_tmp\"", "2", "1"),
+            ("rm -f '$__hermes_snap_tmp'", "2", "1"),
+        ] {
+            let command = format!("{prefix}; {HERMES_SNAPSHOT_WRAPPER}");
+            let del = derive_typed_events(&command, &v)
+                .into_iter()
+                .find(|e| e.kind == EventKind::FileDelete)
+                .expect("combined command must record a FileDelete");
+            assert_eq!(
+                del.metadata
+                    .get(crate::event_buffer::DELETE_COUNT_KEY)
+                    .map(String::as_str),
+                Some(expected_total),
+                "all delete segments must remain represented: {prefix}"
+            );
+            assert_eq!(
+                del.metadata
+                    .get(crate::event_buffer::NON_BUILD_DELETE_COUNT_KEY)
+                    .map(String::as_str),
+                Some(expected_non_build),
+                "authored private-variable deletes must remain counted: {prefix}"
+            );
+        }
+    }
+
+    #[test]
+    fn derive_file_delete_keeps_unproven_variable_cleanup_authored() {
+        let v = raw_verdict_with(Action::Allow, vec![], None);
+        for command in [
+            "rm -f \"$__hermes_snap_tmp\"",
+            "tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX); rm -f \"$tmp\"",
+            "__hermes_snap_tmp=/tmp/hermes-snap-deadbeef.sh.tmp.123; rm -f \"$__hermes_snap_tmp\"",
+            "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX); rm -f \"$__hermes_snap_tmp\"",
+            "__hermes_snap_tmp=$(mktemp /workspace/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX); rm -f \"$__hermes_snap_tmp\"",
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ export -p > \"$__hermes_snap_tmp\" && mv -f \"$__hermes_snap_tmp\" ",
+                "/tmp/hermes-snap-other.sh; } || rm -f \"$__hermes_snap_tmp\"",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.$BASHPID) && ",
+                "{ export -p > \"$__hermes_snap_tmp\" && mv -f \"$__hermes_snap_tmp\" ",
+                "/tmp/hermes-snap-deadbeef.sh; } || rm -f \"$__hermes_snap_tmp\"",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+                "__hermes_snap_tmp=/important && mv -f \"$__hermes_snap_tmp\" ",
+                "/tmp/hermes-snap-deadbeef.sh; } 2>/dev/null || ",
+                "rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+                "printf -v __hermes_snap_tmp /important && ",
+                "mv -f \"$__hermes_snap_tmp\" /tmp/hermes-snap-deadbeef.sh; } ",
+                "2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+                "mv -f \"$__hermes_snap_tmp\" /tmp/hermes-snap-deadbeef.sh; } ",
+                "2>/dev/null || rm \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+                "env FOO=bar mv -f \"$__hermes_snap_tmp\" ",
+                "/tmp/hermes-snap-deadbeef.sh; } 2>/dev/null || ",
+                "rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+                "FOO=bar mv -f \"$__hermes_snap_tmp\" /tmp/hermes-snap-deadbeef.sh; } ",
+                "2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp ",
+                "/workspace/target/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+                "mv -f \"$__hermes_snap_tmp\" ",
+                "/workspace/target/hermes-snap-deadbeef.sh; } 2>/dev/null || ",
+                "rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-first.sh.tmp.XXXXXXXXXX); ",
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+                "mv -f \"$__hermes_snap_tmp\" /tmp/hermes-snap-deadbeef.sh; } ",
+                "2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "mv -f \"$__hermes_snap_tmp\" /tmp/hermes-snap-deadbeef.sh && ",
+                "} > \"$__hermes_snap_tmp\"; } 2>/dev/null || ",
+                "rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } >> \"$__hermes_snap_tmp\" && ",
+                "mv -f \"$__hermes_snap_tmp\" /tmp/hermes-snap-deadbeef.sh; } ",
+                "2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+        ] {
+            let del = derive_typed_events(command, &v)
+                .into_iter()
+                .find(|e| e.kind == EventKind::FileDelete)
+                .expect("variable cleanup must record a FileDelete");
+            assert_eq!(
+                del.metadata
+                    .get(crate::event_buffer::NON_BUILD_DELETE_COUNT_KEY)
+                    .map(String::as_str),
+                Some("1"),
+                "unproven variable cleanup must stay authored: {command}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tirith-core/src/escalation.rs
+++ b/crates/tirith-core/src/escalation.rs
@@ -1044,7 +1044,7 @@ fn generated_hermes_snapshot_cleanup_segment(segments: &[tokenize::Segment]) -> 
     let [(assignment_index, template)] = assignments.as_slice() else {
         return None;
     };
-    let (snapshot_path, _) = template.split_once(".tmp.")?;
+    let snapshot_path = template.strip_suffix(".tmp.XXXXXXXXXX")?;
     if !snapshot_path.ends_with(".sh") {
         return None;
     }
@@ -1079,6 +1079,22 @@ fn generated_hermes_snapshot_cleanup_segment(segments: &[tokenize::Segment]) -> 
         .skip(redirect_index + 1)
         .take(cleanup_index - redirect_index - 1)
         .find_map(|(index, segment)| (segment.raw == expected_mv).then_some(index))?;
+
+    if segments[redirect_index].preceding_separator.as_deref() != Some(";")
+        || segments[mv_index].preceding_separator.as_deref() != Some("&&")
+        || mv_index != redirect_index + 1
+    {
+        return None;
+    }
+
+    let close_index = mv_index + 1;
+    if close_index + 1 != *cleanup_index {
+        return None;
+    }
+    let close = &segments[close_index];
+    if close.preceding_separator.as_deref() != Some(";") || close.raw != "} 2>/dev/null" {
+        return None;
+    }
 
     for (index, segment) in segments
         .iter()
@@ -3560,6 +3576,26 @@ mod tests {
             Some("0"),
             "the generated Hermes snapshot variable resolves only to a temp artifact"
         );
+
+        let command = HERMES_SNAPSHOT_WRAPPER.replace(
+            "/var/folders/ab/cd/T/",
+            "/tmp/hermes-session.tmp.directory/",
+        );
+        let segments = tokenize::tokenize(&command, ShellType::Posix);
+        assert!(
+            generated_hermes_snapshot_cleanup_segment(&segments).is_some(),
+            "a .tmp. component in the parent directory must not truncate the snapshot path"
+        );
+        let del = derive_typed_events(&command, &v)
+            .into_iter()
+            .find(|e| e.kind == EventKind::FileDelete)
+            .expect("snapshot fallback cleanup must record a FileDelete");
+        assert_eq!(
+            del.metadata
+                .get(crate::event_buffer::NON_BUILD_DELETE_COUNT_KEY)
+                .map(String::as_str),
+            Some("0")
+        );
     }
 
     #[test]
@@ -3599,6 +3635,25 @@ mod tests {
                 "authored private-variable deletes must remain counted: {prefix}"
             );
         }
+
+        let command = format!("{HERMES_SNAPSHOT_WRAPPER}; rm -f \"$__hermes_snap_tmp\"");
+        let del = derive_typed_events(&command, &v)
+            .into_iter()
+            .find(|e| e.kind == EventKind::FileDelete)
+            .expect("combined command must record a FileDelete");
+        assert_eq!(
+            del.metadata
+                .get(crate::event_buffer::DELETE_COUNT_KEY)
+                .map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(
+            del.metadata
+                .get(crate::event_buffer::NON_BUILD_DELETE_COUNT_KEY)
+                .map(String::as_str),
+            Some("1"),
+            "an authored delete after the generated wrapper must remain counted"
+        );
     }
 
     #[test]
@@ -3679,6 +3734,13 @@ mod tests {
                 "{ { ( export -p; ) || true; } >> \"$__hermes_snap_tmp\" && ",
                 "mv -f \"$__hermes_snap_tmp\" /tmp/hermes-snap-deadbeef.sh; } ",
                 "2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
+            ),
+            concat!(
+                "__hermes_snap_tmp=$(mktemp /tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX) && ",
+                "{ { ( export -p; ) || true; } > \"$__hermes_snap_tmp\" && ",
+                "mv -f \"$__hermes_snap_tmp\" /tmp/hermes-snap-deadbeef.sh; } ",
+                "2>/dev/null; false || ",
+                "rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true",
             ),
         ] {
             let del = derive_typed_events(command, &v)

--- a/crates/tirith-core/src/util_build_dirs.rs
+++ b/crates/tirith-core/src/util_build_dirs.rs
@@ -38,11 +38,20 @@ pub fn is_build_artifact_path(path: &str) -> bool {
         return true;
     }
 
-    // Hermes Agent atomically rewrites a per-session environment snapshot after
-    // every terminal command, cleaning a `hermes-snap-*.sh.tmp.$BASHPID` file on
-    // failure. These are generated session artifacts, not authored files, and
-    // must not contribute to the mass-file-deletion correlation.
-    let basename = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    // Hermes Agent atomically rewrites per-session environment snapshots and
+    // creates short-lived execute-code sandboxes. Their cleanup is generated
+    // runtime housekeeping, not authored-file deletion, and must not contribute
+    // to the mass-file-deletion correlation.
+    let mut components = path.split(['/', '\\']);
+    let basename = components.next_back().unwrap_or(path);
+    if components.any(|component| {
+        component
+            .strip_prefix("hermes_sandbox_")
+            .is_some_and(|suffix| !suffix.is_empty())
+    }) {
+        return true;
+    }
+
     basename.starts_with("hermes-snap-") && basename.contains(".sh.tmp.")
 }
 
@@ -90,7 +99,18 @@ mod tests {
         assert!(is_build_artifact_path(
             r"C:\Temp\hermes-snap-deadbeef.sh.tmp.1234"
         ));
+        assert!(is_build_artifact_path(
+            "/var/folders/ab/cd/T/hermes_sandbox_deadbeef/script.py"
+        ));
+        assert!(is_build_artifact_path(
+            "/tmp/hermes_sandbox_1234567890abcdef/script.py"
+        ));
+        assert!(is_build_artifact_path(
+            r"C:\\Temp\\hermes_sandbox_deadbeef\\script.py"
+        ));
         assert!(!is_build_artifact_path("src/hermes-snap-not-a-temp.sh"));
+        assert!(!is_build_artifact_path("src/hermes_sandbox_rules.rs"));
+        assert!(!is_build_artifact_path("/tmp/hermes_sandbox_/script.py"));
         assert!(!is_build_artifact_path("src/main.rs"));
     }
 

--- a/crates/tirith-core/src/util_build_dirs.rs
+++ b/crates/tirith-core/src/util_build_dirs.rs
@@ -38,11 +38,23 @@ pub fn is_build_artifact_path(path: &str) -> bool {
         return true;
     }
 
-    // Hermes Agent atomically rewrites per-session environment snapshots and
-    // creates short-lived execute-code sandboxes. Their cleanup is generated
-    // runtime housekeeping, not authored-file deletion, and must not contribute
-    // to the mass-file-deletion correlation.
-    let mut components = path.split(['/', '\\']);
+    // Hermes Agent creates these generated runtime artifacts under the operating
+    // system's temporary roots. Scope the exemption to those roots so authored
+    // files with similar names remain part of deletion correlation.
+    let normalized = path.replace('\\', "/");
+    let lowercase = normalized.to_ascii_lowercase();
+    let in_temp_root = normalized.starts_with("/tmp/")
+        || normalized.starts_with("/private/tmp/")
+        || normalized.starts_with("/var/tmp/")
+        || normalized.starts_with("/var/folders/")
+        || lowercase
+            .get(1..)
+            .is_some_and(|suffix| suffix.starts_with(":/temp/"));
+    if !in_temp_root {
+        return false;
+    }
+
+    let mut components = normalized.split('/');
     let basename = components.next_back().unwrap_or(path);
     if components.any(|component| {
         component
@@ -106,7 +118,13 @@ mod tests {
             "/tmp/hermes_sandbox_1234567890abcdef/script.py"
         ));
         assert!(is_build_artifact_path(
-            r"C:\\Temp\\hermes_sandbox_deadbeef\\script.py"
+            r"C:\Temp\hermes_sandbox_deadbeef\script.py"
+        ));
+        assert!(!is_build_artifact_path(
+            "/workspace/hermes_sandbox_deadbeef/script.py"
+        ));
+        assert!(!is_build_artifact_path(
+            "/workspace/hermes-snap-deadbeef.sh.tmp.1234"
         ));
         assert!(!is_build_artifact_path("src/hermes-snap-not-a-temp.sh"));
         assert!(!is_build_artifact_path("src/hermes_sandbox_rules.rs"));

--- a/crates/tirith-core/src/util_build_dirs.rs
+++ b/crates/tirith-core/src/util_build_dirs.rs
@@ -34,7 +34,16 @@ pub fn should_skip_dir(name: &str) -> bool {
 /// directory. Components are split on both `/` and `\` so the check works for
 /// POSIX and Windows-style paths.
 pub fn is_build_artifact_path(path: &str) -> bool {
-    path.split(['/', '\\']).any(should_skip_dir)
+    if path.split(['/', '\\']).any(should_skip_dir) {
+        return true;
+    }
+
+    // Hermes Agent atomically rewrites a per-session environment snapshot after
+    // every terminal command, cleaning a `hermes-snap-*.sh.tmp.$BASHPID` file on
+    // failure. These are generated session artifacts, not authored files, and
+    // must not contribute to the mass-file-deletion correlation.
+    let basename = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    basename.starts_with("hermes-snap-") && basename.contains(".sh.tmp.")
 }
 
 #[cfg(test)]
@@ -75,6 +84,13 @@ mod tests {
     #[test]
     fn build_artifact_path_detection() {
         assert!(is_build_artifact_path("a/dist/b.js"));
+        assert!(is_build_artifact_path(
+            "/tmp/hermes-snap-deadbeef.sh.tmp.$BASHPID"
+        ));
+        assert!(is_build_artifact_path(
+            r"C:\Temp\hermes-snap-deadbeef.sh.tmp.1234"
+        ));
+        assert!(!is_build_artifact_path("src/hermes-snap-not-a-temp.sh"));
         assert!(!is_build_artifact_path("src/main.rs"));
     }
 

--- a/crates/tirith-core/src/util_build_dirs.rs
+++ b/crates/tirith-core/src/util_build_dirs.rs
@@ -64,7 +64,8 @@ pub fn is_build_artifact_path(path: &str) -> bool {
         return true;
     }
 
-    basename.starts_with("hermes-snap-") && basename.contains(".sh.tmp.")
+    basename.starts_with("hermes-snap-")
+        && (basename.ends_with(".sh") || basename.contains(".sh.tmp."))
 }
 
 #[cfg(test)]
@@ -108,6 +109,10 @@ mod tests {
         assert!(is_build_artifact_path(
             "/tmp/hermes-snap-deadbeef.sh.tmp.$BASHPID"
         ));
+        assert!(is_build_artifact_path("/tmp/hermes-snap-deadbeef.sh"));
+        assert!(is_build_artifact_path(
+            "/var/folders/ab/cd/T/hermes-snap-deadbeef.sh"
+        ));
         assert!(is_build_artifact_path(
             r"C:\Temp\hermes-snap-deadbeef.sh.tmp.1234"
         ));
@@ -125,6 +130,9 @@ mod tests {
         ));
         assert!(!is_build_artifact_path(
             "/workspace/hermes-snap-deadbeef.sh.tmp.1234"
+        ));
+        assert!(!is_build_artifact_path(
+            "/workspace/hermes-snap-deadbeef.sh"
         ));
         assert!(!is_build_artifact_path("src/hermes-snap-not-a-temp.sh"));
         assert!(!is_build_artifact_path("src/hermes_sandbox_rules.rs"));

--- a/crates/tirith-core/src/util_build_dirs.rs
+++ b/crates/tirith-core/src/util_build_dirs.rs
@@ -31,16 +31,16 @@ pub fn should_skip_dir(name: &str) -> bool {
 }
 
 /// Returns true if any component of `path` is a built-in build-artifact
-/// directory. Components are split on both `/` and `\` so the check works for
-/// POSIX and Windows-style paths.
+/// directory, or if the path is a generated Hermes runtime artifact under an
+/// operating-system temporary root. Components are split on both `/` and `\`
+/// so the check works for POSIX and Windows-style paths.
 pub fn is_build_artifact_path(path: &str) -> bool {
-    if path.split(['/', '\\']).any(should_skip_dir) {
-        return true;
-    }
+    path.split(['/', '\\']).any(should_skip_dir) || is_hermes_temp_artifact_path(path)
+}
 
-    // Hermes Agent creates these generated runtime artifacts under the operating
-    // system's temporary roots. Scope the exemption to those roots so authored
-    // files with similar names remain part of deletion correlation.
+/// Returns true only for Hermes Agent runtime artifacts beneath known
+/// operating-system temporary roots.
+pub fn is_hermes_temp_artifact_path(path: &str) -> bool {
     let normalized = path.replace('\\', "/");
     let lowercase = normalized.to_ascii_lowercase();
     let in_temp_root = normalized.starts_with("/tmp/")
@@ -138,6 +138,19 @@ mod tests {
         assert!(!is_build_artifact_path("src/hermes_sandbox_rules.rs"));
         assert!(!is_build_artifact_path("/tmp/hermes_sandbox_/script.py"));
         assert!(!is_build_artifact_path("src/main.rs"));
+    }
+
+    #[test]
+    fn hermes_temp_artifact_excludes_generic_build_directories() {
+        assert!(is_hermes_temp_artifact_path(
+            "/tmp/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX"
+        ));
+        assert!(!is_hermes_temp_artifact_path(
+            "/workspace/target/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX"
+        ));
+        assert!(is_build_artifact_path(
+            "/workspace/target/hermes-snap-deadbeef.sh.tmp.XXXXXXXXXX"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Ignore shell redirection tokens such as `2>/dev/null` when deriving delete operands.
- Classify Hermes `hermes-snap-*.sh.tmp.*` environment snapshots under OS temp roots as generated artifacts.
- Classify files inside `hermes_sandbox_*` execute-code directories under OS temp roots as generated artifacts.
- Keep similarly named authored files outside temp roots in mass-deletion correlation.

## Problem

Hermes removes these generated artifacts during normal terminal and execute-code operations. Parallel agent work could otherwise accumulate enough non-build deletions to trigger mass-file-deletion correlation and block unrelated operations.

The exemption is deliberately constrained to `/tmp`, `/private/tmp`, `/var/tmp`, macOS `/var/folders`, and Windows drive `Temp` roots. It does not exempt similarly named project files or directories.

## Validation

- `cargo fmt --check`
- `cargo test -p tirith-core --lib` (2931 passed, 1 ignored)
- `cargo clippy -p tirith-core --all-targets -- -D warnings`
- release build installed locally
- four concurrent Hermes execute-code sandboxes completed without triggering deletion escalation
- regression tests cover POSIX, macOS, Windows, empty suffixes, and authored paths outside temp roots