### PR TITLE
fix(security): DeepSec R2 2/2: CLI, license server, and CI hardening

### DIFF
--- a/.github/scripts/fetch-threatdb-sources.sh
+++ b/.github/scripts/fetch-threatdb-sources.sh
@@ -9,6 +9,25 @@ set -euo pipefail
 
 OUTPUT_ROOT=${THREATDB_FETCH_OUTPUT_DIR:-/tmp}
 FINAL_DIR="$OUTPUT_ROOT/tirith-threatdb-sources"
+# Resolved upstream revisions are recorded here (next to, never inside, the
+# compiler-visible directory) so the build log and release audit trail show
+# exactly which upstream commits/bytes were signed into the database.
+PINS_FILE="$OUTPUT_ROOT/tirith-threatdb-source-pins.json"
+
+# Pinned upstream source revisions (repo-0241). These are branch-name pins
+# because no reviewed commit SHAs are recorded in this repository yet; replace
+# with full 40-hex commit SHAs after review to make every fetch immutable.
+# The workflow (.github/workflows/threatdb.yml) mirrors these in its env block.
+OSSF_MP_REF=${THREATDB_OSSF_MP_REF:-main}
+DD_MP_REF=${THREATDB_DD_MP_REF:-main}
+
+# Transfer limits for the mutable feed downloads (repo-0241): bounded connect
+# and total transfer times, and a hard response-size cap so a hostile or broken
+# upstream cannot exhaust the runner or suppress the daily update.
+CURL_CONNECT_TIMEOUT_SECONDS=15
+CURL_MAX_TIME_SECONDS=120
+FEODO_MAX_BYTES=$((16 * 1024 * 1024))
+CISA_KEV_MAX_BYTES=$((64 * 1024 * 1024))
 
 mkdir -p -- "$OUTPUT_ROOT"
 if [ -e "$FINAL_DIR" ]; then
@@ -64,25 +83,31 @@ run_fetch() {
   "$TIMEOUT_BIN" --signal=TERM --kill-after=10s "${FETCH_TIMEOUT_SECONDS}s" "$@" &
 }
 
-run_fetch git clone --depth 1 \
+run_fetch git clone --depth 1 --branch "$OSSF_MP_REF" \
   https://github.com/ossf/malicious-packages.git \
   "$STAGED_SOURCES/ossf-mp"
 pids+=("$!")
 labels+=("OpenSSF malicious-packages")
 
-run_fetch git clone --depth 1 \
+run_fetch git clone --depth 1 --branch "$DD_MP_REF" \
   https://github.com/DataDog/malicious-software-packages-dataset.git \
   "$STAGED_SOURCES/dd-mp"
 pids+=("$!")
 labels+=("DataDog malicious-software-packages-dataset")
 
 run_fetch curl -sSfL \
+  --connect-timeout="$CURL_CONNECT_TIMEOUT_SECONDS" \
+  --max-time="$CURL_MAX_TIME_SECONDS" \
+  --max-filesize="$FEODO_MAX_BYTES" \
   https://feodotracker.abuse.ch/downloads/ipblocklist.txt \
   -o "$STAGED_SOURCES/feodo.txt"
 pids+=("$!")
 labels+=("Feodo Tracker")
 
 run_fetch curl -sSfL \
+  --connect-timeout="$CURL_CONNECT_TIMEOUT_SECONDS" \
+  --max-time="$CURL_MAX_TIME_SECONDS" \
+  --max-filesize="$CISA_KEV_MAX_BYTES" \
   https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json \
   -o "$STAGED_SOURCES/cisa-kev.json"
 pids+=("$!")
@@ -110,6 +135,29 @@ if [ ! -d "$STAGED_SOURCES/ossf-mp/.git" ] ||
   echo "::error::one or more required threatdb sources is empty or incomplete" >&2
   exit 1
 fi
+
+# Record the exact upstream revisions that were fetched. A shallow clone's HEAD
+# is the resolved commit for the pinned ref above; feeds have no revision, so
+# their sha256 is recorded instead.
+OSSF_MP_SHA=$(git -C "$STAGED_SOURCES/ossf-mp" rev-parse HEAD)
+DD_MP_SHA=$(git -C "$STAGED_SOURCES/dd-mp" rev-parse HEAD)
+case "$OSSF_MP_SHA$DD_MP_SHA" in
+  *[!0-9a-f]*)
+    echo "::error::resolved source commit is not lowercase hex: ossf=$OSSF_MP_SHA datadog=$DD_MP_SHA" >&2
+    exit 1
+    ;;
+esac
+FEODO_SHA=$(sha256sum "$STAGED_SOURCES/feodo.txt" | cut -d' ' -f1)
+CISA_KEV_SHA=$(sha256sum "$STAGED_SOURCES/cisa-kev.json" | cut -d' ' -f1)
+printf '%s\n' \
+  '{' \
+  "  \"ossf_malicious_packages\": {\"ref\": \"$OSSF_MP_REF\", \"commit\": \"$OSSF_MP_SHA\"}," \
+  "  \"datadog_malicious_software_packages\": {\"ref\": \"$DD_MP_REF\", \"commit\": \"$DD_MP_SHA\"}," \
+  "  \"feodo_tracker_ipblocklist\": {\"sha256\": \"$FEODO_SHA\"}," \
+  "  \"cisa_known_exploited_vulnerabilities\": {\"sha256\": \"$CISA_KEV_SHA\"}" \
+  '}' > "$PINS_FILE"
+echo "Resolved source revisions:"
+cat "$PINS_FILE"
 
 # STAGING_DIR was created inside OUTPUT_ROOT, so this publishes the complete set
 # atomically on the same filesystem. No compiler-visible path exists beforehand.

--- a/.github/scripts/test-fetch-threatdb-sources.sh
+++ b/.github/scripts/test-fetch-threatdb-sources.sh
@@ -19,6 +19,11 @@ mkdir -p -- "$FAKE_BIN" "$OUTPUT_ROOT"
 cat > "$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+# `git -C <dir> rev-parse HEAD` records the resolved source revision.
+if [[ "$*" == *rev-parse* ]]; then
+  echo "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+  exit 0
+fi
 destination=${!#}
 mkdir -p -- "$destination/.git"
 printf 'fixture\n' > "$destination/feed.json"
@@ -184,6 +189,10 @@ do
     echo "a partial source set became visible after $failed_source failed" >&2
     exit 1
   fi
+  if [ -e "$OUTPUT_ROOT/tirith-threatdb-source-pins.json" ]; then
+    echo "source pins were recorded after $failed_source failed" >&2
+    exit 1
+  fi
   if compgen -G "$OUTPUT_ROOT/.tirith-threatdb-fetch.*" >/dev/null; then
     echo "failed source-fetch staging state was not cleaned after $failed_source" >&2
     exit 1
@@ -228,5 +237,10 @@ test -d "$published/ossf-mp/.git"
 test -d "$published/dd-mp/.git"
 test -s "$published/feodo.txt"
 test -s "$published/cisa-kev.json"
+
+# The resolved upstream revisions must be recorded on the success path only.
+test -s "$OUTPUT_ROOT/tirith-threatdb-source-pins.json"
+grep -q '"commit": "da39a3ee5e6b4b0d3255bfef95601890afd80709"' \
+  "$OUTPUT_ROOT/tirith-threatdb-source-pins.json"
 
 echo "threatdb source-fetch orchestration regression passed"

--- a/.github/workflows/threatdb.yml
+++ b/.github/workflows/threatdb.yml
@@ -16,6 +16,13 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Pinned upstream threat-intel source revisions (repo-0241), consumed by
+  # .github/scripts/fetch-threatdb-sources.sh. Branch-name pins: replace with
+  # full 40-hex commit SHAs after an upstream review to make fetches immutable.
+  # The resolved commit SHA of every fetch is recorded in the job log and in
+  # /tmp/tirith-threatdb-source-pins.json.
+  THREATDB_OSSF_MP_REF: main
+  THREATDB_DD_MP_REF: main
 
 jobs:
   build-threatdb:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@
 # Build context must contain:
 #   bin/tirith   — the pre-built binary for the target platform
 #   shell/       — shell hook scripts
-FROM debian:bookworm-slim
+# Pinned by digest (repo-0443): a movable tag could silently swap the base
+# image for attacker-controlled content. Refresh the digest regularly (e.g.
+# via Dependabot/Renovate) to keep receiving Debian security updates.
+# Digest source: registry-1.docker.io manifest list for debian:bookworm-slim.
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/crates/tirith-core/src/artifact/resolver_broker.rs
+++ b/crates/tirith-core/src/artifact/resolver_broker.rs
@@ -239,6 +239,19 @@ impl ResolverBroker {
                                         active,
                                         connections: Arc::clone(&connections),
                                     };
+                                    // Drop's cancellation is a stop store
+                                    // followed by a registry shutdown sweep. A
+                                    // session whose registration missed that
+                                    // sweep would sit in its read deadline
+                                    // unobserved and stall the listener join,
+                                    // so complete the handshake from this side:
+                                    // registration happened above, re-check the
+                                    // flag, and self-cancel when it was already
+                                    // raised.
+                                    if stop.load(Ordering::Acquire) {
+                                        let _ = stream.shutdown(Shutdown::Both);
+                                        return;
+                                    }
                                     let _ = serve_connection(
                                         stream,
                                         &permitted,

--- a/crates/tirith-core/src/capsule/windows.rs
+++ b/crates/tirith-core/src/capsule/windows.rs
@@ -83,28 +83,27 @@ pub const BACKEND_ID: &str = "appcontainer";
 
 /// Resource dimensions enforced by the traced launch path: CPU time, job
 /// memory, and active-process count are mapped into the Job Object by
-/// `job_object_limits`. The current CLI executor waits indefinitely, so a
-/// wall-clock deadline is not claimed until that wait becomes bounded and
-/// terminates the Job on expiry. Open handles have no per-Job mechanism and
-/// output bytes are not captured by this launcher either.
+/// `job_object_limits`. The CLI executor enforces wall-clock deadlines with a
+/// finite wait and terminates the Job on expiry. Open handles have no per-Job
+/// mechanism and output bytes are not captured by this launcher either.
 const RESOURCE_LIMIT_SUPPORT: ResourceLimitSupport = ResourceLimitSupport {
     cpu_seconds: true,
     memory_bytes: true,
     max_processes: true,
     max_open_files: false,
     max_output_bytes: false,
-    wall_clock_seconds: false,
+    wall_clock_seconds: true,
 };
 
 /// The display name handed to `CreateAppContainerProfile` for tirith's containers.
-/// Cosmetic (shown in some diagnostics); the security identity is the derived SID,
-/// not this string.
+/// Cosmetic (shown in some diagnostics); the security identity is the per-launch
+/// SID, not this string.
 pub const APP_CONTAINER_DISPLAY_NAME: &str = "Tirith contained child";
 
-/// The stable prefix every tirith AppContainer moniker (the
-/// `CreateAppContainerProfile` "AppContainerName") starts with. The per-spec
-/// suffix is a deterministic digest so repeated runs of the same spec reuse the
-/// same profile and a `DeleteAppContainerProfile` cleanup is unambiguous.
+/// The stable prefix every tirith AppContainer moniker base starts with. The core
+/// plan adds a deterministic per-spec digest; the Windows executor appends a
+/// per-launch suffix before `CreateAppContainerProfile` so overlapping runs do not
+/// share a SID or temporary ACL grants.
 pub const APP_CONTAINER_NAME_PREFIX: &str = "tirith.capsule.";
 
 /// The maximum length of an AppContainer moniker. Windows caps the
@@ -184,9 +183,9 @@ pub fn probe_appcontainer() -> WindowsProbe {
 ///     (invariant 3). An allow-list spec is therefore degraded on this flag and the
 ///     enforcing surface fails closed.
 ///   - `resource_limits_enforced`: true only when at least one limit is requested
-///     and every requested dimension maps to the Job Object (CPU / memory /
-///     process count). Open-files, output, and wall-clock requests keep the
-///     aggregate bit false.
+///     and every requested dimension maps to the Job Object or the traced launch
+///     wrapper (CPU / memory / process count / wall clock). Open-files and output
+///     requests keep the aggregate bit false.
 ///   - `env_isolated` / `handles_isolated`: true — the executor builds the child's
 ///     environment from the surviving-vars policy (sensitive set stripped, isolated
 ///     HOME/TEMP) and calls `CreateProcessW` with `bInheritHandles = FALSE`.
@@ -249,19 +248,18 @@ impl std::fmt::Display for WindowsCapsuleError {
 
 impl std::error::Error for WindowsCapsuleError {}
 
-/// The AppContainer identity the executor materializes via
-/// `CreateAppContainerProfile` / `DeriveAppContainerSidFromAppContainerName`.
-/// **Pure data** — the executor turns `name` into a real package SID.
+/// The AppContainer identity base the executor materializes via
+/// `CreateAppContainerProfile`. **Pure data** — the executor appends a per-launch
+/// suffix to `name` and turns that unique profile name into a real package SID.
 ///
-/// `name` is a deterministic, host-independent moniker derived from the spec so
-/// repeated runs reuse one profile and cleanup is unambiguous;
+/// `name` is a deterministic, host-independent base derived from the spec;
 /// `networking_capabilities` is empty for `DenyAll` (the whole point — no socket
 /// access) and stays empty in E4 even for an allow-list (which is reported
 /// degraded), so the descriptor never silently grants egress.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppContainerProfile {
-    /// The `AppContainerName` (moniker) for `CreateAppContainerProfile`. Stable per
-    /// spec, `<= APP_CONTAINER_NAME_MAX` UTF-16 units, and a valid profile name.
+    /// Stable per-spec base for the executor's `AppContainerName` (moniker),
+    /// `<= APP_CONTAINER_NAME_MAX` UTF-16 units and valid as a profile-name prefix.
     pub name: String,
     /// The human-readable display name (`CreateAppContainerProfile`'s
     /// `DisplayName` / `Description`).
@@ -272,11 +270,12 @@ pub struct AppContainerProfile {
     pub networking_capabilities: Vec<&'static str>,
 }
 
-/// Derive the deterministic AppContainer moniker for `spec`. The suffix is a
+/// Derive the deterministic AppContainer moniker base for `spec`. The suffix is a
 /// 64-bit FNV-1a digest of the spec's serialized JSON rendered as 16 lowercase hex
-/// chars, so two identical specs map to the same profile (idempotent create /
-/// unambiguous delete) and different specs do not collide in practice. **Pure** and
-/// platform-independent.
+/// chars, so two identical specs map to the same base and different specs do not
+/// collide in practice. The executor adds a per-launch suffix before creating the
+/// profile, which prevents overlapping runs from sharing an ACL identity. **Pure**
+/// and platform-independent.
 ///
 /// The moniker is `APP_CONTAINER_NAME_PREFIX` + 16 hex chars = 30 chars, safely
 /// under `APP_CONTAINER_NAME_MAX` (64). It contains only `[a-z0-9.]`, all valid in
@@ -457,8 +456,8 @@ pub struct JobObjectLimits {
 /// saturating so an absurd value cannot overflow. `max_open_files` has no direct
 /// per-Job equivalent on Windows (handle limits are per-process via other
 /// mechanisms), so it does not appear here and prevents an aggregate resource
-/// coverage claim. Wall-clock and output caps are also not applied by this
-/// backend or its wrapper.
+/// coverage claim. Wall-clock is enforced by the CLI launch wrapper rather than
+/// encoded into the Job Object; output caps remain unsupported.
 pub fn job_object_limits(limits: &ResourceLimits) -> JobObjectLimits {
     JobObjectLimits {
         kill_on_close: true,
@@ -834,13 +833,13 @@ mod tests {
         spec.resources = ResourceLimits::default();
         assert!(!derive_coverage(&spec, &probe).resource_limits_enforced);
 
-        // Wall-clock alone is not claimed while the CLI executor waits without
-        // a deadline.
+        // Wall-clock alone is enforced by the CLI executor's finite wait and
+        // whole-Job termination on expiry.
         spec.resources = ResourceLimits {
             wall_clock_seconds: Some(60),
             ..ResourceLimits::default()
         };
-        assert!(!derive_coverage(&spec, &probe).resource_limits_enforced);
+        assert!(derive_coverage(&spec, &probe).resource_limits_enforced);
 
         // Wall-clock + output are both unsupported, so the combination remains
         // unclaimed as well.

--- a/crates/tirith-core/src/mcp/tools.rs
+++ b/crates/tirith-core/src/mcp/tools.rs
@@ -663,7 +663,10 @@ fn build_cloaking_response(
         // repo-0299: the comparison only ran when every agent returned a
         // non-empty body at the baseline status. If any agent's response was
         // empty/blocked, "no cloaking" was never established — say so.
-        let all_comparable = result.agent_responses.iter().all(|r| r.content_length > 0);
+        // `all` is vacuously true on an empty list, which would report a clean
+        // "no cloaking" for a check that compared nothing at all.
+        let all_comparable = !result.agent_responses.is_empty()
+            && result.agent_responses.iter().all(|r| r.content_length > 0);
         if all_comparable {
             format!("No cloaking detected for {}", result.url)
         } else {

--- a/crates/tirith/Cargo.toml
+++ b/crates/tirith/Cargo.toml
@@ -137,7 +137,9 @@ windows = { version = "0.62", default-features = false, features = [
     "Win32_System_IO",
     "Win32_System_Ioctl",
     "Win32_System_JobObjects",
+    "Win32_System_Memory",
     "Win32_System_SystemInformation",
+    "Win32_System_SystemServices",
     "Win32_System_Threading",
     "Win32_UI_Shell",
 ] }

--- a/crates/tirith/src/bin/tirith_threatdb_compile.rs
+++ b/crates/tirith/src/bin/tirith_threatdb_compile.rs
@@ -266,7 +266,9 @@ fn normalize_name(eco: Ecosystem, name: &str) -> String {
     // This function feeds the legacy v1 publication as well as v2. Keep the
     // exact historical spellings here so v1-only readers continue to hash the
     // same keys; ThreatDbWriter canonicalizes a private working copy only when
-    // it emits v2.
+    // it emits v2 (via `canonical_package_name`), which is the spelling the
+    // current runtime hashes. pr173-0025's casing mismatch is closed by that
+    // v2 canonicalization; the v1 spelling must not change.
     match eco {
         Ecosystem::PyPI => name.to_lowercase().replace(['_', '.'], "-"),
         Ecosystem::Npm => name.to_string(),
@@ -638,8 +640,24 @@ fn parse_ossf(root: &Path) -> FeedResult<(Vec<PackageEntry>, OssfStats, OssfIndi
                     reference: reference.clone(),
                 });
                 stats.parsed_packages += 1;
+            } else if has_ranges && is_confirmed {
+                // pr173-0026: a CONFIRMED malicious record whose affected entry
+                // carries only ranges used to vanish entirely — a victim
+                // version inside the range scored NoRecord (clean). The record
+                // asserts the package itself is malicious, so mark all
+                // versions malicious rather than dropping the record.
+                entries.push(PackageEntry {
+                    ecosystem,
+                    name,
+                    affected_versions: Vec::new(),
+                    all_versions_malicious: true,
+                    source: ThreatSource::OssfMalicious,
+                    confidence,
+                    reference: reference.clone(),
+                });
+                stats.parsed_packages += 1;
             } else if has_ranges {
-                // Ranges but no explicit version list — skipped in Phase A.
+                // Unconfirmed range-only records remain skipped (counted).
                 stats.skipped_range_only_count += 1;
             } else if is_confirmed {
                 // Confirmed-malicious (legacy MALWARE type or a MAL-* id) with no
@@ -2646,6 +2664,29 @@ fn main() {
     }
     for url in &v2_malicious_urls {
         common_writer.add_malicious_url(url, ThreatSource::OssfMalicious);
+    }
+
+    // pr173-0024: the OpenSSF `iocs.ips` / `iocs.domains` were collected but
+    // never written — connections to a listed IP/domain evaded the gate.
+    // Emit them through the same writer as every other feed.
+    let mut v2_ioc_ips = BTreeSet::new();
+    for ip in &ossf_indicators.ips {
+        if let Ok(addr) = ip.trim().parse::<std::net::Ipv4Addr>() {
+            v2_ioc_ips.insert(addr);
+        }
+    }
+    for addr in &v2_ioc_ips {
+        common_writer.add_ip(*addr, ThreatSource::OssfMalicious);
+    }
+    let mut v2_ioc_domains = BTreeSet::new();
+    for domain in &ossf_indicators.domains {
+        let normalized = domain.trim().trim_end_matches('.').to_ascii_lowercase();
+        if !normalized.is_empty() {
+            v2_ioc_domains.insert(normalized);
+        }
+    }
+    for domain in &v2_ioc_domains {
+        common_writer.add_hostname(domain, ThreatSource::OssfMalicious);
     }
 
     // v2-only: persist the curated malicious file-content hashes into the FileHash

--- a/crates/tirith/src/cli/agent.rs
+++ b/crates/tirith/src/cli/agent.rs
@@ -560,16 +560,38 @@ pub(crate) fn policy_init_for_root(
     let tirith_dir = repo_root.join(".tirith");
     let example_path = tirith_dir.join("agent-policy.yaml.example");
 
-    if example_path.exists() && !force {
-        report_error(
-            json,
-            "tirith agent policy init",
-            &format!(
-                "{} already exists (use --force to overwrite)",
-                example_path.display()
-            ),
-        );
-        return 1;
+    // Symlink-hardened (repo-0355): the output path is derived beneath a
+    // possibly-hostile repo, so every repo-controlled path component is
+    // rejected when symlinked and the publish goes through a root-confined
+    // atomic no-follow writer (`util::ContainedAtomicFile`), never
+    // `std::fs::write` (which follows a planted symlink at the final component
+    // AND a symlinked `.tirith` dir, overwriting/creating a file outside the
+    // repo). `symlink_metadata` (lstat) is used for the friendly pre-check so a
+    // DANGLING symlink — invisible to `exists()` — is refused here rather than
+    // followed into an external create.
+    if let Ok(meta) = std::fs::symlink_metadata(&example_path) {
+        if meta.file_type().is_symlink() {
+            report_error(
+                json,
+                "tirith agent policy init",
+                &format!(
+                    "refusing to write through symlinked path {}",
+                    super::sanitize_for_human_output(&example_path.display().to_string(), false)
+                ),
+            );
+            return 1;
+        }
+        if !force {
+            report_error(
+                json,
+                "tirith agent policy init",
+                &format!(
+                    "{} already exists (use --force to overwrite)",
+                    example_path.display()
+                ),
+            );
+            return 1;
+        }
     }
 
     // Build the scaffold from the audit log (when available).
@@ -618,22 +640,47 @@ pub(crate) fn policy_init_for_root(
         origins,
     };
 
-    if let Err(e) = std::fs::create_dir_all(&tirith_dir) {
-        report_error(
-            json,
-            "tirith agent policy init",
-            &format!("failed to create {}: {e}", tirith_dir.display()),
-        );
-        return 1;
-    }
-
     let yaml_body = render_agent_policy_scaffold_yaml(&scaffold);
-    if let Err(e) = std::fs::write(&example_path, &yaml_body) {
-        report_error(
-            json,
-            "tirith agent policy init",
-            &format!("failed to write {}: {e}", example_path.display()),
-        );
+
+    // Bind the destination beneath the repo root through retained directory
+    // capabilities: `prepare` creates `.tirith` when missing WITHOUT following
+    // attacker-controlled symlinks and rejects any symlinked repo-controlled
+    // component (a symlinked `.tirith` escaping the repo, or a symlinked final
+    // component), closing the check/use gap the friendly pre-check above
+    // cannot.
+    let contained =
+        match tirith_core::util::ContainedAtomicFile::prepare(repo_root, &example_path, true) {
+            Ok(c) => c,
+            Err(e) => {
+                report_error(
+                    json,
+                    "tirith agent policy init",
+                    &format!(
+                        "refusing to write {} through a symlinked or escaping path: {e}",
+                        super::sanitize_for_human_output(
+                            &example_path.display().to_string(),
+                            false
+                        )
+                    ),
+                );
+                return 1;
+            }
+        };
+
+    // Atomic same-directory publish that never follows a final-component
+    // symlink; `overwrite = force` preserves no-clobber unless --force, and a
+    // file planted after the pre-check surfaces as AlreadyExists rather than
+    // being silently clobbered.
+    if let Err(e) = contained.write_atomic(yaml_body.as_bytes(), force) {
+        let message = if e.kind() == std::io::ErrorKind::AlreadyExists {
+            format!(
+                "{} already exists (use --force to overwrite)",
+                example_path.display()
+            )
+        } else {
+            format!("failed to write {}: {e}", example_path.display())
+        };
+        report_error(json, "tirith agent policy init", &message);
         return 1;
     }
 
@@ -1837,6 +1884,74 @@ mod tests {
         assert_eq!(code, 0);
         let body = fs::read_to_string(&example_path).unwrap();
         assert!(!body.contains("SENTINEL"));
+    }
+
+    /// repo-0355: a SYMLINKED `.tirith` directory escaping the repo must be
+    /// refused — even with --force — and nothing may be created at the
+    /// external target.
+    #[cfg(unix)]
+    #[test]
+    fn policy_init_refuses_symlinked_tirith_dir() {
+        let repo = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), repo.path().join(".tirith")).unwrap();
+
+        let code = policy_init_for_root(repo.path(), None, true, false);
+        assert_eq!(code, 1, "symlinked .tirith must be refused");
+        assert!(
+            !outside.path().join("agent-policy.yaml.example").exists(),
+            "no file may be created outside the repo"
+        );
+    }
+
+    /// repo-0355: a DANGLING symlink at the final component is invisible to
+    /// `exists()`; without --force the old code followed it and CREATED an
+    /// external file. Both modes must now refuse, and the target must not
+    /// appear.
+    #[cfg(unix)]
+    #[test]
+    fn policy_init_refuses_dangling_symlink_at_final_component() {
+        let repo = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let victim = outside.path().join("victim.yaml");
+        let tirith_dir = repo.path().join(".tirith");
+        fs::create_dir_all(&tirith_dir).unwrap();
+        let example_path = tirith_dir.join("agent-policy.yaml.example");
+        std::os::unix::fs::symlink(&victim, &example_path).unwrap();
+
+        let code = policy_init_for_root(repo.path(), None, false, false);
+        assert_eq!(code, 1, "dangling symlink must be refused without --force");
+        assert!(
+            !victim.exists(),
+            "no external file may be created through the dangling symlink"
+        );
+
+        let code = policy_init_for_root(repo.path(), None, true, false);
+        assert_eq!(code, 1, "a symlink is refused even with --force");
+        assert!(!victim.exists());
+    }
+
+    /// repo-0355: --force must NOT write through a symlink planted at the
+    /// final component pointing at an EXISTING external file — the write is
+    /// refused and the external target's bytes survive.
+    #[cfg(unix)]
+    #[test]
+    fn policy_init_force_does_not_follow_symlink_to_external_file() {
+        let repo = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let victim = outside.path().join("victim.yaml");
+        fs::write(&victim, "SENTINEL: do not overwrite\n").unwrap();
+        let tirith_dir = repo.path().join(".tirith");
+        fs::create_dir_all(&tirith_dir).unwrap();
+        std::os::unix::fs::symlink(&victim, tirith_dir.join("agent-policy.yaml.example")).unwrap();
+
+        let code = policy_init_for_root(repo.path(), None, true, false);
+        assert_eq!(code, 1, "--force must refuse a symlinked output path");
+        assert_eq!(
+            fs::read_to_string(&victim).unwrap(),
+            "SENTINEL: do not overwrite\n",
+            "external target must be untouched"
+        );
     }
 
     #[test]

--- a/crates/tirith/src/cli/ai.rs
+++ b/crates/tirith/src/cli/ai.rs
@@ -433,7 +433,26 @@ const READ_MAX_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
 /// a TOCTOU race (the file can grow between stat and read). Reading at most
 /// `MAX_BYTES + 1` and rejecting over `MAX_BYTES` bounds memory regardless.
 fn read_capped(path: &Path) -> std::io::Result<Vec<u8>> {
-    let file = std::fs::File::open(path)?;
+    // repo-0356: open no-follow + nonblocking and require a REGULAR file before
+    // reading. A project-controlled FIFO (or device/socket) named like a
+    // config file must not block `ai diff`/`snapshot`/`quarantine` forever.
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC);
+    }
+    let file = options.open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{} is not a regular file; skipping",
+                sanitize_display(&path.display().to_string())
+            ),
+        ));
+    }
     let mut bytes = Vec::new();
     // One byte past the cap so an exactly-`MAX_BYTES` file is accepted.
     file.take(READ_MAX_BYTES as u64 + 1)
@@ -441,7 +460,10 @@ fn read_capped(path: &Path) -> std::io::Result<Vec<u8>> {
     if bytes.len() > READ_MAX_BYTES {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("{} is larger than 10 MiB; skipping", path.display()),
+            format!(
+                "{} is larger than 10 MiB; skipping",
+                sanitize_display(&path.display().to_string())
+            ),
         ));
     }
     Ok(bytes)
@@ -526,7 +548,10 @@ pub fn quarantine(file: &str, do_move: bool, yes: bool, json: bool) -> i32 {
         && !confirm(
             &format!(
                 "Move (DELETE original) {} into quarantine? The original will be removed.",
-                src.display()
+                // repo-0357: `src` is a project-controlled path — sanitize
+                // terminal controls before asking the operator to approve a
+                // deletion.
+                sanitize_display(&src.display().to_string())
             ),
             yes,
         )

--- a/crates/tirith/src/cli/aliases.rs
+++ b/crates/tirith/src/cli/aliases.rs
@@ -118,7 +118,10 @@ fn print_human_scan(scan: &AliasScan, include_runtime: bool) {
 
 fn print_human_explain(name: &str, ex: &aliases::AliasExplain) {
     if ex.matches.is_empty() {
-        eprintln!("tirith aliases: no alias or function named `{name}` found.");
+        eprintln!(
+            "tirith aliases: no alias or function named `{}` found.",
+            super::sanitize_for_human_output(name, false)
+        );
         eprintln!(
             "  (static parse of your rc/profile files; pass --include-runtime to also check \
              live shells.)"
@@ -127,29 +130,43 @@ fn print_human_explain(name: &str, ex: &aliases::AliasExplain) {
     }
 
     eprintln!(
-        "tirith aliases explain `{name}`: {} definition(s).\n",
+        "tirith aliases explain `{}`: {} definition(s).\n",
+        super::sanitize_for_human_output(name, false),
         ex.matches.len()
     );
     for e in &ex.matches {
         eprintln!(
             "  {} ({}) — {}",
-            e.name,
+            super::sanitize_for_human_output(&e.name, false),
             e.kind.as_str(),
-            aliases::short_location(e),
+            super::sanitize_for_human_output(&aliases::short_location(e), false),
         );
         if e.body.is_empty() {
             eprintln!("    body: (empty / not captured)");
         } else if e.body_parsed {
             // Redact body before display — a function body may inline a secret.
-            eprintln!("    body: {}", redact(&e.body));
+            // Then scrub terminal controls/deceptive Unicode: the body is
+            // attacker-controllable shell config and must not inject ANSI/OSC
+            // or forge tirith output rows. Multiline is allowed, with
+            // continuation lines re-indented by the sanitizer.
+            eprintln!(
+                "    body: {}",
+                super::sanitize_for_human_output(&redact(&e.body), true)
+            );
         } else {
-            eprintln!("    body (UNPARSED — review manually): {}", redact(&e.body));
+            eprintln!(
+                "    body (UNPARSED — review manually): {}",
+                super::sanitize_for_human_output(&redact(&e.body), true)
+            );
         }
         eprintln!();
     }
 
     if ex.findings.is_empty() {
-        eprintln!("Analysis: no risk rules fired for `{name}`.");
+        eprintln!(
+            "Analysis: no risk rules fired for `{}`.",
+            super::sanitize_for_human_output(name, false)
+        );
         return;
     }
     eprintln!("Analysis — {} finding(s):", ex.findings.len());
@@ -277,5 +294,22 @@ mod tests {
         let empty = aliases::AliasExplain::default();
         let body2 = explain_json_body("nope", &empty);
         assert_eq!(body2["found"], false);
+    }
+
+    #[test]
+    fn explain_body_display_strips_terminal_controls() {
+        // Regression: repo-0358 — a redacted-but-unsanitized body must not
+        // reach the terminal with ANSI/OSC, bidi, or zero-width content.
+        let body = "cat ~/.aws/credentials \u{1b}]52;c;SGFja2Vk\u{7}\u{202e}\u{200b}evil";
+        let rendered = super::super::sanitize_for_human_output(&redact(body), true);
+        assert!(
+            !rendered.contains('\u{1b}'),
+            "ESC must be stripped: {rendered:?}"
+        );
+        assert!(!rendered.contains('\u{202e}'));
+        assert!(!rendered.contains('\u{200b}'));
+        // Multiline bodies keep newlines but continuation lines are indented.
+        let ml = super::super::sanitize_for_human_output(&redact("line1\nline2"), true);
+        assert!(ml.contains("line1\n  line2"), "continuation indent: {ml:?}");
     }
 }

--- a/crates/tirith/src/cli/audit.rs
+++ b/crates/tirith/src/cli/audit.rs
@@ -155,7 +155,14 @@ pub fn stats(session: Option<&str>, json: bool, entry_type: &str) -> i32 {
                 let mut event_list: Vec<_> = events.iter().collect();
                 event_list.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
                 for (event, count) in event_list {
-                    println!("  {integration} / {event}: {count:>5}");
+                    // repo-0360: integration/event strings come from the audit
+                    // log, which records caller-supplied values — sanitize
+                    // terminal controls before printing.
+                    println!(
+                        "  {} / {}: {count:>5}",
+                        super::sanitize_for_human_output(integration, false),
+                        super::sanitize_for_human_output(event, false),
+                    );
                 }
             }
             if hook_stats.total_events == 0 {

--- a/crates/tirith/src/cli/baseline.rs
+++ b/crates/tirith/src/cli/baseline.rs
@@ -12,7 +12,6 @@
 //! Privacy: the store records only salted-sha256 hashes and low-cardinality
 //! categoricals — never raw hostnames or paths.
 
-use std::io::Write;
 use std::path::PathBuf;
 
 use tirith_core::baseline;
@@ -210,10 +209,39 @@ fn resolve_policy_path() -> Result<PathBuf, i32> {
 /// Idempotently set the `baseline_enabled` line in a policy YAML file:
 /// append-or-rewrite, never touching other lines.
 fn update_baseline_flag(path: &std::path::Path, enable: bool) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    // Baseline enablement must never follow an untrusted repository policy
+    // symlink (repo-0361): confine the read-modify-write beneath the policy
+    // file's own directory (the repository `.tirith` directory or the user
+    // config dir) through a retained no-follow parent capability, refuse a
+    // symlinked destination, and publish atomically. A repository checkout
+    // that points `.tirith/policy.yaml` at `~/.bashrc` is refused instead of
+    // appended to, and an unreadable file is no longer treated as empty
+    // (which would have clobbered its real contents).
+    let root = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "policy path has no parent directory",
+            )
+        })?;
+    let prepared = tirith_core::util::ContainedAtomicFile::prepare(root, path, true)?;
+    let existing = match prepared.read_capped(1024 * 1024) {
+        Ok(bytes) => String::from_utf8(bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "policy file is not UTF-8; refusing to rewrite it",
+            )
+        })?,
+        Err(tirith_core::util::OpenRegularError::NotFound) => String::new(),
+        Err(e) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!("refusing to read unsafe policy file: {e:?}"),
+            ))
+        }
+    };
     let new_line = format!("baseline_enabled: {enable}");
 
     let mut out = String::new();
@@ -236,15 +264,7 @@ fn update_baseline_flag(path: &std::path::Path, enable: bool) -> std::io::Result
         out.push('\n');
     }
 
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
-    }
-    let mut f = opts.open(path)?;
-    f.write_all(out.as_bytes())
+    prepared.write_atomic(out.as_bytes(), true)
 }
 
 #[cfg(test)]
@@ -271,6 +291,27 @@ mod tests {
             content.matches("baseline_enabled:").count(),
             1,
             "must not duplicate the key"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_baseline_flag_refuses_symlinked_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let external = outside.path().join("bashrc-like");
+        std::fs::write(&external, "export PATH=/usr/bin\n").unwrap();
+        let link = dir.path().join("policy.yaml");
+        std::os::unix::fs::symlink(&external, &link).unwrap();
+
+        assert!(
+            update_baseline_flag(&link, true).is_err(),
+            "a symlinked policy must be refused, not appended to"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&external).unwrap(),
+            "export PATH=/usr/bin\n",
+            "the symlink target must remain untouched"
         );
     }
 }

--- a/crates/tirith/src/cli/capsule_windows.rs
+++ b/crates/tirith/src/cli/capsule_windows.rs
@@ -6,16 +6,17 @@
 //! refused if it cannot be honestly enforced) and materializes it with the Win32
 //! AppContainer / ACL / Job Object / process-creation APIs:
 //!
-//! 1. **AppContainer profile + package SID** — `CreateAppContainerProfile`
-//!    (idempotent; an already-existing profile is reused) then
-//!    `DeriveAppContainerSidFromAppContainerName` for the package SID the child runs
-//!    under. No networking capability is ever passed (the plan grants none), so the
-//!    container has no outbound socket access.
+//! 1. **AppContainer profile + package SID** — `CreateAppContainerProfile` with a
+//!    per-launch name derived from the plan's stable base. Concurrent launches
+//!    therefore never share the package SID whose temporary ACL grants are later
+//!    revoked. The profile is deleted after the run. No networking capability is
+//!    ever passed (the plan grants none), so the container has no outbound socket
+//!    access.
 //! 2. **ACL grants (tracked + revoked)** — for each [`AclGrant`], add an
 //!    `EXPLICIT_ACCESS_W` ACE granting the container package SID the requested
 //!    access to the path's DACL via `SetEntriesInAclW` + `SetNamedSecurityInfoW`.
-//!    Each grant is recorded so it can be **revoked** after the child exits (a
-//!    [`AclGuard`] restores the original DACL).
+//!    Each grant is recorded so it can be **revoked** after the child exits (an
+//!    [`AclGuard`] removes exactly its own ACE from the path's live DACL).
 //! 3. **STARTUPINFOEXW with SECURITY_CAPABILITIES** — an attribute list carrying
 //!    `PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES` so the child is created *inside*
 //!    the AppContainer (the package SID + capabilities are bound at creation, not
@@ -61,30 +62,32 @@
 
 use std::ffi::{c_void, OsStr, OsString};
 use std::os::windows::ffi::OsStrExt;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use windows::core::{Error as WinError, PCWSTR, PWSTR};
 use windows::Win32::Foundation::{
-    CloseHandle, LocalFree, ERROR_INSUFFICIENT_BUFFER, GENERIC_EXECUTE, GENERIC_READ,
-    GENERIC_WRITE, HANDLE, HLOCAL, WAIT_OBJECT_0, WIN32_ERROR,
+    CloseHandle, LocalFree, ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_PARAMETER,
+    ERROR_NOT_ENOUGH_MEMORY, GENERIC_EXECUTE, GENERIC_READ, GENERIC_WRITE, HANDLE, HLOCAL,
+    WAIT_OBJECT_0, WAIT_TIMEOUT, WIN32_ERROR,
 };
 use windows::Win32::Security::Authorization::{
     GetNamedSecurityInfoW, SetEntriesInAclW, SetNamedSecurityInfoW, EXPLICIT_ACCESS_W,
     GRANT_ACCESS, NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, TRUSTEE_IS_SID, TRUSTEE_IS_UNKNOWN,
     TRUSTEE_W,
 };
-use windows::Win32::Security::Isolation::{
-    CreateAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
-};
+use windows::Win32::Security::Isolation::{CreateAppContainerProfile, DeleteAppContainerProfile};
 use windows::Win32::Security::{
-    FreeSid, ACE_FLAGS, ACL, DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
-    SECURITY_CAPABILITIES,
+    CopySid, DeleteAce, EqualSid, FreeSid, GetAce, GetLengthSid, ACCESS_ALLOWED_ACE, ACE_FLAGS,
+    ACE_HEADER, ACL, DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, SECURITY_CAPABILITIES,
 };
 use windows::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
-    SetInformationJobObject, JOBOBJECT_BASIC_LIMIT_INFORMATION,
+    SetInformationJobObject, TerminateJobObject, JOBOBJECT_BASIC_LIMIT_INFORMATION,
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_ACTIVE_PROCESS,
     JOB_OBJECT_LIMIT_JOB_MEMORY, JOB_OBJECT_LIMIT_JOB_TIME, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
 };
+use windows::Win32::System::Memory::{LocalAlloc, LPTR};
+use windows::Win32::System::SystemServices::ACCESS_ALLOWED_ACE_TYPE;
 use windows::Win32::System::Threading::{
     CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
     InitializeProcThreadAttributeList, ResumeThread, TerminateProcess, UpdateProcThreadAttribute,
@@ -94,7 +97,7 @@ use windows::Win32::System::Threading::{
 };
 
 use tirith_core::capsule::windows::{
-    command_line_wide_for, AclAccess, AclGrant, WindowsLaunchPlan,
+    command_line_wide_for, AclAccess, AclGrant, WindowsLaunchPlan, APP_CONTAINER_NAME_MAX,
 };
 use tirith_core::capsule::{CapsuleSpec, EnvironmentPolicy};
 
@@ -103,7 +106,7 @@ use tirith_core::capsule::{CapsuleSpec, EnvironmentPolicy};
 /// fail-closed denial without leaking secrets.
 #[derive(Debug)]
 pub enum WindowsLaunchError {
-    /// Creating or deriving the AppContainer identity failed.
+    /// Creating or deleting the AppContainer identity failed.
     AppContainer(String, WinError),
     /// Applying or reverting an ACL grant failed.
     Acl(String, WIN32_ERROR),
@@ -120,6 +123,11 @@ pub enum WindowsLaunchError {
     /// Encoding a string for a Win32 wide-string argument failed (interior NUL).
     Encoding(String),
 }
+
+/// Monotonic per-process component for ephemeral AppContainer profile names.
+/// The process id supplies cross-process separation while this counter supplies
+/// thread-safe separation between overlapping launches in one process.
+static NEXT_PROFILE_ID: AtomicU64 = AtomicU64::new(1);
 
 impl std::fmt::Display for WindowsLaunchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -152,12 +160,32 @@ pub struct ContainedChild {
     /// The ACL grants to revoke when the run is done. Held so the grants outlive
     /// the child but are reverted afterward.
     acl_guards: Vec<AclGuard>,
+    /// The spec-requested wall-clock deadline (seconds), enforced by
+    /// [`wait_for`] as a finite wait plus Job termination on expiry. `None`
+    /// waits indefinitely (the spec requested no deadline).
+    wall_clock_seconds: Option<u64>,
+    /// Deletes this launch's unique AppContainer profile after the ACL grants
+    /// and process lifetime end. Kept last so ordinary field drop closes the Job
+    /// and process handles before profile cleanup.
+    profile: ProfileGuard,
 }
 
 impl ContainedChild {
     /// The raw child process handle, for the caller to wait on / read an exit code.
     pub fn process_handle(&self) -> HANDLE {
         self.process.0
+    }
+
+    /// The raw Job Object handle, for enforcing the wall-clock deadline.
+    fn job_handle(&self) -> HANDLE {
+        self.job.0
+    }
+
+    /// The finite wait timeout (ms) derived from the spec's wall-clock deadline,
+    /// or `INFINITE` when no deadline was requested. Saturates at just under
+    /// `INFINITE` so a huge requested value cannot alias the infinite sentinel.
+    fn wait_timeout_ms(&self) -> u32 {
+        wall_clock_timeout_ms(self.wall_clock_seconds)
     }
 
     /// Revert every ACL grant now (the child has exited). Idempotent: each guard
@@ -171,11 +199,25 @@ impl ContainedChild {
                 }
             }
         }
+        if let Err(e) = self.profile.delete_now() {
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
+        }
         match first_err {
             Some(e) => Err(e),
             None => Ok(()),
         }
     }
+}
+
+/// Convert a policy wall-clock limit into the finite Win32 wait used by
+/// [`wait_for`]. Kept separate from the handle-owning child so the boundary and
+/// saturation behavior remain unit-testable without launching a process.
+fn wall_clock_timeout_ms(wall_clock_seconds: Option<u64>) -> u32 {
+    wall_clock_seconds
+        .map(|s| s.saturating_mul(1000).min(u32::MAX as u64 - 1) as u32)
+        .unwrap_or(INFINITE)
 }
 
 /// Launch `program` + `args` contained per `spec`, on the current Windows host.
@@ -210,25 +252,44 @@ pub fn launch_contained_os(
 ) -> Result<ContainedChild, WindowsLaunchError> {
     let plan = tirith_core::capsule::windows::windows_launch_plan_os(spec, program, args)
         .map_err(|e| WindowsLaunchError::Encoding(e.to_string()))?;
-    apply_plan(&plan, &spec.environment)
+    apply_plan(&plan, &spec.environment, spec.resources.wall_clock_seconds)
 }
 
 /// Wait for a contained child to exit and return its process exit code (E5
-/// run-to-completion). Blocks on the process handle, then reads the exit code via
+/// run-to-completion). Blocks on the process handle — finitely when the spec
+/// requested a wall-clock deadline — then reads the exit code via
 /// `GetExitCodeProcess`. A code that does not fit `i32` is clamped (a child that
 /// exits with a huge unsigned code is reported as the low 31 bits, non-negative);
 /// callers only use this for the consumer "child's code, else non-zero" convention.
+///
+/// Wall-clock enforcement (repo-0363): when the spec carries
+/// `wall_clock_seconds`, the wait uses that deadline instead of `INFINITE` and
+/// an expiry terminates the whole Job (every process in the confined tree)
+/// before failing the run — a contained child can no longer sleep forever under
+/// a policy that promised a deadline.
 pub fn wait_for(child: &ContainedChild) -> Result<i32, WindowsLaunchError> {
     let handle = child.process_handle();
+    let timeout_ms = child.wait_timeout_ms();
     // SAFETY: `handle` is the valid child process handle owned by `child` for the
     // duration of the call; WaitForSingleObject does not consume it.
-    let wait = unsafe { WaitForSingleObject(handle, INFINITE) };
-    // Only `WAIT_OBJECT_0` means the process actually exited. WAIT_TIMEOUT (can't
-    // happen with INFINITE, but be exhaustive), WAIT_ABANDONED, or WAIT_FAILED mean
-    // the process is NOT known to have terminated, so `GetExitCodeProcess` would
-    // return `STILL_ACTIVE` (259) and we would otherwise report that as a clean exit
-    // code. Fail closed instead: the caller must treat this as a launch failure, not
-    // a successful run with exit 259.
+    let wait = unsafe { WaitForSingleObject(handle, timeout_ms) };
+    if wait == WAIT_TIMEOUT {
+        // The deadline expired: kill the entire Job (the child and anything it
+        // spawned) and fail closed. Best-effort: the error below is returned
+        // regardless of the termination result.
+        // SAFETY: `child.job_handle()` is a valid Job handle owned by `child`.
+        let _ = unsafe { TerminateJobObject(child.job_handle(), 137) };
+        return Err(WindowsLaunchError::Wait(format!(
+            "contained child exceeded its wall-clock deadline ({timeout_ms} ms); \
+             the Job was terminated",
+        )));
+    }
+    // Only `WAIT_OBJECT_0` means the process actually exited. WAIT_ABANDONED or
+    // WAIT_FAILED mean the process is NOT known to have terminated, so
+    // `GetExitCodeProcess` would return `STILL_ACTIVE` (259) and we would
+    // otherwise report that as a clean exit code. Fail closed instead: the
+    // caller must treat this as a launch failure, not a successful run with
+    // exit 259.
     if wait != WAIT_OBJECT_0 {
         return Err(WindowsLaunchError::Wait(format!(
             "WaitForSingleObject did not report the child as exited (returned {:#x}); \
@@ -250,9 +311,10 @@ pub fn wait_for(child: &ContainedChild) -> Result<i32, WindowsLaunchError> {
 fn apply_plan(
     plan: &WindowsLaunchPlan,
     env: &EnvironmentPolicy,
+    wall_clock_seconds: Option<u64>,
 ) -> Result<ContainedChild, WindowsLaunchError> {
     // 1. AppContainer profile (idempotent) + package SID.
-    let container_sid = create_or_open_appcontainer(plan)?;
+    let (container_sid, profile) = create_unique_appcontainer(plan)?;
     // `container_sid` owns the PSID and frees it on drop.
 
     // 2. ACL grants — tracked so they are reverted on any later failure or when the
@@ -328,6 +390,8 @@ fn apply_plan(
         process: launched.process,
         thread: launched.thread,
         acl_guards,
+        wall_clock_seconds,
+        profile,
     })
 }
 
@@ -355,112 +419,270 @@ impl Drop for OwnedSid {
     }
 }
 
-/// Create the AppContainer profile (or reuse an existing one) and return its package
-/// SID. `CreateAppContainerProfile` returns the SID directly; if the profile already
-/// exists it fails with `HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)`, in which case we
-/// derive the SID from the name instead (idempotent reuse). No capabilities are ever
-/// passed (the plan grants none), so the container has no networking capability.
-fn create_or_open_appcontainer(plan: &WindowsLaunchPlan) -> Result<OwnedSid, WindowsLaunchError> {
-    let name = wide_nul(&plan.profile.name)
+/// Build a per-launch AppContainer profile name from the pure plan's stable base.
+/// Reusing the base SID would let one overlapping run's cleanup revoke the other
+/// run's ACL grants. The process id plus a checked atomic sequence keeps live
+/// launches distinct across and within processes while remaining under Windows'
+/// 64-code-unit profile-name limit.
+fn unique_profile_name(base: &str) -> Result<String, WindowsLaunchError> {
+    let sequence = NEXT_PROFILE_ID
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+            value.checked_add(1)
+        })
+        .map_err(|_| {
+            WindowsLaunchError::Encoding(
+                "appcontainer launch sequence exhausted; refusing SID reuse".to_string(),
+            )
+        })?;
+    let name = format!("{base}.{:08x}.{sequence:016x}", std::process::id());
+    if name.encode_utf16().count() > APP_CONTAINER_NAME_MAX {
+        return Err(WindowsLaunchError::Encoding(format!(
+            "per-launch appcontainer name exceeds {APP_CONTAINER_NAME_MAX} UTF-16 units"
+        )));
+    }
+    Ok(name)
+}
+
+/// Create a unique AppContainer profile for this launch and return both its package
+/// SID and a guard that deletes the profile after the contained run. No capabilities
+/// are ever passed (the plan grants none), so the container has no networking
+/// capability. Any unexpected name collision fails closed instead of sharing a SID.
+fn create_unique_appcontainer(
+    plan: &WindowsLaunchPlan,
+) -> Result<(OwnedSid, ProfileGuard), WindowsLaunchError> {
+    let profile_name = unique_profile_name(&plan.profile.name)?;
+    let name = wide_nul(&profile_name)
         .map_err(|_| WindowsLaunchError::Encoding("appcontainer name has NUL".to_string()))?;
     let display = wide_nul(&plan.profile.display_name)
         .map_err(|_| WindowsLaunchError::Encoding("display name has NUL".to_string()))?;
 
     // First try to create. `pcapabilities = None` -> no capabilities, so no network.
     // SAFETY: the wide strings are NUL-terminated and outlive the call.
-    let created = unsafe {
+    let sid = unsafe {
         CreateAppContainerProfile(
             PCWSTR(name.as_ptr()),
             PCWSTR(display.as_ptr()),
             PCWSTR(display.as_ptr()),
             None,
         )
-    };
-    match created {
-        Ok(psid) => Ok(OwnedSid(psid)),
-        Err(_) => {
-            // Most likely ERROR_ALREADY_EXISTS: derive the SID from the existing
-            // profile. (Any other error surfaces here too, with a derive failure.)
-            // SAFETY: `name` is NUL-terminated. The windows-crate binding returns the
-            // derived PSID directly (no out-param).
-            let derived =
-                unsafe { DeriveAppContainerSidFromAppContainerName(PCWSTR(name.as_ptr())) };
-            match derived {
-                Ok(psid) => Ok(OwnedSid(psid)),
-                Err(e) => Err(WindowsLaunchError::AppContainer(
-                    "create and derive both failed".to_string(),
-                    e,
-                )),
-            }
+    }
+    .map_err(|e| {
+        WindowsLaunchError::AppContainer("create unique per-launch profile failed".to_string(), e)
+    })?;
+    Ok((
+        OwnedSid(sid),
+        ProfileGuard {
+            name_wide: name,
+            deleted: false,
+        },
+    ))
+}
+
+/// Owns one per-launch AppContainer profile and removes it once the contained
+/// process and its temporary ACL grants are finished. A failed explicit deletion
+/// remains retryable from `Drop`.
+struct ProfileGuard {
+    name_wide: Vec<u16>,
+    deleted: bool,
+}
+
+impl ProfileGuard {
+    fn delete_now(&mut self) -> Result<(), WindowsLaunchError> {
+        if self.deleted {
+            return Ok(());
         }
+        // SAFETY: `name_wide` is a live NUL-terminated string naming the profile
+        // created for this guard; the API borrows it only for this call.
+        unsafe { DeleteAppContainerProfile(PCWSTR(self.name_wide.as_ptr())) }.map_err(|e| {
+            WindowsLaunchError::AppContainer(
+                "delete unique per-launch profile failed".to_string(),
+                e,
+            )
+        })?;
+        self.deleted = true;
+        Ok(())
     }
 }
 
-/// An ACL grant that has been applied to a path's DACL and remembers how to revert
-/// it. On revert it re-installs the path's **original** DACL (the one we read before
-/// adding our ACE), so the grant leaves no residue.
+impl Drop for ProfileGuard {
+    fn drop(&mut self) {
+        let _ = self.delete_now();
+    }
+}
+
+/// An ACL grant that has been applied to a path's DACL and remembers how to
+/// revert it. On revert it re-reads the path's **current** DACL and removes
+/// only the access-allowed ACEs naming the container package SID — the ACEs
+/// this capsule added — instead of restoring a whole-DACL snapshot taken at
+/// grant time (repo-0364). A snapshot restore would silently discard
+/// legitimate ACL changes made between grant and revert, and could clobber an
+/// overlapping capsule run's own grant.
 ///
-/// **Ownership:** `security_descriptor` is the `PSECURITY_DESCRIPTOR` that
-/// `GetNamedSecurityInfoW` allocated; `original_dacl` points *inside* it. The guard
-/// therefore owns the descriptor and `LocalFree`s it only after the final revert, so
-/// `original_dacl` is never dangled (the use-after-free that would result from
-/// freeing the descriptor while the guard still holds the inner DACL pointer).
+/// **Ownership:** `container_sid` is a `LocalAlloc`/`CopySid` duplicate of the
+/// AppContainer package SID (the original `OwnedSid` is freed when `apply_plan`
+/// returns, while the guard lives on inside [`ContainedChild`]); it is freed
+/// with `LocalFree` on drop, after the final revert.
 struct AclGuard {
     /// The path whose DACL we modified (NUL-terminated wide string).
     path_wide: Vec<u16>,
-    /// The security descriptor backing `original_dacl` (owned; `LocalFree`d on drop).
-    security_descriptor: PSECURITY_DESCRIPTOR,
-    /// The original DACL to restore on revert (points into `security_descriptor`;
-    /// may be null == "no explicit DACL").
-    original_dacl: *const ACL,
+    /// Owned duplicate of the container package SID our ACE was granted to;
+    /// matched against the live DACL at revert time.
+    container_sid: OwnedLocalSid,
     /// Whether this guard has already reverted.
     reverted: bool,
 }
 
 impl AclGuard {
-    /// Revert the grant now (restore the original DACL). Idempotent.
+    /// Revert the grant now: remove our own ACE from the path's live DACL.
+    /// Idempotent — and marked reverted only AFTER the revocation actually
+    /// succeeded, so a transient failure is retried by [`Drop`] instead of
+    /// leaking the container's ACE (repo-0364).
     fn revert_now(&mut self) -> Result<(), WindowsLaunchError> {
         if self.reverted {
             return Ok(());
         }
-        self.reverted = true;
-        // SAFETY: `path_wide` is NUL-terminated; `original_dacl` points into the
-        // still-live `security_descriptor` (freed only in Drop, after this revert).
-        let rc = unsafe {
-            SetNamedSecurityInfoW(
+        // Read the path's CURRENT DACL (not a grant-time snapshot).
+        let mut current_dacl: *mut ACL = std::ptr::null_mut();
+        let mut sd = PSECURITY_DESCRIPTOR::default();
+        // SAFETY: `path_wide` is NUL-terminated; out-pointers are valid.
+        let get_rc = unsafe {
+            GetNamedSecurityInfoW(
                 PCWSTR(self.path_wide.as_ptr()),
                 SE_FILE_OBJECT,
                 DACL_SECURITY_INFORMATION,
                 None,
                 None,
-                Some(self.original_dacl),
+                Some(&mut current_dacl as *mut *mut ACL),
                 None,
+                &mut sd,
             )
         };
-        if rc.is_ok() {
-            Ok(())
-        } else {
-            Err(WindowsLaunchError::Acl(
-                "restore original DACL".to_string(),
-                rc,
-            ))
+        if get_rc.is_err() {
+            return Err(WindowsLaunchError::Acl(
+                "read current DACL for revert".to_string(),
+                get_rc,
+            ));
         }
+        // `result` is computed while `sd` is still owned here: `current_dacl`
+        // points inside it and must not outlive the `LocalFree` below.
+        let result = (|| -> Result<(), WindowsLaunchError> {
+            if current_dacl.is_null() {
+                // The object now has no explicit DACL, so our ACE cannot be
+                // present (someone replaced the DACL wholesale). Nothing to
+                // remove — and installing a null DACL would OPEN the object,
+                // so we must not write one.
+                return Ok(());
+            }
+            let ace_count = unsafe { (*current_dacl).AceCount } as u32;
+            // Walk BACKWARD so in-place deletions cannot shift unvisited
+            // entries past the cursor.
+            for i in (0..ace_count).rev() {
+                let mut pace: *mut core::ffi::c_void = std::ptr::null_mut();
+                // SAFETY: `current_dacl` is a live DACL and `i < AceCount`.
+                if let Err(error) = unsafe { GetAce(current_dacl, i, &mut pace) } {
+                    return Err(WindowsLaunchError::Acl(
+                        "read ACE while reverting capsule grant".to_string(),
+                        WIN32_ERROR::from_error(&error).unwrap_or(ERROR_INVALID_PARAMETER),
+                    ));
+                }
+                if pace.is_null() {
+                    return Err(WindowsLaunchError::Acl(
+                        "read ACE while reverting capsule grant returned a null pointer"
+                            .to_string(),
+                        ERROR_INVALID_PARAMETER,
+                    ));
+                }
+                // SAFETY: `pace` names a live ACE inside the DACL for the
+                // duration of this iteration.
+                let header = unsafe { &*(pace as *const ACE_HEADER) };
+                if header.AceType != ACCESS_ALLOWED_ACE_TYPE as u8 {
+                    // Never touch deny/audit entries — only the allow ACEs we
+                    // added are candidates for removal.
+                    continue;
+                }
+                let ace = pace as *mut ACCESS_ALLOWED_ACE;
+                // The ACE's SID begins in-line at `SidStart`.
+                // SAFETY: `ace` names a live allow ACE inside the DACL, so
+                // taking the address of its in-line Sid field reads no memory
+                // and stays inside that allocation.
+                let ace_sid =
+                    PSID(unsafe { std::ptr::addr_of_mut!((*ace).SidStart) }
+                        as *mut core::ffi::c_void);
+                // SAFETY: both SIDs are valid; EqualSid reads only.
+                let is_ours = unsafe { EqualSid(ace_sid, self.container_sid.psid()) }.is_ok();
+                if is_ours {
+                    // SAFETY: `i` indexes a live ACE in `current_dacl`;
+                    // DeleteAce shrinks the ACL in place, which is safe inside
+                    // the owning descriptor buffer.
+                    if let Err(error) = unsafe { DeleteAce(current_dacl, i) } {
+                        return Err(WindowsLaunchError::Acl(
+                            "delete capsule ACE from DACL".to_string(),
+                            WIN32_ERROR::from_error(&error).unwrap_or(ERROR_INVALID_PARAMETER),
+                        ));
+                    }
+                }
+            }
+            // SAFETY: `path_wide` is NUL-terminated; `current_dacl` is the
+            // pruned live DACL.
+            let set_rc = unsafe {
+                SetNamedSecurityInfoW(
+                    PCWSTR(self.path_wide.as_ptr()),
+                    SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION,
+                    None,
+                    None,
+                    Some(current_dacl as *const ACL),
+                    None,
+                )
+            };
+            if set_rc.is_err() {
+                return Err(WindowsLaunchError::Acl(
+                    "remove capsule ACE from DACL".to_string(),
+                    set_rc,
+                ));
+            }
+            Ok(())
+        })();
+        // Free the descriptor we read (current_dacl points into it), exactly
+        // once, before returning.
+        // SAFETY: `sd` was allocated by GetNamedSecurityInfoW above.
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(sd.0)));
+        }
+        result?;
+        self.reverted = true;
+        Ok(())
     }
 }
 
 impl Drop for AclGuard {
     fn drop(&mut self) {
-        // Best-effort revert on drop; an explicit `finish()` reports errors. The
-        // revert reads `original_dacl`, so it MUST happen before we free the backing
-        // descriptor.
+        // Best-effort revert on drop; an explicit `finish()` reports errors. A
+        // FAILED earlier revert left `reverted` clear, so this retries the
+        // revocation instead of leaking the ACE.
         let _ = self.revert_now();
-        if !self.security_descriptor.0.is_null() {
-            // SAFETY: `security_descriptor` was allocated by GetNamedSecurityInfoW and
-            // is freed exactly once here; `original_dacl` is not used after this.
+    }
+}
+
+/// A copied SID whose storage came from `LocalAlloc`. Unlike the SID returned by
+/// `CreateAppContainerProfile`, this allocation must be paired with `LocalFree`,
+/// not `FreeSid` (which is documented for `AllocateAndInitializeSid` results).
+struct OwnedLocalSid(HLOCAL);
+
+impl OwnedLocalSid {
+    fn psid(&self) -> PSID {
+        PSID(self.0 .0)
+    }
+}
+
+impl Drop for OwnedLocalSid {
+    fn drop(&mut self) {
+        if !self.0 .0.is_null() {
+            // SAFETY: this handle was returned by `LocalAlloc` and is freed once.
             unsafe {
-                let _ = LocalFree(Some(HLOCAL(self.security_descriptor.0)));
+                let _ = LocalFree(Some(self.0));
             }
-            self.security_descriptor = PSECURITY_DESCRIPTOR(std::ptr::null_mut());
+            self.0 = HLOCAL(std::ptr::null_mut());
         }
     }
 }
@@ -487,7 +709,8 @@ fn access_mask(access: AclAccess) -> u32 {
 
 /// Apply one ACL grant: read the path's current DACL, add an ACE granting the
 /// container SID the requested access (inheriting to sub-objects), and write the new
-/// DACL back. Returns an [`AclGuard`] that restores the original DACL on revert.
+/// DACL back. Returns an [`AclGuard`] that removes exactly this ACE from the
+/// path's live DACL on revert.
 ///
 /// We use `GetNamedSecurityInfoW` to fetch the existing DACL so the grant is
 /// ADDITIVE (we never clobber existing permissions); `SetEntriesInAclW` merges our
@@ -499,6 +722,28 @@ fn apply_acl_grant(grant: &AclGrant, container_sid: PSID) -> Result<AclGuard, Wi
         .ok_or_else(|| WindowsLaunchError::Encoding(format!("non-UTF-8 path: {:?}", grant.path)))?;
     let path_wide =
         wide_nul(path_str).map_err(|_| WindowsLaunchError::Encoding("path has NUL".to_string()))?;
+
+    // Build the guard's independent SID copy BEFORE modifying the path. If
+    // allocation or copying fails, no ACE has been installed and therefore no
+    // cleanup state can be lost.
+    // SAFETY: `container_sid` came from CreateAppContainerProfile and is valid.
+    let sid_len = unsafe { GetLengthSid(container_sid) };
+    // SAFETY: allocate exactly the byte length reported for the source SID.
+    let sid_buf = unsafe { LocalAlloc(LPTR, sid_len as usize) }.map_err(|error| {
+        WindowsLaunchError::Acl(
+            "allocate container SID copy".to_string(),
+            WIN32_ERROR::from_error(&error).unwrap_or(ERROR_NOT_ENOUGH_MEMORY),
+        )
+    })?;
+    let sid_copy = OwnedLocalSid(sid_buf);
+    // SAFETY: `sid_copy` owns `sid_len` writable bytes and `container_sid` is a
+    // valid source SID. The RAII owner frees the buffer on failure.
+    if let Err(error) = unsafe { CopySid(sid_len, sid_copy.psid(), container_sid) } {
+        return Err(WindowsLaunchError::Acl(
+            "copy container SID for revert".to_string(),
+            WIN32_ERROR::from_error(&error).unwrap_or(ERROR_INVALID_PARAMETER),
+        ));
+    }
 
     // Read the existing DACL (so our grant is additive).
     let mut existing_dacl: *mut ACL = std::ptr::null_mut();
@@ -591,12 +836,17 @@ fn apply_acl_grant(grant: &AclGrant, container_sid: PSID) -> Result<AclGuard, Wi
         ));
     }
 
+    // The grant is installed; the grant-time snapshot descriptor is no longer
+    // needed (the revert removes our ACE from the LIVE DACL instead of
+    // restoring a stale snapshot).
+    // SAFETY: `sd` was allocated by GetNamedSecurityInfoW; freed exactly once.
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(sd.0)));
+    }
+
     Ok(AclGuard {
         path_wide,
-        // The guard OWNS `sd` and frees it on drop (after the final revert);
-        // `existing_dacl` points into it and is the original DACL to restore.
-        security_descriptor: sd,
-        original_dacl: existing_dacl as *const ACL,
+        container_sid: sid_copy,
         reverted: false,
     })
 }
@@ -950,6 +1200,26 @@ mod tests {
     #[test]
     fn wide_nul_rejects_interior_nul() {
         assert!(wide_nul("a\0b").is_err());
+    }
+
+    #[test]
+    fn wall_clock_timeout_is_finite_and_saturates_below_infinite() {
+        assert_eq!(wall_clock_timeout_ms(None), INFINITE);
+        assert_eq!(wall_clock_timeout_ms(Some(0)), 0);
+        assert_eq!(wall_clock_timeout_ms(Some(60)), 60_000);
+        assert_eq!(wall_clock_timeout_ms(Some(u64::MAX)), INFINITE - 1);
+    }
+
+    #[test]
+    fn appcontainer_profile_names_are_unique_and_bounded_per_launch() {
+        let base = "tirith.capsule.0123456789abcdef";
+        let first = unique_profile_name(base).expect("first name");
+        let second = unique_profile_name(base).expect("second name");
+        assert_ne!(first, second);
+        assert!(first.starts_with(base));
+        assert!(second.starts_with(base));
+        assert!(first.encode_utf16().count() <= APP_CONTAINER_NAME_MAX);
+        assert!(second.encode_utf16().count() <= APP_CONTAINER_NAME_MAX);
     }
 
     #[test]

--- a/crates/tirith/src/cli/check.rs
+++ b/crates/tirith/src/cli/check.rs
@@ -228,9 +228,13 @@ pub fn run(
     // Local paths return the engine's policy to avoid a redundant
     // Policy::discover(); the daemon path returns None (analysis was server-side).
     let (mut raw_verdict, engine_policy) = if use_daemon {
-        if let Some(resp) =
-            crate::cli::daemon::try_daemon_check(cmd, shell_name, cwd.as_deref(), interactive)
-        {
+        if let Some(resp) = crate::cli::daemon::try_daemon_check(
+            cmd,
+            shell_name,
+            cwd.as_deref(),
+            interactive,
+            offline,
+        ) {
             if let Some(ref raw_findings) = resp.raw_findings {
                 let raw_action_parsed = resp
                     .raw_action

--- a/crates/tirith/src/cli/checkpoint.rs
+++ b/crates/tirith/src/cli/checkpoint.rs
@@ -84,25 +84,31 @@ pub fn restore_checkpoint(id: &str, json: bool) -> i32 {
                 );
             } else {
                 println!("Restored {restored_n} file(s):");
+                // repo-0366: every persisted path is project-controlled; all
+                // restore/diff output goes through terminal sanitization.
                 for path in &report.restored {
-                    println!("  {path}");
+                    println!("  {}", super::sanitize_for_human_output(path, false));
                 }
                 if !report.missing.is_empty() {
                     println!("Missing backup data ({}):", report.missing.len());
                     for path in &report.missing {
-                        println!("  {path}");
+                        println!("  {}", super::sanitize_for_human_output(path, false));
                     }
                 }
                 if !report.corrupt.is_empty() {
                     println!("Corrupt backup data, skipped ({}):", report.corrupt.len());
                     for path in &report.corrupt {
-                        println!("  {path}");
+                        println!("  {}", super::sanitize_for_human_output(path, false));
                     }
                 }
                 if !report.errors.is_empty() {
                     println!("Errors ({}):", report.errors.len());
                     for (path, err) in &report.errors {
-                        println!("  {path}: {err}");
+                        println!(
+                            "  {}: {}",
+                            super::sanitize_for_human_output(path, false),
+                            super::sanitize_for_human_output(err, false)
+                        );
                     }
                 }
                 println!(
@@ -158,7 +164,10 @@ pub fn diff_checkpoint(id: &str, json: bool) -> i32 {
                             tirith_core::style::red("corrupt", s)
                         }
                     };
-                    println!("  {status:>18}  {}", d.path);
+                    println!(
+                        "  {status:>18}  {}",
+                        super::sanitize_for_human_output(&d.path, false)
+                    );
                 }
                 println!("\n{} difference(s)", diffs.len());
             }

--- a/crates/tirith/src/cli/clipboard.rs
+++ b/crates/tirith/src/cli/clipboard.rs
@@ -582,8 +582,12 @@ pub fn daemon_foreground(json: bool) -> i32 {
         // Audit + stderr warn. Silent-failure fix: a swallowed audit-write failure left
         // `tirith last-trigger <event_id>` empty, so match the result and warn on failure.
         let event_id = uuid::Uuid::new_v4().to_string();
+        // repo-0368: redact with the ACTIVE policy's custom patterns, not an
+        // empty list — otherwise dlp_custom_patterns values persist (and may be
+        // uploaded) in audit evidence.
+        let dlp = tirith_core::policy::Policy::discover_partial(None).dlp_custom_patterns;
         if let Err(e) =
-            tirith_core::audit::log_verdict(&verdict, &text, None, Some(event_id.clone()), &[])
+            tirith_core::audit::log_verdict(&verdict, &text, None, Some(event_id.clone()), &dlp)
         {
             eprintln!("tirith clipboard daemon: audit log write failed (event_id={event_id}): {e}");
         }
@@ -744,32 +748,41 @@ fn analyze_as_paste(
     // threshold as `tirith paste`. A fresh snapshot is fine (clipboard analysis is rare).
     let policy = tirith_core::policy::Policy::discover_partial(None);
     engine::filter_findings_by_paranoia(&mut verdict, policy.paranoia);
+    // repo-0368: every consumer of this verdict (the ScanEnvelope JSON surface
+    // and the audit path) serializes it directly, so DLP redaction must happen
+    // HERE with the active policy's custom patterns — not with an empty
+    // pattern list at the sink.
+    tirith_core::redact::redact_verdict(&mut verdict, &policy.dlp_custom_patterns);
     verdict
 }
 
 /// Read a file with a hard byte cap. Errors map to a CLI exit code.
 fn read_file_capped(path: &Path) -> Result<String, i32> {
-    let meta = match fs::metadata(path) {
-        Ok(m) => m,
-        Err(e) => {
+    // repo-0367: stat-then-read raced the path and followed symlinks — a
+    // zero-length-reported device or a post-stat FIFO swap could block or
+    // allocate past the advertised cap. One no-follow, regular-file-only,
+    // capped read instead.
+    let bytes = match tirith_core::util::read_text_no_follow_capped(path, MAX_COPY_BYTES) {
+        Ok(b) => b,
+        Err(tirith_core::util::OpenRegularError::TooLarge) => {
             eprintln!(
-                "tirith clipboard copy: failed to stat {}: {e}",
+                "tirith clipboard copy: {} exceeds {} bytes — refusing (the clipboard isn't a blob store)",
+                path.display(),
+                MAX_COPY_BYTES
+            );
+            return Err(1);
+        }
+        Err(_) => {
+            eprintln!(
+                "tirith clipboard copy: failed to read {} (not a regular, safely-readable file)",
                 path.display()
             );
             return Err(1);
         }
     };
-    if meta.len() > MAX_COPY_BYTES {
+    String::from_utf8(bytes).map_err(|_| {
         eprintln!(
-            "tirith clipboard copy: {} exceeds {} bytes — refusing (the clipboard isn't a blob store)",
-            path.display(),
-            MAX_COPY_BYTES
-        );
-        return Err(1);
-    }
-    fs::read_to_string(path).map_err(|e| {
-        eprintln!(
-            "tirith clipboard copy: failed to read {}: {e}",
+            "tirith clipboard copy: {} is not valid UTF-8",
             path.display()
         );
         1

--- a/crates/tirith/src/cli/context.rs
+++ b/crates/tirith/src/cli/context.rs
@@ -88,13 +88,15 @@ pub fn status(json: bool) -> i32 {
                     .get(&ctx.label_key())
                     .map(String::as_str)
                     .unwrap_or("(unlabeled)");
-                eprintln!(
-                    "  {:<6} {}  [label: {label}]",
-                    provider.as_str(),
-                    ctx.context,
-                );
+                // Context names and repo-controlled labels are untrusted
+                // display values: scrub terminal controls / deceptive Unicode
+                // before human rendering (JSON stays raw, serde-escaped).
+                let context = super::sanitize_for_human_output(&ctx.context, false);
+                let label = super::sanitize_for_human_output(label, false);
+                eprintln!("  {:<6} {}  [label: {label}]", provider.as_str(), context,);
             }
             (None, Some(failure)) => {
+                let failure = super::sanitize_for_human_output(&failure.to_string(), false);
                 eprintln!("  {:<6} <error: {failure}>", provider.as_str());
             }
             (None, None) => {
@@ -263,18 +265,37 @@ fn resolve_policy_path_for_guard() -> Result<PathBuf, i32> {
 
 /// Idempotently append-or-rewrite the `context_guard_enabled` line in a policy
 /// YAML file, never touching other lines.
+///
+/// Write-side hardening (repo-0371): the discovered path may be a
+/// repository-controlled policy, so this writer
+/// - binds the containing directory and target through retained capabilities,
+///   refusing symlinked/reparse directory or final components,
+/// - never treats an unreadable / non-UTF-8 existing file as empty input
+///   (which previously clobbered the target with only the guard key), and
+/// - publishes through a 0600 atomic temp-file rename instead of truncating
+///   in place.
 fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    let root = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "policy path has no containing directory",
+            )
+        })?;
+    let contained = tirith_core::util::ContainedAtomicFile::prepare(root, path, true)?;
+    let existing = read_existing_policy_for_guard(&contained, path)?;
     let new_line = format!("context_guard_enabled: {enable}");
 
     let mut out = String::new();
     let mut replaced = false;
     for line in existing.lines() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("context_guard_enabled:") {
+        // Root-mapping keys ONLY (column zero). An indented lookalike is a
+        // nested mapping entry — rewriting it at column zero would corrupt
+        // the YAML and suppress the real append, the same failure shape as
+        // repo-0385 in the hooks guard.
+        if line.starts_with("context_guard_enabled:") {
             out.push_str(&new_line);
             out.push('\n');
             replaced = true;
@@ -291,16 +312,69 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
         out.push('\n');
     }
 
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
+    // Verify BEFORE publishing: the candidate must parse and its top-level
+    // `context_guard_enabled` must equal the requested value.
+    verify_context_guard_effective(&out, enable)?;
+
+    contained.write_atomic(out.as_bytes(), true)
+}
+
+/// Parse the candidate policy and require the top-level `context_guard_enabled`
+/// to equal `expected`, so a corrupt or lookalike-only document can never be
+/// published as a successful guard toggle.
+fn verify_context_guard_effective(candidate: &str, expected: bool) -> std::io::Result<()> {
+    let parsed: serde_yaml::Value = serde_yaml::from_str(candidate).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("resulting policy would not parse as YAML: {e}"),
+        )
+    })?;
+    let effective = parsed
+        .get("context_guard_enabled")
+        .and_then(serde_yaml::Value::as_bool);
+    if effective == Some(expected) {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "resulting policy does not have the requested top-level context_guard_enabled value",
+        ))
     }
-    let mut f = opts.open(path)?;
-    use std::io::Write as _;
-    f.write_all(out.as_bytes())
+}
+
+/// Read the existing policy text for a guard update. A missing file is empty
+/// input; ANY other failure (unreadable, non-UTF-8, symlink, oversized) is an
+/// error — never silently treat the target as empty and clobber it.
+fn read_existing_policy_for_guard(
+    contained: &tirith_core::util::ContainedAtomicFile,
+    path: &std::path::Path,
+) -> std::io::Result<String> {
+    use tirith_core::util::OpenRegularError;
+    const GUARD_POLICY_READ_CAP: u64 = 1024 * 1024;
+    match contained.read_capped(GUARD_POLICY_READ_CAP) {
+        Ok(bytes) => String::from_utf8(bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "refusing to update {}: existing policy is not valid UTF-8",
+                    path.display()
+                ),
+            )
+        }),
+        Err(OpenRegularError::NotFound) => Ok(String::new()),
+        Err(OpenRegularError::NotRegularFile) => Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing to update {}: not a regular file (symlink?)",
+                path.display()
+            ),
+        )),
+        Err(OpenRegularError::TooLarge) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("refusing to update {}: exceeds 1 MiB", path.display()),
+        )),
+        Err(OpenRegularError::Io(e)) => Err(e),
+    }
 }
 
 /// `tirith context label <provider:context> <criticality> [--scope user|repo]`.
@@ -435,5 +509,76 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("paranoia: 2"));
         assert!(content.contains("context_guard_enabled: true"));
+    }
+
+    #[test]
+    fn update_policy_guard_key_ignores_indented_lookalike() {
+        // An indented nested-mapping lookalike must not be rewritten at column
+        // zero; the real root key is appended and the document stays valid.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("policy.yaml");
+        std::fs::write(
+            &path,
+            "custom_rule:\n  context_guard_enabled: false\n  other: 1\n",
+        )
+        .unwrap();
+        update_policy_guard_key(&path, true).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("  context_guard_enabled: false"));
+        let top_level = content
+            .lines()
+            .filter(|l| l.starts_with("context_guard_enabled:"))
+            .count();
+        assert_eq!(top_level, 1);
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        assert_eq!(
+            parsed
+                .get("context_guard_enabled")
+                .and_then(|v| v.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_guard_key_refuses_symlink_target() {
+        // Regression: repo-0371 — a repository-controlled policy.yaml symlink
+        // must not turn the guard update into an arbitrary-file rewrite.
+        let dir = tempdir().unwrap();
+        let outside = dir.path().join("outside.txt");
+        std::fs::write(&outside, "do not touch\n").unwrap();
+        let link = dir.path().join("policy.yaml");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        let err = update_policy_guard_key(&link, true).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(std::fs::read_to_string(&outside).unwrap(), "do not touch\n");
+    }
+
+    #[test]
+    fn update_policy_guard_key_refuses_non_utf8_existing() {
+        // Regression: repo-0371 — non-UTF-8 content must not be treated as
+        // empty and clobbered with only the guard key.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("policy.yaml");
+        std::fs::write(&path, [0xff, 0xfe, 0x00, 0x01]).unwrap();
+        let err = update_policy_guard_key(&path, true).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            vec![0xff, 0xfe, 0x00, 0x01],
+            "target must be left untouched"
+        );
+    }
+
+    #[test]
+    fn status_sanitizes_untrusted_fields() {
+        // Regression: repo-0372 — context names / labels must not carry
+        // terminal control sequences into human status output.
+        let s = super::super::sanitize_for_human_output(
+            "aws:default\u{1b}]52;c;SGFja2Vk\u{7}\u{202e}",
+            false,
+        );
+        assert!(!s.contains('\u{1b}'));
+        assert!(!s.contains('\u{202e}'));
     }
 }

--- a/crates/tirith/src/cli/daemon.rs
+++ b/crates/tirith/src/cli/daemon.rs
@@ -301,6 +301,15 @@ pub struct DaemonRequest {
     /// Client-side TIRITH=0 bypass request from the invoking env.
     #[serde(default)]
     pub bypass_requested: bool,
+    /// Client-side offline decision (`--offline` flag OR `TIRITH_OFFLINE` in
+    /// the invoking shell). The persistent daemon outlives any single
+    /// invocation, so the env var set by the CALLER cannot be read server-side
+    /// — it must ride the request. `#[serde(default)]` keeps the wire format
+    /// compatible in both directions: an old client omitting the field
+    /// deserializes as `false` (online, the historical behavior), and an old
+    /// server ignores the unknown field (serde's default) (repo-0373).
+    #[serde(default)]
+    pub offline: bool,
 }
 
 fn default_context() -> String {
@@ -347,6 +356,7 @@ pub fn try_daemon_check(
     shell: &str,
     cwd: Option<&str>,
     interactive: bool,
+    offline: bool,
 ) -> Option<DaemonResponse> {
     let sock = socket_path();
     if !sock.exists() {
@@ -376,6 +386,10 @@ pub fn try_daemon_check(
         shell: Some(shell.to_string()),
         interactive,
         bypass_requested,
+        // The caller's `--offline` flag OR a truthy `TIRITH_OFFLINE` in the
+        // INVOKING shell both force offline analysis; the daemon's own env
+        // (set at server start) is deliberately irrelevant (repo-0373).
+        offline: offline || super::offline_env_active(),
     };
 
     let mut payload = serde_json::to_string(&req).ok()?;
@@ -398,6 +412,7 @@ pub fn try_daemon_check(
     _shell: &str,
     _cwd: Option<&str>,
     _interactive: bool,
+    _offline: bool,
 ) -> Option<DaemonResponse> {
     None
 }
@@ -500,7 +515,14 @@ fn handle_request(req: &DaemonRequest) -> DaemonResponse {
     verdict.findings.extend(runtime_findings);
 
     // Daemon-only: network-aware enrichment is too slow for the sync path.
-    enrich_with_network_checks(&mut verdict.findings);
+    // Skipped entirely when the CALLER asked for offline analysis (repo-0373):
+    // short-URL resolution is HTTP and the blocklist lookups are DNS, and the
+    // daemon's own process env cannot see the invoking shell's TIRITH_OFFLINE,
+    // so the decision arrives on the request. This mirrors the local hot path,
+    // which performs NO HTTP/DNS enrichment at all.
+    if !req.offline {
+        enrich_with_network_checks(&mut verdict.findings);
+    }
 
     // Enrichment may add higher-severity findings; recompute the action.
     verdict.action = upgraded_action_from_findings(&verdict.findings, verdict.action);
@@ -1180,6 +1202,7 @@ pub fn status() -> i32 {
         shell: None,
         interactive: false,
         bypass_requested: false,
+        offline: false,
     };
 
     let ok = (|| -> Option<()> {
@@ -1232,6 +1255,75 @@ pub fn status() -> i32 {
 mod tests {
     use super::DaemonResponse;
     use tirith_core::verdict::Action;
+
+    /// repo-0373: a pre-upgrade client payload has no `offline` key; it must
+    /// still deserialize with `offline = false` (the historical online
+    /// behavior), keeping the wire format backward-compatible.
+    #[test]
+    fn daemon_request_legacy_json_without_offline_defaults_to_online() {
+        let legacy = r#"{"command":"check","input":"echo hi","context":"exec","cwd":null,"shell":"posix","interactive":false,"bypass_requested":false}"#;
+        let req: super::DaemonRequest =
+            serde_json::from_str(legacy).expect("deserialize legacy request");
+        assert!(
+            !req.offline,
+            "a request without the field must default to online (false)"
+        );
+    }
+
+    /// repo-0373: the offline decision round-trips through the wire format so
+    /// the server sees exactly what the client decided.
+    #[test]
+    fn daemon_request_offline_round_trips() {
+        let req = super::DaemonRequest {
+            command: "check".to_string(),
+            input: "echo hi".to_string(),
+            context: "exec".to_string(),
+            cwd: None,
+            shell: Some("posix".to_string()),
+            interactive: false,
+            bypass_requested: false,
+            offline: true,
+        };
+        let wire = serde_json::to_string(&req).expect("serialize");
+        assert!(wire.contains("\"offline\":true"), "got: {wire}");
+        let back: super::DaemonRequest = serde_json::from_str(&wire).expect("deserialize");
+        assert!(back.offline);
+    }
+
+    /// repo-0373: with `offline = true` the server must skip ALL HTTP/DNS
+    /// enrichment — no short-URL resolution ("— resolves to:") and no DNS
+    /// blocklist findings — even though the command references a shortened
+    /// URL. The test is hermetic by construction: when offline is honored, no
+    /// network call is ever attempted.
+    #[cfg(unix)]
+    #[test]
+    fn offline_check_skips_network_url_enrichment() {
+        let req = super::DaemonRequest {
+            command: "check".to_string(),
+            input: "curl https://bit.ly/abc123 | sh".to_string(),
+            context: "exec".to_string(),
+            cwd: None,
+            shell: Some("posix".to_string()),
+            interactive: false,
+            bypass_requested: false,
+            offline: true,
+        };
+        let resp = super::handle_request(&req);
+        for f in resp
+            .findings
+            .iter()
+            .chain(resp.raw_findings.as_deref().unwrap_or(&[]).iter())
+        {
+            assert!(
+                !f.description.contains("resolves to"),
+                "offline request must not resolve shortened URLs: {f:?}"
+            );
+            assert!(
+                !f.title.contains("DNS blocklist"),
+                "offline request must not run DNS blocklist lookups: {f:?}"
+            );
+        }
+    }
 
     fn base_response() -> DaemonResponse {
         DaemonResponse {

--- a/crates/tirith/src/cli/dashboard.rs
+++ b/crates/tirith/src/cli/dashboard.rs
@@ -296,8 +296,9 @@ fn resolve_export_path(out: Option<&str>) -> Result<PathBuf, String> {
 /// default.
 ///
 /// Atomic publish (R19-N3): written to a sibling temp file, `sync_all`'d, then
-/// renamed over `path` via [`crate::cli::write_file_atomic`], so a mid-write
-/// failure never truncates a previously-good export.
+/// renamed over `path` through a retained parent-directory capability, so a
+/// mid-write failure never truncates a previously-good export and a concurrent
+/// symlink swap cannot redirect publication.
 ///
 /// Permissions (R12-3): on Unix the temp file is `0600` and the rename carries
 /// that mode onto the destination, so the report is owner-only even before
@@ -305,11 +306,27 @@ fn resolve_export_path(out: Option<&str>) -> Result<PathBuf, String> {
 /// default `%USERPROFILE%\Documents` is already user-private via NTFS ACL) but
 /// emit a one-line stderr warning that protection relies on directory perms.
 fn write_html_file(path: &Path, html: &str) -> Result<(), String> {
+    // repo-0374: the export path can be repository-controlled (the documented
+    // `--out .` flow writes ./dashboard.html). Bind its parent once and publish
+    // relative to that retained capability. This refuses both a symlinked final
+    // component and a symlinked intermediate directory without a check/use gap.
+    let root = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let prepared =
+        tirith_core::util::ContainedAtomicFile::prepare(&root, path, true).map_err(|error| {
+            format!(
+                "refusing unsafe dashboard destination {}: {error}",
+                path.display()
+            )
+        })?;
     // Atomic temp+fsync+rename; `overwrite = true` replaces an existing export.
-    // On Unix the 0600 temp mode is preserved by the rename; the helper also
-    // creates any missing parent dirs.
-    crate::cli::write_file_atomic(path, html.as_bytes(), /* overwrite = */ true)
-        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    // On Unix the 0600 temp mode is preserved by the rename.
+    prepared
+        .write_atomic(html.as_bytes(), true)
+        .map_err(|error| format!("write {}: {error}", path.display()))?;
 
     // No Unix file modes here — warn (to stderr, keeping --json/stdout clean)
     // that protection relies on the OS directory permissions.
@@ -1016,6 +1033,33 @@ mod tests {
                 "re-exported report must remain 0600, got {mode:o}"
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_html_file_refuses_symlinked_final_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let victim = outside.path().join("victim.html");
+        std::fs::write(&victim, b"SENTINEL").unwrap();
+        let path = dir.path().join("dashboard.html");
+        std::os::unix::fs::symlink(&victim, &path).unwrap();
+
+        assert!(write_html_file(&path, "<html>attacker</html>").is_err());
+        assert_eq!(std::fs::read(&victim).unwrap(), b"SENTINEL");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_html_file_refuses_symlinked_parent_component() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let link = root.path().join("export");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+        let path = link.join("dashboard.html");
+
+        assert!(write_html_file(&path, "<html>attacker</html>").is_err());
+        assert!(!outside.path().join("dashboard.html").exists());
     }
 
     // Light integration test (invariants B/D/E end-to-end over a real socket).

--- a/crates/tirith/src/cli/diff.rs
+++ b/crates/tirith/src/cli/diff.rs
@@ -93,36 +93,66 @@ pub fn run(url: &str, json: bool) -> i32 {
         }
         println!();
     } else {
-        eprintln!("tirith diff: {url}");
+        // repo-0377: the URL and every parsed component are attacker-controlled;
+        // scrub terminal controls before human rendering (JSON stays raw —
+        // serde escapes it).
+        eprintln!(
+            "tirith diff: {}",
+            super::sanitize_for_human_output(url, false)
+        );
         if let Some(h) = &host {
-            eprintln!("  host:       {h}");
+            eprintln!(
+                "  host:       {}",
+                super::sanitize_for_human_output(h, false)
+            );
         }
         if let Some(rh) = &raw_host {
-            eprintln!("  raw_host:   {rh}");
+            eprintln!(
+                "  raw_host:   {}",
+                super::sanitize_for_human_output(rh, false)
+            );
         }
         if host_divergence {
             eprintln!("  WARNING:    host/raw_host diverge (IDNA normalization applied)");
         }
         if let Some(s) = &scheme {
-            eprintln!("  scheme:     {s}");
+            eprintln!(
+                "  scheme:     {}",
+                super::sanitize_for_human_output(s, false)
+            );
         }
         if let Some(sw) = scheme_warning {
-            eprintln!("  WARNING:    {sw}");
+            eprintln!(
+                "  WARNING:    {}",
+                super::sanitize_for_human_output(sw, false)
+            );
         }
         if let Some(p) = &path {
-            eprintln!("  path:       {p}");
+            eprintln!(
+                "  path:       {}",
+                super::sanitize_for_human_output(p, false)
+            );
         }
         if let Some(port) = port {
             eprintln!("  port:       {port}");
         }
         if let Some(pw) = &port_warning {
-            eprintln!("  WARNING:    {pw}");
+            eprintln!(
+                "  WARNING:    {}",
+                super::sanitize_for_human_output(pw, false)
+            );
         }
         if let Some(ui) = &userinfo {
-            eprintln!("  userinfo:   {ui}");
+            eprintln!(
+                "  userinfo:   {}",
+                super::sanitize_for_human_output(ui, false)
+            );
         }
         if let Some(uw) = userinfo_warning {
-            eprintln!("  WARNING:    {uw}");
+            eprintln!(
+                "  WARNING:    {}",
+                super::sanitize_for_human_output(uw, false)
+            );
         }
         eprintln!("  known_domain: {is_known}");
     }

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -428,37 +428,60 @@ blocklist: []
 ";
 
     if let Some(repo_root) = tirith_core::policy::find_repo_root(None) {
-        let policy_dir = repo_root.join(".tirith");
-        if std::fs::create_dir_all(&policy_dir).is_ok() {
-            let path = policy_dir.join("policy.yaml");
-            if path.exists() {
-                return Err(format!(
-                    "policy already exists at {} — not overwriting",
-                    path.display()
-                ));
-            }
-            return std::fs::write(&path, content)
-                .map(|()| path)
-                .map_err(|e| e.to_string());
+        let path = repo_root.join(".tirith").join("policy.yaml");
+        match create_policy_contained(&repo_root, &path, content) {
+            Ok(()) => return Ok(path),
+            Err(e) => return Err(e),
         }
     }
 
     if let Some(config) = tirith_core::policy::config_dir() {
-        if std::fs::create_dir_all(&config).is_ok() {
-            let path = config.join("policy.yaml");
-            if path.exists() {
-                return Err(format!(
-                    "policy already exists at {} — not overwriting",
-                    path.display()
-                ));
-            }
-            return std::fs::write(&path, content)
-                .map(|()| path)
-                .map_err(|e| e.to_string());
+        let path = config.join("policy.yaml");
+        match create_policy_contained(&config, &path, content) {
+            Ok(()) => return Ok(path),
+            Err(e) => return Err(e),
         }
     }
 
     Err("could not determine a location for policy file".to_string())
+}
+
+/// Publish `content` to `path` (a policy file directly beneath `root` or one
+/// directory down) with create-new, no-follow semantics (repo-0378).
+///
+/// `util::ContainedAtomicFile` binds `path` beneath `root` through retained
+/// directory capabilities: every intermediate component is traversed without
+/// following attacker-controlled symlinks (a planted `.tirith` symlink that
+/// escapes the repo is refused, closing the old `create_dir_all` +
+/// `std::fs::write` follow), a symlinked or non-regular final component is
+/// rejected, and the write is an atomic same-directory temp-then-rename.
+/// `overwrite = false` gives create-new semantics: anything already at `path`
+/// (including a dangling symlink the old `exists()` check could not see) fails
+/// with `AlreadyExists` instead of being clobbered or followed.
+fn create_policy_contained(
+    root: &std::path::Path,
+    path: &std::path::Path,
+    content: &str,
+) -> Result<(), String> {
+    let contained =
+        tirith_core::util::ContainedAtomicFile::prepare(root, path, true).map_err(|e| {
+            format!(
+                "refusing to create {} through a symlinked or escaping path: {e}",
+                path.display()
+            )
+        })?;
+    contained
+        .write_atomic(content.as_bytes(), false)
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                format!(
+                    "policy already exists at {} — not overwriting",
+                    path.display()
+                )
+            } else {
+                format!("failed to write {}: {e}", path.display())
+            }
+        })
 }
 
 /// Findings hidden by the current paranoia level.
@@ -3852,5 +3875,67 @@ mod tests {
             // The entry itself returns success in JSON mode.
             assert_eq!(run_quick(true), 0, "run_quick(json=true) must exit 0");
         });
+    }
+
+    /// repo-0378: the starter policy is created beneath the repo root with
+    /// create-new semantics through the contained writer.
+    #[test]
+    fn create_policy_contained_creates_policy() {
+        let repo = tempfile::tempdir().unwrap();
+        let path = repo.path().join(".tirith").join("policy.yaml");
+        create_policy_contained(repo.path(), &path, "fail_mode: open\n").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "fail_mode: open\n");
+    }
+
+    /// repo-0378: an existing policy is never clobbered — the friendly
+    /// "already exists" error is preserved.
+    #[test]
+    fn create_policy_contained_refuses_to_clobber_existing() {
+        let repo = tempfile::tempdir().unwrap();
+        let dir = repo.path().join(".tirith");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("policy.yaml");
+        std::fs::write(&path, "SENTINEL\n").unwrap();
+
+        let err = create_policy_contained(repo.path(), &path, "fail_mode: open\n").unwrap_err();
+        assert!(err.contains("already exists"), "{err}");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "SENTINEL\n");
+    }
+
+    /// repo-0378: a SYMLINKED `.tirith` directory escaping the repo is refused
+    /// (the old `create_dir_all` + `std::fs::write` followed it and created the
+    /// file OUTSIDE the repo).
+    #[test]
+    fn create_policy_contained_refuses_symlinked_tirith_dir() {
+        let repo = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), repo.path().join(".tirith")).unwrap();
+
+        let path = repo.path().join(".tirith").join("policy.yaml");
+        assert!(create_policy_contained(repo.path(), &path, "fail_mode: open\n").is_err());
+        assert!(
+            !outside.path().join("policy.yaml").exists(),
+            "no file may be created outside the repo"
+        );
+    }
+
+    /// repo-0378: a DANGLING symlink at the final component is invisible to
+    /// `exists()`; the old code followed it and created an external file. The
+    /// contained writer refuses it.
+    #[test]
+    fn create_policy_contained_refuses_dangling_symlink_at_final_component() {
+        let repo = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let victim = outside.path().join("victim.yaml");
+        let dir = repo.path().join(".tirith");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("policy.yaml");
+        std::os::unix::fs::symlink(&victim, &path).unwrap();
+
+        assert!(create_policy_contained(repo.path(), &path, "fail_mode: open\n").is_err());
+        assert!(
+            !victim.exists(),
+            "no external file may be created through the dangling symlink"
+        );
     }
 }

--- a/crates/tirith/src/cli/ecosystem.rs
+++ b/crates/tirith/src/cli/ecosystem.rs
@@ -228,10 +228,11 @@ fn exit_code(action: Action) -> i32 {
     }
 }
 
-/// Whether `(eco, name)` is allowlisted: an exact, case-insensitive match (bare
-/// `react` or qualified `npm:react`) against the global allowlist or a
-/// supply-chain rule-scoped one. Exact (not substring) so a short name can't
-/// silence every longer name containing it.
+/// repo-0380: an exact, case-insensitive match (bare `react` or qualified
+/// `npm:react`) against the GLOBAL allowlist only. Rule-scoped entries are
+/// applied per-finding by the scan engine — folding them into this Boolean
+/// suppressed every finding (including malicious-package intelligence) for the
+/// dependency.
 fn package_allowlisted(policy: &Policy, eco: Ecosystem, name: &str) -> bool {
     let bare = name.to_lowercase();
     let qualified = format!("{eco}:{bare}");
@@ -241,23 +242,7 @@ fn package_allowlisted(policy: &Policy, eco: Ecosystem, name: &str) -> bool {
         e == bare || e == qualified
     };
 
-    if policy.allowlist.iter().any(|e| matches_entry(e)) {
-        return true;
-    }
-    // Rule-scoped allowlist, for the rules `ecosystem scan` emits.
-    for rule in &policy.allowlist_rules {
-        let scoped = matches!(
-            rule.rule_id.to_lowercase().as_str(),
-            "threat_malicious_package"
-                | "threat_package_typosquat"
-                | "threat_package_similar_name"
-                | "threat_suspicious_package"
-        );
-        if scoped && rule.patterns.iter().any(|p| matches_entry(p)) {
-            return true;
-        }
-    }
-    false
+    policy.allowlist.iter().any(|e| matches_entry(e))
 }
 
 /// Emit the full report (a `schema_version`-tagged wrapper over
@@ -415,12 +400,15 @@ fn print_integrity_summary(integrity: &tirith_core::ecosystem_scan::InstalledInt
     for dup in &integrity.duplicate_owned_paths {
         eprintln!(
             "    - path '{}' owned by multiple distributions: {}",
-            dup.path,
-            dup.owners.join(", ")
+            super::sanitize_for_human_output(&dup.path, false),
+            super::sanitize_for_human_output(&dup.owners.join(", "), false)
         );
     }
     for hook in &integrity.unowned_startup_hooks {
-        eprintln!("    - unowned startup hook: {hook}");
+        eprintln!(
+            "    - unowned startup hook: {}",
+            super::sanitize_for_human_output(hook, false)
+        );
     }
     if integrity.native_modules_triaged > 0 {
         eprintln!(
@@ -627,7 +615,9 @@ mod tests {
             }],
             ..Default::default()
         };
-        assert!(package_allowlisted(
+        // repo-0380: a rule-scoped entry must NOT widen the package-wide gate;
+        // per-rule suppression is applied per-finding inside the core scan.
+        assert!(!package_allowlisted(
             &policy,
             Ecosystem::PyPI,
             "python-data-helper"

--- a/crates/tirith/src/cli/env_guard.rs
+++ b/crates/tirith/src/cli/env_guard.rs
@@ -14,7 +14,6 @@
 //! - `_snapshot` (hidden): the shell hook execs this child once per session; it
 //!   reads its OWN environment and stores NAMES + 8-char value-hash prefixes.
 
-use std::io::Write;
 use std::path::PathBuf;
 
 use tirith_core::env_guard::{self, EnvSnapshot};
@@ -130,13 +129,53 @@ fn resolve_policy_path_for_guard() -> Result<PathBuf, i32> {
     Ok(user.join("policy.yaml"))
 }
 
+/// Largest policy file we will read-modify-write for a guard toggle. A policy
+/// YAML is hand-authored and tiny; 1 MiB bounds a hostile or symlinked-to-huge
+/// target so the read cannot be turned into an unbounded slurp.
+const MAX_POLICY_SIZE: u64 = 1024 * 1024;
+
 /// Idempotently append-or-rewrite the `env_guard_enabled` line in a policy YAML,
 /// never touching other lines (mirrors `cli::context::update_policy_guard_key`).
+///
+/// Symlink-hardened (repo-0383, mirrors the F16 pattern in
+/// `cli::exec::update_policy_guard_key`): the policy path is a repo-discovered
+/// `<repo>/.tirith/policy.yaml` (or `<config>/tirith/policy.yaml`), so an
+/// attacker who can plant a symlink there could otherwise redirect this
+/// truncating write onto an arbitrary file. A retained directory capability is
+/// traversed from the trusted grandparent without following repo-controlled
+/// symlinks, then used for both the bounded read and atomic 0600 publication.
+///
+/// The grandparent is the right containment root because the policy path is
+/// always at least three components deep (`<root>/.tirith/policy.yaml`); a
+/// malformed path with no grandparent is rejected rather than written.
 fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    // The containment root is the grandparent: <repo>/.tirith/policy.yaml →
+    // <repo>, <config>/tirith/policy.yaml → <config>. A policy path is always
+    // at least three components deep; refuse a malformed shallower path rather
+    // than guess.
+    let containment_root = path.parent().and_then(|p| p.parent()).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "policy path must be <root>/<dir>/policy.yaml",
+        )
+    })?;
+
+    let contained = tirith_core::util::ContainedAtomicFile::prepare(containment_root, path, true)?;
+
+    // Read the current contents WITHOUT following a symlinked final component.
+    // An absent file is an empty baseline (the key is then appended); any other
+    // read failure (symlinked, oversized, I/O) aborts rather than clobbering
+    // blind.
+    let existing = match contained.read_capped(MAX_POLICY_SIZE) {
+        Ok(bytes) => String::from_utf8(bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "policy file is not UTF-8; refusing to rewrite it",
+            )
+        })?,
+        Err(tirith_core::util::OpenRegularError::NotFound) => String::new(),
+        Err(e) => return Err(open_regular_io_error(e)),
+    };
     let new_line = format!("env_guard_enabled: {enable}");
 
     let mut out = String::new();
@@ -159,15 +198,26 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
         out.push('\n');
     }
 
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
+    contained.write_atomic(out.as_bytes(), true)
+}
+
+/// Map an `OpenRegularError` from the no-follow policy read onto an `io::Error`
+/// so the guard read-modify-write surfaces a single failure type to the caller.
+fn open_regular_io_error(e: tirith_core::util::OpenRegularError) -> std::io::Error {
+    match e {
+        tirith_core::util::OpenRegularError::Io(io) => io,
+        tirith_core::util::OpenRegularError::NotRegularFile => std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "policy path is not a regular file (symlink or special file)",
+        ),
+        tirith_core::util::OpenRegularError::TooLarge => std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "policy file exceeds the size cap",
+        ),
+        tirith_core::util::OpenRegularError::NotFound => {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "policy file not found")
+        }
     }
-    let mut f = opts.open(path)?;
-    f.write_all(out.as_bytes())
 }
 
 /// `tirith env diff [--reset]` — show sensitive vars set/changed since shell
@@ -382,5 +432,63 @@ mod tests {
     #[test]
     fn guard_unknown_action_returns_2() {
         assert_eq!(guard("bogus", false), 2);
+    }
+
+    /// repo-0383: a symlinked containing directory (planted `.tirith`) that
+    /// escapes the repo must abort the update BEFORE any read/write, and the
+    /// external target must stay untouched.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_guard_key_refuses_symlinked_containing_dir() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let repo = root.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::os::unix::fs::symlink(outside.path(), repo.join(".tirith")).unwrap();
+
+        let path = repo.join(".tirith").join("policy.yaml");
+        let err = update_policy_guard_key(&path, true).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied, "{err}");
+        assert!(
+            !outside.path().join("policy.yaml").exists(),
+            "no policy file may be created outside the repo"
+        );
+    }
+
+    /// repo-0383: a symlinked FINAL component must be refused on both the read
+    /// and the write; the link target's bytes must be preserved.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_guard_key_refuses_symlinked_final_component() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let victim = outside.path().join("victim.yaml");
+        std::fs::write(&victim, "SENTINEL: do not truncate\n").unwrap();
+        let dir = root.path().join("repo").join(".tirith");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("policy.yaml");
+        std::os::unix::fs::symlink(&victim, &path).unwrap();
+
+        assert!(update_policy_guard_key(&path, true).is_err());
+        assert_eq!(
+            std::fs::read_to_string(&victim).unwrap(),
+            "SENTINEL: do not truncate\n",
+            "symlink target must not be read-modify-written"
+        );
+    }
+
+    /// repo-0383: a non-regular target (a directory named `policy.yaml`)
+    /// surfaces a read error other than NotFound, so the update must abort
+    /// rather than truncate-through an empty baseline.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_guard_key_aborts_on_non_regular_policy() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("repo").join(".tirith");
+        let path = dir.join("policy.yaml");
+        std::fs::create_dir_all(&path).unwrap();
+
+        assert!(update_policy_guard_key(&path, true).is_err());
+        assert!(path.is_dir(), "the directory must remain, not be replaced");
     }
 }

--- a/crates/tirith/src/cli/exec.rs
+++ b/crates/tirith/src/cli/exec.rs
@@ -4,7 +4,6 @@
 //! the expensive probes (stat, `file --brief`, `codesign`) that NEVER run on the
 //! engine hot path — see [`tirith_core::exec_provenance`].
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use tirith_core::exec_provenance::{self, Provenance};
@@ -120,13 +119,10 @@ const MAX_POLICY_SIZE: u64 = 1024 * 1024;
 /// Symlink-hardened (F16): the policy path is a repo-discovered
 /// `<repo>/.tirith/policy.yaml` (or `<config>/tirith/policy.yaml`), so an attacker
 /// who can plant a symlink there could otherwise redirect this truncating write
-/// onto an arbitrary file. Three layers defend the write:
-///   * `canonical_within` against the GRANDPARENT (`<repo>` / `<config>`)
-///     canonicalizes through the containing `.tirith` directory, so a SYMLINKED
-///     `.tirith` that escapes the repo is rejected before any read or write.
-///   * the read uses `O_NOFOLLOW` + a size cap (refuses a symlinked final
-///     component, bounds a hostile target); and
-///   * the write uses `O_NOFOLLOW` + `0600` (refuses a symlinked final component).
+/// onto an arbitrary file. A retained directory capability traverses from the
+/// trusted grandparent without following repo-controlled symlinks, then owns
+/// both the bounded read and atomic 0600 publication. There is no pathname
+/// re-open between validation and mutation.
 ///
 /// The grandparent is the right containment root because the policy path is always
 /// at least three components deep (`<root>/.tirith/policy.yaml`); passing the
@@ -144,27 +140,18 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
         )
     })?;
 
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    // Containment FIRST: reject a symlinked containing directory (e.g. a planted
-    // `.tirith` symlink) that escapes the trusted root before we read or write
-    // through it. `O_NOFOLLOW` on the final component alone misses this, because
-    // the OS still follows an intermediate-dir symlink during path resolution.
-    // Done after create_dir_all so a legit first-run `.tirith` exists to canonicalize.
-    if !tirith_core::util::canonical_within(path, containment_root) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "refusing to write policy through a symlinked path",
-        ));
-    }
+    let contained = tirith_core::util::ContainedAtomicFile::prepare(containment_root, path, true)?;
 
     // Read the current contents WITHOUT following a symlinked final component. An
     // absent file is an empty baseline (the key is then appended); any other read
     // failure (symlinked, oversized, I/O) aborts rather than clobbering blind.
-    let existing = match tirith_core::util::read_text_no_follow_capped(path, MAX_POLICY_SIZE) {
-        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+    let existing = match contained.read_capped(MAX_POLICY_SIZE) {
+        Ok(bytes) => String::from_utf8(bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "policy file is not UTF-8; refusing to rewrite it",
+            )
+        })?,
         Err(tirith_core::util::OpenRegularError::NotFound) => String::new(),
         Err(e) => return Err(open_regular_io_error(e)),
     };
@@ -173,7 +160,7 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
     let mut out = String::new();
     let mut replaced = false;
     for line in existing.lines() {
-        if line.trim_start().starts_with("exec_guard_enabled:") {
+        if line.starts_with("exec_guard_enabled:") {
             out.push_str(&new_line);
             out.push('\n');
             replaced = true;
@@ -190,9 +177,28 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
         out.push('\n');
     }
 
-    // Truncating write that REFUSES to follow a symlinked final component (0600).
-    let mut f = tirith_core::util::open_write_no_follow(path, true)?;
-    f.write_all(out.as_bytes())
+    verify_guard_key_effective(&out, enable)?;
+    contained.write_atomic(out.as_bytes(), true)
+}
+
+fn verify_guard_key_effective(candidate: &str, expected: bool) -> std::io::Result<()> {
+    let parsed: serde_yaml::Value = serde_yaml::from_str(candidate).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("resulting policy would not parse as YAML: {error}"),
+        )
+    })?;
+    let effective = parsed
+        .get("exec_guard_enabled")
+        .and_then(serde_yaml::Value::as_bool);
+    if effective == Some(expected) {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "resulting policy does not have the requested top-level exec_guard_enabled value",
+        ))
+    }
 }
 
 /// Map an `OpenRegularError` from the no-follow policy read onto an `io::Error`
@@ -483,6 +489,62 @@ mod tests {
         assert!(
             parsed.exec_guard_enabled,
             "exec_guard_enabled must round-trip to the engine-readable Policy"
+        );
+    }
+
+    #[test]
+    fn update_policy_guard_key_ignores_indented_lookalike() {
+        let dir = tempfile::tempdir().unwrap();
+        let tirith_dir = dir.path().join(".tirith");
+        std::fs::create_dir(&tirith_dir).unwrap();
+        let path = tirith_dir.join("policy.yaml");
+        std::fs::write(
+            &path,
+            "custom_rule:\n  exec_guard_enabled: false\n  other: 1\nparanoia: 2\n",
+        )
+        .unwrap();
+
+        update_policy_guard_key(&path, true).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("  exec_guard_enabled: false"),
+            "nested key must be preserved with its indentation: {content}"
+        );
+        assert_eq!(
+            content
+                .lines()
+                .filter(|line| line.starts_with("exec_guard_enabled:"))
+                .count(),
+            1,
+            "exactly one top-level key must be present: {content}"
+        );
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        assert_eq!(
+            parsed
+                .get("exec_guard_enabled")
+                .and_then(serde_yaml::Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn update_policy_guard_key_rejects_unparseable_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let tirith_dir = dir.path().join(".tirith");
+        std::fs::create_dir(&tirith_dir).unwrap();
+        let path = tirith_dir.join("policy.yaml");
+        let original = "a:\n - 1\n  - 2\n  bad: [\n";
+        std::fs::write(&path, original).unwrap();
+
+        let result = update_policy_guard_key(&path, true);
+        assert!(
+            result.is_err(),
+            "invalid YAML baseline must fail: {result:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            original,
+            "validation failure must leave the original policy untouched"
         );
     }
 

--- a/crates/tirith/src/cli/hooks.rs
+++ b/crates/tirith/src/cli/hooks.rs
@@ -12,7 +12,6 @@
 //! - `explain <name>` — show every matching surface's body, CREDENTIAL-REDACTED,
 //!   plus findings.
 
-use std::io::Write;
 use std::path::PathBuf;
 
 use tirith_core::policy::{self as policy_mod, Policy};
@@ -220,13 +219,10 @@ const MAX_POLICY_SIZE: u64 = 1024 * 1024;
 /// Symlink-hardened (F16): the policy path is a repo-discovered
 /// `<repo>/.tirith/policy.yaml` (or `<config>/tirith/policy.yaml`), so an attacker
 /// who can plant a symlink there could otherwise redirect this truncating write
-/// onto an arbitrary file. Three layers defend the write:
-///   * `canonical_within` against the GRANDPARENT (`<repo>` / `<config>`)
-///     canonicalizes through the containing `.tirith` directory, so a SYMLINKED
-///     `.tirith` that escapes the repo is rejected before any read or write.
-///   * the read uses `O_NOFOLLOW` + a size cap (refuses a symlinked final
-///     component, bounds a hostile target); and
-///   * the write uses `O_NOFOLLOW` + `0600` (refuses a symlinked final component).
+/// onto an arbitrary file. A retained directory capability traverses from the
+/// trusted grandparent without following repo-controlled symlinks, then owns
+/// both the bounded read and atomic 0600 publication. There is no pathname
+/// re-open between validation and mutation.
 ///
 /// The grandparent is the right containment root because the policy path is always
 /// at least three components deep (`<root>/.tirith/policy.yaml`); passing the
@@ -244,27 +240,18 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
         )
     })?;
 
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    // Containment FIRST: reject a symlinked containing directory (e.g. a planted
-    // `.tirith` symlink) that escapes the trusted root before we read or write
-    // through it. `O_NOFOLLOW` on the final component alone misses this, because
-    // the OS still follows an intermediate-dir symlink during path resolution.
-    // Done after create_dir_all so a legit first-run `.tirith` exists to canonicalize.
-    if !tirith_core::util::canonical_within(path, containment_root) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "refusing to write policy through a symlinked path",
-        ));
-    }
+    let contained = tirith_core::util::ContainedAtomicFile::prepare(containment_root, path, true)?;
 
     // Read the current contents WITHOUT following a symlinked final component. An
     // absent file is an empty baseline (the key is then appended); any other read
     // failure (symlinked, oversized, I/O) aborts rather than clobbering blind.
-    let existing = match tirith_core::util::read_text_no_follow_capped(path, MAX_POLICY_SIZE) {
-        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+    let existing = match contained.read_capped(MAX_POLICY_SIZE) {
+        Ok(bytes) => String::from_utf8(bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "policy file is not UTF-8; refusing to rewrite it",
+            )
+        })?,
         Err(tirith_core::util::OpenRegularError::NotFound) => String::new(),
         Err(e) => return Err(open_regular_io_error(e)),
     };
@@ -273,7 +260,12 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
     let mut out = String::new();
     let mut replaced = false;
     for line in existing.lines() {
-        if line.trim_start().starts_with("hooks_guard_enabled:") {
+        // Root-mapping keys ONLY: a top-level YAML block-mapping key sits at
+        // column zero. An indented `hooks_guard_enabled:` is a NESTED mapping
+        // entry (an attacker-planted lookalike), not the policy switch —
+        // rewriting it at column zero would corrupt the document and suppress
+        // the real append (repo-0385). Comments are excluded too.
+        if line.starts_with("hooks_guard_enabled:") {
             out.push_str(&new_line);
             out.push('\n');
             replaced = true;
@@ -290,9 +282,38 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
         out.push('\n');
     }
 
-    // Truncating write that REFUSES to follow a symlinked final component (0600).
-    let mut f = tirith_core::util::open_write_no_follow(path, true)?;
-    f.write_all(out.as_bytes())
+    // Verify BEFORE publishing: the candidate must parse as YAML and its
+    // effective top-level `hooks_guard_enabled` must equal the requested
+    // value. Otherwise the operator would be told the guard is ON while
+    // subsequent loads fall back to the fail-closed base policy with the
+    // guard disabled.
+    verify_guard_key_effective(&out, enable)?;
+
+    contained.write_atomic(out.as_bytes(), true)
+}
+
+/// Parse the candidate policy and require the top-level `hooks_guard_enabled`
+/// to equal `expected`. Guards against lookalike-key corruption and against
+/// pre-existing invalid YAML silently defeating the toggle.
+fn verify_guard_key_effective(candidate: &str, expected: bool) -> std::io::Result<()> {
+    // An empty file parses as `Value::Null`; treat it as an empty mapping.
+    let parsed: serde_yaml::Value = serde_yaml::from_str(candidate).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("resulting policy would not parse as YAML: {e}"),
+        )
+    })?;
+    let effective = parsed
+        .get("hooks_guard_enabled")
+        .and_then(serde_yaml::Value::as_bool);
+    if effective == Some(expected) {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "resulting policy does not have the requested top-level hooks_guard_enabled value",
+        ))
+    }
 }
 
 /// Map an `OpenRegularError` from the no-follow policy read onto an `io::Error`
@@ -528,6 +549,56 @@ mod tests {
             1,
             "must not duplicate the key"
         );
+    }
+
+    #[test]
+    fn update_policy_guard_key_ignores_indented_lookalike() {
+        // Regression: repo-0385 — an indented (nested-mapping) lookalike key
+        // must NOT be treated as the root key; the real root key is appended
+        // and the document stays valid YAML with the guard effective.
+        let dir = tempfile::tempdir().unwrap();
+        let tirith_dir = dir.path().join(".tirith");
+        std::fs::create_dir(&tirith_dir).unwrap();
+        let path = tirith_dir.join("policy.yaml");
+        std::fs::write(
+            &path,
+            "custom_rule:\n  hooks_guard_enabled: false\n  other: 1\nparanoia: 2\n",
+        )
+        .unwrap();
+
+        update_policy_guard_key(&path, true).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        // The nested lookalike is preserved untouched...
+        assert!(
+            content.contains("  hooks_guard_enabled: false"),
+            "nested key must be preserved with its indentation: {content}"
+        );
+        // ...and a real top-level key was appended exactly once.
+        let top_level = content
+            .lines()
+            .filter(|l| l.starts_with("hooks_guard_enabled:"))
+            .count();
+        assert_eq!(top_level, 1, "exactly one root key: {content}");
+        // The resulting document parses and the guard is effective.
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        assert_eq!(
+            parsed.get("hooks_guard_enabled").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn update_policy_guard_key_rejects_unparseable_candidate() {
+        // Defense in depth for repo-0385: if the existing file is invalid
+        // YAML, the toggle must fail rather than report a guard state that
+        // policy loading would silently ignore.
+        let dir = tempfile::tempdir().unwrap();
+        let tirith_dir = dir.path().join(".tirith");
+        std::fs::create_dir(&tirith_dir).unwrap();
+        let path = tirith_dir.join("policy.yaml");
+        std::fs::write(&path, "a:\n - 1\n  - 2\n  bad: [\n").unwrap();
+        let res = update_policy_guard_key(&path, true);
+        assert!(res.is_err(), "invalid YAML baseline must fail: {res:?}");
     }
 
     /// F16: a guard toggle whose policy path's FINAL component is a SYMLINK must

--- a/crates/tirith/src/cli/hygiene.rs
+++ b/crates/tirith/src/cli/hygiene.rs
@@ -91,7 +91,10 @@ pub fn fix(dry_run: bool, yes: bool, json: bool) -> i32 {
             if !json {
                 eprintln!(
                     "would chmod {:04o} {}  ({} → {})",
-                    mode, path, f.actual, f.expected
+                    mode,
+                    path,
+                    super::sanitize_for_human_output(&f.actual, false),
+                    super::sanitize_for_human_output(&f.expected, false)
                 );
             }
             continue;
@@ -148,13 +151,30 @@ pub fn fix(dry_run: bool, yes: bool, json: bool) -> i32 {
 
 // ─── chmod application ───────────────────────────────────────────────────────
 
-/// Apply a chmod to `path`. On non-Unix this is a no-op success (perm rules
-/// never fire there, so this branch is unreachable in practice).
+/// Apply a chmod to `path` WITHOUT following a final symlink (repo-0386 /
+/// repo-0284): the target is opened with `O_NOFOLLOW`, the live descriptor is
+/// fstat-verified as a regular file, and the mode change is applied through
+/// that descriptor (`fchmod`). A scanned regular file replaced by a symlink
+/// between scan and fix is refused instead of chmodding an attacker-selected
+/// target outside the repository. A file the operator cannot open for reading
+/// fails loudly (manual fix) rather than being opened through a weaker API.
+/// On non-Unix this is a no-op success (perm rules never fire there, so this
+/// branch is unreachable in practice).
 #[cfg(unix)]
 fn apply_chmod(path: &std::path::Path, mode: u32) -> std::io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let perms = std::fs::Permissions::from_mode(mode);
-    std::fs::set_permissions(path, perms)
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing chmod: not a regular file",
+        ));
+    }
+    file.set_permissions(std::fs::Permissions::from_mode(mode))
 }
 
 #[cfg(not(unix))]
@@ -233,15 +253,19 @@ fn print_human_scan(findings: &[HygieneFinding]) {
             FixKind::Chmod { mode } => format!("auto-fixable (chmod {mode:04o})"),
             FixKind::Manual => "manual fix".to_string(),
         };
+        // repo-0285: every finding field that can carry repository-controlled
+        // filenames or SSH configuration values is attacker-controlled; only
+        // the path column was sanitized previously. Treat `actual`,
+        // `expected`, and `fix_suggestion` as untrusted terminal input too.
         eprintln!(
             "  [{}] {}  ({})\n      path:     {}\n      expected: {}\n      actual:   {}\n      fix:      {}\n      {}\n",
             severity_label(f.severity),
             f.rule_id,
             f.category.as_str(),
             super::sanitize_for_human_output(&f.path.display().to_string(), false),
-            f.expected,
-            f.actual,
-            f.fix_suggestion,
+            super::sanitize_for_human_output(&f.expected, false),
+            super::sanitize_for_human_output(&f.actual, false),
+            super::sanitize_for_human_output(&f.fix_suggestion, false),
             auto,
         );
     }
@@ -276,7 +300,7 @@ fn print_human_fix_summary(dry_run: bool, results: &[FixResult], manual: &[&Hygi
                 "  [{}] {}\n      {}",
                 severity_label(f.severity),
                 super::sanitize_for_human_output(&f.path.display().to_string(), false),
-                f.fix_suggestion
+                super::sanitize_for_human_output(&f.fix_suggestion, false)
             );
         }
     }
@@ -396,6 +420,28 @@ mod tests {
             escaped,
             confirmation_path(collapsed_peer),
             "distinct raw mutation targets must never share a confirmation label"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_chmod_refuses_symlink() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real-env");
+        std::fs::write(&target, b"SECRET=1").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let link = dir.path().join(".env");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert!(
+            apply_chmod(&link, 0o600).is_err(),
+            "a symlinked finding path must be refused, not followed"
+        );
+        assert_eq!(
+            std::fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "the link target's mode must be untouched"
         );
     }
 

--- a/crates/tirith/src/cli/iac.rs
+++ b/crates/tirith/src/cli/iac.rs
@@ -351,13 +351,52 @@ fn resolve_policy_path() -> Result<PathBuf, i32> {
     Ok(user.join("policy.yaml"))
 }
 
+/// Largest policy file we will read-modify-write for a policy-key toggle. A
+/// policy YAML is hand-authored and tiny; 1 MiB bounds a hostile or
+/// symlinked-to-huge target so the read cannot be turned into an unbounded
+/// slurp.
+const MAX_POLICY_SIZE: u64 = 1024 * 1024;
+
 /// Idempotent append-or-rewrite of a single policy key. Mirrors the
 /// helper used by `cli::ssh` / `cli::context` for `context_guard_enabled`.
+///
+/// Symlink-hardened (repo-0387, mirrors the F16 pattern in
+/// `cli::exec::update_policy_guard_key`): the policy path is a repo-discovered
+/// `<repo>/.tirith/policy.yaml` (or `<config>/tirith/policy.yaml`), so an
+/// attacker who can plant a symlink there could otherwise redirect this
+/// truncating write onto an arbitrary file. A retained directory capability is
+/// traversed from the trusted grandparent without following repo-controlled
+/// symlinks, then used for both the bounded read and atomic 0600 publication.
+/// Any read error other than genuine absence aborts rather than becoming an
+/// empty baseline.
 fn update_policy_key(path: &Path, key: &str, value: &str) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    // The containment root is the grandparent: <repo>/.tirith/policy.yaml →
+    // <repo>, <config>/tirith/policy.yaml → <config>. A policy path is always
+    // at least three components deep; refuse a malformed shallower path rather
+    // than guess.
+    let containment_root = path.parent().and_then(|p| p.parent()).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "policy path must be <root>/<dir>/policy.yaml",
+        )
+    })?;
+
+    let contained = tirith_core::util::ContainedAtomicFile::prepare(containment_root, path, true)?;
+
+    // Read the current contents WITHOUT following a symlinked final component.
+    // An absent file is an empty baseline (the key is then appended); any other
+    // read failure (symlinked, oversized, I/O) aborts rather than clobbering
+    // blind.
+    let existing = match contained.read_capped(MAX_POLICY_SIZE) {
+        Ok(bytes) => String::from_utf8(bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "policy file is not UTF-8; refusing to rewrite it",
+            )
+        })?,
+        Err(tirith_core::util::OpenRegularError::NotFound) => String::new(),
+        Err(e) => return Err(open_regular_io_error(e)),
+    };
     let new_line = format!("{key}: {value}");
 
     let prefix = format!("{key}:");
@@ -383,16 +422,27 @@ fn update_policy_key(path: &Path, key: &str, value: &str) -> std::io::Result<()>
         out.push('\n');
     }
 
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
+    contained.write_atomic(out.as_bytes(), true)
+}
+
+/// Map an `OpenRegularError` from the no-follow policy read onto an `io::Error`
+/// so the policy-key read-modify-write surfaces a single failure type to the
+/// caller.
+fn open_regular_io_error(e: tirith_core::util::OpenRegularError) -> std::io::Error {
+    match e {
+        tirith_core::util::OpenRegularError::Io(io) => io,
+        tirith_core::util::OpenRegularError::NotRegularFile => std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "policy path is not a regular file (symlink or special file)",
+        ),
+        tirith_core::util::OpenRegularError::TooLarge => std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "policy file exceeds the size cap",
+        ),
+        tirith_core::util::OpenRegularError::NotFound => {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "policy file not found")
+        }
     }
-    let mut f = opts.open(path)?;
-    use std::io::Write as _;
-    f.write_all(out.as_bytes())
 }
 
 #[cfg(test)]
@@ -439,5 +489,64 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("context_guard_enabled: false"));
         assert!(content.contains("iac_require_plan_before_apply: true"));
+    }
+
+    /// repo-0387: a symlinked containing directory (planted `.tirith`) that
+    /// escapes the repo must abort the update BEFORE any read/write, and the
+    /// external target must stay untouched.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_key_refuses_symlinked_containing_dir() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let repo = root.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::os::unix::fs::symlink(outside.path(), repo.join(".tirith")).unwrap();
+
+        let path = repo.join(".tirith").join("policy.yaml");
+        let err = update_policy_key(&path, "iac_require_plan_before_apply", "true").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied, "{err}");
+        assert!(
+            !outside.path().join("policy.yaml").exists(),
+            "no policy file may be created outside the repo"
+        );
+    }
+
+    /// repo-0387: a symlinked FINAL component must be refused; the link
+    /// target's bytes must be preserved (the old code truncated it blind via
+    /// `unwrap_or_default` + a following write).
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_key_refuses_symlinked_final_component() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let victim = outside.path().join("victim.yaml");
+        std::fs::write(&victim, "SENTINEL: do not truncate\n").unwrap();
+        let dir = root.path().join("repo").join(".tirith");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("policy.yaml");
+        std::os::unix::fs::symlink(&victim, &path).unwrap();
+
+        assert!(update_policy_key(&path, "iac_require_plan_before_apply", "true").is_err());
+        assert_eq!(
+            std::fs::read_to_string(&victim).unwrap(),
+            "SENTINEL: do not truncate\n",
+            "symlink target must not be read-modify-written"
+        );
+    }
+
+    /// repo-0387: a read error other than genuine absence (here: the policy
+    /// path is a directory) must abort the update, not fall back to an empty
+    /// baseline that then truncates the target.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_key_aborts_on_non_regular_policy() {
+        let root = tempdir().unwrap();
+        let dir = root.path().join("repo").join(".tirith");
+        let path = dir.join("policy.yaml");
+        std::fs::create_dir_all(&path).unwrap();
+
+        assert!(update_policy_key(&path, "iac_require_plan_before_apply", "true").is_err());
+        assert!(path.is_dir(), "the directory must remain, not be replaced");
     }
 }

--- a/crates/tirith/src/cli/incident.rs
+++ b/crates/tirith/src/cli/incident.rs
@@ -16,7 +16,6 @@
 //! `report` copies the audit log's already-redacted `command_redacted` preview
 //! verbatim and NEVER reconstructs a full command.
 
-use std::io::Write as _;
 use std::path::PathBuf;
 
 use tirith_core::incident::{self, IncidentState, StartError};
@@ -56,13 +55,18 @@ pub fn start(reason: Option<String>, json: bool) -> i32 {
             println!("Incident mode ACTIVE.");
             println!();
             println!("  started_at: {}", state.started_at_display());
-            println!("  started_by: {}", state.started_by);
+            // repo-0287: `started_by`/`reason` are operator/env-controlled and
+            // stored verbatim for JSON; every HUMAN sink sanitizes them.
+            println!(
+                "  started_by: {}",
+                super::sanitize_for_human_output(&state.started_by, false)
+            );
             println!(
                 "  reason:     {}",
                 if state.reason.is_empty() {
-                    "<none>"
+                    "<none>".to_string()
                 } else {
-                    &state.reason
+                    super::sanitize_for_human_output(&state.reason, false)
                 }
             );
             println!();
@@ -106,9 +110,9 @@ pub fn start(reason: Option<String>, json: bool) -> i32 {
                 "tirith incident start: an incident is already active since {} (reason: {}).",
                 existing.started_at_display(),
                 if existing.reason.is_empty() {
-                    "<none>"
+                    "<none>".to_string()
                 } else {
-                    &existing.reason
+                    super::sanitize_for_human_output(&existing.reason, false)
                 }
             );
             eprintln!("Run `tirith incident stop` to end it before starting a new one.");
@@ -292,13 +296,16 @@ pub fn status(json: bool) -> i32 {
         Some(s) => {
             println!("Incident status: ACTIVE");
             println!("  started_at: {}", s.started_at_display());
-            println!("  started_by: {}", s.started_by);
+            println!(
+                "  started_by: {}",
+                super::sanitize_for_human_output(&s.started_by, false)
+            );
             println!(
                 "  reason:     {}",
                 if s.reason.is_empty() {
-                    "<none>"
+                    "<none>".to_string()
                 } else {
-                    &s.reason
+                    super::sanitize_for_human_output(&s.reason, false)
                 }
             );
             println!("  flag:       {flag}");
@@ -391,33 +398,25 @@ pub fn report(out: Option<PathBuf>, json: bool) -> i32 {
 /// Write the report to `path` with `0o600` perms on Unix (it may contain
 /// repo-internal hostnames / paths even after redaction).
 fn write_report_file(path: &std::path::Path, body: &str) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
-        }
-    }
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
-    }
-    let mut f = opts
-        .open(path)
-        .map_err(|e| format!("open {}: {e}", path.display()))?;
-    // `mode(0o600)` only applies on CREATE; a pre-existing `--out` file keeps its
-    // old (possibly world-readable) mode. Re-assert 0600 BEFORE writing the body
-    // and PROPAGATE the error (CodeRabbit R11 #7) so a chmod failure aborts the
-    // write — sensitive repo-internal paths/hostnames are never left readable.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        f.set_permissions(std::fs::Permissions::from_mode(0o600))
-            .map_err(|e| format!("chmod 0600 {}: {e}", path.display()))?;
-    }
-    f.write_all(body.as_bytes())
+    // repo-0388: never open the operator-selected destination with a
+    // path-based create+truncate — a repository can pre-plant the expected
+    // report path as a symlink to another operator-writable file. Confine the
+    // write beneath the destination's own directory through a retained
+    // no-follow parent capability (refusing a symlinked final component AND
+    // any symlinked intermediate directory) and publish atomically: the
+    // report is born mode-0600 in a same-directory temporary file and renamed
+    // over the destination only after the live entry is revalidated. A
+    // pre-existing loose mode is replaced by the rename, so the 0600
+    // confidentiality guarantee holds for overwrites too.
+    let root = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let prepared = tirith_core::util::ContainedAtomicFile::prepare(&root, path, true)
+        .map_err(|e| format!("refusing unsafe report destination {}: {e}", path.display()))?;
+    prepared
+        .write_atomic(body.as_bytes(), true)
         .map_err(|e| format!("write {}: {e}", path.display()))
 }
 
@@ -427,14 +426,17 @@ const REPORT_TOP_FINDINGS: usize = 25;
 const REPORT_TIMELINE_ROWS: usize = 50;
 
 /// Escape a single-line value for safe inline embedding in the Markdown report.
-/// Neutralizes two hazards: STRUCTURE — CR/LF collapse to a space so a
-/// multi-line value (e.g. a `--reason` with a newline) can't break its list item
-/// or inject a `#` heading (the load-bearing fix); RENDERING — inline
-/// Markdown-significant chars (`` ` `` `*` `_` `[` `]` `<` `>` `\` `#` `|`) are
-/// backslash-escaped.
+/// Neutralizes three hazards (repo-0287): TERMINAL — the central display
+/// sanitizer strips C0/C1 controls, ESC/OSC sequences, and deceptive Unicode
+/// so a value rendered from the report later cannot forge output or move the
+/// clipboard; STRUCTURE — CR/LF collapse to a space so a multi-line value
+/// (e.g. a `--reason` with a newline) can't break its list item or inject a
+/// `#` heading; RENDERING — inline Markdown-significant chars (`` ` `` `*`
+/// `_` `[` `]` `<` `>` `\` `#` `|`) are backslash-escaped.
 fn md_inline_escape(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for ch in value.chars() {
+    let sanitized = tirith_core::mcp::output_filter::sanitize_for_display(value);
+    let mut out = String::with_capacity(sanitized.len());
+    for ch in sanitized.chars() {
         match ch {
             // Collapse line breaks to a space (a `\r\n` → two spaces, harmless).
             '\n' | '\r' => out.push(' '),

--- a/crates/tirith/src/cli/intent.rs
+++ b/crates/tirith/src/cli/intent.rs
@@ -51,6 +51,13 @@ pub fn run(intent: &str, command: &str, explain: bool, json: bool) -> i32 {
 }
 
 fn print_human(intent: &str, command: &str, report: &IntentBehaviorReport, explain: bool) {
+    // Untrusted display values: the intent sentence and analyzed command are
+    // attacker-controllable (newlines, ANSI/OSC, bidi, zero-width). Scrub them
+    // through the shared single-line human-output sanitizer before printing so
+    // they cannot forge an OK/MISMATCH row, repaint the terminal, or reach the
+    // clipboard via OSC 52.
+    let intent = super::sanitize_for_human_output(intent, false);
+    let command = super::sanitize_for_human_output(command, false);
     if report.has_mismatch() {
         println!(
             "tirith intend: MISMATCH — the command does more than the stated intent justifies"
@@ -206,5 +213,24 @@ mod tests {
             true,
         );
         assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn human_output_sanitizes_control_sequences() {
+        // Regression: repo-0390 — attacker-controlled intent/command text must
+        // not reach the terminal with ANSI/OSC, bidi, zero-width, or newline
+        // content intact on the human path.
+        let evil_intent = "ok\n\u{1b}]52;c;SGFja2Vk\u{7}\u{202e}\u{200b}";
+        let evil_cmd = "ls\r\n\u{1b}[31mrm -rf /\u{1b}[0m";
+        // Must not panic and must still exit per mismatch semantics.
+        let code = run(evil_intent, evil_cmd, false, false);
+        assert!(code == 0 || code == 1);
+        let sanitized_i = super::super::sanitize_for_human_output(evil_intent, false);
+        let sanitized_c = super::super::sanitize_for_human_output(evil_cmd, false);
+        for s in [sanitized_i, sanitized_c] {
+            assert!(!s.contains('\u{1b}'), "ESC must be stripped: {s:?}");
+            assert!(!s.contains('\n') && !s.contains('\r'));
+            assert!(!s.contains('\u{202e}') && !s.contains('\u{200b}'));
+        }
     }
 }

--- a/crates/tirith/src/cli/last_trigger.rs
+++ b/crates/tirith/src/cli/last_trigger.rs
@@ -68,9 +68,14 @@ pub fn write_last_trigger(
         let redacted_findings =
             tirith_core::redact::redacted_findings(&verdict.findings, custom_patterns);
 
+        // repo-0391: the persisted record is later printed verbatim by
+        // `tirith why` / `tirith trust last`. Redaction removes secrets but
+        // not terminal controls / deceptive Unicode, so scrub every stored
+        // string before it reaches disk — the store must not become a
+        // deferred terminal-injection channel.
         let findings = match redacted_findings
             .iter()
-            .map(serde_json::to_value)
+            .map(|f| serde_json::to_value(f).map(sanitize_stored_json))
             .collect::<Result<Vec<_>, _>>()
         {
             Ok(findings) => findings,
@@ -136,11 +141,36 @@ pub fn write_last_trigger(
 
 fn redact_command(cmd: &str, custom_patterns: &[String]) -> String {
     let scrubbed = tirith_core::redact::redact_command_text(cmd, custom_patterns);
+    let scrubbed = tirith_core::mcp::output_filter::sanitize_for_display(&scrubbed);
     let prefix = truncate_bytes(&scrubbed, 80);
     if prefix.len() == scrubbed.len() {
         scrubbed
     } else {
         format!("{prefix}...")
+    }
+}
+
+/// Recursively strip terminal-control/deceptive content from every string in
+/// a stored JSON value (repo-0391).
+fn sanitize_stored_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(s) => {
+            serde_json::Value::String(tirith_core::mcp::output_filter::sanitize_for_display(&s))
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(sanitize_stored_json).collect())
+        }
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.into_iter()
+                .map(|(k, v)| {
+                    (
+                        tirith_core::mcp::output_filter::sanitize_for_display(&k),
+                        sanitize_stored_json(v),
+                    )
+                })
+                .collect(),
+        ),
+        other => other,
     }
 }
 

--- a/crates/tirith/src/cli/logs.rs
+++ b/crates/tirith/src/cli/logs.rs
@@ -616,7 +616,12 @@ pub fn summarize(path: &Path, safe_for_agent: bool, max_lines: usize, json: bool
     };
 
     if safe_for_agent {
-        let redactor = StreamingLogRedactor::new(ShareAudience::Llm, &customer_patterns, true);
+        // repo-0394: the flag promises hostname redaction; the `Llm` preset is
+        // secrets-only and deliberately keeps `.corp`/`.internal`/`.local`
+        // names. `PublicPaste` is the preset that actually strips internal
+        // hostnames (plus home paths and RFC1918 addresses).
+        let redactor =
+            StreamingLogRedactor::new(ShareAudience::PublicPaste, &customer_patterns, true);
         let result = read_redacted_records(&mut reader, redactor, |record| {
             secret_count += record.total_redactions();
             escape_count += record.escape_count;

--- a/crates/tirith/src/cli/mcp.rs
+++ b/crates/tirith/src/cli/mcp.rs
@@ -1043,19 +1043,23 @@ pub(crate) fn policy_init_for_root(repo_root: &Path, json: bool, force: bool) ->
     // Both forms (human YAML, JSON preview) derive from this same shape.
     let scaffold = build_policy_scaffold(lockfile_opt.as_ref());
 
-    if let Some(parent) = example_path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            report_error_for(
-                json,
-                "tirith mcp policy init",
-                &format!("failed to create {}: {e}", parent.display()),
-            );
-            return 1;
-        }
-    }
-
     let yaml_body = render_policy_scaffold_yaml(&scaffold);
-    if let Err(e) = std::fs::write(&example_path, &yaml_body) {
+    // repo-0395: the scaffold lives under the repo's `.tirith/`, which a
+    // malicious checkout can make a symlink. Write through the contained,
+    // no-follow atomic helper so the write can never land outside the repo.
+    let destination =
+        match tirith_core::util::ContainedAtomicFile::prepare(repo_root, &example_path, true) {
+            Ok(destination) => destination,
+            Err(e) => {
+                report_error_for(
+                    json,
+                    "tirith mcp policy init",
+                    &format!("failed to prepare {}: {e}", example_path.display()),
+                );
+                return 1;
+            }
+        };
+    if let Err(e) = destination.write_atomic(yaml_body.as_bytes(), force) {
         report_error_for(
             json,
             "tirith mcp policy init",

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -587,14 +587,20 @@ pub fn suggest_closest<'a>(
         .map(|(c, _)| c)
 }
 
-/// Prompt for confirmation. `true` only if `--yes`, or stderr is a TTY and the
-/// user types y/yes. `false` in non-interactive contexts without `--yes`, so
-/// destructive operations are never silently approved.
+/// Prompt for confirmation. `true` only if `--yes`, or BOTH stdin and stderr
+/// are TTYs and the user types y/yes. `false` in non-interactive contexts
+/// without `--yes`, so destructive operations are never silently approved.
+///
+/// repo-0398: checking only the prompt stream (stderr) lets a piped stdin
+/// (`yes | tirith <destructive>`) answer the prompt — stderr is still the
+/// user's terminal, but the "human" typing `y` is attacker-controlled input.
+/// Requiring stdin to be a terminal too, as onboard's `is_tty_pair` already
+/// does, closes that approval bypass.
 pub fn confirm(prompt: &str, yes: bool) -> bool {
     if yes {
         return true;
     }
-    if !is_terminal::is_terminal(std::io::stderr()) {
+    if !is_terminal::is_terminal(std::io::stderr()) || !is_terminal::is_terminal(std::io::stdin()) {
         eprintln!("tirith: skipping prompt (not a TTY — use --yes to auto-approve)");
         return false;
     }

--- a/crates/tirith/src/cli/paste.rs
+++ b/crates/tirith/src/cli/paste.rs
@@ -54,13 +54,37 @@ pub fn run(
         is_terminal::is_terminal(std::io::stderr())
     };
 
-    let clipboard_html = html_path.and_then(|path| match std::fs::read_to_string(path) {
-        Ok(html) => Some(html),
-        Err(e) => {
-            eprintln!("tirith: warning: failed to read clipboard HTML from '{path}': {e}");
-            None
+    let clipboard_html = match html_path {
+        Some(path) => {
+            // repo-0402: bounded read — the HTML sidecar was previously slurped
+            // with no cap while the paste input itself is limited to 1 MiB.
+            // repo-0401: an explicitly requested analyzer that cannot run must
+            // FAIL CLOSED (exit non-zero), never silently degrade to plain
+            // text — an unreadable/invalid sidecar means the hidden-content
+            // analysis did not happen.
+            match tirith_core::util::read_text_no_follow_capped(
+                std::path::Path::new(path),
+                MAX_PASTE,
+            ) {
+                Ok(bytes) => match String::from_utf8(bytes) {
+                    Ok(html) => Some(html),
+                    Err(_) => {
+                        eprintln!(
+                            "tirith: clipboard HTML '{path}' is not valid UTF-8; refusing to skip rich-text analysis"
+                        );
+                        return 2;
+                    }
+                },
+                Err(e) => {
+                    eprintln!(
+                        "tirith: cannot read clipboard HTML '{path}' safely ({e:?}); refusing to skip rich-text analysis"
+                    );
+                    return 2;
+                }
+            }
         }
-    });
+        None => None,
+    };
 
     // M12 ch1 G1 TOCTOU fix: only `--with-source` reads `clipboard_source.json`, and
     // exactly ONCE — the same record feeds both the engine (paste_source_mismatch) and

--- a/crates/tirith/src/cli/path.rs
+++ b/crates/tirith/src/cli/path.rs
@@ -219,15 +219,21 @@ fn print_human_audit(report: &PathAuditReport) {
     for e in &report.findings {
         match e.risk {
             PathDirRisk::DuplicateCommand => {
+                // repo-0404: command names and PATH entries are filesystem-derived
+                // and can carry terminal controls — sanitize before rendering.
                 eprintln!(
                     "  [{}] {} (shadowed copy in {})",
                     risk_label(e.risk),
-                    e.command,
-                    e.dir
+                    super::sanitize_for_human_output(&e.command, false),
+                    super::sanitize_for_human_output(&e.dir, false)
                 );
             }
             _ => {
-                eprintln!("  [{}] {}", risk_label(e.risk), e.dir);
+                eprintln!(
+                    "  [{}] {}",
+                    risk_label(e.risk),
+                    super::sanitize_for_human_output(&e.dir, false)
+                );
             }
         }
     }
@@ -235,11 +241,12 @@ fn print_human_audit(report: &PathAuditReport) {
 }
 
 fn print_human_which(cmd: &str, hits: &[std::path::PathBuf], secure: bool, insecure: bool) {
+    let cmd_display = super::sanitize_for_human_output(cmd, false);
     if hits.is_empty() {
-        eprintln!("tirith path which: `{cmd}` not found on $PATH.");
+        eprintln!("tirith path which: `{cmd_display}` not found on $PATH.");
         return;
     }
-    eprintln!("tirith path which `{cmd}`:");
+    eprintln!("tirith path which `{cmd_display}`:");
     for (i, h) in hits.iter().enumerate() {
         let sys = if path_audit::is_system_path(h) {
             " [system]"
@@ -247,16 +254,19 @@ fn print_human_which(cmd: &str, hits: &[std::path::PathBuf], secure: bool, insec
             ""
         };
         let marker = if i == 0 { "→" } else { " " };
-        eprintln!("  {marker} {}{sys}", h.display());
+        eprintln!(
+            "  {marker} {}{sys}",
+            super::sanitize_for_human_output(&h.display().to_string(), false)
+        );
     }
     if secure {
         if insecure {
             eprintln!(
-                "\n--secure: FAIL — `{cmd}` resolves to a non-system binary ({}).",
-                hits[0].display()
+                "\n--secure: FAIL — `{cmd_display}` resolves to a non-system binary ({}).",
+                super::sanitize_for_human_output(&hits[0].display().to_string(), false)
             );
         } else {
-            eprintln!("\n--secure: ok — `{cmd}` resolves to a system binary.");
+            eprintln!("\n--secure: ok — `{cmd_display}` resolves to a system binary.");
         }
     }
 }

--- a/crates/tirith/src/cli/pending.rs
+++ b/crates/tirith/src/cli/pending.rs
@@ -51,7 +51,12 @@ pub fn list(format_json: bool) -> i32 {
         println!("{}", "-".repeat(90));
         for e in &entries {
             let source = format!("{:?}", e.source).to_lowercase();
-            let command = e.command_redacted.chars().take(32).collect::<String>();
+            // repo-0405: the persisted preview is attacker-derived — redaction
+            // strips secrets, not ANSI/OSC/bidi/newlines. Sanitize before print.
+            let command = super::sanitize_for_human_output(
+                &e.command_redacted.chars().take(32).collect::<String>(),
+                false,
+            );
             println!(
                 "{:<10} {:<26} {:<11} {:<9} {}",
                 e.id, e.created_at, source, e.severity, command
@@ -156,10 +161,15 @@ pub fn export(output: Option<PathBuf>) -> i32 {
                     return 2;
                 }
             };
-            // Write atomically (temp + fsync + rename) so a crash/ENOSPC mid-write
-            // cannot leave a half-written export at `path`; a reader sees either the
-            // old file or the complete new one. `overwrite = true`: export replaces.
-            match super::write_file_atomic(&path, json.as_bytes(), true) {
+            // repo-0406: retain the destination's parent capability from secure
+            // traversal through publication. A final or intermediate symlink
+            // cannot redirect the export, including one swapped after binding.
+            let root = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| std::path::PathBuf::from("."));
+            match super::write_file_atomic_contained(&root, &path, json.as_bytes(), true) {
                 Ok(()) => {
                     println!(
                         "Wrote {} pending decision(s) to {}",

--- a/crates/tirith/src/cli/preview.rs
+++ b/crates/tirith/src/cli/preview.rs
@@ -81,7 +81,13 @@ fn print_human(
         Action::Block => "tirith preview: HIGH-IMPACT — do not run without review",
     };
     println!("{banner}");
-    println!("  command: {command}");
+    // repo-0410: the command and any filesystem-derived path are untrusted —
+    // scrub terminal controls before printing (findings below are sanitized
+    // the same way).
+    println!(
+        "  command: {}",
+        super::sanitize_for_human_output(command, false)
+    );
     println!();
 
     let suffix = if report.walk_truncated { "+" } else { "" };
@@ -89,7 +95,11 @@ fn print_human(
     println!("  dirs:     {}{suffix}", report.dir_count);
     println!("  symlinks: {}", report.symlink_count);
     if let Some((path, size)) = &report.largest_file {
-        println!("  largest:  {path} ({})", human_size(*size));
+        println!(
+            "  largest:  {} ({})",
+            super::sanitize_for_human_output(path, false),
+            human_size(*size)
+        );
     }
     if report.glob_expansion_count > 0 {
         println!(

--- a/crates/tirith/src/cli/pypi_integrity.rs
+++ b/crates/tirith/src/cli/pypi_integrity.rs
@@ -210,16 +210,30 @@ fn fetch_provenance_at(url: &str) -> Result<String, FetchError> {
         )));
     }
 
-    // Cap the body: a provenance document is small.
-    let bytes = resp
-        .bytes()
+    // Cap the body BEFORE buffering (repo-0413): reject an excessive
+    // Content-Length up front, then stream the decoded body through a reader
+    // limited to `MAX_PROVENANCE_BYTES + 1` and abort the moment the cap is
+    // crossed — `Response::bytes()` would buffer the complete (possibly
+    // highly-expanded decompressed) response before any check ran.
+    if let Some(len) = resp.content_length() {
+        if len > MAX_PROVENANCE_BYTES as u64 {
+            return Err(FetchError::Transport(format!(
+                "provenance response exceeds the {MAX_PROVENANCE_BYTES}-byte cap"
+            )));
+        }
+    }
+    use std::io::Read as _;
+    let mut limited = resp.take(MAX_PROVENANCE_BYTES as u64 + 1);
+    let mut bytes = Vec::new();
+    limited
+        .read_to_end(&mut bytes)
         .map_err(|e| FetchError::Transport(e.to_string()))?;
     if bytes.len() > MAX_PROVENANCE_BYTES {
         return Err(FetchError::Transport(format!(
             "provenance response exceeds the {MAX_PROVENANCE_BYTES}-byte cap"
         )));
     }
-    String::from_utf8(bytes.to_vec())
+    String::from_utf8(bytes)
         .map_err(|_| FetchError::Transport("provenance response is not valid UTF-8".to_string()))
 }
 
@@ -490,7 +504,14 @@ fn render(
         let _ = serde_json::to_writer_pretty(std::io::stdout().lock(), &out);
         println!();
     } else {
-        eprintln!("tirith pkg attest: {project} {version}");
+        // repo-0414: project/version come from the attacker-controlled wheel
+        // filename; remote identity/reason fields are registry-controlled.
+        // Sanitize everything before the terminal (JSON stays raw).
+        eprintln!(
+            "tirith pkg attest: {} {}",
+            super::sanitize_for_human_output(project, false),
+            super::sanitize_for_human_output(version, false)
+        );
         eprintln!("  artifact sha256: {artifact_sha256}");
         eprintln!("  attestation:     {}", outcome.label());
         match outcome {
@@ -499,11 +520,17 @@ fn render(
                 render_identity(identity);
             }
             AttestationOutcome::Missing { reason } => {
-                eprintln!("  no attestation: {reason}");
+                eprintln!(
+                    "  no attestation: {}",
+                    super::sanitize_for_human_output(reason, false)
+                );
                 eprintln!("  (absence of provenance is not a block; the firewall verdict is over the bytes)");
             }
             AttestationOutcome::Invalid { reason } => {
-                eprintln!("  attestation invalid: {reason}");
+                eprintln!(
+                    "  attestation invalid: {}",
+                    super::sanitize_for_human_output(reason, false)
+                );
             }
             AttestationOutcome::SubjectMismatch {
                 attested_sha256,
@@ -516,11 +543,17 @@ fn render(
                 eprintln!("    artifact: {artifact_sha256}");
             }
             AttestationOutcome::PublisherNotAllowed { identity, reason } => {
-                eprintln!("  publisher not allowed: {reason}");
+                eprintln!(
+                    "  publisher not allowed: {}",
+                    super::sanitize_for_human_output(reason, false)
+                );
                 render_identity(identity);
             }
             AttestationOutcome::VerificationUnavailable { reason } => {
-                eprintln!("  verification unavailable: {reason}");
+                eprintln!(
+                    "  verification unavailable: {}",
+                    super::sanitize_for_human_output(reason, false)
+                );
             }
         }
     }
@@ -530,13 +563,22 @@ fn render(
 /// summary.
 fn render_identity(identity: &PublisherIdentity) {
     if let Some(repo) = &identity.repository {
-        eprintln!("    repository: {repo}");
+        eprintln!(
+            "    repository: {}",
+            super::sanitize_for_human_output(repo, false)
+        );
     }
     if let Some(wf) = &identity.workflow {
-        eprintln!("    workflow:   {wf}");
+        eprintln!(
+            "    workflow:   {}",
+            super::sanitize_for_human_output(wf, false)
+        );
     }
     if let Some(sid) = &identity.signer_identity {
-        eprintln!("    signer:     {sid}");
+        eprintln!(
+            "    signer:     {}",
+            super::sanitize_for_human_output(sid, false)
+        );
     }
 }
 

--- a/crates/tirith/src/cli/receipt.rs
+++ b/crates/tirith/src/cli/receipt.rs
@@ -5,7 +5,11 @@ pub fn last(json: bool) -> i32 {
         Ok(receipts) => {
             if let Some(r) = receipts.first() {
                 if json {
-                    if serde_json::to_writer_pretty(std::io::stdout().lock(), r).is_err() {
+                    // Public DTO: credential-bearing URL userinfo is redacted
+                    // and local-machine metadata (cwd) omitted (repo-0415).
+                    if serde_json::to_writer_pretty(std::io::stdout().lock(), &r.public_view())
+                        .is_err()
+                    {
                         eprintln!("tirith: failed to write JSON output");
                         return 1;
                     }
@@ -30,7 +34,8 @@ pub fn list(json: bool) -> i32 {
     match Receipt::list() {
         Ok(receipts) => {
             if json {
-                if serde_json::to_writer_pretty(std::io::stdout().lock(), &receipts).is_err() {
+                let public: Vec<_> = receipts.iter().map(|r| r.public_view()).collect();
+                if serde_json::to_writer_pretty(std::io::stdout().lock(), &public).is_err() {
                     eprintln!("tirith: failed to write JSON output");
                     return 1;
                 }
@@ -42,7 +47,7 @@ pub fn list(json: bool) -> i32 {
                     eprintln!(
                         "  {} {} ({} bytes) {}",
                         tirith_core::receipt::short_hash(&r.sha256),
-                        r.url,
+                        super::sanitize_for_human_output(&r.url, false),
                         r.size,
                         r.timestamp
                     );
@@ -106,16 +111,31 @@ pub fn verify(sha256: &str, json: bool) -> i32 {
 
 fn print_receipt(r: &Receipt) {
     eprintln!("tirith: receipt");
-    eprintln!("  url:       {}", r.url);
+    eprintln!(
+        "  url:       {}",
+        super::sanitize_for_human_output(&r.url, false)
+    );
     if let Some(ref fu) = r.final_url {
-        eprintln!("  final_url: {fu}");
+        eprintln!(
+            "  final_url: {}",
+            super::sanitize_for_human_output(fu, false)
+        );
     }
     eprintln!("  sha256:    {}", r.sha256);
     eprintln!("  size:      {} bytes", r.size);
-    eprintln!("  analyzed:  {}", r.analysis_method);
-    eprintln!("  privilege: {}", r.privilege);
+    eprintln!(
+        "  analyzed:  {}",
+        super::sanitize_for_human_output(&r.analysis_method, false)
+    );
+    eprintln!(
+        "  privilege: {}",
+        super::sanitize_for_human_output(&r.privilege, false)
+    );
     eprintln!("  when:      {}", r.timestamp);
     if !r.domains_referenced.is_empty() {
-        eprintln!("  domains:   {}", r.domains_referenced.join(", "));
+        eprintln!(
+            "  domains:   {}",
+            super::sanitize_for_human_output(&r.domains_referenced.join(", "), false)
+        );
     }
 }

--- a/crates/tirith/src/cli/rule.rs
+++ b/crates/tirith/src/cli/rule.rs
@@ -346,15 +346,25 @@ pub fn validate(path: Option<&str>, json: bool) -> i32 {
     }
 
     if errors.is_empty() {
-        eprintln!("tirith rule validate: {source} — {total} custom rule(s), all valid");
+        eprintln!(
+            "tirith rule validate: {} — {total} custom rule(s), all valid",
+            super::sanitize_for_human_output(&source, false)
+        );
         0
     } else {
         eprintln!(
-            "tirith rule validate: {source} — {} error(s) in {total} custom rule(s):",
+            "tirith rule validate: {} — {} error(s) in {total} custom rule(s):",
+            super::sanitize_for_human_output(&source, false),
             errors.len()
         );
         for e in &errors {
-            eprintln!("  custom_rules.{}: {}", e.rule, e.message);
+            // repo-0417: rule ids and messages are policy-derived (attacker-
+            // controlled in a repo-scoped policy) — sanitize before rendering.
+            eprintln!(
+                "  custom_rules.{}: {}",
+                super::sanitize_for_human_output(&e.rule, false),
+                super::sanitize_for_human_output(&e.message, false)
+            );
         }
         eprintln!();
         eprintln!("(for whole-policy-file checks, run `tirith policy validate`)");
@@ -439,10 +449,22 @@ fn explain_policy(policy: &Policy, rule_id: &str, json: bool) -> i32 {
         return 0;
     }
 
-    println!("Custom rule: {}", rule.id);
-    println!("  title:    {}", rule.title);
+    // repo-0417: every policy-derived value is attacker-controlled for a
+    // repo-scoped policy — identifiers/titles single-line, the description
+    // re-indented multiline, so injected newlines cannot forge top-level rows.
+    println!(
+        "Custom rule: {}",
+        super::sanitize_for_human_output(&rule.id, false)
+    );
+    println!(
+        "  title:    {}",
+        super::sanitize_for_human_output(&rule.title, false)
+    );
     if !rule.description.is_empty() {
-        println!("  detail:   {}", rule.description);
+        println!(
+            "  detail:   {}",
+            super::sanitize_for_human_output(&rule.description, true)
+        );
     }
     println!("  severity: {}", rule.severity);
     match rule.action {
@@ -456,11 +478,14 @@ fn explain_policy(policy: &Policy, rule_id: &str, json: bool) -> i32 {
             action_name(effective)
         ),
     }
-    println!("  context:  {}", runtime_contexts.join(", "));
+    println!(
+        "  context:  {}",
+        super::sanitize_for_human_output(&runtime_contexts.join(", "), false)
+    );
     println!();
     if let Some(pattern) = &rule.pattern {
         println!("  matcher:  regex");
-        println!("    {pattern}");
+        println!("    {}", super::sanitize_for_human_output(pattern, false));
     } else if let Some(when) = &rule.when {
         println!("  matcher:  when-clause (semantic predicates)");
         print_clause(when, 2);
@@ -696,7 +721,12 @@ fn print_clause(clause: &WhenClause, indent: usize) {
             println!("{pad}not:");
             print_clause(c, indent + 1);
         }
-        leaf => println!("{pad}{}", leaf_to_line(leaf)),
+        // Predicate values come from the (possibly repo-controlled) policy —
+        // sanitize the rendered line (repo-0417).
+        leaf => println!(
+            "{pad}{}",
+            super::sanitize_for_human_output(&leaf_to_line(leaf), false)
+        ),
     }
 }
 

--- a/crates/tirith/src/cli/run.rs
+++ b/crates/tirith/src/cli/run.rs
@@ -58,7 +58,7 @@ pub fn run(
             if json {
                 #[derive(serde::Serialize)]
                 struct RunOutput<'a> {
-                    receipt: &'a tirith_core::receipt::Receipt,
+                    receipt: tirith_core::receipt::PublicReceipt,
                     verdict: Option<&'a tirith_core::verdict::Verdict>,
                     analysis_complete: bool,
                     refused: bool,
@@ -66,7 +66,11 @@ pub fn run(
                     exit_code: Option<i32>,
                 }
                 let out = RunOutput {
-                    receipt: &result.receipt,
+                    // Public DTO: the stored receipt's URL userinfo is redacted
+                    // and local-machine metadata (cwd) omitted, so a
+                    // credential-bearing Git remote cannot reach logs or agent
+                    // context through this JSON (repo-0420).
+                    receipt: result.receipt.public_view(),
                     verdict: result.verdict.as_ref(),
                     analysis_complete: result.analysis_complete,
                     refused: result.refused,

--- a/crates/tirith/src/cli/score.rs
+++ b/crates/tirith/src/cli/score.rs
@@ -78,11 +78,17 @@ fn print_human(
     explain: bool,
 ) {
     if verdict.findings.is_empty() {
-        eprintln!("tirith: {url} — no issues found (score: 0/100)");
+        // repo-0423: the inspected URL is untrusted — sanitize before rendering.
+        eprintln!(
+            "tirith: {} — no issues found (score: 0/100)",
+            super::sanitize_for_human_output(url, false)
+        );
     } else {
         eprintln!(
-            "tirith: {url} — risk score: {}/100 ({})",
-            breakdown.score, breakdown.risk_level
+            "tirith: {} — risk score: {}/100 ({})",
+            super::sanitize_for_human_output(url, false),
+            breakdown.score,
+            breakdown.risk_level
         );
         if output::write_human_auto(verdict, false).is_err() {
             eprintln!("tirith: failed to write output");
@@ -119,9 +125,14 @@ fn write_breakdown_human(
         writeln!(
             w,
             "    {sign}{:<4} {}  (running total: {running})",
-            factor.points, factor.label
+            factor.points,
+            super::sanitize_for_human_output(&factor.label, false)
         )?;
-        writeln!(w, "           {}", factor.detail)?;
+        writeln!(
+            w,
+            "           {}",
+            super::sanitize_for_human_output(&factor.detail, true)
+        )?;
     }
     writeln!(
         w,

--- a/crates/tirith/src/cli/secret.rs
+++ b/crates/tirith/src/cli/secret.rs
@@ -82,7 +82,12 @@ pub fn triage(json: bool, verbose: bool) -> i32 {
     for item in &items {
         println!("  - {}", item.next_step());
         if verbose {
-            println!("      redacted: {}", item.redacted);
+            // repo-0424: DLP redaction removes credential VALUES but not
+            // terminal-control sequences the attacker embedded alongside them.
+            println!(
+                "      redacted: {}",
+                super::sanitize_for_human_output(&item.redacted, false)
+            );
             if let Some(p) = item.provider {
                 println!("      docs:     {}", p.doc_url);
                 println!("      verified: {}", p.last_verified);

--- a/crates/tirith/src/cli/setup/merge.rs
+++ b/crates/tirith/src/cli/setup/merge.rs
@@ -115,6 +115,16 @@ pub fn merge_hooks_json(
         } else {
             json!({"hooks": {}})
         };
+        // repo-0429: when the consumer REQUIRES `version: 1` (Cursor), an
+        // existing project-controlled hooks.json without it must not be
+        // silently extended — Cursor would ignore the whole document and the
+        // hook would never run. Fail loudly instead of reporting success.
+        if require_version && config.get("version") != Some(&json!(1)) {
+            return Err(format!(
+                "tirith: {} exists without a `\"version\": 1` field; Cursor requires it, so no hook was added — fix or remove the file and re-run setup",
+                path.display()
+            ));
+        }
         let hooks = config
             .as_object_mut()
             .ok_or_else(|| format!("{} is not a JSON object", path.display()))?

--- a/crates/tirith/src/cli/ssh.rs
+++ b/crates/tirith/src/cli/ssh.rs
@@ -141,13 +141,51 @@ fn resolve_policy_path_for_guard() -> Result<PathBuf, i32> {
     Ok(user.join("policy.yaml"))
 }
 
+/// Largest policy file we will read-modify-write for a guard toggle. A policy
+/// YAML is hand-authored and tiny; 1 MiB bounds a hostile or symlinked-to-huge
+/// target so the read cannot be turned into an unbounded slurp.
+const MAX_POLICY_SIZE: u64 = 1024 * 1024;
+
 /// Idempotently set the `context_guard_enabled` line (append-or-rewrite, never
 /// touching other lines).
+///
+/// Symlink-hardened (repo-0435, mirrors the F16 pattern in
+/// `cli::exec::update_policy_guard_key`): the policy path is a repo-discovered
+/// `<repo>/.tirith/policy.yaml` (or `<config>/tirith/policy.yaml`), so an
+/// attacker who can plant a symlink there could otherwise redirect this
+/// truncating write onto an arbitrary file. A retained directory capability is
+/// traversed from the trusted grandparent without following repo-controlled
+/// symlinks, then used for both the bounded read and atomic 0600 publication.
+/// Any read error other than genuine absence aborts rather than becoming an
+/// empty baseline.
 fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    // The containment root is the grandparent: <repo>/.tirith/policy.yaml →
+    // <repo>, <config>/tirith/policy.yaml → <config>. A policy path is always
+    // at least three components deep; refuse a malformed shallower path rather
+    // than guess.
+    let containment_root = path.parent().and_then(|p| p.parent()).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "policy path must be <root>/<dir>/policy.yaml",
+        )
+    })?;
+
+    let contained = tirith_core::util::ContainedAtomicFile::prepare(containment_root, path, true)?;
+
+    // Read the current contents WITHOUT following a symlinked final component.
+    // An absent file is an empty baseline (the key is then appended); any other
+    // read failure (symlinked, oversized, I/O) aborts rather than clobbering
+    // blind.
+    let existing = match contained.read_capped(MAX_POLICY_SIZE) {
+        Ok(bytes) => String::from_utf8(bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "policy file is not UTF-8; refusing to rewrite it",
+            )
+        })?,
+        Err(tirith_core::util::OpenRegularError::NotFound) => String::new(),
+        Err(e) => return Err(open_regular_io_error(e)),
+    };
     let new_line = format!("context_guard_enabled: {enable}");
 
     let mut out = String::new();
@@ -171,16 +209,26 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
         out.push('\n');
     }
 
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
+    contained.write_atomic(out.as_bytes(), true)
+}
+
+/// Map an `OpenRegularError` from the no-follow policy read onto an `io::Error`
+/// so the guard read-modify-write surfaces a single failure type to the caller.
+fn open_regular_io_error(e: tirith_core::util::OpenRegularError) -> std::io::Error {
+    match e {
+        tirith_core::util::OpenRegularError::Io(io) => io,
+        tirith_core::util::OpenRegularError::NotRegularFile => std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "policy path is not a regular file (symlink or special file)",
+        ),
+        tirith_core::util::OpenRegularError::TooLarge => std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "policy file exceeds the size cap",
+        ),
+        tirith_core::util::OpenRegularError::NotFound => {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "policy file not found")
+        }
     }
-    let mut f = opts.open(path)?;
-    use std::io::Write as _;
-    f.write_all(out.as_bytes())
 }
 
 // ─── label ─────────────────────────────────────────────────────────────────
@@ -486,5 +534,63 @@ mod tests {
             reattach_user(Some("root"), "alice@host.example.com"),
             "alice@host.example.com"
         );
+    }
+
+    /// repo-0435: a symlinked containing directory (planted `.tirith`) that
+    /// escapes the repo must abort the update BEFORE any read/write, and the
+    /// external target must stay untouched.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_guard_key_refuses_symlinked_containing_dir() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let repo = root.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::os::unix::fs::symlink(outside.path(), repo.join(".tirith")).unwrap();
+
+        let path = repo.join(".tirith").join("policy.yaml");
+        let err = update_policy_guard_key(&path, true).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied, "{err}");
+        assert!(
+            !outside.path().join("policy.yaml").exists(),
+            "no policy file may be created outside the repo"
+        );
+    }
+
+    /// repo-0435: a symlinked FINAL component must be refused on both the read
+    /// and the write; the link target's bytes must be preserved.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_guard_key_refuses_symlinked_final_component() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let victim = outside.path().join("victim.yaml");
+        std::fs::write(&victim, "SENTINEL: do not truncate\n").unwrap();
+        let dir = root.path().join("repo").join(".tirith");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("policy.yaml");
+        std::os::unix::fs::symlink(&victim, &path).unwrap();
+
+        assert!(update_policy_guard_key(&path, true).is_err());
+        assert_eq!(
+            std::fs::read_to_string(&victim).unwrap(),
+            "SENTINEL: do not truncate\n",
+            "symlink target must not be read-modify-written"
+        );
+    }
+
+    /// repo-0435: a read error other than genuine absence (here: the policy
+    /// path is a directory) must abort the update, not convert to an empty
+    /// baseline that then truncates the target.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_guard_key_aborts_on_non_regular_policy() {
+        let root = tempdir().unwrap();
+        let dir = root.path().join("repo").join(".tirith");
+        let path = dir.join("policy.yaml");
+        std::fs::create_dir_all(&path).unwrap();
+
+        assert!(update_policy_guard_key(&path, true).is_err());
+        assert!(path.is_dir(), "the directory must remain, not be replaced");
     }
 }

--- a/crates/tirith/src/cli/sudo.rs
+++ b/crates/tirith/src/cli/sudo.rs
@@ -279,13 +279,52 @@ fn resolve_policy_path() -> Result<PathBuf, i32> {
     Ok(user.join("policy.yaml"))
 }
 
+/// Largest policy file we will read-modify-write for a policy-key toggle. A
+/// policy YAML is hand-authored and tiny; 1 MiB bounds a hostile or
+/// symlinked-to-huge target so the read cannot be turned into an unbounded
+/// slurp.
+const MAX_POLICY_SIZE: u64 = 1024 * 1024;
+
 /// Idempotent append-or-rewrite of a single policy key. Mirrors the
 /// helper used by `cli::ssh` / `cli::context` / `cli::iac`.
+///
+/// Symlink-hardened (repo-0437, mirrors the F16 pattern in
+/// `cli::exec::update_policy_guard_key`): the policy path is a repo-discovered
+/// `<repo>/.tirith/policy.yaml` (or `<config>/tirith/policy.yaml`), so an
+/// attacker who can plant a symlink there could otherwise redirect this
+/// truncating write onto an arbitrary file. A retained directory capability is
+/// traversed from the trusted grandparent without following repo-controlled
+/// symlinks, then used for both the bounded read and atomic 0600 publication.
+/// Any read error other than genuine absence aborts rather than becoming an
+/// empty baseline.
 fn update_policy_key(path: &Path, key: &str, value: &str) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let existing = std::fs::read_to_string(path).unwrap_or_default();
+    // The containment root is the grandparent: <repo>/.tirith/policy.yaml →
+    // <repo>, <config>/tirith/policy.yaml → <config>. A policy path is always
+    // at least three components deep; refuse a malformed shallower path rather
+    // than guess.
+    let containment_root = path.parent().and_then(|p| p.parent()).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "policy path must be <root>/<dir>/policy.yaml",
+        )
+    })?;
+
+    let contained = tirith_core::util::ContainedAtomicFile::prepare(containment_root, path, true)?;
+
+    // Read the current contents WITHOUT following a symlinked final component.
+    // An absent file is an empty baseline (the key is then appended); any other
+    // read failure (symlinked, oversized, I/O) aborts rather than clobbering
+    // blind.
+    let existing = match contained.read_capped(MAX_POLICY_SIZE) {
+        Ok(bytes) => String::from_utf8(bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "policy file is not UTF-8; refusing to rewrite it",
+            )
+        })?,
+        Err(tirith_core::util::OpenRegularError::NotFound) => String::new(),
+        Err(e) => return Err(open_regular_io_error(e)),
+    };
     let new_line = format!("{key}: {value}");
 
     let prefix = format!("{key}:");
@@ -311,16 +350,27 @@ fn update_policy_key(path: &Path, key: &str, value: &str) -> std::io::Result<()>
         out.push('\n');
     }
 
-    let mut opts = std::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
+    contained.write_atomic(out.as_bytes(), true)
+}
+
+/// Map an `OpenRegularError` from the no-follow policy read onto an `io::Error`
+/// so the policy-key read-modify-write surfaces a single failure type to the
+/// caller.
+fn open_regular_io_error(e: tirith_core::util::OpenRegularError) -> std::io::Error {
+    match e {
+        tirith_core::util::OpenRegularError::Io(io) => io,
+        tirith_core::util::OpenRegularError::NotRegularFile => std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "policy path is not a regular file (symlink or special file)",
+        ),
+        tirith_core::util::OpenRegularError::TooLarge => std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "policy file exceeds the size cap",
+        ),
+        tirith_core::util::OpenRegularError::NotFound => {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "policy file not found")
+        }
     }
-    let mut f = opts.open(path)?;
-    use std::io::Write as _;
-    f.write_all(out.as_bytes())
 }
 
 #[cfg(test)]
@@ -366,5 +416,64 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("context_guard_enabled: false"));
         assert!(content.contains("sudo_require_reason: true"));
+    }
+
+    /// repo-0437: a symlinked containing directory (planted `.tirith`) that
+    /// escapes the repo must abort the update BEFORE any read/write, and the
+    /// external target must stay untouched.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_key_refuses_symlinked_containing_dir() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let repo = root.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::os::unix::fs::symlink(outside.path(), repo.join(".tirith")).unwrap();
+
+        let path = repo.join(".tirith").join("policy.yaml");
+        let err = update_policy_key(&path, "sudo_require_reason", "true").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied, "{err}");
+        assert!(
+            !outside.path().join("policy.yaml").exists(),
+            "no policy file may be created outside the repo"
+        );
+    }
+
+    /// repo-0437: a symlinked FINAL component must be refused; the link
+    /// target's bytes must be preserved (the old code truncated it blind via
+    /// `unwrap_or_default` + a following write).
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_key_refuses_symlinked_final_component() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let victim = outside.path().join("victim.yaml");
+        std::fs::write(&victim, "SENTINEL: do not truncate\n").unwrap();
+        let dir = root.path().join("repo").join(".tirith");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("policy.yaml");
+        std::os::unix::fs::symlink(&victim, &path).unwrap();
+
+        assert!(update_policy_key(&path, "sudo_require_reason", "true").is_err());
+        assert_eq!(
+            std::fs::read_to_string(&victim).unwrap(),
+            "SENTINEL: do not truncate\n",
+            "symlink target must not be read-modify-written"
+        );
+    }
+
+    /// repo-0437: a non-regular target is rejected by fstat of the OPEN handle
+    /// (identity, not a re-checkable path); the update aborts rather than
+    /// truncating through an empty baseline.
+    #[cfg(unix)]
+    #[test]
+    fn update_policy_key_aborts_on_non_regular_policy() {
+        let root = tempdir().unwrap();
+        let dir = root.path().join("repo").join(".tirith");
+        let path = dir.join("policy.yaml");
+        std::fs::create_dir_all(&path).unwrap();
+
+        assert!(update_policy_key(&path, "sudo_require_reason", "true").is_err());
+        assert!(path.is_dir(), "the directory must remain, not be replaced");
     }
 }

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -705,39 +705,61 @@ fn update_supplemental_db(policy: &policy::Policy) -> Result<(), String> {
 
     let mut supplemental = SupplementalEntries::default();
     let mut attempted_feeds = 0usize;
+    let mut failed_feeds: Vec<&str> = Vec::new();
 
     if let Some(auth_key) = policy.threat_intel.abusech_auth_key.as_deref() {
         if !auth_key.trim().is_empty() {
             attempted_feeds += 1;
-            log_feed_result(
+            if !log_feed_result(
                 "URLhaus",
                 fetch_urlhaus_feed(&client, auth_key.trim(), &mut supplemental),
-            );
+            ) {
+                failed_feeds.push("URLhaus");
+            }
             attempted_feeds += 1;
-            log_feed_result(
+            if !log_feed_result(
                 "ThreatFox",
                 fetch_threatfox_feed(&client, auth_key.trim(), &mut supplemental),
-            );
+            ) {
+                failed_feeds.push("ThreatFox");
+            }
         }
     }
 
     if policy.threat_intel.phishing_army_enabled {
         attempted_feeds += 1;
-        log_feed_result(
+        if !log_feed_result(
             "Phishing Army",
             fetch_phishing_army_feed(&client, &mut supplemental),
-        );
+        ) {
+            failed_feeds.push("Phishing Army");
+        }
         attempted_feeds += 1;
-        log_feed_result(
+        if !log_feed_result(
             "PhishTank",
             fetch_phishtank_feed(&client, &mut supplemental),
-        );
+        ) {
+            failed_feeds.push("PhishTank");
+        }
     }
 
     // At least one group is enabled here (fully-disabled returned early), so Tor
     // exit is always included as a supplemental IP signal.
     attempted_feeds += 1;
-    log_feed_result("Tor exit", fetch_tor_exit_feed(&client, &mut supplemental));
+    if !log_feed_result("Tor exit", fetch_tor_exit_feed(&client, &mut supplemental)) {
+        failed_feeds.push("Tor exit");
+    }
+
+    // repo-0441: a PARTIAL outage must never replace the last-known-good
+    // supplemental DB — the old code rebuilt from only the successful feeds,
+    // silently dropping every indicator of the failed source.
+    if !failed_feeds.is_empty() {
+        eprintln!(
+            "tirith: warning: supplemental feed(s) failed ({}); keeping the existing supplemental threat DB unchanged",
+            failed_feeds.join(", ")
+        );
+        return Ok(());
+    }
 
     if supplemental.is_empty() {
         eprintln!(
@@ -771,11 +793,20 @@ fn update_supplemental_db(policy: &policy::Policy) -> Result<(), String> {
     Ok(())
 }
 
-fn log_feed_result(feed_name: &str, result: Result<usize, String>) {
+/// Log a feed outcome; `true` when the feed genuinely produced entries.
+/// repo-0441: an EMPTY successful response is treated as a failure for
+/// publication purposes — a wiped/zero-answer upstream must not shrink the DB.
+fn log_feed_result(feed_name: &str, result: Result<usize, String>) -> bool {
     match result {
-        Ok(0) => eprintln!("tirith: warning: {feed_name} feed returned no entries"),
-        Ok(_) => {}
-        Err(e) => eprintln!("tirith: warning: {feed_name} feed failed: {e}"),
+        Ok(0) => {
+            eprintln!("tirith: warning: {feed_name} feed returned no entries");
+            false
+        }
+        Ok(_) => true,
+        Err(e) => {
+            eprintln!("tirith: warning: {feed_name} feed failed: {e}");
+            false
+        }
     }
 }
 
@@ -857,7 +888,20 @@ fn fetch_bytes(client: &reqwest::blocking::Client, url: &str) -> Result<Vec<u8>,
         )
         .send()
         .and_then(|resp| resp.error_for_status())
-        .map_err(|e| format!("fetch failed for {safe}: {e}"))?;
+        // repo-0439: a reqwest error's Display embeds the FULL request URL —
+        // including `?auth-key=` credentials. Map to a coarse, URL-free reason.
+        .map_err(|e| {
+            let reason = if e.is_timeout() {
+                "timed out"
+            } else if e.is_connect() {
+                "connection failed"
+            } else if e.is_status() {
+                "unexpected HTTP status"
+            } else {
+                "request failed"
+            };
+            format!("fetch failed for {safe}: {reason}")
+        })?;
 
     let content_length = response.content_length();
     read_bounded_bytes(response, &safe, content_length, MAX_SUPPLEMENTAL_FEED_SIZE)
@@ -1381,12 +1425,11 @@ fn fetch_manifest_from_with_state_and_client(
                 "manifest too large: {content_len} bytes (max {MAX_MANIFEST_SIZE})"
             ));
         }
-        let body = resp
-            .text()
-            .map_err(|e| format!("failed to read manifest body: {e}"))?;
-        if body.len() as u64 > MAX_MANIFEST_SIZE {
-            return Err(format!("manifest body too large: {} bytes", body.len()));
-        }
+        // repo-0440: bound DURING the read — a chunked/no-length response
+        // bypasses the Content-Length precheck.
+        let body_bytes = read_bounded_bytes(resp, "manifest", None, MAX_MANIFEST_SIZE)?;
+        let body = String::from_utf8(body_bytes)
+            .map_err(|e| format!("manifest body is not valid UTF-8: {e}"))?;
         Some(body)
     } else {
         None
@@ -1453,15 +1496,10 @@ fn fetch_manifest_from_with_state_and_client(
                 .get("etag")
                 .and_then(|v| v.to_str().ok())
                 .map(|s| s.to_string());
-            let retry_body = retry_resp
-                .text()
-                .map_err(|e| format!("failed to read retry body: {e}"))?;
-            if retry_body.len() as u64 > MAX_MANIFEST_SIZE {
-                return Err(format!(
-                    "manifest body too large on retry: {} bytes",
-                    retry_body.len()
-                ));
-            }
+            let retry_body_bytes =
+                read_bounded_bytes(retry_resp, "manifest-retry", None, MAX_MANIFEST_SIZE)?;
+            let retry_body = String::from_utf8(retry_body_bytes)
+                .map_err(|e| format!("retry body is not valid UTF-8: {e}"))?;
             let manifest = serde_json::from_str::<Manifest>(&retry_body)
                 .map_err(|e| format!("invalid manifest JSON on retry: {e}"))?;
             persist_cache_files(&etag_path, retry_etag.as_deref(), &body_path, &retry_body);
@@ -1529,15 +1567,9 @@ fn download_url(url: &str, declared_size: u64) -> Result<Vec<u8>, String> {
         return Err(format!("DB download HTTP {}", resp.status()));
     }
 
-    let bytes = resp
-        .bytes()
-        .map_err(|e| format!("failed to read DB body: {e}"))?;
+    let bytes = read_bounded_bytes(resp, "threatdb", None, MAX_DB_SIZE)?;
 
-    if bytes.len() as u64 > MAX_DB_SIZE {
-        return Err(format!("DB body too large: {} bytes", bytes.len()));
-    }
-
-    Ok(bytes.to_vec())
+    Ok(bytes)
 }
 
 /// Fetch and authenticate the signed v2 index, trying the primary raw URL and
@@ -1625,12 +1657,9 @@ fn fetch_index_v2_from(url: &str) -> Result<IndexV2, String> {
             "v2 index too large: {content_len} bytes (max {MAX_MANIFEST_SIZE})"
         ));
     }
-    let body = resp
-        .text()
-        .map_err(|e| format!("failed to read v2 index body: {e}"))?;
-    if body.len() as u64 > MAX_MANIFEST_SIZE {
-        return Err(format!("v2 index body too large: {} bytes", body.len()));
-    }
+    let body_bytes = read_bounded_bytes(resp, "v2-index", None, MAX_MANIFEST_SIZE)?;
+    let body = String::from_utf8(body_bytes)
+        .map_err(|e| format!("v2 index body is not valid UTF-8: {e}"))?;
     serde_json::from_str::<IndexV2>(&body).map_err(|e| format!("invalid v2 index JSON: {e}"))
 }
 

--- a/crates/tirith/src/cli/yaml.rs
+++ b/crates/tirith/src/cli/yaml.rs
@@ -19,6 +19,42 @@
 /// bytes (`< 0x20`, `0x7f` DEL) are checked separately in [`safe_scalar`].
 pub(crate) const YAML_NEEDS_QUOTING_BYTES: &[u8] = b":#-?,[]{}&*!|>'\"%@` \t";
 
+/// repo-0442: Unicode code points that must never appear verbatim in a YAML
+/// scalar or comment: C1 controls (U+0085 NEL terminates a YAML line, U+009B
+/// CSI reaches the terminal), line/paragraph separators, bidi controls,
+/// zero-width and BOM characters. Byte-level checks (`< 0x20`, DEL) miss all
+/// of these because they are multi-byte UTF-8.
+fn is_risky_unicode(ch: char) -> bool {
+    ch.is_control()
+        || matches!(
+            ch,
+            '\u{2028}' | '\u{2029}'
+                | '\u{202A}'..='\u{202E}'
+                | '\u{2066}'..='\u{2069}'
+                | '\u{200B}'..='\u{200D}'
+                | '\u{FEFF}'
+        )
+}
+
+/// Escape every [`is_risky_unicode`] character left literal in an already
+/// quoted/escaped string as YAML's fixed-width `\uXXXX` form. Every risky
+/// code point above is in the BMP, so `\UXXXXXXXX` is unnecessary. In a
+/// Debug-rendered comment the same spelling stays inert ASCII.
+fn escape_risky_unicode(s: &str) -> String {
+    if !s.chars().any(is_risky_unicode) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if is_risky_unicode(ch) {
+            out.push_str(&format!("\\u{:04X}", ch as u32));
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
 /// Render a scalar (server / tool / matcher name) for a YAML document. Returns
 /// the input unmodified when safe as a bare scalar; otherwise quotes and
 /// JSON-escapes it.
@@ -36,7 +72,8 @@ pub(crate) fn safe_scalar(s: &str) -> String {
     // checked separately so a future indicator change can't drop the guards.
     let needs_quoting = s
         .bytes()
-        .any(|b| YAML_NEEDS_QUOTING_BYTES.contains(&b) || b < 0x20 || b == 0x7f);
+        .any(|b| YAML_NEEDS_QUOTING_BYTES.contains(&b) || b < 0x20 || b == 0x7f)
+        || s.chars().any(is_risky_unicode);
     if !needs_quoting {
         return s.to_string();
     }
@@ -45,7 +82,7 @@ pub(crate) fn safe_scalar(s: &str) -> String {
     // a literal DEL in a quoted scalar; replace with``
     // (pinned by `yaml_safe_scalar_round_trips_del` in `cli/mcp.rs`).
     serde_json::to_string(s)
-        .map(|json| json.replace('\u{7f}', "\\u007F"))
+        .map(|json| escape_risky_unicode(&json.replace('\u{7f}', "\\u007F")))
         .unwrap_or_else(|_| format!("\"{}\"", s.escape_debug()))
 }
 
@@ -54,8 +91,10 @@ pub(crate) fn safe_scalar(s: &str) -> String {
 /// (printable bytes only).
 pub(crate) fn safe_inline_comment(s: &str) -> String {
     // No control bytes → as-is; otherwise debug-escape.
-    if s.bytes().any(|b| b < 0x20 || b == 0x7f) {
-        format!("{s:?}")
+    if s.bytes().any(|b| b < 0x20 || b == 0x7f) || s.chars().any(is_risky_unicode) {
+        // Debug-escape handles C0/DEL; the Unicode pass catches what it leaves
+        // literal (C1, U+2028/2029, bidi, zero-width).
+        escape_risky_unicode(&format!("{s:?}"))
     } else {
         s.to_string()
     }
@@ -64,6 +103,37 @@ pub(crate) fn safe_inline_comment(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn risky_unicode_is_escaped_in_scalars_and_comments() {
+        // repo-0442: C1 NEL/CSI, line separators, bidi and zero-width must
+        // never survive verbatim into a YAML scaffold.
+        for ch in [
+            '\u{85}', '\u{9b}', '\u{2028}', '\u{2029}', '\u{202E}', '\u{200B}', '\u{FEFF}',
+        ] {
+            let raw = format!("server{ch}name");
+            let scalar = safe_scalar(&raw);
+            assert!(
+                scalar.starts_with('"'),
+                "{raw:?} must be quoted: {scalar:?}"
+            );
+            assert!(!scalar.contains(ch), "{raw:?} leaked verbatim: {scalar:?}");
+            assert_eq!(
+                serde_yaml::from_str::<String>(&scalar)
+                    .expect("escaped scalar must stay valid YAML"),
+                raw,
+                "escaped scalar must round-trip through the YAML parser"
+            );
+            let comment = safe_inline_comment(&raw);
+            assert!(
+                !comment.contains(ch),
+                "{raw:?} leaked into comment: {comment:?}"
+            );
+        }
+        // A bare safe name is unchanged (note: '-' is a YAML indicator byte
+        // and intentionally forces quoting, so use a bare-alphanumeric name).
+        assert_eq!(safe_scalar("plainserver"), "plainserver");
+    }
 
     // Full round-trip behavior is pinned by the call-site modules (`cli/mcp.rs`,
     // `cli/agent.rs`); these are a load-bearing smoke subset.

--- a/tools/license-server/src/db.rs
+++ b/tools/license-server/src/db.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 
 use crate::error::AppError;
 
@@ -91,6 +91,22 @@ CREATE INDEX IF NOT EXISTS idx_sub_customer ON subscriptions(customer_id);
 CREATE INDEX IF NOT EXISTS idx_tokens_sub ON tokens(subscription_id);
 CREATE INDEX IF NOT EXISTS idx_api_keys_sub ON api_keys(subscription_id);
 "#;
+
+/// repo-0445: `last_event_at` participates in SQLite `MAX()` over TEXT, which
+/// only matches chronological order when every value shares one fixed-width
+/// UTC encoding. Normalize RFC3339 inputs (any offset/fraction) to
+/// `...T..:..:.. .mmmZ`; unparseable values pass through unchanged (the stale
+/// guards treat them conservatively).
+fn normalize_event_ts(raw: Option<&str>) -> Option<String> {
+    raw.map(|value| {
+        chrono::DateTime::parse_from_rfc3339(value)
+            .map(|ts| {
+                ts.to_utc()
+                    .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+            })
+            .unwrap_or_else(|_| value.to_string())
+    })
+}
 
 impl Db {
     pub fn open(path: &str) -> Result<Self, AppError> {
@@ -195,7 +211,7 @@ impl Db {
                     data.email,
                     data.tier,
                     data.product_id,
-                    data.occurred_at,
+                    normalize_event_ts(data.occurred_at.as_deref()),
                 ],
             )
             .map_err(|e| AppError::Internal(format!("db upsert sub: {e}")))?;
@@ -356,7 +372,7 @@ impl Db {
                     data.email.as_deref().unwrap_or("unknown"),
                     data.tier.as_deref().unwrap_or("unknown"),
                     data.product_id.as_deref().unwrap_or("unknown"),
-                    data.occurred_at,
+                    normalize_event_ts(data.occurred_at.as_deref()),
                 ],
             )
             .map_err(|e| AppError::Internal(format!("db upsert canceled: {e}")))?;
@@ -413,7 +429,7 @@ impl Db {
                     data.email.as_deref().unwrap_or("unknown"),
                     data.tier.as_deref().unwrap_or("unknown"),
                     data.product_id.as_deref().unwrap_or("unknown"),
-                    data.occurred_at,
+                    normalize_event_ts(data.occurred_at.as_deref()),
                 ],
             )
             .map_err(|e| AppError::Internal(format!("db upsert revoked: {e}")))?;
@@ -584,7 +600,7 @@ impl Db {
                     data.tier.as_deref().unwrap_or("unknown"),
                     data.new_status,
                     data.product_id.as_deref().unwrap_or("unknown"),
-                    data.occurred_at,
+                    normalize_event_ts(data.occurred_at.as_deref()),
                 ],
             )
             .map_err(|e| AppError::Internal(format!("db upsert updated: {e}")))?;
@@ -763,23 +779,46 @@ impl Db {
         .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
     }
 
-    pub async fn insert_token(
+    /// Insert a refreshed token only when this subscription has not received one
+    /// within `min_interval_secs`. The age check and insert share one IMMEDIATE
+    /// transaction, so concurrent requests (including separate server processes
+    /// using the same SQLite database) cannot all pass a split check before any
+    /// token becomes visible.
+    pub async fn insert_token_if_interval_elapsed(
         &self,
         sub_id: &str,
         token: &str,
         expires_at: i64,
-    ) -> Result<(), AppError> {
+        min_interval_secs: i64,
+    ) -> Result<bool, AppError> {
         let conn = self.conn.clone();
         let sid = sub_id.to_string();
         let tok = token.to_string();
         tokio::task::spawn_blocking(move || {
-            let conn = acquire_db(&conn);
-            conn.execute(
+            let mut conn = acquire_db(&conn);
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(|e| AppError::Internal(format!("db token tx: {e}")))?;
+            let age = tx
+                .query_row(
+                    "SELECT CAST(strftime('%s','now') AS INTEGER) - CAST(strftime('%s', MAX(created_at)) AS INTEGER) FROM tokens WHERE subscription_id=?1",
+                    params![sid],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+                .map_err(|e| AppError::Internal(format!("db token age: {e}")))?;
+            if age.is_some_and(|seconds| seconds < min_interval_secs) {
+                tx.commit()
+                    .map_err(|e| AppError::Internal(format!("db token tx commit: {e}")))?;
+                return Ok(false);
+            }
+            tx.execute(
                 "INSERT INTO tokens (subscription_id, token, expires_at) VALUES (?1, ?2, ?3)",
                 params![sid, tok, expires_at],
             )
             .map_err(|e| AppError::Internal(format!("db insert token: {e}")))?;
-            Ok(())
+            tx.commit()
+                .map_err(|e| AppError::Internal(format!("db token tx commit: {e}")))?;
+            Ok(true)
         })
         .await
         .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
@@ -859,6 +898,7 @@ impl Db {
         sub_id: &str,
         new_tier: &str,
         new_product_id: &str,
+        expected_last_event_at: Option<String>,
     ) -> Result<(), AppError> {
         let conn = self.conn.clone();
         let sid = sub_id.to_string();
@@ -866,9 +906,12 @@ impl Db {
         let pid = new_product_id.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = acquire_db(&conn);
+            // repo-0448: compare-and-swap on the version observed when the
+            // Polar request STARTED. A plan transition landing mid-flight must
+            // not be overwritten by the stale response.
             conn.execute(
-                "UPDATE subscriptions SET tier=?1, product_id=?2, updated_at=datetime('now') WHERE id=?3 AND tier='unknown'",
-                params![tier, pid, sid],
+                "UPDATE subscriptions SET tier=?1, product_id=?2, updated_at=datetime('now') WHERE id=?3 AND tier='unknown' AND last_event_at IS ?4",
+                params![tier, pid, sid, expected_last_event_at],
             )
             .map_err(|e| AppError::Internal(format!("db retry tier fix: {e}")))?;
             conn.execute(
@@ -1114,6 +1157,50 @@ mod tests {
         let (status, revoked) = read_state(&db, "sub_1");
         assert_eq!(status, "active");
         assert_eq!(revoked, Some(false));
+    }
+
+    #[tokio::test]
+    async fn refreshed_token_interval_check_and_insert_are_atomic() {
+        let db = test_db();
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO subscriptions (id, tier, status) VALUES ('sub_refresh', 'team', 'active')",
+                [],
+            )
+            .unwrap();
+        }
+
+        const REQUESTS: usize = 8;
+        let barrier = Arc::new(tokio::sync::Barrier::new(REQUESTS));
+        let mut tasks = Vec::with_capacity(REQUESTS);
+        for index in 0..REQUESTS {
+            let db = db.clone();
+            let barrier = barrier.clone();
+            tasks.push(tokio::spawn(async move {
+                let token = format!("refresh-token-{index}");
+                barrier.wait().await;
+                db.insert_token_if_interval_elapsed("sub_refresh", &token, 9_999_999_999, 60)
+                    .await
+                    .unwrap()
+            }));
+        }
+
+        let mut admitted = 0;
+        for task in tasks {
+            admitted += usize::from(task.await.unwrap());
+        }
+        assert_eq!(admitted, 1, "only one concurrent refresh may issue");
+
+        let conn = db.conn.lock().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tokens WHERE subscription_id='sub_refresh'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
     }
 
     #[tokio::test]

--- a/tools/license-server/src/main.rs
+++ b/tools/license-server/src/main.rs
@@ -64,7 +64,30 @@ async fn main() {
     // health is trivial.
     let app = routes::router()
         .with_state(state)
-        .layer(TraceLayer::new_for_http());
+        // repo-0447: the default request span records the full URI, which
+        // leaks the one-time receipt secret (`/receipt/{secret}`) and the
+        // checkout capability (`/receipt/lookup?checkout=...`) into logs.
+        // Trace only method + path template, never the raw URI.
+        .layer(
+            TraceLayer::new_for_http().make_span_with(|request: &axum::http::Request<_>| {
+                // The path alone can carry the one-time receipt secret; the
+                // query can carry the checkout capability. Both are replaced
+                // with a static label.
+                let path = request.uri().path();
+                let safe_path = if path.starts_with("/receipt/") && path.len() > "/receipt/".len() {
+                    "/receipt/[redacted]"
+                } else if path == "/receipt/lookup" {
+                    "/receipt/lookup"
+                } else {
+                    path
+                };
+                tracing::info_span!(
+                    "http",
+                    method = %request.method(),
+                    route = %safe_path,
+                )
+            }),
+        );
 
     let addr = format!("0.0.0.0:{port}");
     info!("listening on {addr}");
@@ -206,7 +229,9 @@ async fn retry_dead_letters(
                     tier = %tier,
                     "resolved product via Polar API retry"
                 );
-                let _ = db.apply_retry_tier_fix(entry.id, &sub_id, tier, pid).await;
+                let _ = db
+                    .apply_retry_tier_fix(entry.id, &sub_id, tier, pid, entry.last_event_at.clone())
+                    .await;
             } else {
                 warn!(
                     dead_letter_id = entry.id,

--- a/tools/license-server/src/routes/refresh.rs
+++ b/tools/license-server/src/routes/refresh.rs
@@ -56,10 +56,21 @@ pub async fn refresh(
         }
     }
 
+    // repo-0449: per-subscription issuance interval. Every refresh signs a new
+    // Ed25519 token and INSERTs a row retained ~90 days past expiry, so an
+    // unthrottled loop could exhaust disk and contend on the DB mutex. 60s is
+    // far below any legitimate CLI refresh cadence.
+    const MIN_REFRESH_INTERVAL_SECS: i64 = 60;
     let exp_ts = chrono::Utc::now().timestamp() + (state.config.token_ttl_days * 86400);
     let token = state.signer.sign_token(&sub.tier, exp_ts);
 
-    state.db.insert_token(&sub.id, &token, exp_ts).await?;
+    if !state
+        .db
+        .insert_token_if_interval_elapsed(&sub.id, &token, exp_ts, MIN_REFRESH_INTERVAL_SECS)
+        .await?
+    {
+        return Err(AppError::RateLimited);
+    }
 
     Ok((
         StatusCode::OK,

--- a/tools/sign-license/src/main.rs
+++ b/tools/sign-license/src/main.rs
@@ -18,6 +18,11 @@ mod secure_file_windows;
 
 const B64URL: base64::engine::GeneralPurpose = base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
+/// Maximum accepted token size for `inspect`. A real license token is a few
+/// hundred bytes; anything near 64 KiB is junk or a resource-exhaustion
+/// attempt, so it is rejected before base64/JSON decoding (repo-0451).
+const MAX_INSPECT_TOKEN_BYTES: usize = 64 * 1024;
+
 #[derive(Parser)]
 #[command(name = "tirith-sign", about = "Sign tirith license tokens")]
 struct Cli {
@@ -310,17 +315,25 @@ fn cmd_inspect(token_arg: Option<String>) -> Result<(), String> {
     let token = match token_arg {
         Some(t) => t,
         None => {
-            let mut buf = String::new();
+            // Bounded read: never buffer more than the limit + 1 from stdin.
+            let mut buf = Vec::new();
             std::io::stdin()
-                .read_to_string(&mut buf)
+                .take((MAX_INSPECT_TOKEN_BYTES + 1) as u64)
+                .read_to_end(&mut buf)
                 .map_err(|e| format!("failed to read stdin: {e}"))?;
-            buf
+            String::from_utf8(buf).map_err(|_| "token from stdin is not valid UTF-8")?
         }
     };
     let token = token.trim();
 
     if token.is_empty() {
         return Err("no token provided".to_string());
+    }
+    if token.len() > MAX_INSPECT_TOKEN_BYTES {
+        return Err(format!(
+            "token is too large ({} bytes; max {MAX_INSPECT_TOKEN_BYTES}) — refusing to inspect",
+            token.len()
+        ));
     }
 
     let (payload_b64, sig_b64) = token
@@ -349,12 +362,19 @@ fn cmd_inspect(token_arg: Option<String>) -> Result<(), String> {
         serde_json::to_string_pretty(&payload).unwrap_or_else(|_| format!("{payload:?}"))
     );
 
-    println!("\n--- Summary ---");
+    // `inspect` performs NO signature verification. Every decoded field may be
+    // attacker-controlled, so strings are JSON-escaped before they reach the
+    // operator's terminal (raw ESC/OSC sequences could spoof output or drive
+    // terminal features such as OSC 52 clipboard writes) and the summary is
+    // explicitly labelled unverified (repo-0451).
+    println!(
+        "\n--- Summary (UNVERIFIED — signature NOT checked; fields may be attacker-controlled) ---"
+    );
     if let Some(tier) = payload.get("tier").and_then(|v| v.as_str()) {
-        println!("Tier:    {tier}");
+        println!("Tier:    {}", escape_decoded(tier));
     }
     if let Some(kid) = payload.get("kid").and_then(|v| v.as_str()) {
-        println!("Key ID:  {kid}");
+        println!("Key ID:  {}", escape_decoded(kid));
     }
     if let Some(exp) = payload.get("exp").and_then(|v| v.as_i64()) {
         let exp_dt = chrono::DateTime::from_timestamp(exp, 0)
@@ -371,10 +391,10 @@ fn cmd_inspect(token_arg: Option<String>) -> Result<(), String> {
         println!("Not before: {nbf_dt}");
     }
     if let Some(org) = payload.get("org_id").and_then(|v| v.as_str()) {
-        println!("Org ID:  {org}");
+        println!("Org ID:  {}", escape_decoded(org));
     }
     if let Some(sso) = payload.get("sso_provider").and_then(|v| v.as_str()) {
-        println!("SSO:     {sso}");
+        println!("SSO:     {}", escape_decoded(sso));
     }
     if let Some(seats) = payload.get("seat_count").and_then(|v| v.as_u64()) {
         println!("Seats:   {seats}");
@@ -419,6 +439,14 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
             let _ = write!(s, "{b:02x}");
             s
         })
+}
+
+/// JSON-encode a decoded payload string so terminal control characters
+/// (ESC/OSC/CSI, CR, LF) can never reach the operator's terminal raw when an
+/// unverified token is inspected. The surrounding quotes also make leading or
+/// trailing whitespace visible.
+fn escape_decoded(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"<unencodable>\"".to_string())
 }
 
 fn hex_to_bytes(hex: &str) -> Result<Vec<u8>, String> {
@@ -513,5 +541,37 @@ mod tests {
 
         let sig_decoded = B64URL.decode(right).unwrap();
         assert_eq!(sig_decoded.len(), 64);
+    }
+
+    /// repo-0451: decoded payload strings must be JSON-escaped before they
+    /// reach the terminal, so ANSI/OSC sequences in an unverified token are
+    /// displayed inertly instead of being interpreted by the terminal.
+    #[test]
+    fn test_escape_decoded_neutralizes_control_sequences() {
+        let escaped = escape_decoded("pro\u{1b}]52;c;YXR0YWNr\u{7}\r\nFAKE");
+        assert_eq!(escaped, "\"pro\\u001b]52;c;YXR0YWNr\\u0007\\r\\nFAKE\"");
+        assert!(!escaped.contains('\u{1b}'));
+        assert!(!escaped.contains('\r'));
+        assert!(!escaped.contains('\n'));
+    }
+
+    /// repo-0451: inspect must reject oversized tokens before decoding.
+    #[test]
+    fn test_inspect_rejects_oversized_token() {
+        let oversized = "a".repeat(MAX_INSPECT_TOKEN_BYTES + 1);
+        let err = cmd_inspect(Some(oversized)).unwrap_err();
+        assert!(err.contains("too large"), "unexpected error: {err}");
+    }
+
+    /// repo-0451: a token at the size limit still fails cleanly (not a valid
+    /// token), but with a decode error rather than the size guard.
+    #[test]
+    fn test_inspect_size_limit_boundary() {
+        let at_limit = "a".repeat(MAX_INSPECT_TOKEN_BYTES);
+        let err = cmd_inspect(Some(at_limit)).unwrap_err();
+        assert!(
+            !err.contains("too large"),
+            "boundary token wrongly rejected"
+        );
     }
 }


### PR DESCRIPTION
> [!NOTE]
> Split on 2026-08-06 so Greptile and CodeRabbit can run: this PR originally carried the whole 130-file R2 queue in one commit. It now carries the 50-file second half: the remaining CLI command surface, the license-server and sign-license tools, the Dockerfile, and the threatdb workflow and fetch scripts. The core half moved to #187. The base moved from codex/deepsec-r1-critical-boundaries to codex/deepsec-r2a-core-hardening, and the branch tip tree is byte-identical to the pre-split tip (was 3fcb1dc0, now 8d6f5123). No R2 content changed.

## Stack

| PR | part | files |
|----|------|-------|
| #177 | remediation plan docs | base |
| #183 | R1 1/5: supervised execution, transactional installs, signing | 96 |
| #184 | R1 2/5: network, threatdb, resolver, output boundaries | 92 |
| #185 | R1 3/5: setup transactions, install provenance, script execution | 76 |
| #186 | R1 4/5: execution state, supervision, policy core | 90 |
| #179 | R1 5/5: parser rules, hooks, threatdb, release close-out | 55 |
| #187 | R2 1/2: core hardening queue | 80 |
| #180 | R2 2/2: CLI, license server, and CI hardening | 50 |
| #181 | R3 reliability and convergence queue | 62 |

---

## Summary

Stacked on PR #179 (R1). This is PR 2 of the three-PR DeepSec remediation plan: the 186 P2 roots plus 14 duplicate coverage rows, across the R2-CMP / R2-CMD / R2-IO / R2-NET / R2-SUP packages.

Highlights:

- Completeness and bounded work: bounded manifest reads with an aggregate scan budget and policy-aware coverage-gap findings wired into the verdict; requirements.txt include resolution (contained, depth/count capped); poetry.lock parsing; OSV response/cache byte and cardinality caps; O(N^2) script-analysis dedup removed; PDF compressed object streams decompressed and rescanned (closes the lopdf preflight bypass, justifying the RUSTSEC-2026-0187 waiver); prompt-injection seed and manifest-glob work budgets
- Command/policy: syntax-aware POSIX/PowerShell function balancing (quotes, escapes, heredocs, comments), fish nested-end handling, case-insensitive PowerShell classification with native cmdlets, command-scoped cloud context overrides and cache fingerprint invalidation, debug-only context-detect disable, cloaking status/empty-body/script-channel detection, header exfiltration to absolute origins, entropy underflow fix, class-token a11y exemptions, two-directional clipboard comparison
- Filesystem/state: cross-process locks for the taint store and audit spool, session-ID validation shared with the resolver, fallback-session winner re-read, persisted terminal-control scrubbing across last-trigger/session-warnings/pending/checkpoint/audit surfaces, symlink-refusing exports, contained MCP scaffold writes, Cursor hooks.json version gate
- Network/MCP: webhook origin-only logging, canary entropy fail-closed plus callback cooldown/concurrency caps, CSV formula neutralization, bounded lockfile reads, MCP extra-field scanning, completeness-policy enforcement on MCP resources/tools, PromptsGet blob inspection, MIME parameter spoof fix, per-response URI resolution budget, fail-closed base64 blobs, bounded DNSBL work, shortener-list unification, protocol-relative redirect resolution, aggregate redirect deadline and hard cache cap
- Supply/release: OpenSSF IOC ip/domain emission, confirmed range-only records marked package-malicious, v1/v2 name-spelling contract preserved, multi-tenant Helm registries untrusted, OSV exact-version guard, strict feed CSV readers, credential-free feed errors, bounded DB/manifest reads, partial-feed-outage keeps last-known-good DB, license refresh body cap, license-server event-ordering CAS + normalized timestamps + receipt route log redaction + refresh rate limit

## Verification (exact head, hermetic env, no DeepSec revalidation per request)

- cargo fmt --check, git diff --check: clean
- cargo check --workspace --all-targets: clean (no warnings)
- cargo test -p tirith-core --lib: 4396 passed, 0 failed, 2 ignored
- cargo test --workspace --all-targets: all binaries green

## Notes

- No DeepSec revalidation run (excluded by request).
- The two setup_codex masking tests require TMPDIR on a non-symlinked path on macOS (pre-existing environmental sensitivity, verified passing hermetically).
- broker_drop_cancels_partial_unauthenticated_session carries a 2s timing budget and flakes under heavy load; passes in isolation and in the clean full-suite rerun.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens the remaining CLI, Windows capsule, ThreatDB, licensing, and CI surfaces from the second DeepSec R2 tranche. Most previously reported concurrency fixes are now effective, but the dead-letter CAS repair remains incomplete.

- Uses per-launch Windows AppContainer identities and targeted live-DACL cleanup.
- Adds bounded and hardened CLI, feed-fetching, output, filesystem, and network behavior.
- Makes refresh throttling atomic through a single immediate SQLite transaction.
- Adds event-ordering protection to license retries, while still deleting retry state after a failed CAS.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a raced dead-letter retry can still discard the only repair record after its conditional tier update fails.

The refresh-throttle and Windows capsule fixes close their reported races, but `apply_retry_tier_fix` does not condition dead-letter deletion on a successful subscription update, so concurrent webhook ordering can leave an unknown-tier subscription permanently unrepaired.

**Files Needing Attention:** tools/license-server/src/db.rs

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith/src/cli/capsule_windows.rs | Replaces shared deterministic AppContainer identities with bounded per-launch profiles and launch-specific ACL cleanup, resolving the overlapping-capsule revocation issue. |
| crates/tirith/src/bin/tirith_threatdb_compile.rs | Emits previously omitted OpenSSF indicators and deliberately treats confirmed range-only malicious-package records as package-wide malicious claims. |
| tools/license-server/src/routes/refresh.rs | Routes refresh issuance through the new atomic interval-check-and-insert operation, preventing concurrent duplicate admissions. |
| tools/license-server/src/db.rs | Adds atomic refresh throttling and retry CAS protection, but still deletes a dead letter when the conditional tier repair affects no rows. |
| .github/scripts/fetch-threatdb-sources.sh | Adds bounded feed transfers and records resolved source commits and hashes for the ThreatDB build audit trail. |
| Dockerfile | Pins the Debian runtime image to a specific manifest digest. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Dead-letter worker
    participant DB as License database
    participant W as Newer webhook
    R->>DB: "Read unknown subscription and last_event_at=T1"
    W->>DB: "Update subscription with last_event_at=T2"
    R->>DB: "UPDATE ... WHERE last_event_at=T1"
    DB-->>R: 0 rows updated
    R->>DB: DELETE dead_letter
    Note over DB: Unknown tier may remain without retry state
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (5)</h3></summary>

1. `tools/license-server/src/db.rs`, line 913-917 ([link](https://github.com/sheeki03/tirith/blob/8d6f5123db8f5b8ca4b8dfc1406f8493e195ace7/tools/license-server/src/db.rs#L913-L917)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed CAS discards retry state**

   When a newer webhook changes `last_event_at` after a retry captures the old value, the conditional tier update affects no rows, but this unconditional delete still removes the dead letter. The subscription remains at the unknown tier with no retry record left to repair it.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tools%2Flicense-server%2Fsrc%2Fdb.rs%0ALine%3A%20913-917%0A%0AComment%3A%0A**Failed%20CAS%20discards%20retry%20state**%0A%0AWhen%20a%20newer%20webhook%20changes%20%60last_event_at%60%20after%20a%20retry%20captures%20the%20old%20value%2C%20the%20conditional%20tier%20update%20affects%20no%20rows%2C%20but%20this%20unconditional%20delete%20still%20removes%20the%20dead%20letter.%20The%20subscription%20remains%20at%20the%20unknown%20tier%20with%20no%20retry%20record%20left%20to%20repair%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sheeki03%2Ftirith&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

2. `tools/license-server/src/routes/refresh.rs`, line 64-73 ([link](https://github.com/sheeki03/tirith/blob/8d6f5123db8f5b8ca4b8dfc1406f8493e195ace7/tools/license-server/src/routes/refresh.rs#L64-L73)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Split refresh check permits duplicates**

   If two refresh requests for one subscription overlap, both can complete the age check before either independently inserts its token. Both requests then issue signed tokens inside the same 60-second window, bypassing the new per-subscription throttle.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tools%2Flicense-server%2Fsrc%2Froutes%2Frefresh.rs%0ALine%3A%2064-73%0A%0AComment%3A%0A**Split%20refresh%20check%20permits%20duplicates**%0A%0AIf%20two%20refresh%20requests%20for%20one%20subscription%20overlap%2C%20both%20can%20complete%20the%20age%20check%20before%20either%20independently%20inserts%20its%20token.%20Both%20requests%20then%20issue%20signed%20tokens%20inside%20the%20same%2060-second%20window%2C%20bypassing%20the%20new%20per-subscription%20throttle.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sheeki03%2Ftirith&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

3. `tools/license-server/src/routes/refresh.rs`, line 64-73 ([link](https://github.com/sheeki03/tirith/blob/6e929041ba8a5f450d6f8d35f70fabba8456a39c/tools/license-server/src/routes/refresh.rs#L64-L73)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Refresh throttle permits duplicates**

   If two authenticated refresh requests for the same subscription overlap after the previous token becomes eligible, both can complete `seconds_since_last_token` before either calls `insert_token`. Because these operations use separate database lock acquisitions and the token table has no uniqueness constraint, both requests issue and persist tokens inside the same 60-second interval, bypassing the throttle and increasing retained token rows.

   **How this was verified:** The age query and insertion use separate mutex acquisitions, and the token table has no constraint preventing both inserts.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tools%2Flicense-server%2Fsrc%2Froutes%2Frefresh.rs%0ALine%3A%2064-73%0A%0AComment%3A%0A**Refresh%20throttle%20permits%20duplicates**%0A%0AIf%20two%20authenticated%20refresh%20requests%20for%20the%20same%20subscription%20overlap%20after%20the%20previous%20token%20becomes%20eligible%2C%20both%20can%20complete%20%60seconds_since_last_token%60%20before%20either%20calls%20%60insert_token%60.%20Because%20these%20operations%20use%20separate%20database%20lock%20acquisitions%20and%20the%20token%20table%20has%20no%20uniqueness%20constraint%2C%20both%20requests%20issue%20and%20persist%20tokens%20inside%20the%20same%2060-second%20interval%2C%20bypassing%20the%20throttle%20and%20increasing%20retained%20token%20rows.%0A%0A**How%20this%20was%20verified%3A**%20The%20age%20query%20and%20insertion%20use%20separate%20mutex%20acquisitions%2C%20and%20the%20token%20table%20has%20no%20constraint%20preventing%20both%20inserts.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sheeki03%2Ftirith&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

4. `tools/license-server/src/db.rs`, line 907-916 ([link](https://github.com/sheeki03/tirith/blob/6e929041ba8a5f450d6f8d35f70fabba8456a39c/tools/license-server/src/db.rs#L907-L916)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed CAS discards retry state**

   If a newer subscription event changes `last_event_at` while the dead-letter worker is waiting for Polar, this update affects zero rows, but the unconditional delete still removes the dead letter. The subscription can remain at the unknown tier with no retry record left to repair it.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tools%2Flicense-server%2Fsrc%2Fdb.rs%0ALine%3A%20907-916%0A%0AComment%3A%0A**Failed%20CAS%20discards%20retry%20state**%0A%0AIf%20a%20newer%20subscription%20event%20changes%20%60last_event_at%60%20while%20the%20dead-letter%20worker%20is%20waiting%20for%20Polar%2C%20this%20update%20affects%20zero%20rows%2C%20but%20the%20unconditional%20delete%20still%20removes%20the%20dead%20letter.%20The%20subscription%20can%20remain%20at%20the%20unknown%20tier%20with%20no%20retry%20record%20left%20to%20repair%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sheeki03%2Ftirith&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

5. `tools/license-server/src/db.rs`, line 917-920 ([link](https://github.com/sheeki03/tirith/blob/26546fdb035752732da49205679544a84fe965f3/tools/license-server/src/db.rs#L917-L920)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed CAS still deletes retry**

   If a newer subscription webhook changes `last_event_at` after the dead-letter worker reads the subscription, the conditional tier update affects zero rows but the following deletion still removes the dead letter. The subscription can remain at the unknown tier with no retry record left to repair it.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tools%2Flicense-server%2Fsrc%2Fdb.rs%0ALine%3A%20917-920%0A%0AComment%3A%0A**Failed%20CAS%20still%20deletes%20retry**%0A%0AIf%20a%20newer%20subscription%20webhook%20changes%20%60last_event_at%60%20after%20the%20dead-letter%20worker%20reads%20the%20subscription%2C%20the%20conditional%20tier%20update%20affects%20zero%20rows%20but%20the%20following%20deletion%20still%20removes%20the%20dead%20letter.%20The%20subscription%20can%20remain%20at%20the%20unknown%20tier%20with%20no%20retry%20record%20left%20to%20repair%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sheeki03%2Ftirith&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20sheeki03%2Ftirith%20PR%20%23180%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=sheeki03%2Ftirith&pr=180&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atools%2Flicense-server%2Fsrc%2Fdb.rs%3A917-920%0A**Failed%20CAS%20still%20deletes%20retry**%0A%0AIf%20a%20newer%20subscription%20webhook%20changes%20%60last_event_at%60%20after%20the%20dead-letter%20worker%20reads%20the%20subscription%2C%20the%20conditional%20tier%20update%20affects%20zero%20rows%20but%20the%20following%20deletion%20still%20removes%20the%20dead%20letter.%20The%20subscription%20can%20remain%20at%20the%20unknown%20tier%20with%20no%20retry%20record%20left%20to%20repair%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sheeki03%2Ftirith&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(security): complete DeepSec R2 CLI a..."](https://github.com/sheeki03/tirith/commit/26546fdb035752732da49205679544a84fe965f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50745589)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [CLI Entrypoint and Command Dispatch](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/cli-and-commands.md)
- Knowledge Base — [ThreatDB: compilation, versioning, and update flow](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/threatdb.md)
- Knowledge Base — [Packaging and Distribution](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/packaging-and-distribution.md)
</details>


<!-- /greptile_comment -->