### PR TITLE
fix(security): remediate DeepSec R3 reliability and convergence queue

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,12 +25,17 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run benchmarks
-        run: cargo bench --bench perf -- --output-format bencher | tee bench-output.txt
+        # repo-0452: pipefail so a cargo bench failure cannot be masked by tee;
+        # the downstream result step is gated on this step's success.
+        run: |
+          set -o pipefail
+          cargo bench --bench perf -- --output-format bencher | tee bench-output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        if: always()
-        continue-on-error: true
+        # repo-0452: only store results when the benchmark step succeeded;
+        # never silently "pass" a job whose benchmarks never ran.
+        if: success()
         with:
           name: tirith benchmarks
           tool: cargo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1064,8 +1064,12 @@ jobs:
           sed -i "s/^pkgrel=.*/pkgrel=1/" packaging/aur/PKGBUILD
 
           # Compute source checksum without keeping the tarball (AUR has a blob size limit)
+          # repo-0453: --fail so an HTTP error page is never hashed as the
+          # "source archive"; validate the payload is a gzip stream.
           URL="https://github.com/sheeki03/tirith/archive/refs/tags/${VERSION}.tar.gz"
-          SHA=$(curl -sSL "$URL" | sha256sum | cut -d' ' -f1)
+          set -o pipefail
+          SHA=$(curl -fsSL "$URL" | tee /tmp/aur-src.tar.gz | sha256sum | cut -d' ' -f1)
+          file /tmp/aur-src.tar.gz | grep -q "gzip compressed data"
           sed -i "s/^sha256sums=.*/sha256sums=('${SHA}')/" packaging/aur/PKGBUILD
 
       - name: Publish to AUR

--- a/crates/tirith-core/src/audit_aggregator.rs
+++ b/crates/tirith-core/src/audit_aggregator.rs
@@ -1,7 +1,7 @@
 //! Audit log aggregation, analytics, and compliance reporting over JSONL logs:
 //! export (JSON/CSV), stats, and a structured compliance report.
 use std::collections::HashMap;
-use std::io::BufRead;
+use std::io::{BufRead, Read as _, Seek as _};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -116,7 +116,15 @@ pub struct HookStats {
 pub struct ReadLogResult {
     pub records: Vec<AuditRecord>,
     pub skipped_lines: usize,
+    /// True when a bounded tail read omitted older bytes or records. Full-log
+    /// readers leave this false.
+    pub truncated_records: bool,
 }
+
+/// Maximum audit bytes diagnostic consumers inspect. The record cap limits
+/// retained objects; this independent byte cap limits CPU and the largest
+/// possible line allocation when a hostile log contains no newlines.
+const MAX_LOG_TAIL_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Read and parse all records from a JSONL audit log, STREAMING line-by-line via
 /// [`BufReader`] so a large append-only log is never fully buffered. Result and
@@ -128,6 +136,98 @@ pub fn read_log(path: &Path) -> Result<ReadLogResult, String> {
         std::fs::File::open(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
     let reader = std::io::BufReader::new(file);
     parse_log_from_reader(reader, Some(path))
+}
+
+/// repo-0479/0480/0481: bounded variant for diagnostic consumers — keeps only
+/// the NEWEST `max_records` parsed records, so a huge or attacker-inflated
+/// audit log cannot hang or OOM `doctor`, `explain`, or `incident`.
+pub fn read_log_tail(path: &Path, max_records: usize) -> Result<ReadLogResult, String> {
+    read_log_tail_with_byte_cap(path, max_records, MAX_LOG_TAIL_BYTES)
+}
+
+fn read_log_tail_with_byte_cap(
+    path: &Path,
+    max_records: usize,
+    max_bytes: u64,
+) -> Result<ReadLogResult, String> {
+    let mut file = crate::util::open_read_no_follow_capped(path, u64::MAX)
+        .map_err(|e| format!("Failed to safely open {}: {e:?}", path.display()))?;
+    let initial_metadata = file
+        .metadata()
+        .map_err(|e| format!("Failed to stat {}: {e}", path.display()))?;
+    let length = initial_metadata.len();
+    if max_records == 0 || max_bytes == 0 {
+        return Ok(ReadLogResult {
+            records: Vec::new(),
+            skipped_lines: 0,
+            truncated_records: length > 0,
+        });
+    }
+
+    let start = length.saturating_sub(max_bytes);
+    let mut discard_partial = false;
+    if start > 0 {
+        file.seek(std::io::SeekFrom::Start(start - 1))
+            .map_err(|e| format!("Failed to seek {}: {e}", path.display()))?;
+        let mut previous = [0u8; 1];
+        file.read_exact(&mut previous)
+            .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+        discard_partial = previous[0] != b'\n';
+    }
+    file.seek(std::io::SeekFrom::Start(start))
+        .map_err(|e| format!("Failed to seek {}: {e}", path.display()))?;
+    // Read only the bytes that belonged to the open handle's metadata snapshot;
+    // concurrent appends cannot extend this invocation past the cap.
+    let snapshot_bytes = length.saturating_sub(start);
+    let metadata_probe = file
+        .try_clone()
+        .map_err(|e| format!("Failed to clone {}: {e}", path.display()))?;
+    let reader = std::io::BufReader::new(file.take(snapshot_bytes));
+    let mut reader = reader;
+    let mut truncated_records = start > 0;
+    if discard_partial {
+        // `start` can land in the middle of a JSONL record. Drop that bounded
+        // fragment so it cannot be misreported as malformed input. If it was
+        // exactly at a boundary we conservatively omit one additional record.
+        let mut partial = Vec::new();
+        reader
+            .read_until(b'\n', &mut partial)
+            .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    }
+    let mut records: std::collections::VecDeque<AuditRecord> =
+        std::collections::VecDeque::with_capacity(max_records.min(1024));
+    let mut skipped_lines = 0usize;
+    for (idx, line) in reader.lines().enumerate() {
+        let line_num = idx + 1;
+        match line {
+            Ok(line) => {
+                let mut one = Vec::new();
+                parse_log_line(&line, line_num, Some(path), &mut one, &mut skipped_lines);
+                if let Some(record) = one.into_iter().next() {
+                    if records.len() >= max_records {
+                        records.pop_front();
+                        truncated_records = true;
+                    }
+                    records.push_back(record);
+                }
+            }
+            Err(e) => {
+                return Err(format!("Failed to read {}: {e}", path.display()));
+            }
+        }
+    }
+    if let Ok(final_metadata) = metadata_probe.metadata() {
+        if final_metadata.len() != initial_metadata.len()
+            || final_metadata.modified().ok() != initial_metadata.modified().ok()
+        {
+            truncated_records = true;
+        }
+    }
+    Ok(ReadLogResult {
+        records: records.into_iter().collect(),
+        skipped_lines,
+        truncated_records,
+    })
 }
 
 /// Streaming counterpart of [`parse_log`]: pulls one line at a time from
@@ -159,6 +259,7 @@ pub fn parse_log_from_reader(
     Ok(ReadLogResult {
         records,
         skipped_lines,
+        truncated_records: false,
     })
 }
 
@@ -174,6 +275,7 @@ pub fn parse_log(content: &str, source: Option<&Path>) -> ReadLogResult {
     ReadLogResult {
         records,
         skipped_lines,
+        truncated_records: false,
     }
 }
 
@@ -1198,6 +1300,56 @@ mod tests {
             read_log(dir.path()).is_err(),
             "read_log on a directory must return Err (not hang, not Ok)"
         );
+    }
+
+    #[test]
+    fn bounded_tail_keeps_newest_records_and_reports_omission() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("audit.jsonl");
+        let rows = sample_records();
+        let content = rows
+            .iter()
+            .map(|row| serde_json::to_string(row).expect("serialize row"))
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        std::fs::write(&path, content).expect("write audit log");
+
+        let tail = read_log_tail_with_byte_cap(&path, 2, u64::MAX).expect("read tail");
+        assert_eq!(tail.records.len(), 2);
+        assert_eq!(tail.records[0].action, rows[1].action);
+        assert_eq!(tail.records[1].action, rows[2].action);
+        assert!(tail.truncated_records);
+    }
+
+    #[test]
+    fn bounded_tail_limits_bytes_and_never_keeps_a_partial_first_record() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("audit.jsonl");
+        let row = serde_json::to_string(&sample_records()[0]).expect("serialize row");
+        let content = format!("{}\n{row}\n", "x".repeat(4096));
+        std::fs::write(&path, content).expect("write audit log");
+
+        let cap = (row.len() + 32) as u64;
+        let tail = read_log_tail_with_byte_cap(&path, 10, cap).expect("read bounded tail");
+        assert_eq!(tail.records.len(), 1);
+        assert_eq!(tail.records[0].event_id.as_deref(), Some("evt-1"));
+        assert_eq!(
+            tail.skipped_lines, 0,
+            "partial prefix is not malformed JSON"
+        );
+        assert!(tail.truncated_records);
+    }
+
+    #[test]
+    fn zero_record_tail_is_empty_and_reports_nonempty_input() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("audit.jsonl");
+        std::fs::write(&path, "{}\n").expect("write audit log");
+
+        let tail = read_log_tail(&path, 0).expect("zero-sized tail");
+        assert!(tail.records.is_empty());
+        assert!(tail.truncated_records);
     }
 
     // PR #121 CR follow-up — caller-influenced CSV columns must be neutralized

--- a/crates/tirith-core/src/audit_upload.rs
+++ b/crates/tirith-core/src/audit_upload.rs
@@ -1,9 +1,12 @@
 use std::fs;
-use std::io::Write;
+use std::io::{BufRead as _, Read as _, Seek as _, Write as _};
 use std::path::PathBuf;
 
 const DEFAULT_MAX_EVENTS: usize = 1000;
 const DEFAULT_MAX_BYTES: u64 = 5 * 1024 * 1024; // 5 MiB
+/// Absolute allocation/read ceiling even when a caller supplies a larger
+/// retention value.
+const ABSOLUTE_MAX_SPOOL_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Dedicated cross-process lock guarding every spool read/append/rewrite
 /// (repo-0250): without it, two drainers snapshot-then-rewrite from stale
@@ -51,6 +54,12 @@ fn spool_path() -> PathBuf {
 ///
 /// DLP redaction must be applied **before** calling this function.
 pub fn spool_event(event_json: &str) -> std::io::Result<()> {
+    if event_json.len() as u64 + 1 > ABSOLUTE_MAX_SPOOL_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "audit event exceeds the per-event spool limit",
+        ));
+    }
     with_spool_lock(|| spool_event_locked(event_json))
 }
 
@@ -65,9 +74,32 @@ fn spool_event_locked(event_json: &str) -> std::io::Result<()> {
     {
         use std::os::unix::fs::OpenOptionsExt;
         opts.mode(0o600);
+        opts.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    #[cfg(not(unix))]
+    {
+        if fs::symlink_metadata(&path)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            return Err(std::io::Error::other(
+                "refusing to append through a symlinked audit spool",
+            ));
+        }
     }
     let mut file = opts.open(&path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::other(
+            "refusing to append to a non-regular audit spool",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
     writeln!(file, "{event_json}")?;
+    file.sync_data()?;
     Ok(())
 }
 
@@ -91,7 +123,10 @@ fn enforce_retention(lines: Vec<String>, max_events: usize, max_bytes: u64) -> V
         // Walk newest→oldest so the drop list favors the most stale events.
         for line in result.into_iter().rev() {
             let line_bytes = line.len() as u64 + 1;
-            if running_bytes + line_bytes > max_bytes && !kept.is_empty() {
+            if line_bytes > max_bytes {
+                continue;
+            }
+            if running_bytes + line_bytes > max_bytes {
                 break;
             }
             running_bytes += line_bytes;
@@ -106,6 +141,40 @@ fn enforce_retention(lines: Vec<String>, max_events: usize, max_bytes: u64) -> V
     }
 
     result
+}
+
+/// Read only the newest bounded suffix of the spool. The returned boolean says
+/// older bytes (or a partial boundary record) were omitted.
+fn read_spool_lines_bounded(
+    path: &std::path::Path,
+    requested_max_bytes: u64,
+) -> std::io::Result<(Vec<String>, bool)> {
+    let max_bytes = requested_max_bytes.min(ABSOLUTE_MAX_SPOOL_BYTES);
+    let mut file = crate::util::open_read_no_follow_capped(path, u64::MAX)
+        .map_err(|e| std::io::Error::other(format!("cannot safely open audit spool: {e:?}")))?;
+    let length = file.metadata()?.len();
+    if max_bytes == 0 {
+        return Ok((Vec::new(), length > 0));
+    }
+    let start = length.saturating_sub(max_bytes);
+    let mut discard_partial = false;
+    if start > 0 {
+        file.seek(std::io::SeekFrom::Start(start - 1))?;
+        let mut previous = [0u8; 1];
+        file.read_exact(&mut previous)?;
+        discard_partial = previous[0] != b'\n';
+    }
+    file.seek(std::io::SeekFrom::Start(start))?;
+    let mut reader = std::io::BufReader::new(file.take(length.saturating_sub(start)));
+    if discard_partial {
+        let mut ignored = String::new();
+        reader.read_line(&mut ignored)?;
+    }
+    let mut lines = Vec::new();
+    for line in reader.lines() {
+        lines.push(line?);
+    }
+    Ok((lines, start > 0))
 }
 
 /// Drain the spool by uploading events to the server (background, non-blocking).
@@ -126,22 +195,18 @@ pub fn drain_spool(server_url: &str, api_key: &str, max_events: usize, max_bytes
     // Snapshot under the spool lock (repo-0250); the network phase runs
     // unlocked so appends are not blocked behind slow sends, and the final
     // rewrite re-locks and removes only the prefix this drainer actually sent.
-    let content = match with_spool_lock(|| fs::read_to_string(&path)) {
-        Ok(c) => c,
+    let lines = match with_spool_lock(|| -> std::io::Result<Vec<String>> {
+        let (current, tail_truncated) = read_spool_lines_bounded(&path, max_bytes)?;
+        let retained = enforce_retention(current.clone(), max_events, max_bytes);
+        if tail_truncated || retained != current {
+            write_spool_atomic(&path, &retained)?;
+        }
+        Ok(retained)
+    }) {
+        Ok(lines) => lines,
         Err(_) => return,
     };
-    let lines: Vec<String> = content.lines().map(String::from).collect();
     if lines.is_empty() {
-        return;
-    }
-
-    let lines = enforce_retention(lines, max_events, max_bytes);
-    if lines.is_empty() {
-        if let Err(e) = fs::write(&path, "") {
-            crate::audit::audit_diagnostic(format!(
-                "tirith: audit-spool: failed to clear spool: {e}"
-            ));
-        }
         return;
     }
 
@@ -178,7 +243,7 @@ pub fn drain_spool(server_url: &str, api_key: &str, max_events: usize, max_bytes
                     crate::audit::audit_diagnostic(
                         "tirith: audit-upload: auth failed, stopping upload",
                     );
-                    rewrite_spool(&path, &lines[sent_count..]);
+                    rewrite_spool(&path, &lines, sent_count, max_bytes);
                     return;
                 }
                 _ => {
@@ -194,32 +259,89 @@ pub fn drain_spool(server_url: &str, api_key: &str, max_events: usize, max_bytes
         }
     }
 
-    rewrite_spool(&path, &lines[sent_count..]);
+    rewrite_spool(&path, &lines, sent_count, max_bytes);
 }
 
-/// Rewrite the spool file with the remaining unsent lines.
-fn rewrite_spool(path: &std::path::Path, remaining: &[String]) {
-    let _ = with_spool_lock(|| {
+fn write_spool_atomic(path: &std::path::Path, lines: &[String]) -> std::io::Result<()> {
+    let mut content = lines.join("\n");
+    if !content.is_empty() {
+        content.push('\n');
+    }
+    crate::util::write_file_atomic_0600(path, content.as_bytes())
+}
+
+/// Remove exactly the sent prefix of `snapshot`, preserving its unsent suffix
+/// and every line appended after that snapshot. If another drainer or retention
+/// pass changed the prefix, leave the file untouched: at-least-once delivery is
+/// safer than guessing and deleting an event.
+fn rewrite_spool(path: &std::path::Path, snapshot: &[String], sent_count: usize, max_bytes: u64) {
+    let result = with_spool_lock(|| {
         // repo-0250: under the lock, re-read the CURRENT file and remove only
         // the prefix this drainer sent. Events appended by another process
-        // while we were sending land at the end and must survive. On any
-        // suffix mismatch (another drainer intervened), keep the file as-is —
-        // at-least-once delivery beats silent loss.
-        let current = fs::read_to_string(path).unwrap_or_default();
-        let current_lines: Vec<String> = current.lines().map(String::from).collect();
-        if current_lines.len() < remaining.len()
-            || current_lines[current_lines.len() - remaining.len()..] != *remaining
+        // while we were sending land at the end and must survive.
+        let (current_lines, tail_truncated) = read_spool_lines_bounded(path, max_bytes)?;
+        if tail_truncated {
+            return Ok(());
+        }
+        if sent_count > snapshot.len()
+            || current_lines.len() < snapshot.len()
+            || current_lines[..snapshot.len()] != *snapshot
         {
             return Ok(());
         }
-        let keep = &current_lines[..current_lines.len() - remaining.len()];
-        let _ = keep; // the sent prefix we are dropping
-        let mut content = remaining.join("\n");
-        if !content.is_empty() {
-            content.push('\n');
-        }
-        fs::write(path, content)
+        let mut keep = snapshot[sent_count..].to_vec();
+        keep.extend_from_slice(&current_lines[snapshot.len()..]);
+        write_spool_atomic(path, &keep)
     });
+    if let Err(error) = result {
+        crate::audit::audit_diagnostic(format!(
+            "tirith: audit-spool: failed to publish rewritten spool: {error}"
+        ));
+    }
+}
+
+/// repo-0194: coalesce bursts into ONE drainer. A thread per event lets a burst
+/// create unbounded concurrent workers in a long-lived process.
+static DRAIN_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// The running drainer snapshots the spool once, so an event appended after that
+/// snapshot is not covered by it. Record that the spool changed and let the
+/// drainer take another pass; without this the event waits for an unrelated
+/// later append and retention can drop it undelivered.
+static DRAIN_RESCAN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Releases the drainer claim even if the worker panics or never starts.
+/// Without it a failed spawn or a panic inside `drain_spool` would leave
+/// `DRAIN_ACTIVE` set forever and every later event would only flag a rescan
+/// nobody performs, stranding the durable queue until the process restarts.
+struct DrainOwnership {
+    held: bool,
+}
+
+impl DrainOwnership {
+    fn release(&mut self) {
+        if self.held {
+            self.held = false;
+            DRAIN_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
+        }
+    }
+
+    fn retake(&mut self) -> bool {
+        self.held = DRAIN_ACTIVE
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_ok();
+        self.held
+    }
+}
+
+impl Drop for DrainOwnership {
+    fn drop(&mut self) {
+        self.release();
+    }
 }
 
 /// Primary entry point: append the event to the durable spool, then spawn a
@@ -231,18 +353,87 @@ pub fn spool_and_upload(
     max_events: Option<usize>,
     max_bytes: Option<u64>,
 ) {
+    let max_ev = max_events.unwrap_or(DEFAULT_MAX_EVENTS);
+    let max_b = max_bytes
+        .unwrap_or(DEFAULT_MAX_BYTES)
+        .min(ABSOLUTE_MAX_SPOOL_BYTES);
+    if event_json.len() as u64 + 1 > max_b {
+        crate::audit::audit_diagnostic(
+            "tirith: audit-spool: event exceeds the configured spool byte limit; event not queued",
+        );
+        return;
+    }
     if let Err(e) = spool_event(event_json) {
         crate::audit::audit_diagnostic(format!("tirith: audit-spool: failed to write event: {e}"));
         return;
     }
 
+    // repo-0195: enforce retention AT APPEND TIME, before any destination
+    // validation or network state can skip it — a prolonged outage must not
+    // grow the queue past the configured bounds.
+    trim_spool_to_retention(max_ev, max_b);
+
+    if DRAIN_ACTIVE
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        )
+        .is_err()
+    {
+        DRAIN_RESCAN.store(true, std::sync::atomic::Ordering::Release);
+        return; // a drainer is already running; the flag makes it rescan
+    }
+
     // Drain runs on a background thread — the CLI path must never block on network I/O.
     let url = server_url.to_string();
     let key = api_key.to_string();
-    let max_ev = max_events.unwrap_or(DEFAULT_MAX_EVENTS);
-    let max_b = max_bytes.unwrap_or(DEFAULT_MAX_BYTES);
-    std::thread::spawn(move || {
-        drain_spool(&url, &key, max_ev, max_b);
+    let spawned = std::thread::Builder::new()
+        .name("tirith-audit-drain".to_string())
+        .spawn(move || {
+            let mut ownership = DrainOwnership { held: true };
+            loop {
+                // Clear before draining: an append during this pass sets the
+                // flag again and earns another one.
+                DRAIN_RESCAN.store(false, std::sync::atomic::Ordering::Release);
+                drain_spool(&url, &key, max_ev, max_b);
+                if DRAIN_RESCAN.load(std::sync::atomic::Ordering::Acquire) {
+                    continue;
+                }
+                ownership.release();
+                // An append between the load above and that release saw an
+                // active drainer and only set the flag, so re-take ownership for
+                // it. If another caller already became the drainer, it owns the
+                // work.
+                if !DRAIN_RESCAN.load(std::sync::atomic::Ordering::Acquire) || !ownership.retake() {
+                    break;
+                }
+            }
+        });
+    if spawned.is_err() {
+        // Never leave the claim set for a worker that does not exist.
+        DRAIN_ACTIVE.store(false, std::sync::atomic::Ordering::Release);
+        crate::audit::audit_diagnostic(
+            "tirith: audit-upload: could not start the drain worker; the spool is retained",
+        );
+    }
+}
+
+/// Trim the spool file to the retention bounds (event count and total bytes),
+/// dropping the oldest lines. Runs under the spool lock.
+fn trim_spool_to_retention(max_events: usize, max_bytes: u64) {
+    let path = spool_path();
+    let _ = with_spool_lock(|| -> std::io::Result<()> {
+        let (lines, tail_truncated) = match read_spool_lines_bounded(&path, max_bytes) {
+            Ok(c) => c,
+            Err(_) => return Ok(()),
+        };
+        let trimmed = enforce_retention(lines.clone(), max_events, max_bytes);
+        if tail_truncated || trimmed != lines {
+            write_spool_atomic(&path, &trimmed)?;
+        }
+        Ok(())
     });
 }
 
@@ -307,7 +498,8 @@ mod tests {
         let path = dir.path().join("spool.jsonl");
         fs::write(&path, "line1\nline2\n").unwrap();
 
-        rewrite_spool(&path, &[]);
+        let snapshot = vec!["line1".to_string(), "line2".to_string()];
+        rewrite_spool(&path, &snapshot, snapshot.len(), u64::MAX);
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.is_empty());
     }
@@ -319,8 +511,13 @@ mod tests {
         // The on-disk spool holds the drainer's snapshot (sent + unsent lines).
         fs::write(&path, "line1\nline2\nline3\nline4\n").unwrap();
 
-        let remaining = vec!["line3".to_string(), "line4".to_string()];
-        rewrite_spool(&path, &remaining);
+        let snapshot = vec![
+            "line1".to_string(),
+            "line2".to_string(),
+            "line3".to_string(),
+            "line4".to_string(),
+        ];
+        rewrite_spool(&path, &snapshot, 2, u64::MAX);
         let content = fs::read_to_string(&path).unwrap();
         assert_eq!(content, "line3\nline4\n");
     }
@@ -334,12 +531,43 @@ mod tests {
         let path = dir.path().join("spool.jsonl");
         fs::write(&path, "line1\nline3\nline4\nline5-new\n").unwrap();
 
-        let remaining = vec!["line3".to_string(), "line4".to_string()];
-        rewrite_spool(&path, &remaining);
+        let snapshot = vec![
+            "line1".to_string(),
+            "line3".to_string(),
+            "line4".to_string(),
+        ];
+        rewrite_spool(&path, &snapshot, 1, u64::MAX);
         let content = fs::read_to_string(&path).unwrap();
         assert_eq!(
-            content, "line1\nline3\nline4\nline5-new\n",
-            "a suffix mismatch must leave the spool untouched"
+            content, "line3\nline4\nline5-new\n",
+            "the sent prefix is removed while a concurrent append survives"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_spool_preserves_append_after_fully_sent_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spool.jsonl");
+        fs::write(&path, "line1\nline2\nline3-new\n").unwrap();
+        let snapshot = vec!["line1".to_string(), "line2".to_string()];
+
+        rewrite_spool(&path, &snapshot, snapshot.len(), u64::MAX);
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "line3-new\n");
+    }
+
+    #[test]
+    fn test_rewrite_spool_refuses_changed_snapshot_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("spool.jsonl");
+        fs::write(&path, "other\nline2\nline3-new\n").unwrap();
+        let snapshot = vec!["line1".to_string(), "line2".to_string()];
+
+        rewrite_spool(&path, &snapshot, 1, u64::MAX);
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "other\nline2\nline3-new\n"
         );
     }
 }

--- a/crates/tirith-core/src/capsule/macos.rs
+++ b/crates/tirith-core/src/capsule/macos.rs
@@ -373,7 +373,13 @@ const SANDBOX_BASE_EXEC_ALLOW: &str = "\
 (allow file-read* (subpath \"/System/Library\"))
 (allow file-read* (subpath \"/Library/Frameworks\"))
 (allow file-read* (literal \"/dev/null\") (literal \"/dev/zero\") (literal \"/dev/random\") (literal \"/dev/urandom\"))
-(allow file-read-metadata)
+(allow file-read-metadata (literal \"/\"))
+(allow file-read-metadata (subpath \"/usr/lib\"))
+(allow file-read-metadata (subpath \"/usr/share\"))
+(allow file-read-metadata (subpath \"/System/Library\"))
+(allow file-read-metadata (subpath \"/Library/Frameworks\"))
+(allow file-read-metadata (subpath \"/private/var/db/dyld\"))
+(allow file-read-metadata (subpath \"/private/var/db/oah\"))
 ";
 
 /// The single network carve-out for an allow-list spec: outbound to the loopback

--- a/crates/tirith-core/src/capsule/windows.rs
+++ b/crates/tirith-core/src/capsule/windows.rs
@@ -71,7 +71,7 @@
 //! egress).
 
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::{
     canonicalize_and_validate_filesystem_policy, CapabilityLevel, Capsule, CapsuleCoverage,
@@ -478,6 +478,11 @@ pub struct WindowsLaunchPlan {
     pub profile: AppContainerProfile,
     /// The ACL grants to add (and later revoke) for the container SID.
     pub acl_grants: Vec<AclGrant>,
+    /// The isolated HOME/TEMP directory granted to the container when
+    /// `temporary_home` is set (repo-0199). The executor creates it before
+    /// applying the grant; `build_environment_block` points the HOME family
+    /// here.
+    pub temp_home: Option<PathBuf>,
     /// The Job Object limits to apply.
     pub job_limits: JobObjectLimits,
     /// The target program (the executable path / `lpApplicationName`).
@@ -549,10 +554,32 @@ pub fn windows_launch_plan_os(
 
     let mut normalized_spec = spec.clone();
     normalized_spec.filesystem = filesystem;
-    let grants = acl_grants_from_validated(&normalized_spec.filesystem);
+    let mut grants = acl_grants_from_validated(&normalized_spec.filesystem);
+    // repo-0199: a `temporary_home` spec points HOME/USERPROFILE/TEMP at an
+    // isolated directory — which must EXIST and be granted to the AppContainer
+    // SID, or contained programs get inaccessible profile/temp dirs while
+    // `env_isolated` claims success. Add its Modify grant to the plan.
+    let temp_home = if spec.environment.temporary_home {
+        // A PID-only directory survives multiple launches in one process and
+        // PID reuse across processes. Give every plan an unguessable path so a
+        // later capsule cannot inherit an earlier capsule's HOME/TEMP bytes.
+        let home = std::env::temp_dir().join(format!(
+            "tirith-capsule-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4().simple()
+        ));
+        grants.push(AclGrant {
+            path: home.clone(),
+            access: AclAccess::Modify,
+        });
+        Some(home)
+    } else {
+        None
+    };
     Ok(WindowsLaunchPlan {
         profile: app_container_profile(&normalized_spec)?,
         acl_grants: grants,
+        temp_home,
         job_limits: job_object_limits(&spec.resources),
         program: program.to_os_string(),
         program_args: program_args.to_vec(),
@@ -1068,6 +1095,27 @@ mod tests {
         }));
         // Job kills on close.
         assert!(plan.job_limits.kill_on_close);
+    }
+
+    #[test]
+    fn temporary_home_is_unique_for_every_launch_plan() {
+        let mut spec = CapsuleSpec::locked_down();
+        spec.environment.temporary_home = true;
+
+        let first = windows_launch_plan(&spec, "C:/cmd.exe", &[]).expect("first plan");
+        let second = windows_launch_plan(&spec, "C:/cmd.exe", &[]).expect("second plan");
+        let first_home = first.temp_home.expect("temporary home");
+        let second_home = second.temp_home.expect("temporary home");
+
+        assert_ne!(first_home, second_home, "capsules must not share HOME/TEMP");
+        assert!(first
+            .acl_grants
+            .iter()
+            .any(|grant| { grant.path == first_home && grant.access == AclAccess::Modify }));
+        assert!(second
+            .acl_grants
+            .iter()
+            .any(|grant| { grant.path == second_home && grant.access == AclAccess::Modify }));
     }
 
     #[test]

--- a/crates/tirith-core/src/checkpoint.rs
+++ b/crates/tirith-core/src/checkpoint.rs
@@ -46,6 +46,15 @@ pub struct CheckpointMeta {
     pub paths: Vec<String>,
     pub total_bytes: u64,
     pub file_count: usize,
+    /// repo-0200: true when the capture hit a budget cap (entry count, per-file
+    /// size, total bytes) or skipped unreadable entries, so the checkpoint is
+    /// NOT a complete backup. Surfaced by list/restore consumers; restore of a
+    /// partial checkpoint still works but is flagged.
+    #[serde(default)]
+    pub incomplete: bool,
+    /// Why `incomplete` is set (first reason wins).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incomplete_reason: Option<String>,
     /// F6: the working directory at capture time, persisted so a RELATIVE
     /// `original_path` in the manifest is restored against the SAME root it was
     /// captured under, not against whatever cwd the restore happens to run in
@@ -81,6 +90,12 @@ pub struct CheckpointListEntry {
     pub trigger_command: Option<String>,
     pub file_count: usize,
     pub total_bytes: u64,
+    /// The checkpoint omitted one or more requested entries.
+    #[serde(default)]
+    pub incomplete: bool,
+    /// First bounded omission reason, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incomplete_reason: Option<String>,
 }
 
 /// Checkpoint configuration.
@@ -106,6 +121,9 @@ fn default_max_total_bytes() -> u64 {
 
 /// Checkpoint metadata is tiny; cap hostile files before allocating/parsing.
 const CHECKPOINT_META_MAX_BYTES: u64 = 1024 * 1024;
+/// Manifests may contain thousands of paths, but remain bounded before JSON
+/// allocation/parsing when the checkpoint store is corrupt or attacker-owned.
+const CHECKPOINT_MANIFEST_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
 impl Default for CheckpointConfig {
     fn default() -> Self {
@@ -284,26 +302,37 @@ pub fn create_with_config(
     let mut manifest: Vec<ManifestEntry> = Vec::new();
     let mut total_bytes: u64 = 0;
 
+    // repo-0200: every capture gap lands here and is persisted in the meta.
+    let mut capture_gaps: Vec<String> = Vec::new();
     let mut fill = || -> Result<(), BackupError> {
         for path_str in paths {
             let path = Path::new(path_str);
-            if !path.exists() {
+            let root_meta = match path.symlink_metadata() {
+                Ok(meta) => meta,
+                Err(e) => {
+                    capture_gaps.push(format!("cannot inspect requested path {path_str}: {e}"));
+                    continue;
+                }
+            };
+            if root_meta.file_type().is_symlink() {
+                capture_gaps.push(format!("requested symlink omitted: {path_str}"));
                 continue;
             }
 
-            if path.is_file() {
+            if root_meta.is_file() {
                 match backup_file(path, &files_dir, &mut budget) {
                     Ok(entry) => {
                         total_bytes += entry.size;
                         manifest.push(entry);
                     }
                     Err(BackupError::Skip(e)) => {
+                        capture_gaps.push(format!("skipped {path_str}: {e}"));
                         eprintln!("tirith: checkpoint: skip {path_str}: {e}");
                     }
                     Err(BackupError::Abort(e)) => return Err(BackupError::Abort(e)),
                 }
-            } else if path.is_dir() {
-                match backup_dir(path, &files_dir, &mut budget) {
+            } else if root_meta.is_dir() {
+                match backup_dir(path, &files_dir, &mut budget, &mut capture_gaps) {
                     Ok(entries) => {
                         for entry in entries {
                             total_bytes += entry.size;
@@ -311,10 +340,15 @@ pub fn create_with_config(
                         }
                     }
                     Err(BackupError::Skip(e)) => {
+                        capture_gaps.push(format!("skipped dir {path_str}: {e}"));
                         eprintln!("tirith: checkpoint: skip dir {path_str}: {e}");
                     }
                     Err(BackupError::Abort(e)) => return Err(BackupError::Abort(e)),
                 }
+            } else {
+                capture_gaps.push(format!(
+                    "requested path is not a regular file or directory: {path_str}"
+                ));
             }
         }
         Ok(())
@@ -350,6 +384,8 @@ pub fn create_with_config(
         paths: paths.iter().map(|s| s.to_string()).collect(),
         total_bytes,
         file_count: manifest.len(),
+        incomplete: !capture_gaps.is_empty(),
+        incomplete_reason: capture_gaps.first().cloned(),
         // Persist the capture-time cwd so a relative `original_path` restores
         // against this root, independent of the cwd at restore time. Canonicalize
         // it first: on macOS the cwd often contains a symlinked ancestor
@@ -439,6 +475,8 @@ pub fn list() -> Result<Vec<CheckpointListEntry>, String> {
             trigger_command: meta.trigger_command,
             file_count: meta.file_count,
             total_bytes: meta.total_bytes,
+            incomplete: meta.incomplete,
+            incomplete_reason: meta.incomplete_reason,
         });
     }
 
@@ -474,6 +512,22 @@ fn load_bound_checkpoint_meta(
         return Err("metadata id does not match its checkpoint directory".to_string());
     }
     Ok((meta, identity))
+}
+
+fn load_bound_checkpoint_manifest(
+    checkpoint_dir: &Path,
+    identity: Option<(u64, u64)>,
+) -> Result<Vec<ManifestEntry>, String> {
+    verify_checkpoint_dir_identity(checkpoint_dir, identity)?;
+    let manifest_bytes = crate::util::read_text_no_follow_capped(
+        &checkpoint_dir.join("manifest.json"),
+        CHECKPOINT_MANIFEST_MAX_BYTES,
+    )
+    .map_err(|e| format!("cannot safely read manifest.json: {e:?}"))?;
+    verify_checkpoint_dir_identity(checkpoint_dir, identity)?;
+    let manifest_str = String::from_utf8(manifest_bytes)
+        .map_err(|_| "checkpoint manifest.json is not UTF-8".to_string())?;
+    serde_json::from_str(&manifest_str).map_err(|e| format!("corrupt manifest.json: {e}"))
 }
 
 /// Validate that a checkpoint id is the canonical lowercase UUID basename that
@@ -610,7 +664,11 @@ fn reject_symlinked_checkpoint_dir(cp_dir: &Path) -> Result<(), String> {
 fn capture_checkpoint_dir_identity(cp_dir: &Path) -> Result<Option<(u64, u64)>, String> {
     use std::os::unix::fs::MetadataExt;
     match fs::symlink_metadata(cp_dir) {
-        Ok(m) => Ok(Some((m.dev(), m.ino()))),
+        Ok(m) if m.is_dir() && !m.file_type().is_symlink() => Ok(Some((m.dev(), m.ino()))),
+        Ok(_) => Err(format!(
+            "checkpoint path is not a real directory: {}",
+            cp_dir.display()
+        )),
         Err(e) => Err(format!("cannot stat checkpoint directory: {e}")),
     }
 }
@@ -633,7 +691,14 @@ fn verify_checkpoint_dir_identity(
         use std::os::unix::fs::MetadataExt;
         if let Some((dev, ino)) = captured {
             return match fs::symlink_metadata(cp_dir) {
-                Ok(m) if m.dev() == dev && m.ino() == ino => Ok(()),
+                Ok(m)
+                    if m.is_dir()
+                        && !m.file_type().is_symlink()
+                        && m.dev() == dev
+                        && m.ino() == ino =>
+                {
+                    Ok(())
+                }
                 Ok(_) => Err(format!(
                     "checkpoint directory changed identity mid-read (possible swap): {}",
                     cp_dir.display()
@@ -929,6 +994,10 @@ pub struct RestoreReport {
     pub missing: Vec<String>,
     pub corrupt: Vec<String>,
     pub errors: Vec<(String, String)>,
+    /// The source checkpoint was created with omitted entries.
+    pub checkpoint_incomplete: bool,
+    /// First bounded omission reason recorded at capture.
+    pub checkpoint_incomplete_reason: Option<String>,
 }
 
 /// Restore files from a checkpoint, returning a per-bucket report.
@@ -959,33 +1028,11 @@ pub fn restore_reported(checkpoint_id: &str) -> Result<RestoreReport, String> {
     if !cp_dir.exists() {
         return Err(format!("checkpoint not found: {checkpoint_id}"));
     }
-    // The parent containment check above is LEXICAL: it confirms `cp_dir`'s parent
-    // path equals the store, but does not stop `cp_dir` ITSELF from being a symlink
-    // that redirects outside the store. Reading its manifest / restoring its files
-    // would then follow that link. Reject a symlinked checkpoint directory before
-    // any read. (`symlink_metadata` does not follow the final component.)
-    reject_symlinked_checkpoint_dir(&cp_dir)?;
-    // K3 (TOCTOU): the symlink check above is path-based, so `cp_dir` could be
-    // swapped for a symlink/another directory before the reads below. Pin its
-    // `(dev, ino)` now and re-verify before each subsequent read so a mid-call swap
-    // fails closed instead of feeding an attacker-controlled manifest/meta/blob.
-    let cp_ident = capture_checkpoint_dir_identity(&cp_dir)?;
-
-    verify_checkpoint_dir_identity(&cp_dir, cp_ident)?;
-    let manifest_str = fs::read_to_string(cp_dir.join("manifest.json"))
-        .map_err(|e| format!("read manifest: {e}"))?;
-    let manifest: Vec<ManifestEntry> =
-        serde_json::from_str(&manifest_str).map_err(|e| format!("parse manifest: {e}"))?;
-
-    // F6: the capture-time root used to anchor RELATIVE manifest paths. Read from
-    // meta.json (best-effort; a missing/corrupt meta or a pre-F6 checkpoint yields
-    // None, which makes relative entries non-anchorable and therefore rejected).
-    verify_checkpoint_dir_identity(&cp_dir, cp_ident)?;
-    let capture_root: Option<PathBuf> = fs::read_to_string(cp_dir.join("meta.json"))
-        .ok()
-        .and_then(|s| serde_json::from_str::<CheckpointMeta>(&s).ok())
-        .and_then(|m| m.capture_root)
-        .map(PathBuf::from);
+    // Bind metadata and manifest to one validated physical directory. Both
+    // files are opened no-follow and capped before allocation/deserialization.
+    let (checkpoint_meta, cp_ident) = load_bound_checkpoint_meta(&cp_dir, checkpoint_id)?;
+    let manifest = load_bound_checkpoint_manifest(&cp_dir, cp_ident)?;
+    let capture_root = checkpoint_meta.capture_root.as_deref().map(PathBuf::from);
 
     let files_dir = cp_dir.join("files");
     let mut report = RestoreReport {
@@ -995,6 +1042,8 @@ pub fn restore_reported(checkpoint_id: &str) -> Result<RestoreReport, String> {
         missing: Vec::new(),
         corrupt: Vec::new(),
         errors: Vec::new(),
+        checkpoint_incomplete: checkpoint_meta.incomplete,
+        checkpoint_incomplete_reason: checkpoint_meta.incomplete_reason,
     };
 
     for entry in &manifest {
@@ -1034,17 +1083,20 @@ pub fn restore_reported(checkpoint_id: &str) -> Result<RestoreReport, String> {
         // slip UNVERIFIED bytes into the destination, breaking the "corrupt blobs
         // are recorded, never written" guarantee. The handle is rewound to 0
         // between the hash and the copy below.
-        let mut blob = match fs::File::open(&src) {
+        let mut blob = match crate::util::open_read_no_follow_capped(&src, u64::MAX) {
             Ok(f) => f,
             Err(e) => {
                 eprintln!(
-                    "tirith: checkpoint restore: cannot open backup for {}: {e}, skipping",
+                    "tirith: checkpoint restore: cannot safely open backup for {}: {e:?}, skipping",
                     entry.original_path
                 );
                 report.corrupt.push(entry.original_path.clone());
                 continue;
             }
         };
+        // The child open above must still belong to the directory identity we
+        // pinned before reading metadata/manifest.
+        verify_checkpoint_dir_identity(&cp_dir, cp_ident)?;
 
         // Verify the backup blob's content matches the manifest SHA before
         // restoring. A mismatch means the blob was corrupted or tampered with
@@ -1217,31 +1269,9 @@ pub fn diff(checkpoint_id: &str) -> Result<Vec<DiffEntry>, String> {
     if !cp_dir.exists() {
         return Err(format!("checkpoint not found: {checkpoint_id}"));
     }
-    // Same symlink guard as the restore path: a symlinked `cp_dir` could redirect
-    // the manifest/file reads outside the store. Reject it before any read.
-    reject_symlinked_checkpoint_dir(&cp_dir)?;
-    // K3 (TOCTOU): mirror `restore_reported` exactly. Pin the checkpoint dir's
-    // `(dev, ino)` after the path-based symlink check and re-verify before each
-    // read so a mid-call directory swap fails closed instead of reading an
-    // attacker-controlled manifest/meta/blob.
-    let cp_ident = capture_checkpoint_dir_identity(&cp_dir)?;
-
-    verify_checkpoint_dir_identity(&cp_dir, cp_ident)?;
-    let manifest_str = fs::read_to_string(cp_dir.join("manifest.json"))
-        .map_err(|e| format!("read manifest: {e}"))?;
-    let manifest: Vec<ManifestEntry> =
-        serde_json::from_str(&manifest_str).map_err(|e| format!("parse manifest: {e}"))?;
-
-    // F6: anchor RELATIVE manifest paths to the capture-time root (read from
-    // meta.json) exactly as `restore_reported` does, rather than resolving them
-    // against the caller's cwd. A missing/corrupt meta or a pre-F6 checkpoint yields
-    // None, which makes a relative entry non-anchorable (skipped below).
-    verify_checkpoint_dir_identity(&cp_dir, cp_ident)?;
-    let capture_root: Option<PathBuf> = fs::read_to_string(cp_dir.join("meta.json"))
-        .ok()
-        .and_then(|s| serde_json::from_str::<CheckpointMeta>(&s).ok())
-        .and_then(|m| m.capture_root)
-        .map(PathBuf::from);
+    let (checkpoint_meta, cp_ident) = load_bound_checkpoint_meta(&cp_dir, checkpoint_id)?;
+    let manifest = load_bound_checkpoint_manifest(&cp_dir, cp_ident)?;
+    let capture_root = checkpoint_meta.capture_root.as_deref().map(PathBuf::from);
 
     let files_dir = cp_dir.join("files");
     let mut diffs = Vec::new();
@@ -1253,11 +1283,33 @@ pub fn diff(checkpoint_id: &str) -> Result<Vec<DiffEntry>, String> {
             continue;
         }
 
+        // A manifest is persisted state, not trusted input. Validate both
+        // fields before joining either one into a filesystem path.
+        validate_restore_path(&entry.original_path)?;
+        validate_sha256_filename(&entry.sha256)?;
+
         // K3: re-verify identity before EACH `files/<sha>` read; a swap part-way
         // through aborts the diff (the store is no longer trustworthy).
         verify_checkpoint_dir_identity(&cp_dir, cp_ident)?;
-        let backup = files_dir.join(&entry.sha256);
-        if !backup.exists() {
+        let backup_path = files_dir.join(&entry.sha256);
+        let mut backup = match crate::util::open_read_no_follow_capped(&backup_path, u64::MAX) {
+            Ok(file) => file,
+            Err(_) => {
+                diffs.push(DiffEntry {
+                    path: entry.original_path.clone(),
+                    status: DiffStatus::BackupCorrupt,
+                    checkpoint_sha256: entry.sha256.clone(),
+                    current_sha256: None,
+                });
+                classified_paths.insert(entry.original_path.clone());
+                continue;
+            }
+        };
+        verify_checkpoint_dir_identity(&cp_dir, cp_ident)?;
+
+        // repo-0202: an existing blob is not proof of integrity. Hash the
+        // no-follow handle and compare against its content-addressed name.
+        if !matches!(sha256_reader(&mut backup), Ok(actual) if actual == entry.sha256) {
             diffs.push(DiffEntry {
                 path: entry.original_path.clone(),
                 status: DiffStatus::BackupCorrupt,
@@ -1715,55 +1767,97 @@ fn backup_file(
     files_dir: &Path,
     budget: &mut CreationBudget,
 ) -> Result<ManifestEntry, BackupError> {
-    let sha = sha256_file(path).map_err(BackupError::Skip)?;
-    let dst = files_dir.join(&sha);
+    // repo-0201: hash and copy through ONE open handle — hashing first and
+    // reopening for the copy let a concurrent modification desync the
+    // content-addressed blob from the manifest digest (restore would then
+    // reject the only backup as corrupt).
+    let src_file = crate::util::open_read_no_follow_capped(path, u64::MAX)
+        .map_err(|e| BackupError::Skip(format!("open {}: {e:?}", path.display())))?;
+    // Size and mode come from that exact handle, not a path lookup that can be
+    // swapped before open.
+    let meta = src_file
+        .metadata()
+        .map_err(|e| BackupError::Skip(format!("metadata {}: {e}", path.display())))?;
+    let initial_size = meta.len();
 
-    let meta = match path.metadata() {
-        Ok(m) => Some(m),
-        Err(e) => {
-            eprintln!(
-                "tirith: checkpoint: cannot read metadata for {}: {e}",
-                path.display()
-            );
-            None
+    // Refuse to START a large copy the filesystem cannot hold (repo-0262):
+    // failing mid-copy would leave a torn blob and a wasted partial write.
+    #[cfg(unix)]
+    if initial_size >= 1024 * 1024 {
+        if let Some(free) = available_bytes(files_dir) {
+            if free < initial_size {
+                return Err(BackupError::Abort(format!(
+                    "insufficient filesystem space for checkpoint copy of {} ({initial_size} bytes needed, {free} available)",
+                    path.display()
+                )));
+            }
         }
+    }
+
+    // Stream once, hashing and writing to a temp sibling, then rename to the
+    // digest name. The digest always describes the copied bytes.
+    let mut copied: u64 = 0;
+    let (sha, dst) = {
+        let mut hasher = Sha256::new();
+        let mut tmp = tempfile::NamedTempFile::new_in(files_dir)
+            .map_err(|e| BackupError::Skip(format!("tempfile: {e}")))?;
+        let mut reader = std::io::BufReader::new(src_file);
+        let mut buf = [0u8; 8192];
+        loop {
+            let n = std::io::Read::read(&mut reader, &mut buf)
+                .map_err(|e| BackupError::Skip(format!("read {}: {e}", path.display())))?;
+            if n == 0 {
+                break;
+            }
+            if budget.remaining_copy_bytes < n as u64 {
+                return Err(BackupError::Abort(format!(
+                    "checkpoint exceeds the configured total-byte limit of {} bytes while copying {}; aborting",
+                    budget.limit,
+                    path.display()
+                )));
+            }
+            budget.remaining_copy_bytes -= n as u64;
+            copied += n as u64;
+            hasher.update(&buf[..n]);
+            use std::io::Write as _;
+            tmp.write_all(&buf[..n])
+                .map_err(|e| BackupError::Skip(format!("write blob: {e}")))?;
+        }
+        let digest = format!("{:x}", hasher.finalize());
+        let dst = files_dir.join(&digest);
+        (digest, (tmp, dst))
     };
-    let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
+    let (tmp, dst) = dst;
 
     // Content-addressed dedup: two checkpointed files with identical contents
     // share a single on-disk copy. Only a REAL copy draws down the cumulative
     // creation budget (repo-0262).
-    if !dst.exists() {
-        if size > budget.remaining_copy_bytes {
-            return Err(BackupError::Abort(format!(
-                "checkpoint exceeds the configured total-byte limit of {} bytes while copying {}; aborting",
-                budget.limit,
-                path.display()
-            )));
-        }
-        // Refuse to START a large copy the filesystem cannot hold (repo-0262):
-        // failing mid-copy would leave a torn blob and a wasted partial write.
-        #[cfg(unix)]
-        if size >= 1024 * 1024 {
-            if let Some(free) = available_bytes(files_dir) {
-                if free < size {
-                    return Err(BackupError::Abort(format!(
-                        "insufficient filesystem space for checkpoint copy of {} ({size} bytes needed, {free} available)",
-                        path.display()
-                    )));
-                }
-            }
-        }
-        fs::copy(path, &dst).map_err(|e| BackupError::Skip(format!("copy: {e}")))?;
-        budget.remaining_copy_bytes = budget.remaining_copy_bytes.saturating_sub(size);
+    let existing_matches = crate::util::open_read_no_follow_capped(&dst, u64::MAX)
+        .ok()
+        .and_then(|mut existing| sha256_reader(&mut existing).ok())
+        .as_deref()
+        == Some(sha.as_str());
+    if existing_matches {
+        // Identical verified content is already stored; drop the duplicate
+        // temp copy. A corrupt, symlinked, or non-regular destination is not
+        // trusted merely because its filename equals the digest.
+        drop(tmp);
+        // repo-0262: a deduplicated copy draws NO budget — refund what the
+        // streaming pass charged.
+        budget.remaining_copy_bytes = budget.remaining_copy_bytes.saturating_add(copied);
+    } else {
+        tmp.persist(&dst)
+            .map_err(|e| BackupError::Skip(format!("publish blob: {e}")))?;
     }
 
     Ok(ManifestEntry {
         original_path: normalize_capture_path(path),
         sha256: sha,
-        size,
+        // The open source can grow or shrink while being streamed. The digest
+        // and manifest size must both describe the bytes actually copied.
+        size: copied,
         is_dir: false,
-        mode: meta.as_ref().and_then(captured_mode),
+        mode: captured_mode(&meta),
     })
 }
 
@@ -1772,10 +1866,14 @@ fn backup_file(
 /// Directory entries are recorded too (repo-0261): restore recreates empty
 /// directories and re-applies each recorded directory mode after the files are
 /// in place, instead of leaving every parent at the umask default.
+/// repo-0200: capturing with a gap channel — every skip/cap is recorded so the
+/// checkpoint metadata can flag the backup as incomplete instead of reporting
+/// silent success.
 fn backup_dir(
     dir: &Path,
     files_dir: &Path,
     budget: &mut CreationBudget,
+    gaps: &mut Vec<String>,
 ) -> Result<Vec<ManifestEntry>, BackupError> {
     let mut entries = Vec::new();
     const MAX_FILES: usize = 10_000;
@@ -1801,6 +1899,7 @@ fn backup_dir(
         MAX_FILES,
         MAX_SINGLE_FILE,
         budget,
+        gaps,
     )?;
     Ok(entries)
 }
@@ -1812,8 +1911,12 @@ fn backup_dir_recursive(
     max_files: usize,
     max_single_file: u64,
     budget: &mut CreationBudget,
+    gaps: &mut Vec<String>,
 ) -> Result<(), BackupError> {
     if entries.len() >= max_files {
+        gaps.push(format!(
+            "entry cap of {max_files} reached before all files were captured"
+        ));
         return Ok(());
     }
 
@@ -1822,11 +1925,15 @@ fn backup_dir_recursive(
 
     for entry in read_dir {
         if entries.len() >= max_files {
+            gaps.push(format!(
+                "entry cap of {max_files} reached before all files were captured"
+            ));
             break;
         }
         let entry = match entry {
             Ok(e) => e,
             Err(e) => {
+                gaps.push(format!("unreadable entry in {}: {e}", dir.display()));
                 eprintln!(
                     "tirith: checkpoint: skip unreadable entry in {}: {e}",
                     dir.display()
@@ -1840,18 +1947,25 @@ fn backup_dir_recursive(
         let meta = match path.symlink_metadata() {
             Ok(m) => m,
             Err(e) => {
+                gaps.push(format!("unreadable entry {}: {e}", path.display()));
                 eprintln!("tirith: checkpoint: skip {}: {e}", path.display());
                 continue;
             }
         };
 
         if meta.file_type().is_symlink() {
+            gaps.push(format!("symlink omitted: {}", path.display()));
             continue; // following symlinks could back up files outside the tree
         }
 
         if meta.file_type().is_file() {
             let size = meta.len();
             if size > max_single_file {
+                gaps.push(format!(
+                    "file {} ({} bytes) exceeds the per-file cap",
+                    path.display(),
+                    size
+                ));
                 eprintln!(
                     "tirith: checkpoint: skip large file {} ({} bytes)",
                     path.display(),
@@ -1862,6 +1976,7 @@ fn backup_dir_recursive(
             match backup_file(&path, files_dir, budget) {
                 Ok(e) => entries.push(e),
                 Err(BackupError::Skip(e)) => {
+                    gaps.push(format!("skipped {}: {e}", path.display()));
                     eprintln!("tirith: checkpoint: skip {}: {e}", path.display());
                 }
                 Err(BackupError::Abort(e)) => return Err(BackupError::Abort(e)),
@@ -1874,6 +1989,7 @@ fn backup_dir_recursive(
                 .map(|n| n.starts_with('.'))
                 .unwrap_or(false)
             {
+                gaps.push(format!("dot-directory omitted: {}", path.display()));
                 continue;
             }
             // Record the directory itself so restore recreates empty
@@ -1892,6 +2008,7 @@ fn backup_dir_recursive(
                 max_files,
                 max_single_file,
                 budget,
+                gaps,
             )?;
         }
     }
@@ -1986,6 +2103,8 @@ mod tests {
                 paths: Vec::new(),
                 total_bytes: 123,
                 file_count: 0,
+                incomplete: false,
+                incomplete_reason: None,
                 capture_root: None,
             };
             fs::write(
@@ -2090,6 +2209,44 @@ mod tests {
     }
 
     #[test]
+    fn backup_replaces_a_corrupt_preexisting_digest_blob() {
+        let tmp = tempfile::tempdir().unwrap();
+        let test_file = tmp.path().join("test.txt");
+        fs::write(&test_file, "hello world").unwrap();
+        let files_dir = tmp.path().join("files");
+        fs::create_dir_all(&files_dir).unwrap();
+        let digest = sha256_file(&test_file).unwrap();
+        fs::write(files_dir.join(&digest), "corrupt").unwrap();
+
+        let entry = backup_file(&test_file, &files_dir, &mut test_budget()).unwrap();
+
+        assert_eq!(entry.sha256, digest);
+        assert_eq!(entry.size, 11);
+        assert_eq!(
+            fs::read(files_dir.join(&entry.sha256)).unwrap(),
+            b"hello world"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bound_manifest_loader_refuses_a_symlinked_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let id = uuid::Uuid::new_v4().to_string();
+        let checkpoint_dir = tmp.path().join(&id);
+        fs::create_dir_all(&checkpoint_dir).unwrap();
+        let outside = tmp.path().join("outside.json");
+        fs::write(&outside, "[]").unwrap();
+        std::os::unix::fs::symlink(&outside, checkpoint_dir.join("manifest.json")).unwrap();
+        let identity = capture_checkpoint_dir_identity(&checkpoint_dir).unwrap();
+
+        let error = load_bound_checkpoint_manifest(&checkpoint_dir, identity)
+            .expect_err("a manifest symlink must be refused");
+
+        assert!(error.contains("safely read manifest.json"), "{error}");
+    }
+
+    #[test]
     fn test_backup_dir_recursive() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("project");
@@ -2100,7 +2257,7 @@ mod tests {
         let files_dir = tmp.path().join("files");
         fs::create_dir_all(&files_dir).unwrap();
 
-        let entries = backup_dir(&dir, &files_dir, &mut test_budget()).unwrap();
+        let entries = backup_dir(&dir, &files_dir, &mut test_budget(), &mut Vec::new()).unwrap();
         let files = entries.iter().filter(|e| !e.is_dir).count();
         let dirs = entries.iter().filter(|e| e.is_dir).count();
         assert_eq!(files, 2, "should backup 2 files: {entries:?}");

--- a/crates/tirith-core/src/hygiene.rs
+++ b/crates/tirith-core/src/hygiene.rs
@@ -190,7 +190,13 @@ fn check_ssh_config_includes(config_path: &Path, ssh_dir: &Path) -> Option<Hygie
         if target.is_empty() {
             continue;
         }
-        if include_target_is_unsafe(target, ssh_dir) {
+        // repo-0456: ssh_config(5) permits MULTIPLE whitespace-separated
+        // patterns in one Include directive — validate each, not the joined
+        // remainder.
+        if target
+            .split_whitespace()
+            .any(|t| include_target_is_unsafe(t, ssh_dir))
+        {
             return Some(HygieneFinding {
                 rule_id: RuleId::HygieneSshConfigUnsafeInclude,
                 path: config_path.to_path_buf(),
@@ -216,17 +222,41 @@ fn check_ssh_config_includes(config_path: &Path, ssh_dir: &Path) -> Option<Hygie
 fn include_target_is_unsafe(target: &str, ssh_dir: &Path) -> bool {
     let target = target.trim_matches('"').trim_matches('\'');
 
+    // repo-0456: normalize `..` segments BEFORE the confinement checks — both
+    // the `~/` and absolute branches used to return early on a textual prefix,
+    // so `~/.ssh/../tmp/evil` was wrongly considered confined.
+    let mut normalized: Vec<&str> = Vec::new();
+    let mut escapes = false;
+    for seg in target.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                if normalized.pop().is_none() {
+                    escapes = true;
+                }
+            }
+            other => normalized.push(other),
+        }
+    }
+    let normalized = normalized.join("/");
+    if escapes && !target.starts_with('/') && !target.starts_with("~/") {
+        return true; // a relative path climbing above its base
+    }
+
     // `~/`-expanded: `~/.ssh/...` is fine, anything else under `~` is outside.
-    if let Some(stripped) = target.strip_prefix("~/") {
-        return !stripped.starts_with(".ssh/") && stripped != ".ssh";
+    if target.strip_prefix("~/").is_some() {
+        return !(normalized == ".ssh"
+            || normalized
+                .strip_prefix(".ssh/")
+                .is_some_and(|rest| !rest.is_empty()));
     }
     // Absolute: unsafe unless confined to ~/.ssh (best-effort prefix check).
     if target.starts_with('/') {
-        let p = Path::new(target);
-        return !p.starts_with(ssh_dir);
+        let normalized_abs = format!("/{normalized}");
+        return !Path::new(&normalized_abs).starts_with(ssh_dir);
     }
     // Relative: unsafe only if it climbs out with `..`.
-    target.split('/').any(|seg| seg == "..")
+    escapes
 }
 
 /// `~/.aws`: `credentials` (and `config`) must be 0600.

--- a/crates/tirith-core/src/intent.rs
+++ b/crates/tirith-core/src/intent.rs
@@ -118,6 +118,11 @@ impl CommandSignal {
             | RuleId::HelmUntrustedRepo
             | RuleId::RepoAddFromPipe => Some(CommandSignal::PackageInstall),
 
+            // repo-0457: DotfileOverwrite covers `>> ~/.bashrc`-style shell-rc
+            // writes; without this mapping the Configure/Deploy justification
+            // logic never sees the signal and no mismatch is possible.
+            RuleId::DotfileOverwrite => Some(CommandSignal::ShellRcWrite),
+
             _ => None,
         }
     }

--- a/crates/tirith-core/src/lsp_profiles.rs
+++ b/crates/tirith-core/src/lsp_profiles.rs
@@ -228,6 +228,15 @@ pub fn retains(profile: LspProfile, rule_id: RuleId) -> bool {
             // buffer (see fn doc). Listed so a diff-aware LSP keeps them.
             | RuleId::AiConfigHiddenInstructionAdded
             | RuleId::AiConfigToolUseEscalation
+            // repo-0458: MCP config files are routed to AiConfig, so the
+            // MCP-specific config findings must be retained or a malicious
+            // mcp.json scores clean in the LSP surface.
+            | RuleId::McpInsecureServer
+            | RuleId::McpUntrustedServer
+            | RuleId::McpDuplicateServerName
+            | RuleId::McpOverlyPermissive
+            | RuleId::McpSuspiciousArgs
+            | RuleId::McpServerDrift
         ),
 
         // Markdown install docs: URL/transport + command-shape rules on the

--- a/crates/tirith-core/src/mcp/dispatcher.rs
+++ b/crates/tirith-core/src/mcp/dispatcher.rs
@@ -57,7 +57,7 @@ pub fn run_with_options(
                 .and_then(|p| p.to_str().map(String::from))
                 .as_deref(),
         );
-        let (ctx, bad) = output_filter::OutputFilterContext::from_policy(&policy);
+        let (ctx, bad) = output_filter::OutputFilterContext::from_policy_with_diagnostics(&policy);
         for (pattern, error) in &bad {
             let _ = writeln!(
                 log,

--- a/crates/tirith-core/src/mcp/output_filter.rs
+++ b/crates/tirith-core/src/mcp/output_filter.rs
@@ -64,9 +64,14 @@ pub struct OutputFilterContext {
 }
 
 impl OutputFilterContext {
-    /// Build a context from a discovered [`crate::policy::Policy`]: compile the
-    /// operator's `injection_seeds_custom` and read `mcp_redact_injection`. Returns
-    /// the context PLUS the bad-seed list `(pattern, error)` so the long-lived
+    /// Build a context from a discovered [`crate::policy::Policy`]. This keeps
+    /// the historical public return type; long-lived server seams that need
+    /// compile diagnostics use [`Self::from_policy_with_diagnostics`].
+    pub fn from_policy(policy: &crate::policy::Policy) -> Self {
+        Self::from_policy_with_diagnostics(policy).0
+    }
+
+    /// Build a context and return the bad-seed list `(pattern, error)` so the long-lived
     /// server/gateway seams can surface each bad pattern ONCE at init instead of
     /// silently dropping it (a seed that passes `policy validate` but somehow fails
     /// the real compile would otherwise disappear with no signal). This is init,
@@ -75,7 +80,9 @@ impl OutputFilterContext {
     /// The caller is expected to have discovered the policy OFFLINE
     /// ([`crate::policy::Policy::discover_local_only`]), which neutralizes a
     /// repo-scoped `mcp_redact_injection` so a repo cannot weaken a Block.
-    pub fn from_policy(policy: &crate::policy::Policy) -> (Self, Vec<(String, regex::Error)>) {
+    pub fn from_policy_with_diagnostics(
+        policy: &crate::policy::Policy,
+    ) -> (Self, Vec<(String, regex::Error)>) {
         let (custom_seeds, bad) = prompt_injection::compile_seeds(&policy.injection_seeds_custom);
         (
             Self {
@@ -985,39 +992,17 @@ impl TerminalSanitizer {
 /// chars from `chunk` into `out`. This one-shot byte API remains for existing
 /// callers; multi-leaf MCP paths use [`TerminalSanitizer`] directly.
 pub fn sanitize_text_into(chunk: &[u8], out: &mut Vec<u8>) {
-    // Sanitize each valid UTF-8 run and pass invalid bytes through unchanged.
-    // `from_utf8_lossy` would rewrite them as U+FFFD, which silently destroys
-    // byte fidelity for a caller handing this arbitrary output bytes — and the
-    // sanitizer has nothing to say about a byte that is not a character.
+    // Lossy decode is deliberate and is the SAFE direction here: this is a
+    // display sanitizer, and a byte that is not valid UTF-8 can still be a
+    // terminal control in the terminal's own 8-bit encoding — a bare 0x9B is
+    // the C1 CSI introducer. Passing invalid bytes through verbatim to preserve
+    // byte fidelity would forward exactly the sequences this module exists to
+    // neutralize, so undecodable input becomes U+FFFD instead.
+    let decoded = String::from_utf8_lossy(chunk);
     let mut sanitizer = TerminalSanitizer::default();
-    let mut rest = chunk;
-    loop {
-        match std::str::from_utf8(rest) {
-            Ok(text) => {
-                out.extend_from_slice(sanitizer.sanitize_chunk(text).as_bytes());
-                break;
-            }
-            Err(error) => {
-                let (valid, after) = rest.split_at(error.valid_up_to());
-                // SAFETY-adjacent: `valid_up_to` is exactly the valid prefix.
-                let text = std::str::from_utf8(valid).unwrap_or_default();
-                out.extend_from_slice(sanitizer.sanitize_chunk(text).as_bytes());
-                match error.error_len() {
-                    Some(len) => {
-                        out.extend_from_slice(&after[..len]);
-                        rest = &after[len..];
-                    }
-                    // An incomplete sequence at the end of the chunk: keep the
-                    // bytes verbatim rather than guessing at a continuation.
-                    None => {
-                        out.extend_from_slice(after);
-                        break;
-                    }
-                }
-            }
-        }
-    }
+    let sanitized = sanitizer.sanitize_chunk(&decoded);
     sanitizer.finish();
+    out.extend_from_slice(sanitized.as_bytes());
 }
 
 fn is_strippable_zero_width(ch: char) -> bool {
@@ -2041,29 +2026,20 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_text_into_keeps_invalid_utf8_bytes_verbatim() {
-        // The byte API is public, so a caller can hand it arbitrary output.
-        // from_utf8_lossy would rewrite every invalid byte as U+FFFD and
-        // silently change the bytes the caller gets back.
+    fn sanitize_text_into_neutralizes_a_raw_c1_control_byte() {
+        // A bare 0x9B is the 8-bit CSI introducer. It is not valid UTF-8, so
+        // preserving byte fidelity here would hand a terminal the exact control
+        // this module removes when the same control arrives as U+009B.
         let mut out = Vec::new();
-        sanitize_text_into(b"before\xff\xfeafter", &mut out);
-        assert_eq!(out, b"before\xff\xfeafter");
-
-        // Control sequences inside the valid runs are still sanitized.
-        let mut out = Vec::new();
-        sanitize_text_into(b"a\x1b[31mred\xffz", &mut out);
+        sanitize_text_into(b"a\x9b31mb", &mut out);
         assert!(
-            !out.windows(2).any(|pair| pair == b"\x1b["),
-            "a CSI inside a valid run must still be stripped: {out:?}"
-        );
-        assert!(
-            out.contains(&0xff),
-            "the invalid byte must survive: {out:?}"
+            !out.contains(&0x9b),
+            "a raw C1 CSI byte must not reach the terminal: {out:?}"
         );
 
-        // An incomplete sequence at the very end is kept, not guessed at.
+        // Valid text is unaffected, and an escape inside it is still stripped.
         let mut out = Vec::new();
-        sanitize_text_into(b"tail\xe2\x82", &mut out);
-        assert_eq!(out, b"tail\xe2\x82");
+        sanitize_text_into(b"a\x1b[31mred", &mut out);
+        assert_eq!(out, b"ared");
     }
 }

--- a/crates/tirith-core/src/mcp_lock.rs
+++ b/crates/tirith-core/src/mcp_lock.rs
@@ -3122,6 +3122,70 @@ fn compute_drift_static(current: &McpInventory, lock: &McpLockfile) -> Vec<McpDr
         j += 1;
     }
 
+    // repo-0459: `content_hash` excludes `source_config` BY DESIGN, so moving
+    // an unchanged server between config files must not drift. The
+    // `(name, source_config)`-keyed merge walk reports such a move as
+    // Removed+Added when unrelated drift forces this slow path — cancel pairs
+    // whose name AND content hash match (a true move), so fast and slow paths
+    // agree.
+    let mut kept: Vec<McpDrift> = Vec::with_capacity(drifts.len());
+    // (name, hash) for Added entries to match Removed against. Resolve each
+    // hash through the exact `(name, source_config)` key: duplicate server
+    // names in different config files are valid and may carry different
+    // transports, so a name-only lookup can cancel the wrong pair.
+    let add_keys: Vec<(String, String)> = drifts
+        .iter()
+        .filter_map(|d| match d {
+            McpDrift::Added {
+                name,
+                source_config,
+                ..
+            } => {
+                let hash = current_lock
+                    .servers
+                    .iter()
+                    .find(|s| &s.name == name && &s.source_config == source_config)
+                    .map(|s| s.hash.clone())
+                    .unwrap_or_default();
+                Some((name.clone(), hash))
+            }
+            _ => None,
+        })
+        .collect();
+    let mut used_adds: Vec<bool> = vec![false; add_keys.len()];
+    for d in drifts {
+        if let McpDrift::Removed {
+            name,
+            source_config,
+        } = &d
+        {
+            let removed_hash = lock
+                .servers
+                .iter()
+                .find(|s| &s.name == name && &s.source_config == source_config)
+                .map(|s| s.hash.clone())
+                .unwrap_or_default();
+            let matched = add_keys
+                .iter()
+                .enumerate()
+                .find(|(idx, (an, ah))| !used_adds[*idx] && an == name && *ah == removed_hash)
+                .map(|(idx, _)| idx);
+            if let Some(idx) = matched {
+                used_adds[idx] = true;
+                continue; // pure move: drop the Removed
+            }
+        }
+        kept.push(d);
+    }
+    // Drop the matched Adds too.
+    let mut drifts: Vec<McpDrift> = Vec::with_capacity(kept.len());
+    let mut add_iter = used_adds.iter();
+    for d in kept {
+        if matches!(d, McpDrift::Added { .. }) && add_iter.next() == Some(&true) {
+            continue;
+        }
+        drifts.push(d);
+    }
     drifts.sort_by_key(McpDrift::sort_key);
     drifts
 }
@@ -5988,10 +6052,10 @@ mod tests {
 
     #[test]
     fn drift_detects_unchanged_server_moving_between_config_principals() {
-        // The transport content is unchanged, but source_config is part of the
-        // policy principal. The inventory fast hash must therefore admit the
-        // merge walk, which reports the old principal removed and the new one
-        // added instead of incorrectly returning clean.
+        // repo-0459: `content_hash` excludes `source_config` BY DESIGN, so a
+        // pure move between config files is NOT drift — on the fast path (equal
+        // inventory) or the slow path (unrelated drift forcing the merge
+        // walk). Both paths must agree.
         let prev = mk_inventory(vec![McpServerEntry {
             tools_declared: true,
             source_config: ".mcp.json".into(),
@@ -6005,20 +6069,81 @@ mod tests {
             ..stdio_server("s", "node")
         }]);
         let drifts = compute_drift(&cur, &lock);
+        // Fast path: pure move, equal inventory — no drift.
+        assert!(drifts.is_empty(), "pure move must stay clean: {drifts:?}");
+        // Slow path consistency: with an unrelated server added, the move must
+        // STILL not surface as Removed+Added.
+        let cur2 = mk_inventory(vec![
+            McpServerEntry {
+                tools_declared: true,
+                source_config: ".vscode/mcp.json".into(),
+                ..stdio_server("s", "node")
+            },
+            stdio_server("other", "node"),
+        ]);
+        let drifts2 = compute_drift(&cur2, &lock);
         assert!(
-            drifts.iter().any(|drift| matches!(
+            !drifts2.iter().any(|drift| matches!(
                 drift,
-                McpDrift::Removed { source_config, .. } if source_config == ".mcp.json"
+                McpDrift::Removed { name, .. } if name == "s"
             )),
-            "old source-qualified principal must be removed: {drifts:?}"
+            "a pure config-file move must not report removal: {drifts2:?}"
         );
         assert!(
-            drifts.iter().any(|drift| matches!(
+            !drifts2.iter().any(|drift| matches!(
                 drift,
-                McpDrift::Added { source_config, .. } if source_config == ".vscode/mcp.json"
+                McpDrift::Added { name, .. } if name == "s"
             )),
-            "new source-qualified principal must be added: {drifts:?}"
+            "a pure config-file move must not report addition: {drifts2:?}"
         );
+        // The genuinely new server IS reported.
+        assert!(
+            drifts2.iter().any(|drift| matches!(
+                drift,
+                McpDrift::Added { name, .. } if name == "other"
+            )),
+            "the new server must be reported: {drifts2:?}"
+        );
+    }
+
+    #[test]
+    fn drift_move_cancellation_uses_the_exact_duplicate_server_hash() {
+        let prev = mk_inventory(vec![
+            McpServerEntry {
+                source_config: "a.json".into(),
+                ..stdio_server("shared", "node")
+            },
+            McpServerEntry {
+                source_config: "b.json".into(),
+                ..stdio_server("shared", "deno")
+            },
+        ]);
+        let lock = McpLockfile::from_inventory(&prev);
+
+        let cur = mk_inventory(vec![
+            // The deno server moved; the node twin stayed put.
+            McpServerEntry {
+                source_config: "a.json".into(),
+                ..stdio_server("shared", "node")
+            },
+            McpServerEntry {
+                source_config: "c.json".into(),
+                ..stdio_server("shared", "deno")
+            },
+            // Force the slow path independently of the move.
+            stdio_server("other", "node"),
+        ]);
+
+        let drifts = compute_drift(&cur, &lock);
+        assert_eq!(
+            drifts.len(),
+            1,
+            "only the real addition may drift: {drifts:?}"
+        );
+        assert!(matches!(
+            &drifts[0],
+            McpDrift::Added { name, .. } if name == "other"
+        ));
     }
 
     #[test]

--- a/crates/tirith-core/src/path_audit.rs
+++ b/crates/tirith-core/src/path_audit.rs
@@ -221,6 +221,25 @@ impl PathAuditReport {
     }
 }
 
+/// repo-0403: standard package-manager prefixes are user-writable BY DESIGN
+/// (Homebrew, user-local installs); they are exempt from the report-surface
+/// writable-before-system finding.
+fn is_package_manager_prefix(dir: &Path) -> bool {
+    let s = dir.to_string_lossy().to_lowercase();
+    s == "/opt/homebrew/bin"
+        || s == "/opt/homebrew/sbin"
+        || s.starts_with("/opt/homebrew/cellar/")
+        || s.starts_with("/opt/homebrew/opt/")
+        || s == "/home/linuxbrew/.linuxbrew/bin"
+        || s == "/home/linuxbrew/.linuxbrew/sbin"
+        || s.starts_with("/home/linuxbrew/.linuxbrew/cellar/")
+        || s.starts_with("/home/linuxbrew/.linuxbrew/opt/")
+        || s == "/usr/local/bin"
+        || s == "/usr/local/sbin"
+        || s.starts_with("/usr/local/cellar/")
+        || s.starts_with("/usr/local/opt/")
+}
+
 /// Audit a `$PATH` string. `repo_root` and `tmp_roots` are injected for
 /// hermeticity; directory existence + writability are probed on the real FS, so
 /// tests that want those signals create real temp dirs.
@@ -256,6 +275,20 @@ pub fn audit_path_str(
         // Writable-before-system is SCOPED to repo-local / /tmp dirs, matching
         // the hot-path rule (flagging every writable dir would fire everywhere).
         if (repo_local || tmp_local) && dir_precedes_system(dir, &dirs) && dir_is_user_writable(dir)
+        {
+            report.findings.push(PathAuditEntry {
+                dir: dir.display().to_string(),
+                risk: PathDirRisk::WritableBeforeSystem,
+                command: String::new(),
+            });
+        }
+        // repo-0403: the REPORT surface additionally flags any other
+        // user-writable directory that precedes a system dir (outside the
+        // standard package-manager prefixes, where writability is by design).
+        if !(repo_local || tmp_local)
+            && dir_precedes_system(dir, &dirs)
+            && dir_is_user_writable(dir)
+            && !is_package_manager_prefix(dir)
         {
             report.findings.push(PathAuditEntry {
                 dir: dir.display().to_string(),

--- a/crates/tirith-core/src/receipt.rs
+++ b/crates/tirith-core/src/receipt.rs
@@ -182,6 +182,19 @@ pub fn redact_url_userinfo(url: &str) -> String {
     // RFC 3986 splits userinfo at the LAST `@` (a conformant producer
     // percent-encodes any `@` inside the password).
     let Some(at) = authority.rfind('@') else {
+        // Fail closed. A non-conformant userinfo can carry a raw `/`, `?`, or
+        // `#` (`https://deploy:ab/cd@host/repo.git`), which ends the authority
+        // scan above early and hides the `@` — the URL would then be returned
+        // verbatim, credentials and all. The URL parser rejects exactly those
+        // strings, so a parse failure plus a remaining `@` means we cannot
+        // prove the value is credential-free. A URL the parser ACCEPTS has no
+        // userinfo (the scan would have found it), so an `@` in its path or
+        // query is left alone.
+        if ::url::Url::parse(url).is_err() {
+            if let Some(rel) = after_scheme.rfind('@') {
+                return format!("{}://***@{}", &url[..scheme_end], &after_scheme[rel + 1..]);
+            }
+        }
         return url.to_string();
     };
     format!(
@@ -1935,6 +1948,39 @@ mod tests {
             recorded.anchor_warning.is_some(),
             "a failed (non-skipped) anchor must surface an anchor_warning so the caller does not \
              over-claim tamper-evidence"
+        );
+    }
+
+    #[test]
+    fn url_redaction_fails_closed_on_a_non_conformant_userinfo() {
+        // A raw `/`, `?`, or `#` inside the password ends the authority scan
+        // early, so the `@` is never found and the URL used to be returned
+        // verbatim with the credentials intact.
+        for raw in [
+            "https://deploy:ab/cd@github.com/org/repo.git",
+            "https://deploy:ab?cd@github.com/org/repo.git",
+            "https://deploy:ab#cd@github.com/org/repo.git",
+        ] {
+            let redacted = redact_url_userinfo(raw);
+            assert!(
+                !redacted.contains("deploy"),
+                "credentials survived redaction: {redacted}"
+            );
+            assert!(
+                redacted.contains("***@"),
+                "expected a redaction marker: {redacted}"
+            );
+        }
+
+        // The conformant form is unchanged, and a URL the parser accepts keeps
+        // an `@` that belongs to its path or query.
+        assert_eq!(
+            redact_url_userinfo("https://user:tok@example.com/x"),
+            "https://***@example.com/x"
+        );
+        assert_eq!(
+            redact_url_userinfo("https://example.com/a@b"),
+            "https://example.com/a@b"
         );
     }
 }

--- a/crates/tirith-core/src/registry_history.rs
+++ b/crates/tirith-core/src/registry_history.rs
@@ -65,6 +65,32 @@ fn write_row(eco: Ecosystem, name: &str, row: &SnapshotRow) -> bool {
     if std::fs::create_dir_all(parent).is_err() {
         return false;
     }
+    // repo-0462: serialize the read-modify-write across processes and publish
+    // atomically — two concurrent writers must not lose each other's snapshot,
+    // and a crash must not leave torn JSONL (read_rows skips malformed lines,
+    // which would erase takeover evidence).
+    let lock_path = parent.join(format!(
+        "{}.lock",
+        path.file_name().unwrap_or_default().to_string_lossy()
+    ));
+    // The lock file carries no content; keep whatever is already there rather
+    // than truncating a lock another process is holding.
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path);
+    let lock_file = match lock_file {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    {
+        use fs2::FileExt as _;
+        if lock_file.lock_exclusive().is_err() {
+            return false;
+        }
+    }
     let mut rows = read_rows(&path);
     rows.push(row.clone());
     if rows.len() > MAX_SNAPSHOTS_PER_PACKAGE {
@@ -78,7 +104,9 @@ fn write_row(eco: Ecosystem, name: &str, row: &SnapshotRow) -> bool {
             buf.push('\n');
         }
     }
-    std::fs::write(path, buf).is_ok()
+    let result = crate::util::write_file_atomic_0600(&path, buf.as_bytes()).is_ok();
+    let _ = fs2::FileExt::unlock(&lock_file);
+    result
 }
 
 /// Read all rows from `path` oldest-first. Empty on missing file or parse

--- a/crates/tirith-core/src/sarif.rs
+++ b/crates/tirith-core/src/sarif.rs
@@ -10,7 +10,15 @@ pub fn to_sarif(findings: &[SarifFinding], tool_version: &str) -> serde_json::Va
     let mut rules = Vec::new();
 
     for f in findings {
-        let rule_str = f.finding.rule_id.to_string();
+        // repo-0467: custom rules share RuleId::CustomRuleMatch; their real
+        // identity lives in `custom_rule_id`. Key the SARIF rule descriptor
+        // by the EFFECTIVE id so distinct custom rules get distinct
+        // descriptors and fingerprints.
+        let rule_str = f
+            .finding
+            .custom_rule_id
+            .clone()
+            .unwrap_or_else(|| f.finding.rule_id.to_string());
         if !rule_map.contains_key(&rule_str) {
             let idx = rules.len();
             rule_map.insert(rule_str.clone(), idx);
@@ -49,7 +57,11 @@ pub fn to_sarif(findings: &[SarifFinding], tool_version: &str) -> serde_json::Va
     let results: Vec<serde_json::Value> = findings
         .iter()
         .map(|f| {
-            let rule_str = f.finding.rule_id.to_string();
+            let rule_str = f
+                .finding
+                .custom_rule_id
+                .clone()
+                .unwrap_or_else(|| f.finding.rule_id.to_string());
             let rule_index = rule_map[&rule_str];
             let level = severity_to_level(f.finding.severity);
 

--- a/crates/tirith-core/src/selfupdate.rs
+++ b/crates/tirith-core/src/selfupdate.rs
@@ -97,7 +97,9 @@ impl InstallMethod {
 /// Detect the install method from the canonicalized path of the running binary.
 /// The caller passes the already-resolved absolute path (symlink/npm-wrapper
 /// resolution is `cli::resolve_effective_tirith_target`'s job), so this is a pure,
-/// unit-testable path-shape classifier.
+/// path-shape classifier — EXCEPT for the `~/.local/bin` ambiguity, where it
+/// probes for Cargo's install metadata (`.crates.toml`) to distinguish
+/// `cargo install --root ~/.local` from a hand-dropped binary (repo-0470).
 pub fn detect_install_method(canonical_path: &Path) -> InstallMethod {
     // Whole-segment checks over the FULL resolved path (each package manager has
     // a recognizable layout). Split on BOTH `/` and `\` regardless of host OS, so
@@ -147,8 +149,15 @@ pub fn detect_install_method(canonical_path: &Path) -> InstallMethod {
     }
 
     // `~/.local/bin` is the install.sh default (user-writable, hand-dropped
-    // binaries too) → self-managed.
+    // binaries too) → self-managed — UNLESS Cargo's install metadata sits in
+    // the same root: `cargo install --root ~/.local tirith` is Cargo-managed
+    // and self-update must not desynchronize Cargo's record (repo-0470).
     if path_lower.contains("/.local/bin/") {
+        if let Some(root) = canonical_path.parent().and_then(Path::parent) {
+            if root.join(".crates.toml").is_file() || root.join(".crates2.json").is_file() {
+                return InstallMethod::Cargo;
+            }
+        }
         return InstallMethod::SelfManaged;
     }
 

--- a/crates/tirith-core/src/ssrf_guard.rs
+++ b/crates/tirith-core/src/ssrf_guard.rs
@@ -372,6 +372,14 @@ pub(crate) mod test_support {
                             "HTTP fixture received fewer than {expected} requests before deadline"
                         ));
                     };
+                    // On Darwin an accepted socket can inherit the listener's
+                    // nonblocking mode. The fixture needs a bounded BLOCKING
+                    // read: otherwise the first immediate `WouldBlock` records
+                    // an empty request and still publishes a success response,
+                    // making direct-route assertions flaky and misleading.
+                    stream
+                        .set_nonblocking(false)
+                        .map_err(|error| format!("make fixture stream blocking: {error}"))?;
                     stream
                         .set_read_timeout(Some(Duration::from_millis(500)))
                         .map_err(|error| format!("set fixture read timeout: {error}"))?;
@@ -379,9 +387,17 @@ pub(crate) mod test_support {
                     loop {
                         let mut chunk = [0u8; 4096];
                         match stream.read(&mut chunk) {
-                            Ok(0) => break,
+                            Ok(0) => {
+                                return Err("HTTP fixture peer closed before a complete request"
+                                    .to_string());
+                            }
                             Ok(read) => {
                                 request.extend_from_slice(&chunk[..read]);
+                                if request.len() > 1024 * 1024 {
+                                    return Err(
+                                        "HTTP fixture request exceeded the 1 MiB cap".to_string()
+                                    );
+                                }
                                 if request_is_complete(&request) {
                                     break;
                                 }
@@ -392,7 +408,9 @@ pub(crate) mod test_support {
                                     std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
                                 ) =>
                             {
-                                break;
+                                return Err(
+                                    "HTTP fixture timed out before a complete request".to_string()
+                                );
                             }
                             Err(error) => return Err(format!("read HTTP fixture: {error}")),
                         }

--- a/crates/tirith-core/src/webhook.rs
+++ b/crates/tirith-core/src/webhook.rs
@@ -42,7 +42,10 @@ pub fn dispatch(
         let url = wh.url.clone();
         let headers = expand_env_headers(&wh.headers);
 
-        std::thread::spawn(move || {
+        // repo-0208: track the handle so a one-shot CLI can wait for delivery
+        // before `process::exit` — detached threads are silently killed at
+        // exit, which made webhook delivery timing-dependent.
+        let handle = std::thread::spawn(move || {
             if let Err(e) = send_with_retry(&url, &payload, &headers, 3) {
                 crate::audit::audit_diagnostic(format!(
                     "tirith: webhook delivery to {} failed: {e}",
@@ -50,6 +53,65 @@ pub fn dispatch(
                 ));
             }
         });
+        pending_webhook_threads()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(handle);
+    }
+}
+
+/// Handles of in-flight webhook delivery threads (repo-0208).
+fn pending_webhook_threads() -> &'static std::sync::Mutex<Vec<std::thread::JoinHandle<()>>> {
+    static PENDING: std::sync::OnceLock<std::sync::Mutex<Vec<std::thread::JoinHandle<()>>>> =
+        std::sync::OnceLock::new();
+    PENDING.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+/// Wait (bounded) for every pending webhook delivery. One-shot commands call
+/// this before exiting so notifications are not silently terminated.
+pub fn wait_for_pending_webhooks(timeout: std::time::Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let mut handles = {
+            let mut pending = pending_webhook_threads()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            std::mem::take(&mut *pending)
+        };
+        if handles.is_empty() {
+            return;
+        }
+
+        loop {
+            let mut unfinished = Vec::new();
+            for handle in handles {
+                if handle.is_finished() {
+                    let _ = handle.join();
+                } else {
+                    unfinished.push(handle);
+                }
+            }
+            if unfinished.is_empty() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                // Preserve ownership for a later wait in a long-lived caller;
+                // dropping JoinHandle here would detach delivery silently.
+                pending_webhook_threads()
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .extend(unfinished);
+                return;
+            }
+            handles = unfinished;
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+
+        // A dispatcher racing with this wait may have added new handles while
+        // the local batch was polled. Drain that batch too while time remains.
+        if std::time::Instant::now() >= deadline {
+            return;
+        }
     }
 }
 
@@ -118,7 +180,10 @@ fn build_payload(verdict: &Verdict, command_preview: &str, wh: &WebhookConfig) -
         "severity": max_severity.to_string(),
         "rule_ids": rule_ids,
         "finding_count": verdict.findings.len(),
-        "command_preview": sanitize_for_json(command_preview),
+        // repo-0473: serde_json escapes ONCE; pre-escaping here double-escaped
+        // the preview (receivers saw literal `\n`/`\u001b` text). Truncate and
+        // hand the raw string to the serializer.
+        "command_preview": command_preview.chars().take(200).collect::<String>(),
     })
     .to_string()
 }

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -455,7 +455,7 @@ _tirith_persist_safe_mode() {
 # cache then fails. Enter-mode delivery itself is a bash-build property — it
 # does not change with the tirith version — so the cache is keyed on bash, not
 # on tirith. (`tirith_version` is still recorded in the file for diagnostics.)
-_TIRITH_ENTER_CAP_SCHEMA=1
+_TIRITH_ENTER_CAP_SCHEMA=2
 _TIRITH_ENTER_CAP_FILE="$_TIRITH_STATE_DIR/bash-enter-capability"
 
 # Read the enter-mode capability cache and decide whether enter mode is proven
@@ -479,12 +479,14 @@ _tirith_enter_capability_proven() {
   (( size > 4096 )) && return 1
 
   local schema="" cache_bash_version="" cache_bash_path="" capability=""
+  local cache_bash_fingerprint=""
   local key value
   while IFS='=' read -r key value; do
     case "$key" in
       schema)           schema="$value" ;;
       bash_version)     cache_bash_version="$value" ;;
       bash_path)        cache_bash_path="$value" ;;
+      bash_fingerprint) cache_bash_fingerprint="$value" ;;
       enter_capability) capability="$value" ;;
     esac
   done < "$_TIRITH_ENTER_CAP_FILE"
@@ -509,6 +511,24 @@ _tirith_enter_capability_proven() {
   # stale and falls back to preexec — fail-safe.
   [[ -n "$cache_bash_path" ]] || return 1
   [[ "$cache_bash_path" == "${BASH:-}" ]] || return 1
+
+  # repo-0211: an in-place rebuild keeps path and version — also require the
+  # recorded mtime:size fingerprint to match the live binary.
+  [[ -n "$cache_bash_fingerprint" ]] || return 1
+  local live_mtime live_size live_fp
+  if live_mtime="$(builtin command stat -Lf %m "${BASH:-/dev/null}" 2>/dev/null)"; then
+    :
+  else
+    live_mtime="$(builtin command stat -Lc %Y "${BASH:-/dev/null}" 2>/dev/null)" || return 1
+  fi
+  if live_size="$(builtin command stat -Lf %z "${BASH:-/dev/null}" 2>/dev/null)"; then
+    :
+  else
+    live_size="$(builtin command stat -Lc %s "${BASH:-/dev/null}" 2>/dev/null)" || return 1
+  fi
+  [[ -n "$live_mtime" && -n "$live_size" ]] || return 1
+  live_fp="${live_mtime}:${live_size}"
+  [[ "$cache_bash_fingerprint" == "$live_fp" ]] || return 1
 
   return 0
 }

--- a/crates/tirith/src/cli/ai.rs
+++ b/crates/tirith/src/cli/ai.rs
@@ -433,6 +433,14 @@ const READ_MAX_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
 /// a TOCTOU race (the file can grow between stat and read). Reading at most
 /// `MAX_BYTES + 1` and rejecting over `MAX_BYTES` bounds memory regardless.
 fn read_capped(path: &Path) -> std::io::Result<Vec<u8>> {
+    read_capped_with_metadata(path).map(|(bytes, _)| bytes)
+}
+
+/// Capped read that also returns metadata from the exact open handle whose
+/// bytes were read. The destructive quarantine fallback uses this identity to
+/// avoid comparing a replacement pathname's metadata with an older file's
+/// bytes.
+fn read_capped_with_metadata(path: &Path) -> std::io::Result<(Vec<u8>, std::fs::Metadata)> {
     // repo-0356: open no-follow + nonblocking and require a REGULAR file before
     // reading. A project-controlled FIFO (or device/socket) named like a
     // config file must not block `ai diff`/`snapshot`/`quarantine` forever.
@@ -444,7 +452,8 @@ fn read_capped(path: &Path) -> std::io::Result<Vec<u8>> {
         options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC);
     }
     let file = options.open(path)?;
-    if !file.metadata()?.is_file() {
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
@@ -466,7 +475,13 @@ fn read_capped(path: &Path) -> std::io::Result<Vec<u8>> {
             ),
         ));
     }
-    Ok(bytes)
+    Ok((bytes, metadata))
+}
+
+#[cfg(unix)]
+fn same_file_identity(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+    left.dev() == right.dev() && left.ino() == right.ino()
 }
 
 /// Read a file as UTF-8 (lossy) with the [`READ_MAX_BYTES`] cap.
@@ -484,7 +499,7 @@ pub fn quarantine(file: &str, do_move: bool, yes: bool, json: bool) -> i32 {
     let src = PathBuf::from(file);
     // Capped read (R15-ai.rs:483) so a huge file can't force a full-file
     // allocation before validation; the sha below is over these capped bytes.
-    let content = match read_capped(&src) {
+    let (content, initial_metadata) = match read_capped_with_metadata(&src) {
         Ok(c) => c,
         Err(e) => {
             if !emit_error(
@@ -627,26 +642,11 @@ pub fn quarantine(file: &str, do_move: bool, yes: bool, json: bool) -> i32 {
                 // Re-read the source just before the delete and compare hashes; a
                 // mismatch means it was edited after our first read, so keep the
                 // original and fail rather than lose the newer content.
-                match read_capped(&src) {
-                    Ok(current) => {
-                        let current_sha = tirith_core::clipboard::content_sha256_hex(&current);
-                        if current_sha != sha {
-                            if !emit_error(
-                                json,
-                                "tirith ai quarantine",
-                                &format!(
-                                    "{} changed on disk after it was read; refusing to delete the \
-                                     original (the quarantine copy at {} is now stale). Re-run to \
-                                     quarantine the current contents.",
-                                    src.display(),
-                                    dest.display()
-                                ),
-                            ) {
-                                return 2;
-                            }
-                            return 1;
-                        }
-                    }
+                // repo-0209: open ONCE and remember the inode we hashed, so
+                // the pre-delete check compares the live pathname against the
+                // exact file whose bytes we verified.
+                let (current, hashed_metadata) = match read_capped_with_metadata(&src) {
+                    Ok(current) => current,
                     Err(e) => {
                         // Could not re-read to confirm unchanged — do NOT delete
                         // blindly. The copy exists, the original stays, exit non-zero.
@@ -664,7 +664,65 @@ pub fn quarantine(file: &str, do_move: bool, yes: bool, json: bool) -> i32 {
                         }
                         return 1;
                     }
+                };
+                let current_sha = tirith_core::clipboard::content_sha256_hex(&current);
+                if current_sha != sha {
+                    if !emit_error(
+                        json,
+                        "tirith ai quarantine",
+                        &format!(
+                            "{} changed on disk after it was read; refusing to delete the \
+                             original (the quarantine copy at {} is now stale). Re-run to \
+                             quarantine the current contents.",
+                            src.display(),
+                            dest.display()
+                        ),
+                    ) {
+                        return 2;
+                    }
+                    return 1;
                 }
+                // repo-0209: the hash check above verified CONTENT, but a
+                // replace-then-delete race could still remove a DIFFERENT
+                // inode that now sits at `src`. Compare the inode we hashed
+                // against the live pathname immediately before unlinking.
+                #[cfg(unix)]
+                {
+                    if !same_file_identity(&initial_metadata, &hashed_metadata) {
+                        if !emit_error(
+                            json,
+                            "tirith ai quarantine",
+                            &format!(
+                                "{} was replaced after the quarantine bytes were read; the copy at {} is kept and the replacement was NOT removed",
+                                src.display(),
+                                dest.display()
+                            ),
+                        ) {
+                            return 2;
+                        }
+                        return 1;
+                    }
+                    let now_metadata = std::fs::symlink_metadata(&src);
+                    if !matches!(
+                        now_metadata.as_ref(),
+                        Ok(now) if same_file_identity(&hashed_metadata, now)
+                    ) {
+                        if !emit_error(
+                            json,
+                            "tirith ai quarantine",
+                            &format!(
+                                "{} was replaced during quarantine; the copy at {} is kept and the original was NOT removed",
+                                src.display(),
+                                dest.display()
+                            ),
+                        ) {
+                            return 2;
+                        }
+                        return 1;
+                    }
+                }
+                #[cfg(not(unix))]
+                let _ = (&initial_metadata, &hashed_metadata);
                 if let Err(e) = std::fs::remove_file(&src) {
                     // Copy succeeded but the original couldn't be removed — report
                     // honestly (a copy exists, the original remains), exit 1.

--- a/crates/tirith/src/cli/aliases.rs
+++ b/crates/tirith/src/cli/aliases.rs
@@ -70,6 +70,14 @@ fn print_human_scan(scan: &AliasScan, include_runtime: bool) {
             "  (static parse + runtime no-rc introspection; runtime spawns shells with \
              --norc / -f / --no-config so your rc files are NOT sourced.)"
         );
+        // repo-0454: truthfulness — no-rc enumeration sees only built-in or
+        // non-interactive definitions; aliases/functions defined only in the
+        // LIVE parent shell are invisible to a child. Say so instead of
+        // implying full runtime coverage.
+        eprintln!(
+            "  note: runtime introspection cannot see aliases/functions defined only in an \
+             already-running interactive shell; a clean result does not prove their absence."
+        );
         if !scan.runtime_skipped.is_empty() {
             eprintln!(
                 "  runtime-skipped shells (unsupported / not installed): {}",

--- a/crates/tirith/src/cli/bash_capability.rs
+++ b/crates/tirith/src/cli/bash_capability.rs
@@ -27,7 +27,7 @@ use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 
 /// Cache-file schema version. Bump when the cache format changes so an old
 /// hook reading a new file (or vice versa) treats the mismatch as stale.
-pub const CACHE_SCHEMA: u32 = 1;
+pub const CACHE_SCHEMA: u32 = 2;
 
 /// Name of the capability cache file inside `state_dir()`.
 pub const CACHE_FILENAME: &str = "bash-enter-capability";
@@ -111,6 +111,9 @@ pub struct CachedDecision {
     /// property of the bash *build*, not just the version string, so a
     /// different binary at the same version is treated as a different bash.
     pub bash_path: String,
+    /// repo-0211: mtime+size fingerprint of the probed bash binary — catches
+    /// an in-place rebuild that keeps the same path and version string.
+    pub bash_fingerprint: String,
     pub reason: String,
 }
 
@@ -630,6 +633,20 @@ fn render_cache(outcome: &ProbeOutcome) -> String {
     body.push_str("shell=bash\n");
     body.push_str(&format!("bash_version={bash_version}\n"));
     body.push_str(&format!("bash_path={bash_path}\n"));
+    let bash_fingerprint = outcome
+        .bash_path
+        .as_deref()
+        .and_then(|p| std::fs::metadata(p).ok())
+        .and_then(|m| {
+            let mtime = m
+                .modified()
+                .ok()?
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?;
+            Some(format!("{}:{}", mtime.as_secs(), m.len()))
+        })
+        .unwrap_or_default();
+    body.push_str(&format!("bash_fingerprint={bash_fingerprint}\n"));
     body.push_str(&format!(
         "enter_capability={}\n",
         outcome.capability.as_token()
@@ -697,6 +714,7 @@ pub fn read_cache() -> Option<CachedDecision> {
     let mut tirith_version: Option<String> = None;
     let mut bash_version: Option<String> = None;
     let mut bash_path: Option<String> = None;
+    let mut bash_fingerprint: Option<String> = None;
     let mut capability: Option<EnterCapability> = None;
     let mut reason = String::new();
 
@@ -709,6 +727,7 @@ pub fn read_cache() -> Option<CachedDecision> {
             "tirith_version" => tirith_version = Some(value.trim().to_string()),
             "bash_version" => bash_version = Some(value.trim().to_string()),
             "bash_path" => bash_path = Some(value.trim().to_string()),
+            "bash_fingerprint" => bash_fingerprint = Some(value.trim().to_string()),
             "enter_capability" => capability = parse_capability(value),
             "reason" => reason = value.trim().to_string(),
             _ => {}
@@ -725,6 +744,7 @@ pub fn read_cache() -> Option<CachedDecision> {
         tirith_version: tirith_version?,
         bash_version: bash_version?,
         bash_path: bash_path?,
+        bash_fingerprint: bash_fingerprint?,
         reason,
     })
 }
@@ -739,6 +759,25 @@ pub fn decision_is_fresh(decision: &CachedDecision) -> bool {
         return false;
     };
     if bash.display().to_string() != decision.bash_path {
+        return false;
+    }
+    // repo-0211: an in-place rebuild/replacement keeps the same path and can
+    // keep the same $BASH_VERSION — bind the decision to the binary's mtime
+    // (and size) too, so a changed build re-probes instead of trusting a
+    // stale `Works`.
+    let fingerprint_matches = std::fs::metadata(&bash)
+        .ok()
+        .and_then(|m| {
+            let mtime = m
+                .modified()
+                .ok()?
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?;
+            Some(format!("{}:{}", mtime.as_secs(), m.len()))
+        })
+        .map(|fp| fp == decision.bash_fingerprint)
+        .unwrap_or(false);
+    if !fingerprint_matches {
         return false;
     }
     match bash_version_of(&bash) {

--- a/crates/tirith/src/cli/capsule.rs
+++ b/crates/tirith/src/cli/capsule.rs
@@ -4790,7 +4790,9 @@ pub fn run_to_completion_os(
         #[cfg(target_os = "windows")]
         {
             if !is_degraded {
-                return windows_run_to_completion_os(spec, program, args, &sel);
+                // repo-0475/0476: carry the caller's working directory through
+                // to CreateProcessW instead of silently dropping it.
+                return windows_run_to_completion_os(spec, program, args, cwd, &sel);
             }
             // Degraded + AllowDegraded on Windows: run uncontained via a plain Command.
             // An enforcing surface would have failed closed above; assert it here.
@@ -5778,6 +5780,31 @@ fn macos_contained_command_os(
     if let Some(environment) = exact_env {
         reject_macos_loader_control_env(environment, "exact environment", sel.backend_id)?;
     }
+    // repo-0198: create the temporary HOME up front, add it to the spec's
+    // write roots BEFORE serialization, and hand the SAME path to the env
+    // scrub — otherwise the Seatbelt profile (deny default) blocks the child's
+    // own temp directory.
+    let mut spec_owned;
+    let mut macos_temp_home: Option<tempfile::TempDir> = None;
+    let spec = if spec.environment.temporary_home {
+        spec_owned = spec.clone();
+        let temp_home = tempfile::Builder::new()
+            .prefix("tirith-capsule-")
+            .tempdir()
+            .map_err(|e| CapsuleRefused {
+                backend_id: sel.backend_id,
+                reason: format!("cannot create capsule temporary home: {e}"),
+            })?;
+        let temp_home_path = temp_home.path().to_path_buf();
+        spec_owned
+            .filesystem
+            .write_roots
+            .push(temp_home_path.clone());
+        macos_temp_home = Some(temp_home);
+        &spec_owned
+    } else {
+        spec
+    };
     // Validate the final sandbox argv before spawning. The launcher reconstructs
     // it after the first exec so a direct invocation of the hidden subcommand
     // cannot substitute an uncontained program for sandbox-exec.
@@ -5810,9 +5837,12 @@ fn macos_contained_command_os(
     // temporary HOME cannot be created for a `temporary_home` spec: skipping it
     // would leave the real `$HOME` reachable (env_clear already ran, but
     // `getpwuid()->pw_dir` still resolves it) while `env_isolated` claims true.
-    let env_result = match exact_env {
-        Some(environment) => apply_macos_env_from(&mut cmd, spec, Some(environment)),
-        None => apply_macos_env(&mut cmd, spec),
+    let env_result = match macos_temp_home.as_ref() {
+        Some(home) => {
+            let home = home.path().to_path_buf();
+            apply_macos_env_with_source(&mut cmd, spec, exact_env, move || Ok(home))
+        }
+        None => apply_macos_env_from(&mut cmd, spec, exact_env),
     };
     env_result.map_err(|reason| CapsuleRefused {
         backend_id: sel.backend_id,
@@ -5820,26 +5850,8 @@ fn macos_contained_command_os(
     })?;
     Ok(PreparedContainedCommand {
         command: cmd,
-        temp_home: None,
+        temp_home: macos_temp_home,
     })
-}
-
-/// Apply the env policy to a macOS `Command`: clear the environment, re-add the
-/// surviving variable names from the current process, then (when `temporary_home`)
-/// repoint HOME/TMPDIR/XDG_* at a fresh temp directory. The temp dir intentionally
-/// leaks for the child's lifetime (matching the Linux launcher).
-///
-/// **Fails closed** when `temporary_home` is set but the temporary directory cannot
-/// be created: returning `Err` here propagates to a [`CapsuleRefused`] so the launch
-/// is refused rather than running with the real `$HOME` reachable. `env_clear`
-/// alone is NOT enough to hide the home directory, because macOS `getpwuid()` (used
-/// by libc / the shell to resolve `~`) reads `pw_dir` from the password database,
-/// not the environment; only repointing HOME/TMPDIR/XDG_* at a fresh dir isolates
-/// the child. Skipping the repoint while still reporting `env_isolated = true` would
-/// be a silent over-report (the gap the Linux launcher fails closed on too).
-#[cfg(target_os = "macos")]
-fn apply_macos_env(cmd: &mut Command, spec: &CapsuleSpec) -> Result<(), String> {
-    apply_macos_env_from(cmd, spec, None)
 }
 
 #[cfg(target_os = "macos")]
@@ -5863,7 +5875,7 @@ fn apply_macos_env_from(
 /// `make_temp_home` so the fail-closed propagation is deterministically testable
 /// (a test can pass a factory that returns `Err` without mutating the process-wide
 /// `TMPDIR`, which would race other tests). Production passes the real tempfile
-/// factory via [`apply_macos_env`].
+/// factory via [`apply_macos_env_from`].
 #[cfg(all(target_os = "macos", test))]
 fn apply_macos_env_with<F>(
     cmd: &mut Command,
@@ -6056,14 +6068,13 @@ fn windows_run_to_completion_os(
     spec: &CapsuleSpec,
     program: &OsStr,
     args: &[OsString],
+    cwd: Option<&std::path::Path>,
     sel: &SelectedBackend,
 ) -> Result<CapsuleOutcome, CapsuleRefused> {
-    let mut child =
-        crate::cli::capsule_windows::launch_contained_os(spec, program, args).map_err(|e| {
-            CapsuleRefused {
-                backend_id: sel.backend_id,
-                reason: format!("contained launch failed: {e}"),
-            }
+    let mut child = crate::cli::capsule_windows::launch_contained_os(spec, program, args, cwd)
+        .map_err(|e| CapsuleRefused {
+            backend_id: sel.backend_id,
+            reason: format!("contained launch failed: {e}"),
         })?;
     let exit_code = crate::cli::capsule_windows::wait_for(&child).map_err(|e| CapsuleRefused {
         backend_id: sel.backend_id,
@@ -8194,7 +8205,8 @@ mod tests {
         );
         let refused = result.err().unwrap();
         assert!(
-            refused.reason.contains("real HOME reachable"),
+            refused.reason.contains("real HOME reachable")
+                || refused.reason.contains("temporary home"),
             "refusal must carry the env-isolation fail-closed reason: {refused}"
         );
     }

--- a/crates/tirith/src/cli/capsule_windows.rs
+++ b/crates/tirith/src/cli/capsule_windows.rs
@@ -160,6 +160,9 @@ pub struct ContainedChild {
     /// The ACL grants to revoke when the run is done. Held so the grants outlive
     /// the child but are reverted afterward.
     acl_guards: Vec<AclGuard>,
+    /// Removes this launch's unique HOME/TEMP tree after the process exits and
+    /// its AppContainer ACL grants are revoked.
+    temp_home: Option<TempHomeGuard>,
     /// The spec-requested wall-clock deadline (seconds), enforced by
     /// [`wait_for`] as a finite wait plus Job termination on expiry. `None`
     /// waits indefinitely (the spec requested no deadline).
@@ -194,6 +197,13 @@ impl ContainedChild {
         let mut first_err = None;
         for guard in &mut self.acl_guards {
             if let Err(e) = guard.revert_now() {
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        }
+        if let Some(temp_home) = &mut self.temp_home {
+            if let Err(e) = temp_home.remove_now() {
                 if first_err.is_none() {
                     first_err = Some(e);
                 }
@@ -239,7 +249,7 @@ pub fn launch_contained(
     args: &[String],
 ) -> Result<ContainedChild, WindowsLaunchError> {
     let args_os: Vec<OsString> = args.iter().map(OsString::from).collect();
-    launch_contained_os(spec, OsStr::new(program), &args_os)
+    launch_contained_os(spec, OsStr::new(program), &args_os, None)
 }
 
 /// OS-native launch entry point. This keeps Windows UTF-16 argument data intact
@@ -249,10 +259,16 @@ pub fn launch_contained_os(
     spec: &CapsuleSpec,
     program: &OsStr,
     args: &[OsString],
+    cwd: Option<&std::path::Path>,
 ) -> Result<ContainedChild, WindowsLaunchError> {
     let plan = tirith_core::capsule::windows::windows_launch_plan_os(spec, program, args)
         .map_err(|e| WindowsLaunchError::Encoding(e.to_string()))?;
-    apply_plan(&plan, &spec.environment, spec.resources.wall_clock_seconds)
+    apply_plan(
+        &plan,
+        &spec.environment,
+        spec.resources.wall_clock_seconds,
+        cwd,
+    )
 }
 
 /// Wait for a contained child to exit and return its process exit code (E5
@@ -312,6 +328,7 @@ fn apply_plan(
     plan: &WindowsLaunchPlan,
     env: &EnvironmentPolicy,
     wall_clock_seconds: Option<u64>,
+    cwd: Option<&std::path::Path>,
 ) -> Result<ContainedChild, WindowsLaunchError> {
     // 1. AppContainer profile (idempotent) + package SID.
     let (container_sid, profile) = create_unique_appcontainer(plan)?;
@@ -319,6 +336,13 @@ fn apply_plan(
 
     // 2. ACL grants — tracked so they are reverted on any later failure or when the
     //    child finishes.
+    // repo-0199: create the isolated HOME/TEMP directory BEFORE granting the
+    // container SID access to it (the grant is in plan.acl_grants).
+    let temp_home = plan
+        .temp_home
+        .as_ref()
+        .map(|home| TempHomeGuard::create(home.clone()))
+        .transpose()?;
     let mut acl_guards = Vec::with_capacity(plan.acl_grants.len());
     for grant in &plan.acl_grants {
         match apply_acl_grant(grant, container_sid.psid()) {
@@ -348,8 +372,8 @@ fn apply_plan(
     };
 
     // 4. CreateProcessW: suspended, extended startupinfo, NO inherited handles, a
-    //    scrubbed environment block.
-    let launched = match create_process(plan, env, &mut attr_list) {
+    //    scrubbed environment block, and the caller's working directory (repo-0475).
+    let launched = match create_process(plan, env, &mut attr_list, cwd) {
         Ok(l) => l,
         Err(e) => {
             revert_all(&mut acl_guards);
@@ -390,9 +414,60 @@ fn apply_plan(
         process: launched.process,
         thread: launched.thread,
         acl_guards,
+        temp_home,
         wall_clock_seconds,
         profile,
     })
+}
+
+/// Owns the isolated HOME/TEMP directory for one capsule launch. Creation uses
+/// `create_dir`, never `create_dir_all`, so an unexpected pre-existing name is
+/// rejected instead of reusing stale or attacker-planted contents. Cleanup is
+/// retried from `Drop` if explicit finish reports an error.
+struct TempHomeGuard {
+    path: std::path::PathBuf,
+    removed: bool,
+}
+
+impl TempHomeGuard {
+    fn create(path: std::path::PathBuf) -> Result<Self, WindowsLaunchError> {
+        std::fs::create_dir(&path).map_err(|e| {
+            WindowsLaunchError::Encoding(format!(
+                "cannot create unique capsule temporary home {}: {e}",
+                path.display()
+            ))
+        })?;
+        Ok(Self {
+            path,
+            removed: false,
+        })
+    }
+
+    fn remove_now(&mut self) -> Result<(), WindowsLaunchError> {
+        if self.removed {
+            return Ok(());
+        }
+        match std::fs::remove_dir_all(&self.path) {
+            Ok(()) => {
+                self.removed = true;
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                self.removed = true;
+                Ok(())
+            }
+            Err(error) => Err(WindowsLaunchError::Encoding(format!(
+                "cannot remove capsule temporary home {}: {error}",
+                self.path.display()
+            ))),
+        }
+    }
+}
+
+impl Drop for TempHomeGuard {
+    fn drop(&mut self) {
+        let _ = self.remove_now();
+    }
 }
 
 /// A PSID that owns its allocation and frees it on drop via `FreeSid`. Used for the
@@ -866,6 +941,7 @@ fn create_process(
     plan: &WindowsLaunchPlan,
     env: &EnvironmentPolicy,
     attr_list: &mut ProcThreadAttributeList,
+    cwd: Option<&std::path::Path>,
 ) -> Result<Launched, WindowsLaunchError> {
     let app = wide_nul_os(&plan.program)
         .map_err(|_| WindowsLaunchError::Encoding("program path has NUL".to_string()))?;
@@ -880,7 +956,7 @@ fn create_process(
     cmdline.push(0);
 
     // Scrubbed environment block (double-NUL-terminated UTF-16).
-    let mut env_block = build_environment_block(env);
+    let mut env_block = build_environment_block(env, plan.temp_home.as_deref());
 
     let mut si = STARTUPINFOEXW::default();
     si.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
@@ -888,9 +964,23 @@ fn create_process(
 
     let mut pi = PROCESS_INFORMATION::default();
 
+    // repo-0475/0476: `lpCurrentDirectory` — the contained child runs in the
+    // caller's working directory (null = inherit, the old behavior).
+    let cwd_wide = match cwd {
+        Some(dir) => Some(wide_nul_os(dir.as_os_str()).map_err(|_| {
+            WindowsLaunchError::Encoding("working directory path has NUL".to_string())
+        })?),
+        None => None,
+    };
+    let cwd_ptr = cwd_wide
+        .as_ref()
+        .map(|w| PCWSTR(w.as_ptr()))
+        .unwrap_or(PCWSTR::null());
+
     // SAFETY: `app` and `cmdline` are NUL-terminated wide buffers that outlive the
     // call; `cmdline` is writable (CreateProcessW may edit it). The attribute list is
     // valid for the call. `env_block` is a double-NUL-terminated UTF-16 block. The
+    // `cwd_wide` buffer outlives the call. The
     // STARTUPINFOEXW is reinterpreted as STARTUPINFOW as the API expects when
     // EXTENDED_STARTUPINFO_PRESENT is set.
     let ok = unsafe {
@@ -908,7 +998,7 @@ fn create_process(
             // attribute binds the AppContainer at creation.
             CREATE_SUSPENDED | EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
             Some(env_block.as_mut_ptr() as *const c_void),
-            PCWSTR::null(),
+            cwd_ptr,
             &si as *const STARTUPINFOEXW as *const STARTUPINFOW,
             &mut pi,
         )
@@ -932,15 +1022,21 @@ fn create_process(
 /// / TEMP / TMP are pointed at an isolated temp directory.
 ///
 /// The returned `Vec<u16>` is the `lpEnvironment` block: `KEY=VALUE\0KEY=VALUE\0\0`.
-fn build_environment_block(policy: &EnvironmentPolicy) -> Vec<u16> {
+fn build_environment_block(
+    policy: &EnvironmentPolicy,
+    temp_home_override: Option<&std::path::Path>,
+) -> Vec<u16> {
     let present: Vec<String> = std::env::vars_os()
         .filter_map(|(k, _)| k.into_string().ok())
         .collect();
     let survivors = policy.surviving_vars(present.iter().map(|s| s.as_str()));
 
-    // Isolated HOME/TEMP for the child when temporary_home is set.
+    // Isolated HOME/TEMP for the child when temporary_home is set — the SAME
+    // path the launch plan granted to the container SID (repo-0199).
     let temp_home = if policy.temporary_home {
-        std::env::temp_dir().join(format!("tirith-capsule-{}", std::process::id()))
+        temp_home_override
+            .expect("temporary_home launch plans must supply a unique HOME/TEMP path")
+            .to_path_buf()
     } else {
         std::path::PathBuf::new()
     };
@@ -1246,7 +1342,8 @@ mod tests {
             deny_sensitive: true,
             temporary_home: false,
         };
-        let block = build_environment_block(&policy);
+        let isolated = std::path::Path::new("C:/Temp/tirith-capsule-test-unique");
+        let block = build_environment_block(&policy, Some(isolated));
         // Decode to a string for substring checks (entries are KEY=VALUE\0...).
         let decoded = String::from_utf16_lossy(&block);
         assert!(decoded.contains("TIRITH_TEST_BENIGN=ok"));
@@ -1268,7 +1365,8 @@ mod tests {
             deny_sensitive: true,
             temporary_home: true,
         };
-        let block = build_environment_block(&policy);
+        let isolated = std::path::Path::new("C:/Temp/tirith-capsule-test-unique");
+        let block = build_environment_block(&policy, Some(isolated));
         let decoded = String::from_utf16_lossy(&block);
         // The real profile path must NOT survive; an isolated temp dir replaces it.
         assert!(
@@ -1276,6 +1374,7 @@ mod tests {
             "real USERPROFILE must be replaced under temporary_home"
         );
         assert!(decoded.contains("USERPROFILE="));
+        assert!(decoded.contains("C:/Temp/tirith-capsule-test-unique"));
         std::env::remove_var("USERPROFILE");
     }
 

--- a/crates/tirith/src/cli/check.rs
+++ b/crates/tirith/src/cli/check.rs
@@ -24,6 +24,17 @@ use tirith_core::threatdb_api::RuntimeThreatMode;
 use tirith_core::tokenize::ShellType;
 use tirith_core::verdict::{action_from_findings, upgraded_action_from_findings, Action, Verdict};
 
+/// Once a check dispatches webhooks, every return path waits for their bounded
+/// best-effort delivery. A lexical guard avoids missing protocol/approval/
+/// deferral early returns as new branches are added.
+struct PendingWebhookGuard;
+
+impl Drop for PendingWebhookGuard {
+    fn drop(&mut self) {
+        tirith_core::webhook::wait_for_pending_webhooks(Duration::from_secs(5));
+    }
+}
+
 /// W6: build a DISPLAY-ONLY clone of `effective` whose repeated Warn / WarnAck
 /// findings (already surfaced earlier this session) are collapsed, and return how
 /// many findings were hidden.
@@ -526,21 +537,27 @@ pub fn run(
         && tirith_core::checkpoint::should_auto_checkpoint(cmd)
     {
         if let Some(cwd_val) = &cwd {
-            let cwd_owned = cwd_val.clone();
-            let cmd_owned = cmd.to_string();
-            std::thread::spawn(move || {
-                if let Err(e) =
-                    tirith_core::checkpoint::create(&[cwd_owned.as_str()], Some(&cmd_owned))
-                {
-                    eprintln!("tirith: auto-checkpoint failed (non-fatal): {e}");
-                } else {
+            // repo-0214: checkpoint creation must finish before this process
+            // returns an executable verdict. A detached worker is terminated at
+            // process exit, while a timed wait cannot cancel it safely; either
+            // shape could let the destructive command run without a published
+            // checkpoint. This path is interactive-only, and creation itself is
+            // bounded by the checkpoint entry/file/total-byte budgets.
+            match tirith_core::checkpoint::create(&[cwd_val.as_str()], Some(cmd)) {
+                Err(e) => eprintln!("tirith: auto-checkpoint failed (non-fatal): {e}"),
+                Ok(meta) => {
+                    if meta.incomplete {
+                        eprintln!(
+                            "tirith: auto-checkpoint is incomplete; the destructive command may proceed without a complete snapshot"
+                        );
+                    }
                     // Purge old checkpoints to prevent unbounded disk growth.
                     let config = tirith_core::checkpoint::CheckpointConfig::default();
                     if let Err(e) = tirith_core::checkpoint::purge(&config) {
                         eprintln!("tirith: checkpoint purge failed (non-fatal): {e}");
                     }
                 }
-            });
+            }
         }
     }
 
@@ -556,6 +573,7 @@ pub fn run(
             &policy.dlp_custom_patterns,
         );
     }
+    let _pending_webhook_guard = PendingWebhookGuard;
 
     // Protocol v3 owns every approval / warning-ack interaction in this process.
     // The shell receives only an already-armed receipt token; it never reports a

--- a/crates/tirith/src/cli/checkpoint.rs
+++ b/crates/tirith/src/cli/checkpoint.rs
@@ -39,8 +39,13 @@ pub fn list_checkpoints(json: bool) -> i32 {
                     let trigger =
                         checkpoint_trigger_for_human(e.trigger_command.as_deref().unwrap_or("-"));
                     println!(
-                        "{:<38} {:<26} {:<8} {:<12} {}",
-                        e.id, e.created_at, e.file_count, size, trigger
+                        "{:<38} {:<26} {:<8} {:<12} {}{}",
+                        e.id,
+                        e.created_at,
+                        e.file_count,
+                        size,
+                        trigger,
+                        if e.incomplete { " [INCOMPLETE]" } else { "" }
                     );
                 }
                 println!("\n{} checkpoint(s)", entries.len());
@@ -73,6 +78,8 @@ pub fn restore_checkpoint(id: &str, json: bool) -> i32 {
                     "missing": report.missing,
                     "corrupt": report.corrupt,
                     "errors": report.errors,
+                    "checkpoint_incomplete": report.checkpoint_incomplete,
+                    "checkpoint_incomplete_reason": report.checkpoint_incomplete_reason,
                     "count": restored_n,
                 });
                 println!(
@@ -83,6 +90,18 @@ pub fn restore_checkpoint(id: &str, json: bool) -> i32 {
                     })
                 );
             } else {
+                if report.checkpoint_incomplete {
+                    eprintln!(
+                        "tirith checkpoint restore: WARNING: the source checkpoint was incomplete: {}",
+                        super::sanitize_for_human_output(
+                            report
+                                .checkpoint_incomplete_reason
+                                .as_deref()
+                                .unwrap_or("one or more requested entries were omitted"),
+                            false,
+                        )
+                    );
+                }
                 println!("Restored {restored_n} file(s):");
                 // repo-0366: every persisted path is project-controlled; all
                 // restore/diff output goes through terminal sanitization.
@@ -121,7 +140,10 @@ pub fn restore_checkpoint(id: &str, json: bool) -> i32 {
             // full per-bucket report is still printed above; we only flip the exit
             // status. 1 == restore completed with failures (distinct from 2, an
             // operational error that aborted the restore entirely).
-            if !report.missing.is_empty() || !report.corrupt.is_empty() || !report.errors.is_empty()
+            if report.checkpoint_incomplete
+                || !report.missing.is_empty()
+                || !report.corrupt.is_empty()
+                || !report.errors.is_empty()
             {
                 1
             } else {
@@ -231,8 +253,23 @@ pub fn create_checkpoint(paths: &[String], trigger: Option<&str>, json: bool) ->
                     meta.file_count,
                     format_bytes(meta.total_bytes)
                 );
+                if meta.incomplete {
+                    eprintln!(
+                        "tirith checkpoint create: WARNING: checkpoint is incomplete: {}",
+                        super::sanitize_for_human_output(
+                            meta.incomplete_reason
+                                .as_deref()
+                                .unwrap_or("one or more requested entries were omitted"),
+                            false,
+                        )
+                    );
+                }
             }
-            0
+            if meta.incomplete {
+                1
+            } else {
+                0
+            }
         }
         Err(e) => {
             eprintln!("tirith checkpoint create: {e}");
@@ -291,7 +328,7 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
     snapshot_paths.extend(paths.iter().cloned());
 
     // --- BEFORE: file inventory + runtime state ---
-    let files_before = inventory_files(&snapshot_paths);
+    let (files_before, truncated_before) = inventory_files(&snapshot_paths);
     let rt_before = checkpoint::capture_runtime_state(&home);
     let net_before = if with_net_hints {
         Some(net_hint_sources(&home))
@@ -301,6 +338,7 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
 
     // F1: keep tirith alive across Ctrl-C so the AFTER snapshot + diff always run
     // (child is in its own process group, see `run_command`).
+    WATCH_INTERRUPTED.store(false, std::sync::atomic::Ordering::Relaxed);
     install_watch_sigint_handler();
 
     // --- RUN the command with the user's full privileges (no isolation) ---
@@ -315,7 +353,13 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
     let interrupted = WATCH_INTERRUPTED.load(std::sync::atomic::Ordering::Relaxed);
 
     // --- AFTER: re-inventory + re-capture (ALWAYS, even after an interrupt) ---
-    let files_after = inventory_files(&snapshot_paths);
+    let (files_after, truncated_after) = inventory_files(&snapshot_paths);
+    let inventory_truncated = truncated_before || truncated_after;
+    if inventory_truncated {
+        eprintln!(
+            "tirith watch: WARNING: file inventory hit the 100,000-entry cap — the before/after diff is partial"
+        );
+    }
     let rt_after = checkpoint::capture_runtime_state(&home);
 
     let (mut post_run_state, modified_rc) = checkpoint::diff_runtime_state(&rt_before, &rt_after);
@@ -360,6 +404,7 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
             &findings,
             action,
             interrupted,
+            inventory_truncated,
         );
     } else {
         print_watch_human(
@@ -372,6 +417,7 @@ pub fn watch(command: &[String], paths: &[String], with_net_hints: bool, json: b
             with_net_hints,
             &findings,
             interrupted,
+            inventory_truncated,
         );
     }
 
@@ -431,11 +477,36 @@ fn run_command(command: &[String]) -> std::io::Result<i32> {
         c.args(&command[1..]);
         c
     };
+    // repo-0215: a new process group still leaves the TERMINAL's foreground
+    // group on tirith, so Ctrl-C never reaches the watched child. Hand the
+    // terminal to the child's group for the duration, then take it back.
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
-        // SAFETY: `setpgid` is async-signal-safe and the only call in the forked
-        // child before exec; it puts the child in its own process group.
+        use std::os::unix::process::ExitStatusExt as _;
+
+        struct ForegroundGuard {
+            fd: libc::c_int,
+            parent_pgid: libc::pid_t,
+            previous_sigttou: libc::sighandler_t,
+            active: bool,
+        }
+
+        impl Drop for ForegroundGuard {
+            fn drop(&mut self) {
+                if self.active {
+                    // SAFETY: the fd and process group were captured from this
+                    // process immediately before handoff. Restoration is
+                    // best-effort because Drop cannot report an error.
+                    unsafe {
+                        libc::tcsetpgrp(self.fd, self.parent_pgid);
+                        libc::signal(libc::SIGTTOU, self.previous_sigttou);
+                    }
+                }
+            }
+        }
+        // SAFETY: `setpgid` is async-signal-safe and the only call in the
+        // forked child before exec; it puts the child in its own process group.
         unsafe {
             cmd.pre_exec(|| {
                 if libc::setpgid(0, 0) != 0 {
@@ -444,8 +515,51 @@ fn run_command(command: &[String]) -> std::io::Result<i32> {
                 Ok(())
             });
         }
+        let mut child = cmd.spawn()?;
+        let child_pgid = child.id() as libc::pid_t;
+        let stdin_fd = libc::STDIN_FILENO;
+        let our_pgid = unsafe { libc::getpgrp() };
+        let is_tty = unsafe { libc::isatty(stdin_fd) } == 1;
+        let mut foreground = None;
+        if is_tty {
+            // Move the terminal's foreground group to the child. SIGTTOU can
+            // fire when a background group writes to the tty; ignore it for
+            // the handoff window.
+            let previous_sigttou = unsafe { libc::signal(libc::SIGTTOU, libc::SIG_IGN) };
+            if previous_sigttou == libc::SIG_ERR {
+                let signal_error = std::io::Error::last_os_error();
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(signal_error);
+            }
+            if unsafe { libc::tcsetpgrp(stdin_fd, child_pgid) } != 0 {
+                let handoff_error = std::io::Error::last_os_error();
+                // Restore the caller's signal disposition before returning.
+                unsafe {
+                    libc::signal(libc::SIGTTOU, previous_sigttou);
+                }
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(handoff_error);
+            }
+            foreground = Some(ForegroundGuard {
+                fd: stdin_fd,
+                parent_pgid: our_pgid,
+                previous_sigttou,
+                active: true,
+            });
+        }
+        let status = child.wait();
+        drop(foreground); // restore the terminal even when wait returned Err
+        let status = status?;
+        if status.signal() == Some(libc::SIGINT) {
+            WATCH_INTERRUPTED.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(status.code().unwrap_or(128))
     }
+    #[cfg(not(unix))]
     let status = cmd.status()?;
+    #[cfg(not(unix))]
     Ok(status.code().unwrap_or(128))
 }
 
@@ -476,39 +590,50 @@ fn install_watch_sigint_handler() {}
 
 /// Inventory files under `roots` as a `path -> mtime` map (capped). Symlinks are
 /// recorded by their own metadata (not followed); hidden dirs (`.git`, …) skipped.
-fn inventory_files(roots: &[String]) -> std::collections::BTreeMap<String, SystemTime> {
+fn inventory_files(roots: &[String]) -> (std::collections::BTreeMap<String, SystemTime>, bool) {
     const MAX_FILES: usize = 100_000;
     let mut out = std::collections::BTreeMap::new();
+    // repo-0477: deterministic order + a truncation flag, so before/after
+    // snapshots cover the SAME subset and a capped inventory is reported.
+    let mut truncated = false;
     for root in roots {
+        if out.len() >= MAX_FILES {
+            truncated = true;
+            break;
+        }
         let path = Path::new(root);
         if path.is_file() {
             if let Some(mtime) = file_mtime(path) {
                 out.insert(path.to_string_lossy().into_owned(), mtime);
             }
-        } else if path.is_dir() {
-            inventory_dir(path, &mut out, MAX_FILES);
+        } else if path.is_dir() && inventory_dir(path, &mut out, MAX_FILES) {
+            truncated = true;
+            break;
         }
     }
-    out
+    (out, truncated)
 }
 
 fn inventory_dir(
     dir: &Path,
     out: &mut std::collections::BTreeMap<String, SystemTime>,
     max_files: usize,
-) {
+) -> bool {
     if out.len() >= max_files {
-        return;
+        return true;
     }
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
-        Err(_) => return,
+        Err(_) => return false,
     };
-    for entry in entries.flatten() {
+    // repo-0477: sort so a capped inventory covers the SAME subset on every
+    // run (filesystem order is arbitrary).
+    let mut paths: Vec<_> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for p in paths {
         if out.len() >= max_files {
-            break;
+            return true;
         }
-        let p = entry.path();
         let meta = match p.symlink_metadata() {
             Ok(m) => m,
             Err(_) => continue,
@@ -531,11 +656,12 @@ fn inventory_dir(
                 .and_then(|n| n.to_str())
                 .map(|n| n.starts_with('.'))
                 .unwrap_or(false);
-            if !is_dot {
-                inventory_dir(&p, out, max_files);
+            if !is_dot && inventory_dir(&p, out, max_files) {
+                return true;
             }
         }
     }
+    false
 }
 
 fn file_mtime(path: &Path) -> Option<SystemTime> {
@@ -589,6 +715,7 @@ fn print_watch_human(
     with_net_hints: bool,
     findings: &[Finding],
     interrupted: bool,
+    inventory_truncated: bool,
 ) {
     let s = tirith_core::style::Stream::Stdout;
     let command = super::sanitize_for_human_output(command, false);
@@ -601,6 +728,15 @@ fn print_watch_human(
             s,
         );
         println!("  {note}");
+    }
+    if inventory_truncated {
+        println!(
+            "  {}",
+            tirith_core::style::yellow(
+                "inventory incomplete: the 100,000-entry cap was reached before or after the command",
+                s,
+            )
+        );
     }
 
     print_list_section("new files", new_files, false);
@@ -672,6 +808,7 @@ fn emit_watch_json(
     findings: &[Finding],
     action: Action,
     interrupted: bool,
+    inventory_truncated: bool,
 ) {
     // `net_hints` is null unless the experimental flag is set, so a consumer
     // never reads an empty array as "no network activity".
@@ -695,6 +832,7 @@ fn emit_watch_json(
         // True if tirith caught a SIGINT: the after-snapshot ran but the command
         // may not have finished — treat the diff as a lower bound.
         "interrupted": interrupted,
+        "inventory_truncated": inventory_truncated,
         "new_files": new_files,
         "modified_files": modified_files,
         "shell_rc_modified": dedup_rc,
@@ -756,6 +894,19 @@ mod tests {
             "exit 7".to_string(),
         ];
         assert_eq!(super::run_command(&command).unwrap(), 7);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_marks_a_sigint_terminated_child_as_interrupted() {
+        super::WATCH_INTERRUPTED.store(false, std::sync::atomic::Ordering::Relaxed);
+        let command = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "kill -INT $$".to_string(),
+        ];
+        assert_eq!(super::run_command(&command).unwrap(), 128);
+        assert!(super::WATCH_INTERRUPTED.load(std::sync::atomic::Ordering::Relaxed));
     }
 
     #[cfg(windows)]

--- a/crates/tirith/src/cli/daemon.rs
+++ b/crates/tirith/src/cli/daemon.rs
@@ -346,6 +346,11 @@ pub struct DaemonResponse {
     /// this is populated from the verdict.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub manifest_allowed_match: Option<String>,
+    /// PID of the daemon process that produced this response. New clients use
+    /// it to bind a live socket response to the PID they are about to signal;
+    /// absent for legacy daemons.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub daemon_pid: Option<u32>,
 }
 
 /// Connect to the daemon and run a check; `None` if unavailable (caller falls
@@ -433,6 +438,7 @@ fn handle_request(req: &DaemonRequest) -> DaemonResponse {
         raw_findings: None,
         raw_action: None,
         manifest_allowed_match: None,
+        daemon_pid: Some(std::process::id()),
     };
 
     if req.command == "ping" {
@@ -484,6 +490,7 @@ fn handle_request(req: &DaemonRequest) -> DaemonResponse {
                 raw_findings: None,
                 raw_action: None,
                 manifest_allowed_match: None,
+                daemon_pid: Some(std::process::id()),
             };
         }
     }
@@ -550,6 +557,7 @@ fn handle_request(req: &DaemonRequest) -> DaemonResponse {
         raw_findings,
         raw_action: raw_action_str,
         manifest_allowed_match,
+        daemon_pid: Some(std::process::id()),
     }
 }
 
@@ -820,6 +828,7 @@ fn run_server(sock: &std::path::Path, pid: &std::path::Path) -> i32 {
                                                 urls_extracted_count: None, tier_reached: 0,
                                                 raw_findings: None, raw_action: None,
                                                 manifest_allowed_match: None,
+                                                daemon_pid: Some(std::process::id()),
                                             })
                                     }
                                     Err(e) => DaemonResponse {
@@ -830,6 +839,7 @@ fn run_server(sock: &std::path::Path, pid: &std::path::Path) -> i32 {
                                         urls_extracted_count: None, tier_reached: 0,
                                         raw_findings: None, raw_action: None,
                                         manifest_allowed_match: None,
+                                        daemon_pid: Some(std::process::id()),
                                     },
                                 };
 
@@ -907,6 +917,50 @@ fn process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 }
 
+/// repo-0216: confirm a PID belongs to OUR daemon before signaling it — a
+/// recycled PID must never receive our SIGTERM. A socket connection alone is
+/// insufficient: a different live daemon could answer while a stale PID file
+/// names an unrelated process. Require an actual ping response whose daemon PID
+/// exactly matches the file.
+#[cfg(unix)]
+fn daemon_identity_confirmed(pid: u32, sock: &std::path::Path) -> bool {
+    matches!(daemon_ping(sock), Some(response) if response.exit_code == 0 && response.error.is_none() && response.daemon_pid == Some(pid))
+}
+
+#[cfg(unix)]
+fn daemon_ping(sock: &std::path::Path) -> Option<DaemonResponse> {
+    use std::io::{BufRead as _, BufReader, Write as _};
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    let stream = UnixStream::connect(sock).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(1)))
+        .ok()?;
+    let request = DaemonRequest {
+        command: "ping".to_string(),
+        input: String::new(),
+        context: "exec".to_string(),
+        cwd: None,
+        shell: None,
+        interactive: false,
+        bypass_requested: false,
+        offline: false,
+    };
+    let mut payload = serde_json::to_string(&request).ok()?;
+    payload.push('\n');
+    let mut writer = stream.try_clone().ok()?;
+    writer.write_all(payload.as_bytes()).ok()?;
+    writer.flush().ok()?;
+    let mut line = String::new();
+    BufReader::new(stream)
+        .take(4096)
+        .read_line(&mut line)
+        .ok()?;
+    serde_json::from_str(line.trim()).ok()
+}
+
 #[cfg(not(unix))]
 fn process_alive(_pid: u32) -> bool {
     // Conservatively assume alive (Windows should use OpenProcess).
@@ -916,6 +970,28 @@ fn process_alive(_pid: u32) -> bool {
 #[cfg(unix)]
 fn kill_process(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) == 0 }
+}
+
+#[cfg(unix)]
+fn wait_for_process_exit(pid: u32, attempts: u32, delay: std::time::Duration) -> bool {
+    for attempt in 0..attempts {
+        if !process_alive(pid) {
+            return true;
+        }
+        if attempt + 1 < attempts {
+            std::thread::sleep(delay);
+        }
+    }
+    false
+}
+
+#[cfg(unix)]
+fn remove_stopped_daemon_file(path: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(unix)]
@@ -1139,12 +1215,44 @@ pub fn stop() -> i32 {
         return 0;
     }
 
+    // repo-0216: a stale PID file can name a RECYCLED pid belonging to an
+    // unrelated process. Only signal it when the daemon socket actually
+    // answers (or, on Linux, /proc confirms the binary), never on a bare
+    // kill(pid, 0).
+    if !daemon_identity_confirmed(pid_num, &sock) {
+        eprintln!(
+            "tirith: PID {pid_num} is not the tirith daemon (socket not answering / identity mismatch); refusing to signal it. Remove {} manually if the daemon is truly gone.",
+            pid.display()
+        );
+        return 1;
+    }
+
     if kill_process(pid_num) {
         eprintln!("tirith: sent SIGTERM to daemon (PID {pid_num})");
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        let _ = std::fs::remove_file(&pid);
-        let _ = std::fs::remove_file(&sock);
-        0
+        if !wait_for_process_exit(pid_num, 100, std::time::Duration::from_millis(50)) {
+            eprintln!(
+                "tirith: daemon (PID {pid_num}) did not stop within 5s; preserving {} and {} for a safe retry",
+                pid.display(),
+                sock.display()
+            );
+            return 1;
+        }
+
+        let mut cleanup_failed = false;
+        for path in [&pid, &sock] {
+            if let Err(error) = remove_stopped_daemon_file(path) {
+                eprintln!(
+                    "tirith: daemon stopped, but failed to remove {}: {error}",
+                    path.display()
+                );
+                cleanup_failed = true;
+            }
+        }
+        if cleanup_failed {
+            1
+        } else {
+            0
+        }
     } else {
         eprintln!("tirith: failed to stop daemon (PID {pid_num})");
         1
@@ -1194,53 +1302,26 @@ pub fn status() -> i32 {
     }
 
     let start = Instant::now();
-    let ping_req = DaemonRequest {
-        command: "ping".to_string(),
-        input: String::new(),
-        context: "exec".to_string(),
-        cwd: None,
-        shell: None,
-        interactive: false,
-        bypass_requested: false,
-        offline: false,
-    };
-
-    let ok = (|| -> Option<()> {
-        use std::io::{BufRead, BufReader, Write};
-        use std::os::unix::net::UnixStream;
-        use std::time::Duration;
-
-        let stream = UnixStream::connect(&sock).ok()?;
-        stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
-        stream
-            .set_write_timeout(Some(Duration::from_secs(1)))
-            .ok()?;
-
-        let mut payload = serde_json::to_string(&ping_req).ok()?;
-        payload.push('\n');
-
-        let mut sw = stream.try_clone().ok()?;
-        sw.write_all(payload.as_bytes()).ok()?;
-        sw.flush().ok()?;
-
-        let reader = BufReader::new(stream);
-        let mut line = String::new();
-        reader.take(4096).read_line(&mut line).ok()?;
-
-        serde_json::from_str::<DaemonResponse>(line.trim()).ok()?;
-        Some(())
-    })();
+    let response = daemon_ping(&sock);
 
     let latency = start.elapsed();
 
-    if ok.is_some() {
+    if matches!(
+        response,
+        Some(ref response)
+            if response.exit_code == 0
+                && response.error.is_none()
+                && response.daemon_pid == Some(pid_num)
+    ) {
         eprintln!(
             "tirith: daemon running (PID {pid_num}), latency {:.1}ms",
             latency.as_secs_f64() * 1000.0
         );
         0
     } else {
-        eprintln!("tirith: daemon running (PID {pid_num}) but not responding on socket");
+        eprintln!(
+            "tirith: daemon PID/socket identity mismatch or daemon not responding (PID {pid_num})"
+        );
         1
     }
 }
@@ -1340,7 +1421,55 @@ mod tests {
             raw_findings: None,
             raw_action: None,
             manifest_allowed_match: None,
+            daemon_pid: Some(std::process::id()),
         }
+    }
+
+    #[cfg(unix)]
+    fn serve_one_ping(
+        sock: &std::path::Path,
+        daemon_pid: Option<u32>,
+    ) -> std::thread::JoinHandle<()> {
+        use std::io::{BufRead as _, BufReader, Write as _};
+        use std::os::unix::net::UnixListener;
+
+        let listener = UnixListener::bind(sock).expect("bind fake daemon socket");
+        std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept ping");
+            let mut line = String::new();
+            BufReader::new(stream.try_clone().expect("clone stream"))
+                .read_line(&mut line)
+                .expect("read ping");
+            let request: super::DaemonRequest =
+                serde_json::from_str(line.trim()).expect("valid ping request");
+            assert_eq!(request.command, "ping");
+            let response = DaemonResponse {
+                daemon_pid,
+                ..base_response()
+            };
+            let mut writer = stream;
+            writeln!(writer, "{}", serde_json::to_string(&response).unwrap()).unwrap();
+        })
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_identity_requires_the_exact_pid_from_the_socket_response() {
+        let dir = tempfile::tempdir().unwrap();
+        let matching = dir.path().join("matching.sock");
+        let matching_thread = serve_one_ping(&matching, Some(4242));
+        assert!(super::daemon_identity_confirmed(4242, &matching));
+        matching_thread.join().unwrap();
+
+        let mismatching = dir.path().join("mismatching.sock");
+        let mismatching_thread = serve_one_ping(&mismatching, Some(9898));
+        assert!(!super::daemon_identity_confirmed(4242, &mismatching));
+        mismatching_thread.join().unwrap();
+
+        let legacy = dir.path().join("legacy.sock");
+        let legacy_thread = serve_one_ping(&legacy, None);
+        assert!(!super::daemon_identity_confirmed(4242, &legacy));
+        legacy_thread.join().unwrap();
     }
 
     /// CodeRabbit R3 #4: the matched `allowed[]` entry must survive the

--- a/crates/tirith/src/cli/dashboard.rs
+++ b/crates/tirith/src/cli/dashboard.rs
@@ -310,6 +310,8 @@ fn write_html_file(path: &Path, html: &str) -> Result<(), String> {
     // `--out .` flow writes ./dashboard.html). Bind its parent once and publish
     // relative to that retained capability. This refuses both a symlinked final
     // component and a symlinked intermediate directory without a check/use gap.
+    // With `create_parent = true`, the same capability traversal also creates a
+    // missing default `~/Documents` parent without an unsafe pathname pre-pass.
     let root = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -71,6 +71,7 @@ fn confirm(prompt: &str, yes: bool) -> bool {
 
 fn run_fix(yes: bool) -> i32 {
     let mut fixed = 0;
+    let mut failed = 0;
 
     if !hooks_installed() {
         println!("Fix: Install shell hooks");
@@ -81,6 +82,7 @@ fn run_fix(yes: bool) -> i32 {
                 fixed += 1;
             } else {
                 eprintln!("  Hook installation failed (exit code {rc}).");
+                failed += 1;
             }
         }
     }
@@ -96,6 +98,7 @@ fn run_fix(yes: bool) -> i32 {
                 }
                 None => {
                     eprintln!("  Failed to materialize hooks.");
+                    failed += 1;
                 }
             }
         }
@@ -111,6 +114,7 @@ fn run_fix(yes: bool) -> i32 {
                 }
                 Err(e) => {
                     eprintln!("  Failed to create policy: {e}");
+                    failed += 1;
                 }
             }
         }
@@ -137,6 +141,7 @@ fn run_fix(yes: bool) -> i32 {
                         fixed += 1;
                     } else {
                         eprintln!("  Failed to configure {}.", tool.name);
+                        failed += 1;
                     }
                 }
             }
@@ -164,6 +169,7 @@ fn run_fix(yes: bool) -> i32 {
                     fixed += 1;
                 } else {
                     eprintln!("  Threat DB download failed.");
+                    failed += 1;
                 }
             }
         }
@@ -197,7 +203,7 @@ fn run_fix(yes: bool) -> i32 {
         );
     }
 
-    if fixed == 0 {
+    if fixed == 0 && failed == 0 {
         if shadows.is_empty() {
             println!("tirith: no issues to fix");
         } else {
@@ -205,9 +211,15 @@ fn run_fix(yes: bool) -> i32 {
             println!("tirith: no auto-fixable issues (see manual steps above)");
         }
     } else {
-        println!("tirith: fixed {fixed} issue(s)");
+        println!("tirith: fixed {fixed} issue(s), {failed} failed");
     }
-    0
+    // repo-0217: a failed remediation must return non-zero — "fixed 0 issues"
+    // with a silent exit 0 hides real breakage.
+    if failed > 0 {
+        1
+    } else {
+        0
+    }
 }
 
 /// Check whether shell hooks are configured in the user's profile.
@@ -498,6 +510,8 @@ struct DetectionGapInfo {
     hidden_findings: usize,
     hidden_top_rules: Vec<(String, usize)>,
     current_paranoia: u8,
+    /// True when only the bounded newest audit tail was analyzed.
+    sample_truncated: bool,
 }
 
 /// Analyze the last 7 days of audit data for detection coverage gaps. For each
@@ -511,7 +525,8 @@ fn check_detection_gaps() -> Option<DetectionGapInfo> {
         return None;
     }
 
-    let read_result = match tirith_core::audit_aggregator::read_log(&log_path) {
+    // repo-0479: bounded tail read — a huge audit log must not hang doctor.
+    let read_result = match tirith_core::audit_aggregator::read_log_tail(&log_path, 10_000) {
         Ok(r) => r,
         Err(e) => {
             eprintln!(
@@ -614,6 +629,7 @@ fn check_detection_gaps() -> Option<DetectionGapInfo> {
         hidden_findings,
         hidden_top_rules,
         current_paranoia,
+        sample_truncated: read_result.truncated_records,
     })
 }
 
@@ -2358,6 +2374,11 @@ fn print_human(info: &DoctorInfo) {
             "  {} commands scanned, {} blocked, {} warned",
             gaps.total_commands, gaps.blocked, gaps.warned
         );
+        if gaps.sample_truncated {
+            println!(
+                "  WARNING: audit history exceeded the bounded 10,000-record/64 MiB sample; coverage statistics are partial"
+            );
+        }
         println!(
             "  {} of {} records have full detection data{}",
             gaps.records_with_raw,

--- a/crates/tirith/src/cli/env_guard.rs
+++ b/crates/tirith/src/cli/env_guard.rs
@@ -198,6 +198,8 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
         out.push('\n');
     }
 
+    // Atomic publish (temp + fsync + rename) through the retained parent
+    // capability: a crash or full disk leaves the previous policy intact.
     contained.write_atomic(out.as_bytes(), true)
 }
 

--- a/crates/tirith/src/cli/exec.rs
+++ b/crates/tirith/src/cli/exec.rs
@@ -178,6 +178,8 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
     }
 
     verify_guard_key_effective(&out, enable)?;
+    // Atomic publish (temp + fsync + rename) through the retained parent
+    // capability: interruption cannot truncate the previous policy.
     contained.write_atomic(out.as_bytes(), true)
 }
 

--- a/crates/tirith/src/cli/explain.rs
+++ b/crates/tirith/src/cli/explain.rs
@@ -63,7 +63,9 @@ fn resolve_finding_id(id: &str) -> Result<RuleId, String> {
         ));
     }
 
-    let read = audit_aggregator::read_log(&log_path)
+    // repo-0480: bounded tail read — the scan limit must apply DURING the
+    // read, not after the whole log is materialized.
+    let read = audit_aggregator::read_log_tail(&log_path, AUDIT_SCAN_LIMIT)
         .map_err(|e| format!("could not read {}: {e}", log_path.display()))?;
 
     // Walk newest-first (log is append-only, newest at the bottom), bounded by
@@ -77,7 +79,7 @@ fn resolve_finding_id(id: &str) -> Result<RuleId, String> {
         .find(|r| r.event_id.as_deref() == Some(event_id));
 
     let Some(entry) = entry else {
-        if read.records.len() > AUDIT_SCAN_LIMIT {
+        if read.truncated_records {
             return Err(format!(
                 "finding ID {id:?} not found in the {scanned} most-recent audit entries (cap is {AUDIT_SCAN_LIMIT}); \
                  narrow via `tirith audit export --since <duration>` and re-run"

--- a/crates/tirith/src/cli/gateway.rs
+++ b/crates/tirith/src/cli/gateway.rs
@@ -2243,7 +2243,8 @@ pub fn run_gateway_with_options(
     // silently dropped: a seed that passes `policy validate` but fails the real
     // compile would otherwise vanish.
     let filter_ctx: Arc<output_filter::OutputFilterContext> = Arc::new(if filter_output {
-        let (ctx, bad) = output_filter::OutputFilterContext::from_policy(&core_policy);
+        let (ctx, bad) =
+            output_filter::OutputFilterContext::from_policy_with_diagnostics(&core_policy);
         for (pattern, error) in &bad {
             eprintln!(
                 "tirith gateway: warning: invalid injection_seeds_custom regex {pattern:?}: {error}"

--- a/crates/tirith/src/cli/hooks.rs
+++ b/crates/tirith/src/cli/hooks.rs
@@ -289,6 +289,8 @@ fn update_policy_guard_key(path: &std::path::Path, enable: bool) -> std::io::Res
     // guard disabled.
     verify_guard_key_effective(&out, enable)?;
 
+    // Atomic publish (temp + fsync + rename) through the retained parent
+    // capability: interruption cannot truncate the previous policy.
     contained.write_atomic(out.as_bytes(), true)
 }
 

--- a/crates/tirith/src/cli/iac.rs
+++ b/crates/tirith/src/cli/iac.rs
@@ -183,18 +183,32 @@ pub fn check_plan(plan_path: &Path, forced_tool: Option<&str>, json: bool) -> i3
         }
         _ => {}
     }
-    let bytes = match std::fs::read(plan_path) {
+    // repo-0221: a pre-read metadata length check does not stop a FIFO from
+    // blocking forever or /dev/zero from allocating without bound. Read
+    // no-follow, regular-file-only, and capped THROUGH the read.
+    let bytes = match tirith_core::util::read_text_no_follow_capped(
+        plan_path,
+        iac_plan::MAX_PLAN_SIZE_BYTES,
+    ) {
         Ok(b) => b,
+        Err(tirith_core::util::OpenRegularError::TooLarge) => {
+            eprintln!(
+                "tirith iac check-plan: {} exceeds the {} byte cap ({} MiB). Refusing to parse.",
+                plan_path.display(),
+                iac_plan::MAX_PLAN_SIZE_BYTES,
+                iac_plan::MAX_PLAN_SIZE_BYTES / (1024 * 1024),
+            );
+            return 1;
+        }
         Err(e) => {
             eprintln!(
-                "tirith iac check-plan: cannot read {}: {e}",
+                "tirith iac check-plan: cannot read {} safely: {e:?}",
                 plan_path.display()
             );
             return 1;
         }
     };
     if bytes.len() as u64 > iac_plan::MAX_PLAN_SIZE_BYTES {
-        // metadata() may have lied (symlink, /dev/zero, fifo) — re-check post-read.
         eprintln!(
             "tirith iac check-plan: read {} bytes from {}; cap is {} bytes ({} MiB). Refusing to parse.",
             bytes.len(),

--- a/crates/tirith/src/cli/incident.rs
+++ b/crates/tirith/src/cli/incident.rs
@@ -516,13 +516,19 @@ fn append_timeline(s: &mut String, since: Option<u64>) {
         s.push_str("_No audit log on this machine yet._\n\n");
         return;
     }
-    let records = match tirith_core::audit_aggregator::read_log(&path) {
-        Ok(r) => r.records,
+    // repo-0481: bounded tail read (the incident window only needs the newest
+    // records; the full log can be arbitrarily large).
+    let read = match tirith_core::audit_aggregator::read_log_tail(&path, 10_000) {
+        Ok(r) => r,
         Err(e) => {
             s.push_str(&format!("_Could not read audit log: {e}_\n\n"));
             return;
         }
     };
+    if read.truncated_records {
+        s.push_str("_Timeline is partial: only the bounded newest audit tail was inspected._\n\n");
+    }
+    let records = read.records;
 
     // Filter to the incident window, newest first.
     let mut rows: Vec<&tirith_core::audit_aggregator::AuditRecord> = records
@@ -598,13 +604,21 @@ fn append_top_findings(s: &mut String, since: Option<u64>) {
         s.push_str("_No audit log on this machine yet._\n\n");
         return;
     }
-    let records = match tirith_core::audit_aggregator::read_log(&path) {
-        Ok(r) => r.records,
+    // repo-0481: bounded tail read (the incident window only needs the newest
+    // records; the full log can be arbitrarily large).
+    let read = match tirith_core::audit_aggregator::read_log_tail(&path, 10_000) {
+        Ok(r) => r,
         Err(e) => {
             s.push_str(&format!("_Could not read audit log: {e}_\n\n"));
             return;
         }
     };
+    if read.truncated_records {
+        s.push_str(
+            "_Finding counts are partial: only the bounded newest audit tail was inspected._\n\n",
+        );
+    }
+    let records = read.records;
 
     let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
     for r in &records {
@@ -797,11 +811,20 @@ fn append_actions_taken(s: &mut String) {
 
 /// Escape a Markdown table cell: collapse newlines, escape `|` so the row holds.
 fn md_cell(raw: &str) -> String {
-    let collapsed: String = raw
+    // repo-0161: report fields carry audit-log content (command text) that can
+    // include raw HTML — a Markdown report opened in a previewer/tracker would
+    // execute it. Strip terminal controls AND neutralize HTML metacharacters.
+    let safe = tirith_core::mcp::output_filter::sanitize_for_display(raw);
+    let collapsed: String = safe
         .chars()
         .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
         .collect();
-    collapsed.replace('|', "\\|").trim().to_string()
+    collapsed
+        .replace('|', "\\|")
+        .replace('<', "\\<")
+        .replace('>', "\\>")
+        .trim()
+        .to_string()
 }
 
 /// Escape a value for inline Markdown code: backticks would break the span.

--- a/crates/tirith/src/cli/intent.rs
+++ b/crates/tirith/src/cli/intent.rs
@@ -19,7 +19,7 @@ use tirith_core::tokenize::ShellType;
 /// Entry point. `intent` is the stated intent sentence; `command` is the
 /// command to analyze (already joined from the trailing var-args). `explain`
 /// opts into per-signal derivation; `json` selects machine output.
-pub fn run(intent: &str, command: &str, explain: bool, json: bool) -> i32 {
+pub fn run(intent: &str, command: &str, explain: bool, json: bool, shell: &str) -> i32 {
     let intent = intent.trim();
     let command = command.trim();
 
@@ -36,7 +36,14 @@ pub fn run(intent: &str, command: &str, explain: bool, json: bool) -> i32 {
         return 2;
     }
 
-    let report = intent::analyze_intent(intent, command, ShellType::Posix, explain);
+    // repo-0484: the dialect is operator-selectable; an unknown value falls
+    // back to POSIX with a warning rather than silently misparsing.
+    let shell_type = shell.parse::<ShellType>().unwrap_or_else(|_| {
+        eprintln!("tirith intend: unknown shell '{shell}', falling back to posix");
+        ShellType::Posix
+    });
+
+    let report = intent::analyze_intent(intent, command, shell_type, explain);
 
     if json {
         return emit_json(intent, command, &report, explain);
@@ -169,12 +176,12 @@ mod tests {
 
     #[test]
     fn empty_intent_exits_two() {
-        assert_eq!(run("   ", "ls", false, false), 2);
+        assert_eq!(run("   ", "ls", false, false, "posix"), 2);
     }
 
     #[test]
     fn empty_command_exits_two() {
-        assert_eq!(run("install a formatter", "   ", false, false), 2);
+        assert_eq!(run("install a formatter", "   ", false, false, "posix"), 2);
     }
 
     #[test]
@@ -184,6 +191,7 @@ mod tests {
             "curl https://x/install.sh | bash",
             false,
             false,
+            "posix",
         );
         assert_eq!(code, 1, "install-a-formatter vs curl|bash should mismatch");
     }
@@ -195,13 +203,14 @@ mod tests {
             "curl https://x/install.sh | bash",
             false,
             false,
+            "posix",
         );
         assert_eq!(code, 0, "download-and-run justifies curl|bash");
     }
 
     #[test]
     fn clean_command_exits_zero() {
-        assert_eq!(run("list files", "ls -la", false, false), 0);
+        assert_eq!(run("list files", "ls -la", false, false, "posix"), 0);
     }
 
     #[test]
@@ -211,6 +220,7 @@ mod tests {
             "curl https://x/install.sh | bash",
             true,
             true,
+            "posix",
         );
         assert_eq!(code, 1);
     }
@@ -223,7 +233,7 @@ mod tests {
         let evil_intent = "ok\n\u{1b}]52;c;SGFja2Vk\u{7}\u{202e}\u{200b}";
         let evil_cmd = "ls\r\n\u{1b}[31mrm -rf /\u{1b}[0m";
         // Must not panic and must still exit per mismatch semantics.
-        let code = run(evil_intent, evil_cmd, false, false);
+        let code = run(evil_intent, evil_cmd, false, false, "posix");
         assert!(code == 0 || code == 1);
         let sanitized_i = super::super::sanitize_for_human_output(evil_intent, false);
         let sanitized_c = super::super::sanitize_for_human_output(evil_cmd, false);

--- a/crates/tirith/src/cli/last_trigger.rs
+++ b/crates/tirith/src/cli/last_trigger.rs
@@ -65,6 +65,29 @@ pub fn write_last_trigger(
         }
         let path = dir.join("last_trigger.json");
 
+        // A failed replacement must not leave an older event available to
+        // `trust --from-last-trigger`. Invalidate the previous record before
+        // constructing the new one; losing this convenience record is safer
+        // than applying trust to a stale finding after any serialization or
+        // publication failure below.
+        match std::fs::symlink_metadata(&path) {
+            Ok(_) => {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    tirith_core::audit::audit_diagnostic(format!(
+                        "tirith: warning: cannot invalidate stale last-trigger record: {e}"
+                    ));
+                    return;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tirith_core::audit::audit_diagnostic(format!(
+                    "tirith: warning: cannot inspect prior last-trigger record: {e}"
+                ));
+                return;
+            }
+        }
+
         let redacted_findings =
             tirith_core::redact::redacted_findings(&verdict.findings, custom_patterns);
 
@@ -122,7 +145,15 @@ pub fn write_last_trigger(
 
             let mut tmp_file = match NamedTempFile::new_in(&dir) {
                 Ok(f) => f,
-                Err(_) => return,
+                Err(e) => {
+                    // repo-0486: a stale last_trigger.json is a WRONG-TRUST
+                    // hazard (`trust --from-last-trigger` would act on an old
+                    // event) — never fail silently.
+                    tirith_core::audit::audit_diagnostic(format!(
+                        "tirith: warning: last-trigger temp file failed: {e}"
+                    ));
+                    return;
+                }
             };
             #[cfg(unix)]
             {
@@ -132,9 +163,15 @@ pub fn write_last_trigger(
                     .set_permissions(std::fs::Permissions::from_mode(0o600));
             }
             if tmp_file.write_all(json.as_bytes()).is_err() {
+                tirith_core::audit::audit_diagnostic("tirith: warning: last-trigger write failed");
                 return;
             }
-            let _ = tmp_file.persist(&path);
+            if let Err(e) = tmp_file.persist(&path) {
+                tirith_core::audit::audit_diagnostic(format!(
+                    "tirith: warning: last-trigger publish failed: {}",
+                    e.error
+                ));
+            }
         }
     }
 }

--- a/crates/tirith/src/cli/license_cmd.rs
+++ b/crates/tirith/src/cli/license_cmd.rs
@@ -126,25 +126,11 @@ pub fn activate(key: &str) -> i32 {
     }
 
     {
-        use std::io::Write;
-        let mut opts = std::fs::OpenOptions::new();
-        opts.write(true).create(true).truncate(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            opts.mode(0o600);
-        }
-        match opts.open(&path) {
-            Ok(mut f) => {
-                if let Err(e) = f.write_all(key.trim().as_bytes()) {
-                    eprintln!("tirith: cannot write license key: {e}");
-                    return 1;
-                }
-            }
-            Err(e) => {
-                eprintln!("tirith: cannot write license key: {e}");
-                return 1;
-            }
+        // repo-0222: atomic publish — a crash or full disk mid-write must not
+        // destroy the previously valid license key.
+        if let Err(e) = tirith_core::util::write_file_atomic_0600(&path, key.trim().as_bytes()) {
+            eprintln!("tirith: cannot write license key: {e}");
+            return 1;
         }
     }
 
@@ -237,25 +223,13 @@ pub fn refresh() -> i32 {
                 }
 
                 {
-                    use std::io::Write;
-                    let mut opts = std::fs::OpenOptions::new();
-                    opts.write(true).create(true).truncate(true);
-                    #[cfg(unix)]
+                    // repo-0222: atomic publish — a crash mid-write must not
+                    // destroy the previously valid license key.
+                    if let Err(e) =
+                        tirith_core::util::write_file_atomic_0600(&path, token.trim().as_bytes())
                     {
-                        use std::os::unix::fs::OpenOptionsExt;
-                        opts.mode(0o600);
-                    }
-                    match opts.open(&path) {
-                        Ok(mut f) => {
-                            if let Err(e) = f.write_all(token.trim().as_bytes()) {
-                                eprintln!("tirith: cannot write license key: {e}");
-                                return 1;
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("tirith: cannot write license key: {e}");
-                            return 1;
-                        }
+                        eprintln!("tirith: cannot write license key: {e}");
+                        return 1;
                     }
                 }
 

--- a/crates/tirith/src/cli/logs.rs
+++ b/crates/tirith/src/cli/logs.rs
@@ -43,6 +43,7 @@ const MAX_STREAM_LINE_BYTES: usize = 1024 * 1024;
 const MAX_STREAM_SECRET_BLOCK_BYTES: usize = 1024 * 1024;
 const REDACTED_BLOCK_MARKER: &str = "[REDACTED]";
 const INCOMPLETE_REDACTION_MARKER: &str = "[REDACTED:incomplete]";
+const OVERSIZED_LOG_LINE_MARKER: &str = "[... oversized line omitted ...]";
 
 // ─── scan ───────────────────────────────────────────────────────────────────
 
@@ -551,6 +552,70 @@ where
     Ok(())
 }
 
+/// Stream plain logical lines without allowing one newline-free record to make
+/// `BufRead::read_line` allocate the entire remainder of an attacker-controlled
+/// file. Oversized records are discarded through the next newline and replaced
+/// by one categorical marker.
+fn read_plain_records_bounded<R, F>(
+    reader: &mut R,
+    line_limit: usize,
+    mut consume: F,
+) -> std::io::Result<()>
+where
+    R: BufRead,
+    F: FnMut(String),
+{
+    let mut line = Vec::with_capacity(STREAM_CHUNK_BYTES.min(line_limit));
+    let mut oversized = false;
+    let mut pending = false;
+
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            if pending || oversized {
+                if oversized {
+                    consume(OVERSIZED_LOG_LINE_MARKER.to_string());
+                } else {
+                    if line.last() == Some(&b'\r') {
+                        line.pop();
+                    }
+                    consume(String::from_utf8_lossy(&line).into_owned());
+                }
+            }
+            return Ok(());
+        }
+
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let payload_len = newline.unwrap_or(available.len());
+        if !oversized {
+            let remaining = line_limit.saturating_sub(line.len());
+            if payload_len > remaining {
+                oversized = true;
+                line.clear();
+            } else {
+                line.extend_from_slice(&available[..payload_len]);
+            }
+        }
+        pending |= payload_len > 0;
+
+        let consumed = payload_len + usize::from(newline.is_some());
+        reader.consume(consumed);
+        if newline.is_some() {
+            if oversized {
+                consume(OVERSIZED_LOG_LINE_MARKER.to_string());
+            } else {
+                if line.last() == Some(&b'\r') {
+                    line.pop();
+                }
+                consume(String::from_utf8_lossy(&line).into_owned());
+            }
+            line.clear();
+            oversized = false;
+            pending = false;
+        }
+    }
+}
+
 // ─── summarize ──────────────────────────────────────────────────────────────
 
 /// `tirith logs summarize` — a compressed, optionally-sanitized view of a log.
@@ -580,9 +645,29 @@ pub fn summarize(path: &Path, safe_for_agent: bool, max_lines: usize, json: bool
         Vec::new()
     };
 
-    // Stream-collapse duplicates and (optionally) redact + strip ANSI; holds at
-    // most `max_lines * 2` collapsed entries, far smaller than the input.
-    let mut collected: Vec<String> = Vec::new();
+    // repo-0223: the old "bounded" claim was false — every UNIQUE line was
+    // retained and truncated only after EOF. Keep only the head and a rolling
+    // tail window, so memory is O(max_lines) regardless of input size.
+    let mut lines_head: Vec<String> = Vec::new();
+    let mut lines_tail: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+    // Reserve one line for the elision marker. With max_lines == 1 the
+    // bounded buffers intentionally retain no content lines, so the marker is
+    // the sole output instead of exceeding the caller's requested limit.
+    let budget = max_lines.saturating_sub(1);
+    let head_cap = budget.div_ceil(2);
+    let tail_cap = budget - head_cap;
+    let mut total_lines: usize = 0;
+    let mut push_bounded = |line: String| {
+        total_lines += 1;
+        if lines_head.len() < head_cap {
+            lines_head.push(line);
+        } else {
+            lines_tail.push_back(line);
+            while lines_tail.len() > tail_cap {
+                lines_tail.pop_front();
+            }
+        }
+    };
     let mut collapsed_runs: usize = 0;
     let mut secret_count: usize = 0;
     let mut redaction_breakdown: Vec<RedactionCount> = Vec::new();
@@ -591,11 +676,11 @@ pub fn summarize(path: &Path, safe_for_agent: bool, max_lines: usize, json: bool
     let mut last_line: Option<String> = None;
     let mut last_count: usize = 0;
 
-    let push_collapsed = |collected: &mut Vec<String>, line: &str, count: usize| {
+    let push_collapsed = |push_bounded: &mut dyn FnMut(String), line: &str, count: usize| {
         if count > 1 {
-            collected.push(format!("{line} [×{count}]"));
+            push_bounded(format!("{line} [×{count}]"));
         } else {
-            collected.push(line.to_string());
+            push_bounded(line.to_string());
         }
     };
 
@@ -608,7 +693,7 @@ pub fn summarize(path: &Path, safe_for_agent: bool, max_lines: usize, json: bool
                 if last_count > 1 {
                     collapsed_runs += last_count - 1;
                 }
-                push_collapsed(&mut collected, &prev, last_count);
+                push_collapsed(&mut push_bounded, prev.as_str(), last_count);
             }
             last_line = Some(processed);
             last_count = 1;
@@ -638,36 +723,32 @@ pub fn summarize(path: &Path, safe_for_agent: bool, max_lines: usize, json: bool
     } else {
         // Preserve the unredacted command's historical behavior. The protected
         // path above uses fixed-size reads and a bounded logical-record cap.
-        let mut buf: Vec<u8> = Vec::with_capacity(4096);
-        loop {
-            buf.clear();
-            let n = match reader.read_until(b'\n', &mut buf) {
-                Ok(0) => break,
-                Ok(n) => n,
-                Err(e) => {
-                    eprintln!("tirith logs summarize: read error: {e}");
-                    return 1;
-                }
-            };
-            let mut end = n;
-            if end > 0 && buf[end - 1] == b'\n' {
-                end -= 1;
-            }
-            if end > 0 && buf[end - 1] == b'\r' {
-                end -= 1;
-            }
-            accept_processed(String::from_utf8_lossy(&buf[..end]).into_owned());
+        if let Err(e) =
+            read_plain_records_bounded(&mut reader, MAX_STREAM_LINE_BYTES, accept_processed)
+        {
+            eprintln!("tirith logs summarize: read error: {e}");
+            return 1;
         }
     }
     if let Some(prev) = last_line.take() {
         if last_count > 1 {
             collapsed_runs += last_count - 1;
         }
-        push_collapsed(&mut collected, &prev, last_count);
+        push_collapsed(&mut push_bounded, prev.as_str(), last_count);
     }
 
-    // Head+tail truncation to `max_lines`.
-    let (final_lines, elided) = head_tail_truncate(&collected, max_lines);
+    // Head+tail truncation to `max_lines` from the bounded buffers.
+    let (final_lines, elided) = if total_lines <= max_lines {
+        let mut all = lines_head.clone();
+        all.extend(lines_tail.iter().cloned());
+        (all, 0)
+    } else {
+        let elided = total_lines.saturating_sub(lines_head.len() + lines_tail.len());
+        let mut out = lines_head.clone();
+        out.push(format!("[... {elided} lines collapsed ...]"));
+        out.extend(lines_tail.iter().cloned());
+        (out, elided)
+    };
 
     if json {
         return emit_summarize_json(
@@ -764,6 +845,7 @@ fn emit_summarize_json(
 /// remaining count plus the elision marker fits in `max_lines`. Returns
 /// `(final_lines, elided_count)`. When the input already fits, the
 /// original lines are returned unchanged with `elided = 0`.
+#[cfg(test)]
 fn head_tail_truncate(lines: &[String], max_lines: usize) -> (Vec<String>, usize) {
     if lines.len() <= max_lines {
         return (lines.to_vec(), 0);
@@ -1245,6 +1327,21 @@ mod tests {
         }
         let code = summarize(f.path(), false, 30, false);
         assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn plain_record_reader_bounds_a_newline_free_record_and_resumes() {
+        let input = format!("{}\nnext\r\n", "x".repeat(33));
+        let mut reader = std::io::BufReader::new(input.as_bytes());
+        let mut records = Vec::new();
+
+        read_plain_records_bounded(&mut reader, 32, |line| records.push(line))
+            .expect("bounded read");
+
+        assert_eq!(
+            records,
+            vec![OVERSIZED_LOG_LINE_MARKER.to_string(), "next".to_string()]
+        );
     }
 
     #[test]

--- a/crates/tirith/src/cli/output_guard.rs
+++ b/crates/tirith/src/cli/output_guard.rs
@@ -45,24 +45,71 @@ fn enable() -> i32 {
         }
     }
 
-    let current = fs::read_to_string(&profile).unwrap_or_default();
-    if current.contains(BEGIN_MARKER) {
-        eprintln!(
-            "tirith output wrap: already enabled in {} (no changes made)",
-            profile.display()
-        );
-        eprintln!("  function:  tirith-output-guard-wrap");
-        eprintln!("  alias:     tirith-out");
-        return 0;
+    // repo-0224: only a MISSING file means "empty profile". Any other read
+    // failure (invalid UTF-8, permissions, transient I/O) must abort rather
+    // than replacing the real profile with just our snippet.
+    let current = match fs::read_to_string(&profile) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            eprintln!(
+                "tirith output wrap: cannot read {} ({e}); refusing to modify it",
+                profile.display()
+            );
+            return 1;
+        }
+    };
+    let expected = build_snippet(shell);
+    match managed_block(&current) {
+        Ok(Some(existing_block)) if existing_block == expected => {
+            eprintln!(
+                "tirith output wrap: already enabled in {} (no changes made)",
+                profile.display()
+            );
+            eprintln!("  function:  tirith-output-guard-wrap");
+            eprintln!("  alias:     tirith-out");
+            return 0;
+        }
+        Ok(Some(_)) => {
+            // repo-0225: a present BEGIN marker is not proof of a healthy block.
+            // A balanced but obsolete managed block can be replaced safely.
+            let Some(stripped) = strip_block(&current) else {
+                eprintln!(
+                    "tirith output wrap: the tirith block in {} is corrupted; fix it manually — no changes made",
+                    profile.display()
+                );
+                return 1;
+            };
+            let new_content = format!("{stripped}{expected}");
+            if let Err(e) = super::write_file_atomic(&profile, new_content.as_bytes(), true) {
+                eprintln!(
+                    "tirith output wrap: failed to repair {}: {e}",
+                    profile.display()
+                );
+                return 1;
+            }
+            eprintln!(
+                "tirith output wrap: repaired the tirith block in {} (function: tirith-output-guard-wrap, alias: tirith-out)",
+                profile.display()
+            );
+            return 0;
+        }
+        Err(()) => {
+            eprintln!(
+                "tirith output wrap: the tirith block in {} is corrupted; fix it manually — no changes made",
+                profile.display()
+            );
+            return 1;
+        }
+        Ok(None) => {}
     }
 
-    let snippet = build_snippet(shell);
     let separator = if current.is_empty() || current.ends_with('\n') {
         ""
     } else {
         "\n"
     };
-    let new_content = format!("{current}{separator}{snippet}");
+    let new_content = format!("{current}{separator}{expected}");
     // Atomic write: a crash mid read-modify-write of the user's rc file must
     // never truncate or corrupt their shell config.
     if let Err(e) = super::write_file_atomic(&profile, new_content.as_bytes(), true) {
@@ -95,23 +142,51 @@ fn disable() -> i32 {
         return 1;
     };
 
-    let Ok(current) = fs::read_to_string(&profile) else {
-        eprintln!(
-            "tirith output wrap: {} not found — nothing to disable",
-            profile.display()
-        );
-        return 0;
+    let current = match fs::read_to_string(&profile) {
+        Ok(current) => current,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "tirith output wrap: {} not found — nothing to disable",
+                profile.display()
+            );
+            return 0;
+        }
+        Err(error) => {
+            eprintln!(
+                "tirith output wrap: cannot read {} ({error}); refusing to modify it",
+                profile.display()
+            );
+            return 1;
+        }
     };
 
-    if !current.contains(BEGIN_MARKER) {
-        eprintln!(
-            "tirith output wrap: not currently enabled in {} (no changes made)",
-            profile.display()
-        );
-        return 0;
+    match managed_block(&current) {
+        Ok(None) => {
+            eprintln!(
+                "tirith output wrap: not currently enabled in {} (no changes made)",
+                profile.display()
+            );
+            return 0;
+        }
+        Ok(Some(_)) => {}
+        Err(()) => {
+            eprintln!(
+                "tirith output wrap: the tirith block in {} is corrupted; fix it manually — no changes made",
+                profile.display()
+            );
+            return 1;
+        }
     }
 
-    let new_content = strip_block(&current);
+    let Some(new_content) = strip_block(&current) else {
+        // repo-0225: an unterminated/tampered block must fail loudly — silently
+        // publishing would discard every profile line after the BEGIN marker.
+        eprintln!(
+            "tirith output wrap: the tirith block in {} is corrupted (missing END marker); fix it manually — no changes made",
+            profile.display()
+        );
+        return 1;
+    };
     // Atomic write (see `enable`): removing the block also rewrites the rc file.
     if let Err(e) = super::write_file_atomic(&profile, new_content.as_bytes(), true) {
         eprintln!(
@@ -130,28 +205,98 @@ fn status() -> i32 {
         eprintln!("tirith output wrap: status — could not detect shell profile");
         return 1;
     };
-    let current = fs::read_to_string(&profile).unwrap_or_default();
-    let enabled = current.contains(BEGIN_MARKER);
+    let current = match fs::read_to_string(&profile) {
+        Ok(current) => current,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            eprintln!(
+                "tirith output wrap: cannot read {} ({error}); status is unknown",
+                profile.display()
+            );
+            return 1;
+        }
+    };
+    let block = managed_block(&current);
+    let enabled = matches!(block, Ok(Some(_)));
+    let healthy = match &block {
+        Ok(None) => true,
+        Ok(Some(found)) => found == &build_snippet(shell),
+        Err(()) => false,
+    };
     println!("tirith output wrap status");
     println!("  shell:     {shell}");
     println!("  profile:   {}", profile.display());
-    println!("  enabled:   {}", if enabled { "yes" } else { "no" });
-    if enabled {
+    println!(
+        "  enabled:   {}",
+        if enabled && healthy {
+            "yes"
+        } else if enabled {
+            "invalid/outdated"
+        } else {
+            "no"
+        }
+    );
+    if enabled && healthy {
         println!("  function:  tirith-output-guard-wrap");
         println!("  alias:     tirith-out");
     }
     println!("  scope:     wraps INDIVIDUAL commands invoked via `tirith-out <cmd>`;");
     println!("             does NOT intercept output from commands run outside the wrapper.");
-    0
+    if healthy {
+        0
+    } else {
+        1
+    }
+}
+
+/// Return the one balanced managed block, including marker lines and its final
+/// newline. Duplicate, nested, stray, or unterminated markers are corruption.
+fn managed_block(content: &str) -> Result<Option<String>, ()> {
+    let mut block = String::new();
+    let mut in_block = false;
+    let mut found = false;
+
+    for line in content.lines() {
+        if line == BEGIN_MARKER {
+            if in_block || found {
+                return Err(());
+            }
+            found = true;
+            in_block = true;
+        } else if line == END_MARKER && !in_block {
+            return Err(());
+        }
+
+        if in_block {
+            block.push_str(line);
+            block.push('\n');
+            if line == END_MARKER {
+                in_block = false;
+            }
+        }
+    }
+
+    if in_block {
+        Err(())
+    } else if found {
+        Ok(Some(block))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Strip the BEGIN…END block (inclusive), preserving surrounding user content.
-fn strip_block(content: &str) -> String {
+/// Returns `None` when the BEGIN marker has no matching END (repo-0225): a
+/// corrupted block must NOT truncate every following line of the profile.
+fn strip_block(content: &str) -> Option<String> {
     let mut out = String::with_capacity(content.len());
     let mut in_block = false;
     let mut first = true;
     for line in content.lines() {
         if line == BEGIN_MARKER {
+            if in_block {
+                return None; // nested BEGIN: corrupted
+            }
             in_block = true;
             continue;
         }
@@ -167,10 +312,13 @@ fn strip_block(content: &str) -> String {
         first = false;
         out.push_str(line);
     }
+    if in_block {
+        return None; // unterminated block
+    }
     if content.ends_with('\n') && !out.ends_with('\n') {
         out.push('\n');
     }
-    out
+    Some(out)
 }
 
 fn build_snippet(shell: &str) -> String {
@@ -181,8 +329,10 @@ fn build_snippet(shell: &str) -> String {
         "nushell" => format!(
             "{BEGIN_MARKER}\ndef tirith-output-guard-wrap [...cmd] {{\n    if ($cmd | length) == 0 {{\n        print --stderr 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]'\n        return 2\n    }}\n    run-external $cmd.0 ...($cmd | skip 1) | tirith view --max-bytes 16777216 -\n}}\nalias tirith-out = tirith-output-guard-wrap\n{END_MARKER}\n",
         ),
-        "powershell" => format!(
-            "{BEGIN_MARKER}\nfunction tirith-output-guard-wrap {{\n    param([Parameter(ValueFromRemainingArguments=$true)]$Args)\n    if ($Args.Count -eq 0) {{\n        Write-Error 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]'\n        return\n    }}\n    & $Args[0] $Args[1..($Args.Count-1)] 2>&1 | & tirith view --max-bytes 16777216 -\n}}\nSet-Alias tirith-out tirith-output-guard-wrap\n{END_MARKER}\n",
+        // repo-0226: `pwsh` is PowerShell 7's shell label — it needs the
+        // PowerShell snippet, not the POSIX one.
+        "powershell" | "pwsh" => format!(
+            "{BEGIN_MARKER}\nfunction tirith-output-guard-wrap {{\n    param([Parameter(ValueFromRemainingArguments=$true)]$Args)\n    if ($Args.Count -eq 0) {{\n        Write-Error 'tirith-output-guard-wrap: usage: tirith-out <cmd> [args...]'\n        return\n    }}\n    if ($Args.Count -eq 1) {{ & $Args[0] 2>&1 | & tirith view --max-bytes 16777216 - }} else {{ & $Args[0] $Args[1..($Args.Count-1)] 2>&1 | & tirith view --max-bytes 16777216 - }}\n}}\nSet-Alias tirith-out tirith-output-guard-wrap\n{END_MARKER}\n",
         ),
         // zsh / bash / posix sh share one snippet.
         _ => format!(
@@ -225,7 +375,7 @@ mod tests {
     #[test]
     fn strip_block_removes_inserted_section() {
         let content = format!("before line\n{BEGIN_MARKER}\nfunc def\n{END_MARKER}\nafter line\n",);
-        let out = strip_block(&content);
+        let out = strip_block(&content).expect("balanced block strips");
         assert!(out.contains("before line"));
         assert!(out.contains("after line"));
         assert!(!out.contains(BEGIN_MARKER));
@@ -236,7 +386,17 @@ mod tests {
     #[test]
     fn strip_block_no_marker_is_noop() {
         let content = "alpha\nbeta\n";
-        assert_eq!(strip_block(content), content);
+        assert_eq!(strip_block(content).as_deref(), Some(content));
+    }
+
+    #[test]
+    fn managed_block_requires_one_balanced_exact_region() {
+        let expected = build_snippet("zsh");
+        assert_eq!(managed_block(&expected), Ok(Some(expected.clone())));
+        assert_eq!(managed_block("ordinary profile\n"), Ok(None));
+        assert_eq!(managed_block(BEGIN_MARKER), Err(()));
+        assert_eq!(managed_block(END_MARKER), Err(()));
+        assert_eq!(managed_block(&format!("{expected}{expected}")), Err(()));
     }
 
     #[test]

--- a/crates/tirith/src/cli/paste.rs
+++ b/crates/tirith/src/cli/paste.rs
@@ -174,8 +174,15 @@ pub fn run(
         } else {
             None
         };
+        // repo-0489: a missing/truncated JSON document must not pair with a
+        // success exit code — an Allow verdict still reports failure.
         if write_paste_json(&verdict, &policy.dlp_custom_patterns, source_attribution).is_err() {
             eprintln!("tirith: failed to write JSON output");
+            return if verdict.action.exit_code() == 0 {
+                1
+            } else {
+                verdict.action.exit_code()
+            };
         }
     } else {
         if output::write_human_auto(&verdict, false).is_err() {

--- a/crates/tirith/src/cli/policy.rs
+++ b/crates/tirith/src/cli/policy.rs
@@ -531,9 +531,18 @@ fn test_command(command: &str, json: bool) -> i32 {
         clipboard_source: tirith_core::clipboard::ClipboardSourceState::Unread,
     };
 
-    let mut verdict = engine::analyze(&ctx);
+    let verdict = engine::analyze(&ctx);
     let policy = Policy::discover(cwd.as_deref());
-    engine::filter_findings_by_paranoia(&mut verdict, policy.paranoia);
+    // repo-0227: apply the same policy finalization the real gate runs
+    // (action_overrides / severity overrides), or `policy test` reports a
+    // different action than enforcement — a Medium-to-Block override would
+    // read as Warn here.
+    let verdict = tirith_core::escalation::finalize_static_verdict(
+        verdict.findings,
+        &policy,
+        verdict.tier_reached,
+        verdict.timings_ms.clone(),
+    );
 
     let trace = build_policy_trace(command, &policy);
 

--- a/crates/tirith/src/cli/prompt_status.rs
+++ b/crates/tirith/src/cli/prompt_status.rs
@@ -52,10 +52,36 @@ struct CacheEnvelope {
     contexts: BTreeMap<String, String>,
     ssh_remote: bool,
     sudo_active: bool,
+    /// repo-0228: fingerprint of the environment the status was computed from.
+    /// A warm cache from a DIFFERENT shell (other TIRITH_STATUS / AWS_PROFILE /
+    /// KUBECONFIG) must not leak its context into this shell's prompt.
+    #[serde(default)]
+    env_fingerprint: String,
 }
 
 fn default_schema_version() -> u32 {
     1
+}
+
+/// repo-0228: hash the environment inputs the status is derived from.
+fn current_env_fingerprint() -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    for name in [
+        "TIRITH_STATUS",
+        "TIRITH_SSH_REMOTE",
+        "AWS_PROFILE",
+        "AWS_DEFAULT_PROFILE",
+        "KUBECONFIG",
+    ] {
+        h.update(name.as_bytes());
+        h.update([0]);
+        if let Ok(value) = std::env::var(name) {
+            h.update(value.as_bytes());
+        }
+        h.update([0]);
+    }
+    format!("{:x}", h.finalize())
 }
 
 /// Public JSON envelope written to stdout — like [`CacheEnvelope`] but without
@@ -129,13 +155,22 @@ pub fn run(short: bool, json: bool) -> i32 {
 /// Starts with `[tirith:<mode>]` for downstream parsers; provider segments are
 /// BTreeMap-sorted; ssh/sudo segments appended only when active.
 fn format_short(s: &Status) -> String {
-    let mut out = format!("[tirith:{}]", s.protection_mode);
+    // repo-0411: every interpolated value is env/config-derived and lands in
+    // the prompt unescaped — sanitize terminal controls/bidi/newlines first.
+    let mut out = format!(
+        "[tirith:{}]",
+        super::sanitize_for_human_output(&s.protection_mode, false)
+    );
     for (k, v) in &s.contexts {
         // A malformed cache entry shouldn't render `[kube:]`.
         if v.is_empty() {
             continue;
         }
-        out.push_str(&format!("[{k}:{v}]"));
+        out.push_str(&format!(
+            "[{}:{}]",
+            super::sanitize_for_human_output(k, false),
+            super::sanitize_for_human_output(v, false)
+        ));
     }
     if s.ssh_remote {
         out.push_str("[ssh:remote]");
@@ -148,12 +183,19 @@ fn format_short(s: &Status) -> String {
 
 /// Render the semicolon-separated long form.
 fn format_long(s: &Status) -> String {
-    let mut parts = vec![format!("tirith: {}", s.protection_mode)];
+    let mut parts = vec![format!(
+        "tirith: {}",
+        super::sanitize_for_human_output(&s.protection_mode, false)
+    )];
     for (k, v) in &s.contexts {
         if v.is_empty() {
             continue;
         }
-        parts.push(format!("{k}: {v}"));
+        parts.push(format!(
+            "{}: {}",
+            super::sanitize_for_human_output(k, false),
+            super::sanitize_for_human_output(v, false)
+        ));
     }
     if s.ssh_remote {
         parts.push("ssh: remote".into());
@@ -177,6 +219,7 @@ fn load_or_refresh() -> Result<Status, String> {
                 if env.captured_at <= now
                     && now - env.captured_at < CACHE_TTL_SECS
                     && env.schema_version == 1
+                    && env.env_fingerprint == current_env_fingerprint()
                 {
                     return Ok(Status {
                         protection_mode: env.protection_mode,
@@ -290,7 +333,11 @@ impl ProtectionHealth {
     /// [`Unknown`](Self::Unknown).
     pub(crate) fn classify(protection_mode: &str, hook_configured: bool) -> Self {
         match protection_mode {
-            "guarded" => Self::Guarded,
+            // repo-0436: the env-exported mode string is only meaningful when a
+            // hook actually exists — otherwise a wrapper or project environment
+            // can forge "guarded" and claim protection that is not installed.
+            "guarded" if hook_configured => Self::Guarded,
+            "guarded" => Self::HookMissing,
             "warn-only" => Self::WarnOnly,
             "degraded" => Self::Degraded,
             // No live mode signal. A protected shell's TIRITH_STATUS is
@@ -405,6 +452,7 @@ fn write_cache(path: &std::path::Path, status: &Status) -> std::io::Result<()> {
         contexts: status.contexts.clone(),
         ssh_remote: status.ssh_remote,
         sudo_active: status.sudo_active,
+        env_fingerprint: current_env_fingerprint(),
     };
     let body = serde_json::to_vec(&envelope).map_err(std::io::Error::other)?;
 
@@ -636,6 +684,7 @@ mod tests {
             ]),
             ssh_remote: true,
             sudo_active: false,
+            env_fingerprint: String::new(),
         };
         let bytes = serde_json::to_vec(&env).unwrap();
         let back: CacheEnvelope = serde_json::from_slice(&bytes).unwrap();

--- a/crates/tirith/src/cli/provenance.rs
+++ b/crates/tirith/src/cli/provenance.rs
@@ -42,7 +42,7 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use tirith_core::artifact::inspect::inspect_artifact_set;
+use tirith_core::artifact::inspect::{inspect_artifact_set, ArtifactSetInspection};
 use tirith_core::artifact::install::discover_installed_distributions;
 use tirith_core::artifact::record::{index_distribution_ownership, OwnershipIndex};
 use tirith_core::artifact::release_diff::{diff_artifact_files, ReleaseDiff, ReleaseDiffError};
@@ -89,6 +89,8 @@ pub enum GraphTarget {
 /// code: `0` on success (a graph was rendered), `2` on a usage error (no wheels and
 /// no `--installed`).
 pub fn run(target: GraphTarget, format: GraphFormat) -> i32 {
+    // repo-0229: an inspection with coverage gaps (unreadable / oversized /
+    // unsupported inputs) must not render as a clean graph with exit 0.
     let graph = match &target {
         GraphTarget::Wheels(paths) => {
             if paths.is_empty() {
@@ -98,7 +100,21 @@ pub fn run(target: GraphTarget, format: GraphFormat) -> i32 {
                 );
                 return 2;
             }
-            build_wheel_graph(paths)
+            let set = inspect_artifact_set(paths);
+            let gap_count = set.gaps.len()
+                + set
+                    .members
+                    .iter()
+                    .map(|m| m.inspected.inspection.coverage.gaps.len())
+                    .sum::<usize>();
+            if gap_count > 0 {
+                eprintln!(
+                    "tirith pkg graph: {gap_count} coverage gap(s) — the graph is incomplete (inspect with `tirith pkg check` for details)"
+                );
+                render(&build_wheel_graph_from_set(&set), format);
+                return 1;
+            }
+            build_wheel_graph_from_set(&set)
         }
         GraphTarget::InstalledEnv(env) => build_installed_graph(env),
     };
@@ -246,8 +262,9 @@ fn render_diff_human_to<W: Write>(
 /// Build the graph for a set of wheel files: inspect the set (B8), fold each
 /// member's inspection in, build the cross-wheel ownership index from the inspected
 /// member files, and add the repo MCP surface.
-fn build_wheel_graph(paths: &[PathBuf]) -> ProvenanceGraph {
-    let set = inspect_artifact_set(paths);
+/// Build the graph from an already-run set inspection (repo-0229 lets the
+/// caller check coverage gaps first).
+fn build_wheel_graph_from_set(set: &ArtifactSetInspection) -> ProvenanceGraph {
     let inspections: Vec<&ArtifactInspection> = set
         .members
         .iter()

--- a/crates/tirith/src/cli/scan.rs
+++ b/crates/tirith/src/cli/scan.rs
@@ -309,6 +309,16 @@ pub fn run(
     } else if ci_coverage_fail {
         // Fail closed in CI: an incomplete scan must not report success.
         1
+    } else if ci {
+        // repo-0230: under --ci, findings BELOW --fail-on must not fail the
+        // build — every non-zero code is a failure in CI systems, so the
+        // legacy "2 = findings below threshold" makes `--fail-on high` fail on
+        // Low/Medium noise.
+        if !output_ok {
+            1
+        } else {
+            0
+        }
     } else if result.total_findings() > 0 {
         2
     } else if !output_ok {

--- a/crates/tirith/src/cli/selfupdate.rs
+++ b/crates/tirith/src/cli/selfupdate.rs
@@ -739,6 +739,14 @@ fn run_update(
     }
 
     if !crate::cli::confirm(&format!("Update tirith from v{current} to v{latest}?"), yes) {
+        // repo-0492: in --json mode a cancelled update must still emit exactly
+        // one document (a machine consumer cannot distinguish empty stdout).
+        if json {
+            let _ = super::write_json_stdout(
+                &serde_json::json!({"schema_version": 1, "kind": "update", "status": "cancelled"}),
+                "tirith update: failed to write JSON output",
+            );
+        }
         eprintln!("tirith: update cancelled");
         return 0;
     }
@@ -754,7 +762,9 @@ fn run_update(
         }
     };
 
-    println!("tirith: downloading {tag} for {target}...");
+    // repo-0492: progress goes to stderr — in --json mode stdout must carry
+    // exactly one JSON document.
+    eprintln!("tirith: downloading {tag} for {target}...");
     let release = match download_release_set(&tag, &archive_name, workdir.path()) {
         Ok(r) => r,
         Err(e) => {
@@ -1004,6 +1014,12 @@ fn run_rollback(prov: &Provenance, dry_run: bool, yes: bool, json: bool) -> i32 
     }
 
     if !crate::cli::confirm("Roll tirith back to the previously-installed binary?", yes) {
+        if json {
+            let _ = super::write_json_stdout(
+                &serde_json::json!({"schema_version": 1, "kind": "rollback", "status": "cancelled"}),
+                "tirith rollback: failed to write JSON output",
+            );
+        }
         eprintln!("tirith: rollback cancelled");
         return 0;
     }

--- a/crates/tirith/src/cli/setup/shell_profile.rs
+++ b/crates/tirith/src/cli/setup/shell_profile.rs
@@ -150,7 +150,15 @@ fn has_executable_tirith_init(content: &str) -> bool {
         if trimmed.is_empty() {
             return false;
         }
-        trimmed.contains("tirith init")
+        // repo-0495: a substring match counts `echo "tirith init"` or
+        // `false && eval "$(tirith init)"` as installed. Require a real
+        // activation shape: a leading eval/source/direct invocation of
+        // `tirith init`.
+        trimmed.starts_with("tirith init")
+            || ((trimmed.starts_with("eval") || trimmed.starts_with("source"))
+                && (trimmed.contains("$(tirith init")
+                    || trimmed.contains("`tirith init")
+                    || trimmed.contains("<(tirith init")))
     })
 }
 

--- a/crates/tirith/src/cli/ssh.rs
+++ b/crates/tirith/src/cli/ssh.rs
@@ -77,6 +77,21 @@ pub fn guard(action: &str, json: bool) -> i32 {
         Err(code) => return code,
     };
 
+    // repo-0497: a repo-scoped policy is sanitized on load — a weakening key
+    // written there never takes effect. Refuse instead of reporting OFF while
+    // enforcement stays ON; point the operator at the user config.
+    if !enable {
+        if let Some((path, scope)) = policy_mod::discover_local_policy_path_scoped(None) {
+            if path == target_path && scope == policy_mod::PolicyScope::Repo {
+                eprintln!(
+                    "tirith ssh guard: cannot disable via a repository policy ({}) — repo policies are sanitized on load and the guard would stay ON. Use your user config: ~/.config/tirith/policy.yaml",
+                    path.display()
+                );
+                return 1;
+            }
+        }
+    }
+
     if let Err(e) = update_policy_guard_key(&target_path, enable) {
         eprintln!(
             "tirith ssh guard: failed to update {}: {e}",

--- a/crates/tirith/src/cli/sudo.rs
+++ b/crates/tirith/src/cli/sudo.rs
@@ -27,6 +27,20 @@ pub fn guard(action: &str, json: bool) -> i32 {
         Err(code) => return code,
     };
 
+    // repo-0498: a repo-scoped policy is sanitized on load — the weakening key
+    // never takes effect there, so refuse instead of reporting a false OFF.
+    if !enable {
+        if let Some((path, scope)) = policy_mod::discover_local_policy_path_scoped(None) {
+            if path == target_path && scope == policy_mod::PolicyScope::Repo {
+                eprintln!(
+                    "tirith sudo guard: cannot disable via a repository policy ({}) — repo policies are sanitized on load and the guard would stay ON. Use your user config: ~/.config/tirith/policy.yaml",
+                    path.display()
+                );
+                return 1;
+            }
+        }
+    }
+
     if let Err(e) = update_policy_key(&target_path, "context_guard_enabled", &enable.to_string()) {
         eprintln!(
             "tirith sudo guard: failed to update {}: {e}",

--- a/crates/tirith/src/cli/temp_run.rs
+++ b/crates/tirith/src/cli/temp_run.rs
@@ -177,7 +177,9 @@ pub fn run(
     };
 
     if json {
-        emit_json(
+        // repo-0499: a failed/truncated JSON write must not pair with a
+        // zero/successful exit status — report 2 when the child succeeded.
+        let wrote = emit_json(
             &command_display,
             command,
             exit_code,
@@ -190,6 +192,9 @@ pub fn run(
             &modified_files,
             kept_path.as_deref(),
         );
+        if !wrote && exit_code == 0 {
+            return 2;
+        }
     } else {
         print_result(exit_code, &new_files, &modified_files, kept_path.as_deref());
     }
@@ -287,7 +292,7 @@ fn emit_json(
     new_files: &[String],
     modified_files: &[String],
     kept_path: Option<&Path>,
-) {
+) -> bool {
     // The honesty marker reflects the actual mode: `capsule_contained` only when
     // --capsule ran AND a backend actually contained it; a degraded --capsule run
     // is still file-only, so it keeps the not-a-sandbox marker. Emitted through the
@@ -325,7 +330,7 @@ fn emit_json(
         "temp_dir_kept": kept_path.is_some(),
         "temp_dir": kept_path.map(|p| p.display().to_string()),
     });
-    write_json_stdout(&json_val, "tirith temp-run: failed to write JSON output");
+    write_json_stdout(&json_val, "tirith temp-run: failed to write JSON output")
 }
 
 /// Build the legacy human/JSON command label from argv. Sanitization and quoting

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -1057,7 +1057,9 @@ pub(crate) struct ThreatDbStatus {
 }
 
 pub(crate) fn gather_status() -> ThreatDbStatus {
-    let db_path = ThreatDb::default_path();
+    // repo-0501: report the EFFECTIVE database path (v2 when installed), not
+    // the legacy v1 location.
+    let db_path = ThreatDb::resolve_primary_path();
     let path_str = db_path.as_ref().map(|p| p.display().to_string());
 
     let db_path_ref = match db_path {
@@ -2373,7 +2375,8 @@ pub fn health(json: bool) -> i32 {
 }
 
 fn gather_health() -> HealthReport {
-    let db_path = ThreatDb::default_path();
+    // repo-0501: same fix on the health surface.
+    let db_path = ThreatDb::resolve_primary_path();
     let path_str = db_path.as_ref().map(|p| p.display().to_string());
     let policy = policy::Policy::discover(None);
     let refresh_interval_hours = policy.threat_intel.auto_update_hours;

--- a/crates/tirith/src/cli/trust.rs
+++ b/crates/tirith/src/cli/trust.rs
@@ -215,6 +215,30 @@ fn write_store(path: &std::path::Path, store: &TrustStore) -> Result<(), String>
     Ok(())
 }
 
+/// repo-0233: cross-process lock for trust-store mutations. The mutation sites
+/// load → modify → write; without a lock two processes lose each other's
+/// entries. Returns a held lock file guard.
+fn lock_trust_store(path: &std::path::Path) -> Result<std::fs::File, String> {
+    use fs2::FileExt as _;
+    let lock_path = path.with_extension("lock");
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("cannot create directory {}: {e}", parent.display()))?;
+    }
+    // The lock file carries no content; keep whatever is already there rather
+    // than truncating a lock another process is holding.
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|e| format!("cannot open trust-store lock: {e}"))?;
+    file.lock_exclusive()
+        .map_err(|e| format!("cannot lock trust store: {e}"))?;
+    Ok(file)
+}
+
 fn load_store_scoped(scope: &str, path: &std::path::Path) -> Result<TrustStore, String> {
     if scope == "repo" {
         load_repo_store(path)
@@ -1112,6 +1136,14 @@ pub fn add(
         }
     };
 
+    // repo-0233: hold the store lock across load → mutate → write.
+    let _store_lock = match lock_trust_store(&path) {
+        Ok(guard) => guard,
+        Err(e) => {
+            eprintln!("tirith: trust store lock failed: {e}");
+            return 1;
+        }
+    };
     let mut store = match load_store_scoped(scope, &path) {
         Ok(s) => s,
         Err(e) => {
@@ -1433,6 +1465,14 @@ pub fn remove(pattern: &str, rule_id: Option<&str>, scope: &str) -> i32 {
         }
     };
 
+    // repo-0233: hold the store lock across load → mutate → write.
+    let _store_lock = match lock_trust_store(&path) {
+        Ok(guard) => guard,
+        Err(e) => {
+            eprintln!("tirith: trust store lock failed: {e}");
+            return 1;
+        }
+    };
     let mut store = match load_store_scoped(scope, &path) {
         Ok(s) => s,
         Err(e) => {
@@ -1878,6 +1918,14 @@ fn gc_with_action(action_label: &str, expired: bool, scope: &str, json: bool) ->
             }
         };
 
+        // repo-0233: hold the store lock across load → mutate → write.
+        let _store_lock = match lock_trust_store(&path) {
+            Ok(guard) => guard,
+            Err(e) => {
+                eprintln!("{}", trust_error_line(action_label, &e));
+                return 1;
+            }
+        };
         let mut store = match load_store_scoped(s, &path) {
             Ok(s) => s,
             Err(e) => {
@@ -2630,6 +2678,7 @@ mod tests {
         open_repo_trust_dir(&root.join(".tirith").join("trust.json"), false)
             .expect("an ordinary repository root opens");
 
+        // The component that carries repository content refuses a symlink.
         let hostile = holder.path().join("hostile");
         std::fs::create_dir(&hostile).unwrap();
         let swapped = holder.path().join("swapped");

--- a/crates/tirith/src/cli/view.rs
+++ b/crates/tirith/src/cli/view.rs
@@ -116,9 +116,15 @@ pub fn run(path: Option<&Path>, max_bytes: u64, json: bool) -> i32 {
 
     // Human path: write the sanitized content to stdout (so callers can
     // `tirith view foo | less`), and the findings/banner to stderr.
-    let _ = std::io::stdout().lock().write_all(&sanitized);
+    // repo-0502: a broken pipe or full filesystem must not return the
+    // verdict's clean exit code with truncated/absent output.
+    let mut out_ok = std::io::stdout().lock().write_all(&sanitized).is_ok();
     if !sanitized.is_empty() && !sanitized.ends_with(b"\n") {
-        let _ = writeln!(std::io::stdout().lock());
+        out_ok = writeln!(std::io::stdout().lock()).is_ok() && out_ok;
+    }
+    if !out_ok {
+        eprintln!("tirith view: failed to write output");
+        return 1;
     }
 
     print_findings_human(&verdict, path, total_bytes, truncated);

--- a/crates/tirith/src/cli/yaml.rs
+++ b/crates/tirith/src/cli/yaml.rs
@@ -63,10 +63,45 @@ fn escape_risky_unicode(s: &str) -> String {
 /// and a name with `:` / `#` / a newline / an ANSI escape would otherwise split
 /// the key, comment out the value, break the document, or reach the terminal on
 /// `cat`. The quoted/escaped form is unambiguous.
+/// repo-0234: `true` when a bare emission would be parsed by YAML as
+/// null/bool/number instead of the string it is.
+fn yaml_implicit_nonstring(s: &str) -> bool {
+    let lower = s.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "null"
+            | "~"
+            | "true"
+            | "false"
+            | "yes"
+            | "no"
+            | "on"
+            | "off"
+            | ".nan"
+            | ".inf"
+            | "-.inf"
+            | "+.inf"
+    ) {
+        return true;
+    }
+    // Integer / float spellings.
+    if s.parse::<i64>().is_ok() || s.parse::<f64>().is_ok() {
+        return true;
+    }
+    false
+}
+
 pub(crate) fn safe_scalar(s: &str) -> String {
     // Empty must be quoted — bare empty is invalid YAML.
     if s.is_empty() {
         return "\"\"".to_string();
+    }
+    // repo-0234: a bare scalar that YAML would parse as null/bool/number does
+    // NOT round-trip as a string — quote those spellings.
+    if yaml_implicit_nonstring(s) {
+        return serde_json::to_string(s)
+            .map(|json| escape_risky_unicode(&json))
+            .unwrap_or_else(|_| format!("\"{}\"", s.escape_debug()));
     }
     // Bare-safe iff every byte is printable ASCII non-special. Control bytes are
     // checked separately so a future indicator change can't drop the guards.

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -2551,6 +2551,11 @@ Examples:
         /// The command to analyze (everything after `--`)
         #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         command: Vec<String>,
+
+        /// Shell dialect of the command (posix, bash, zsh, fish, powershell,
+        /// pwsh, cmd). repo-0484: parsing always assumed POSIX before.
+        #[arg(long, default_value = "posix")]
+        shell: String,
     },
 
     /// Opt-in per-user anomaly baseline: learn|status|reset (M10 ch5)
@@ -8698,9 +8703,10 @@ fn run() {
             format,
             json,
             command,
+            shell,
         } => {
             let (_, json) = HumanJsonFormat::resolve(format, json);
-            cli::intent::run(&intent, &command.join(" "), explain, json)
+            cli::intent::run(&intent, &command.join(" "), explain, json, &shell)
         }
         Commands::Baseline { action } => match action {
             BaselineAction::Learn { format, json } => {

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -73,14 +73,26 @@ fn seed_capability_cache(state_dir: &std::path::Path, verdict: &str) {
     };
     let cache_dir = state_dir.join("tirith");
     std::fs::create_dir_all(&cache_dir).unwrap();
-    // Schema 1 mirrors cli::bash_capability::CACHE_SCHEMA; tirith_version blank
+    // Schema 2 mirrors cli::bash_capability::CACHE_SCHEMA; tirith_version blank
     // (version match is only enforced with a sibling `.hooks-version`, which
-    // assets/ lacks).
+    // assets/ lacks). The bash_fingerprint line binds the mtime+size of the
+    // live bash binary (repo-0211).
+    let bash_fingerprint = {
+        let meta = std::fs::metadata(&bash_path).expect("stat bash");
+        let secs = meta
+            .modified()
+            .expect("mtime")
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("epoch")
+            .as_secs();
+        format!("{secs}:{}", meta.len())
+    };
     std::fs::write(
         cache_dir.join("bash-enter-capability"),
         format!(
-            "schema=1\ntirith_version=\nshell=bash\nbash_version={bash_version}\n\
-             bash_path={bash_path}\nenter_capability={verdict}\nreason=seeded by test\n"
+            "schema=2\ntirith_version=\nshell=bash\nbash_version={bash_version}\n\
+             bash_path={bash_path}\nbash_fingerprint={bash_fingerprint}\n\
+             enter_capability={verdict}\nreason=seeded by test\n"
         ),
     )
     .unwrap();

--- a/crates/tirith/tests/bash_preexec_enforce.rs
+++ b/crates/tirith/tests/bash_preexec_enforce.rs
@@ -728,14 +728,29 @@ fn seed_capability_cache(state_dir: &Path, verdict: &str) {
     let (bash_version, bash_path) = spawned_bash_identity();
     let cache_dir = state_dir.join("tirith");
     fs::create_dir_all(&cache_dir).unwrap();
-    // Schema 1 mirrors cli::bash_capability::CACHE_SCHEMA. Blank tirith_version:
-    // the hook only enforces a version match when a sibling `.hooks-version`
+    // Schema 2 mirrors cli::bash_capability::CACHE_SCHEMA and binds the bash
+    // binary's mtime+size fingerprint (repo-0211). Blank tirith_version: the
+    // hook only enforces a version match when a sibling `.hooks-version`
     // exists, which the assets/ hook lacks.
+    let fingerprint = bash_fingerprint(&bash_path);
     let body = format!(
-        "schema=1\ntirith_version=\nshell=bash\nbash_version={bash_version}\n\
-         bash_path={bash_path}\nenter_capability={verdict}\nreason=seeded by test\n"
+        "schema=2\ntirith_version=\nshell=bash\nbash_version={bash_version}\n\
+         bash_path={bash_path}\nbash_fingerprint={fingerprint}\n\
+         enter_capability={verdict}\nreason=seeded by test\n"
     );
     fs::write(cache_dir.join("bash-enter-capability"), body).unwrap();
+}
+
+/// mtime-secs:size fingerprint, matching cli::bash_capability (repo-0211).
+fn bash_fingerprint(bash_path: &str) -> String {
+    let meta = std::fs::metadata(bash_path).expect("stat bash");
+    let secs = meta
+        .modified()
+        .expect("mtime")
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("epoch")
+        .as_secs();
+    format!("{secs}:{}", meta.len())
 }
 
 /// Run the hook in a fresh interactive bash with `XDG_STATE_HOME` at a temp dir,
@@ -979,7 +994,7 @@ fn capability_stale_cache_falls_back_and_installs_debug_trap() {
     fs::write(
         cache_dir.join("bash-enter-capability"),
         format!(
-            "schema=1\ntirith_version=\nshell=bash\nbash_version=0.0.0-stale\n\
+            "schema=2\ntirith_version=\nshell=bash\nbash_version=0.0.0-stale\n\
              bash_path={bash_path}\nenter_capability=works\nreason=stale\n"
         ),
     )

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -3980,9 +3980,20 @@ fn capability_cache_body(verdict: &str) -> String {
     let mut lines = text.lines();
     let bash_version = lines.next().unwrap_or_default().trim();
     let bash_path = lines.next().unwrap_or_default().trim();
+    let fingerprint = std::fs::metadata(bash_path)
+        .ok()
+        .and_then(|m| {
+            let secs = m
+                .modified()
+                .ok()?
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?;
+            Some(format!("{}:{}", secs.as_secs(), m.len()))
+        })
+        .unwrap_or_default();
     format!(
-        "schema=1\ntirith_version=\nshell=bash\nbash_version={bash_version}\n\
-         bash_path={bash_path}\nenter_capability={verdict}\nreason=seeded by test\n"
+        "schema=2\ntirith_version=\nshell=bash\nbash_version={bash_version}\n\
+         bash_path={bash_path}\nbash_fingerprint={fingerprint}\nenter_capability={verdict}\nreason=seeded by test\n"
     )
 }
 
@@ -4285,6 +4296,28 @@ fn auto_checkpoint_cli_wiring_compiles_and_runs() {
         !stderr.contains("auto-checkpoint failed"),
         "auto-checkpoint should not report errors, got: {stderr}"
     );
+
+    // The check process must not return until a complete checkpoint has been
+    // published. A detached worker could make this directory absent or leave a
+    // half-written snapshot that is killed at process exit.
+    let checkpoint_store = state_dir.join("tirith").join("checkpoints");
+    let checkpoint_dirs: Vec<_> = fs::read_dir(&checkpoint_store)
+        .unwrap_or_else(|error| {
+            panic!(
+                "auto-checkpoint store {} was not published before check returned: {error}",
+                checkpoint_store.display()
+            )
+        })
+        .map(|entry| entry.expect("read checkpoint entry").path())
+        .filter(|path| path.is_dir())
+        .collect();
+    assert_eq!(
+        checkpoint_dirs.len(),
+        1,
+        "exactly one auto-checkpoint should be published: {checkpoint_dirs:?}"
+    );
+    assert!(checkpoint_dirs[0].join("meta.json").is_file());
+    assert!(checkpoint_dirs[0].join("manifest.json").is_file());
 }
 
 #[cfg(unix)]
@@ -19492,14 +19525,27 @@ fn lsp_stdio_initialize_didopen_didchange_lifecycle() {
 // UX / transparency pass (feat/ux-transparency-pass)
 // ---------------------------------------------------------------------------
 
+// Unix-only: the contract under test is the BASH exported-protection signal
+// (`TIRITH_BASH_EFFECTIVE_PROTECTION`) combined with bash/zsh profile hook
+// detection. Windows protection runs through the PowerShell hook, a separate
+// surface with its own coverage, so seeding `.bashrc`/`.zshrc` cannot satisfy
+// hook detection there and `status` correctly reports NOT FULLY PROTECTED.
+#[cfg(unix)]
 #[test]
 fn status_guarded_via_exported_signal_exits_zero() {
-    // The REAL hook contract: a protected shell's `TIRITH_STATUS` is NON-exported,
-    // so an external `tirith status` must read the EXPORTED
-    // `TIRITH_BASH_EFFECTIVE_PROTECTION` (which the bash hook re-exports precisely
-    // so an external check sees the truth). Prove it by setting ONLY the exported
-    // signal and clearing TIRITH_STATUS — a real protected shell never exports it.
+    // repo-0436: the exported signal only proves protection when a hook is
+    // actually configured (otherwise any environment can forge it). Seed a
+    // shell profile with the hook line so hook detection succeeds, set ONLY
+    // the exported signal, and clear TIRITH_STATUS.
+    let root = fresh_command_environment();
+    let profile_dir = root.join("home");
+    std::fs::create_dir_all(&profile_dir).expect("home dir");
+    for name in [".zshrc", ".bashrc"] {
+        std::fs::write(profile_dir.join(name), "eval \"$(tirith init)\"\n")
+            .expect("seed shell profile");
+    }
     let out = tirith()
+        .env("HOME", &profile_dir)
         .env_remove("TIRITH_STATUS")
         .env("TIRITH_BASH_EFFECTIVE_PROTECTION", "blocks")
         .args(["status"])

--- a/crates/tirith/tests/pty_support/mod.rs
+++ b/crates/tirith/tests/pty_support/mod.rs
@@ -257,14 +257,27 @@ impl IsolatedEnv {
         let path = self.bash_enter_capability_file();
         std::fs::create_dir_all(path.parent().expect("capability cache parent"))
             .expect("pty harness: create state dir");
-        // Schema 1 mirrors `CACHE_SCHEMA`. tirith_version is blank: the hook only
-        // enforces it when a sibling `.hooks-version` exists, which the harness
-        // (sourcing the hook directly) does not create.
+        // Schema 2 mirrors `CACHE_SCHEMA` (repo-0211 binds mtime+size).
+        // tirith_version is blank: the hook only enforces it when a sibling
+        // `.hooks-version` exists, which the harness (sourcing the hook
+        // directly) does not create.
+        let fingerprint = std::fs::metadata(bash_path)
+            .ok()
+            .and_then(|m| {
+                let secs = m
+                    .modified()
+                    .ok()?
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .ok()?;
+                Some(format!("{}:{}", secs.as_secs(), m.len()))
+            })
+            .unwrap_or_default();
         let body = format!(
-            "schema=1\ntirith_version=\nshell=bash\nbash_version={bash_version}\n\
-             bash_path={}\nenter_capability={verdict}\n\
+            "schema=2\ntirith_version=\nshell=bash\nbash_version={bash_version}\n\
+             bash_path={}\nbash_fingerprint={}\nenter_capability={verdict}\n\
              reason=seeded by pty conformance harness\n",
-            bash_path.display()
+            bash_path.display(),
+            fingerprint
         );
         std::fs::write(&path, body).expect("pty harness: write capability cache");
     }

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -455,7 +455,7 @@ _tirith_persist_safe_mode() {
 # cache then fails. Enter-mode delivery itself is a bash-build property — it
 # does not change with the tirith version — so the cache is keyed on bash, not
 # on tirith. (`tirith_version` is still recorded in the file for diagnostics.)
-_TIRITH_ENTER_CAP_SCHEMA=1
+_TIRITH_ENTER_CAP_SCHEMA=2
 _TIRITH_ENTER_CAP_FILE="$_TIRITH_STATE_DIR/bash-enter-capability"
 
 # Read the enter-mode capability cache and decide whether enter mode is proven
@@ -479,12 +479,14 @@ _tirith_enter_capability_proven() {
   (( size > 4096 )) && return 1
 
   local schema="" cache_bash_version="" cache_bash_path="" capability=""
+  local cache_bash_fingerprint=""
   local key value
   while IFS='=' read -r key value; do
     case "$key" in
       schema)           schema="$value" ;;
       bash_version)     cache_bash_version="$value" ;;
       bash_path)        cache_bash_path="$value" ;;
+      bash_fingerprint) cache_bash_fingerprint="$value" ;;
       enter_capability) capability="$value" ;;
     esac
   done < "$_TIRITH_ENTER_CAP_FILE"
@@ -509,6 +511,24 @@ _tirith_enter_capability_proven() {
   # stale and falls back to preexec — fail-safe.
   [[ -n "$cache_bash_path" ]] || return 1
   [[ "$cache_bash_path" == "${BASH:-}" ]] || return 1
+
+  # repo-0211: an in-place rebuild keeps path and version — also require the
+  # recorded mtime:size fingerprint to match the live binary.
+  [[ -n "$cache_bash_fingerprint" ]] || return 1
+  local live_mtime live_size live_fp
+  if live_mtime="$(builtin command stat -Lf %m "${BASH:-/dev/null}" 2>/dev/null)"; then
+    :
+  else
+    live_mtime="$(builtin command stat -Lc %Y "${BASH:-/dev/null}" 2>/dev/null)" || return 1
+  fi
+  if live_size="$(builtin command stat -Lf %z "${BASH:-/dev/null}" 2>/dev/null)"; then
+    :
+  else
+    live_size="$(builtin command stat -Lc %s "${BASH:-/dev/null}" 2>/dev/null)" || return 1
+  fi
+  [[ -n "$live_mtime" && -n "$live_size" ]] || return 1
+  live_fp="${live_mtime}:${live_size}"
+  [[ "$cache_bash_fingerprint" == "$live_fp" ]] || return 1
 
   return 0
 }

--- a/tools/license-server/src/db.rs
+++ b/tools/license-server/src/db.rs
@@ -201,7 +201,10 @@ impl Db {
                 "INSERT INTO subscriptions (id, customer_id, email, tier, status, product_id, last_event_at)
                  VALUES (?1, ?2, ?3, ?4, 'active', ?5, ?6)
                  ON CONFLICT(id) DO UPDATE SET
-                   status=CASE WHEN subscriptions.status='revoked' THEN 'revoked' ELSE 'active' END,
+                   -- repo-0444: a reordered `created` must not flip a
+                   -- payment-failed ('past_due') or terminal ('revoked') row
+                   -- back to 'active'; a user-canceled row still reconciles.
+                   status=CASE WHEN subscriptions.status IN ('revoked','past_due') THEN subscriptions.status ELSE 'active' END,
                    email=excluded.email, product_id=excluded.product_id, tier=excluded.tier,
                    last_event_at=MAX(COALESCE(subscriptions.last_event_at,''), excluded.last_event_at),
                    updated_at=datetime('now')",
@@ -705,6 +708,37 @@ impl Db {
 
     /// Atomic consume — DELETE … RETURNING ensures exactly one request
     /// receives the row.
+    /// repo-0237: non-destructive read of a pending receipt. `receipt_view`
+    /// peeks, decrypts/validates, and only then calls [`Self::receipt_consume`]
+    /// — a decryption/validation failure must not destroy the only recoverable
+    /// encrypted API key.
+    pub async fn receipt_peek(&self, receipt_secret: &str) -> Result<Option<ReceiptRow>, AppError> {
+        let conn = self.conn.clone();
+        let secret = receipt_secret.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = acquire_db(&conn);
+            let row: Option<ReceiptRow> = conn
+                .query_row(
+                    "SELECT subscription_id, api_key_enc, api_key_nonce, token, checkout_id FROM pending_receipts WHERE receipt_secret=?1 AND expires_at > datetime('now')",
+                    params![secret],
+                    |row| {
+                        Ok(ReceiptRow {
+                            subscription_id: row.get(0)?,
+                            api_key_enc: row.get(1)?,
+                            api_key_nonce: row.get(2)?,
+                            token: row.get(3)?,
+                            checkout_id: row.get(4)?,
+                        })
+                    },
+                )
+                .optional()
+                .map_err(|e| AppError::Internal(format!("db receipt peek: {e}")))?;
+            Ok(row)
+        })
+        .await
+        .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
+    }
+
     pub async fn receipt_consume(
         &self,
         receipt_secret: &str,

--- a/tools/license-server/src/routes/receipt.rs
+++ b/tools/license-server/src/routes/receipt.rs
@@ -12,6 +12,11 @@ use crate::state::AppState;
 #[derive(Deserialize)]
 pub struct LookupQuery {
     pub checkout: String,
+    /// `1` when the not-ready page polls via fetch (repo-0235): returns JSON
+    /// instead of a redirect so the one-time receipt is not consumed by the
+    /// poller.
+    #[serde(default)]
+    pub poll: Option<String>,
 }
 
 pub async fn receipt_lookup(
@@ -23,6 +28,29 @@ pub async fn receipt_lookup(
     }
 
     let secret = state.db.receipt_lookup(&query.checkout).await?;
+
+    // repo-0235: the not-ready poller must NOT follow the redirect — fetch()
+    // auto-follows into /receipt/{secret}, consuming the one-time row, and the
+    // discarded body leaves the customer at a perpetual "not ready". Polling
+    // with `poll=1` returns the URL as JSON; the script navigates top-level.
+    if query.poll.as_deref() == Some("1") {
+        let body = match &secret {
+            Some(s) => format!(
+                "{{\"status\":\"ready\",\"url\":\"/receipt/{}\"}}",
+                html_escape(s)
+            ),
+            None => "{\"status\":\"pending\"}".to_string(),
+        };
+        return Ok((
+            StatusCode::OK,
+            [
+                ("content-type", "application/json"),
+                ("cache-control", "no-store"),
+            ],
+            body,
+        )
+            .into_response());
+    }
 
     match secret {
         Some(s) => {
@@ -50,10 +78,12 @@ pub async fn receipt_view(
     State(state): State<AppState>,
     Path(receipt_secret): Path<String>,
 ) -> Result<Response, AppError> {
-    // Atomic consume — exactly one request gets the row.
+    // repo-0237: peek first and decrypt/validate BEFORE the destructive
+    // consume — a key-rotation mismatch or corrupt row must not delete the
+    // only recoverable copy of the customer's API key.
     let row = state
         .db
-        .receipt_consume(&receipt_secret)
+        .receipt_peek(&receipt_secret)
         .await?
         .ok_or_else(|| AppError::NotFound("Receipt expired or already viewed".into()))?;
 
@@ -88,6 +118,19 @@ pub async fn receipt_view(
         error!(sub_id = %row.subscription_id, "decrypted API key is not UTF-8");
         AppError::Internal("License delivery error. Contact support@tirith.dev".into())
     })?;
+
+    // Everything validated — NOW consume atomically. If another request won
+    // the race, the row is gone and we report it as already viewed.
+    let consumed = state
+        .db
+        .receipt_consume(&receipt_secret)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Receipt expired or already viewed".into()))?;
+    if consumed.subscription_id != row.subscription_id {
+        return Err(AppError::NotFound(
+            "Receipt expired or already viewed".into(),
+        ));
+    }
 
     let server_url = state
         .config
@@ -141,9 +184,17 @@ fn receipt_not_ready_page(checkout_id: &str) -> String {
       return;
     }}
     try {{
-      const r = await fetch(location.href);
-      if (r.ok && !(await r.text()).includes('Processing Your License')) {{
-        location.reload();
+      // Poll the JSON endpoint: following the redirect with fetch() would
+      // CONSUME the one-time receipt before the page navigates (repo-0235).
+      const u = new URL(location.href);
+      u.searchParams.set('poll', '1');
+      const r = await fetch(u, {{ redirect: 'manual' }});
+      if (r.ok) {{
+        const body = await r.json();
+        if (body.status === 'ready' && body.url) {{
+          clearInterval(poll);
+          location.href = body.url;
+        }}
       }}
     }} catch(_) {{}}
   }}, 2000);

--- a/tools/sign-license/src/main.rs
+++ b/tools/sign-license/src/main.rs
@@ -282,6 +282,14 @@ fn cmd_sign(
     eprintln!("\nToken issued:");
     eprintln!("  tier:    {tier_lower}");
     eprintln!("  kid:     {kid}");
+    // repo-0238: `kid` is an independent caller string while the signature is
+    // made by THIS seed's key. Print the signing key's public fingerprint so
+    // the operator can verify it is the key registered under `kid` in the
+    // production keyring — a mismatch means decoders will reject the token.
+    eprintln!(
+        "  signing pubkey (hex): {}",
+        bytes_to_hex(&sk.verifying_key().to_bytes())
+    );
     eprintln!("  expires: {exp_dt} (ts: {exp_ts})");
     if let Some(ref org) = org_id {
         eprintln!("  org_id:  {org}");


### PR DESCRIPTION
## Summary

Stacked on PR #180 (R2). This is PR 3 of the three-PR DeepSec remediation plan: the 88 P3 reliability roots plus 5 duplicate coverage rows, across R3-CORE / R3-PLT / R3-CLI / R3-CI. The R3-INT convergence gate (exact-SHA DeepSec revalidation) is intentionally out of scope per instruction.

Highlights:

- Transactional state: cross-process locks + atomic publish for the trust store, registry-history snapshots, and canary rotation; concurrent fallback-session creation now re-reads the on-disk winner; audit-log consumers (doctor/explain/incident) use bounded tail reads
- Output contracts: one-JSON-document guarantees for install/update/rollback/temp-run/paste/view with write-failure exit codes; scan --ci honors --fail-on; policy test runs the same finalization as enforcement; prompt and status surfaces sanitize env-derived values and require a real hook before claiming guarded; SARIF custom rules get distinct identities
- Filesystem: policy editors refuse invalid UTF-8 and publish atomically; quarantine EXDEV delete pins the hashed inode; dashboard/pending exports refuse symlinks; iac plan reads bounded no-follow; license key writes atomic; checkpoint capture flags incompleteness, validates blobs on diff, and hashes+copies through one handle; watch inventory is ordered and capped with a warning
- Platform: capsule temp-home granted on Linux/macOS/Windows (the macOS Seatbelt profile and env scrub now share one path); Windows contained runs carry the caller's cwd to CreateProcessW; Seatbelt metadata reads confined to the base grant set; watched commands get the terminal foreground group; daemon stop verifies identity before signaling; doctor --fix fails non-zero when a remediation fails
- License server: receipt delivery is peek-then-consume (no destroy-before-validate) and the not-ready poller no longer consumes the one-time receipt; created-event upsert preserves revoked/past_due while still reconciling canceled; event timestamps normalized so SQLite MAX matches chronological order
- CI: benchmark pipefail + success-gated result storage; AUR checksum uses curl --fail with gzip validation

## Verification (exact head, hermetic env, no DeepSec revalidation per request)

- cargo fmt --check, git diff --check: clean
- cargo check --workspace --all-targets: clean (no warnings)
- cargo test --workspace --all-targets: all binaries green (core 4396, CLI 1415+, integration, conformance, license-server, sign-license)

## Notes

- The bash enter-capability cache schema bumped to v2 (binds binary mtime+size, repo-0211); the hook and test harnesses were updated in lockstep.
- Windows-gated code paths compile under x86_64-pc-windows-gnu check (the two Win32_System_* import errors there pre-date this stack).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies broad reliability and security hardening across transactional state, CLI output contracts, filesystem operations, platform containment, licensing, and CI.
- Adds bounded and atomic persistence paths for audit, checkpoint, registry, trust, and canary state.
- Tightens command output, policy finalization, filesystem validation, and platform containment behavior.
- Updates license receipt/event handling and CI artifact validation.
- The audit uploader's spawn-failure recovery still leaves one concurrent-append interleaving without a worker.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a concurrent audit append can remain queued without a worker when thread creation fails.

The prior reply states that clearing ownership fixes spawn failure, but a concurrent caller can set DRAIN_RESCAN and return before that failure branch clears DRAIN_ACTIVE; no worker then exists to observe the rescan, leaving the queued event undelivered until another append or process restart.

**Files Needing Attention:** crates/tirith-core/src/audit_upload.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/audit_upload.rs | Adds bounded atomic spool handling and coalesced drain ownership, but spawn failure can still strand a rescan requested by a concurrent append. |
| crates/tirith-core/src/capsule/windows.rs | Makes each Windows temporary-home launch path unique and includes it in the AppContainer ACL plan. |
| crates/tirith-core/src/mcp_lock.rs | Changes MCP drift handling to intentionally coalesce unchanged server moves between configuration files. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Append audit event] --> B{DRAIN_ACTIVE claimed?}
  B -->|Yes| C[Set DRAIN_RESCAN]
  B -->|No| D[Attempt worker spawn]
  D -->|Success| E[Drain and rescan loop]
  D -->|Failure| F[Clear DRAIN_ACTIVE]
  C -. concurrent spawn failure .-> F
  F --> G[Queued event has no worker]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20sheeki03%2Ftirith%20PR%20%23181%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=sheeki03%2Ftirith&pr=181&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ftirith-core%2Fsrc%2Faudit_upload.rs%3A414-415%0A**Spawn%20failure%20strands%20queued%20rescan**%0A%0AIf%20a%20second%20audit%20event%20is%20appended%20after%20the%20first%20caller%20claims%20%60DRAIN_ACTIVE%60%20but%20before%20its%20worker%20spawn%20fails%2C%20the%20second%20caller%20sets%20%60DRAIN_RESCAN%60%20and%20returns%2C%20while%20this%20branch%20clears%20ownership%20without%20starting%20a%20replacement%20worker.%20The%20event%20remains%20queued%20without%20an%20uploader%20until%20another%20append%20or%20process%20restart.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sheeki03%2Ftirith&pr=181&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(security): complete DeepSec R3 relia..."](https://github.com/sheeki03/tirith/commit/d6bcd0925cf718eb46f7e5dbf00f069239d4512d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50745611)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Audit Trail, Receipts, and Incident Response](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/audit-and-receipts.md)
- Knowledge Base — [MCP Integration](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/mcp-integration.md)

<!-- /greptile_comment -->