### PR TITLE
fix(terminal): treat non-ASCII punctuation as a word boundary in confusable_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#196:** `confusable_text` no longer fires on ordinary Japanese prose where U+3002 (ideographic full stop) is immediately followed by an ASCII word (`。oEmbed`). The #126 fix only covered the trailing form (`Rustを使う。`); the word expansion still walked *forwards* through U+3002 because its Unicode script is `Common`. Non-ASCII punctuation is now a word boundary in both directions, so a `tirith scan --ci` gate no longer fails on Japanese docs. Genuine homoglyphs are unaffected: `curl gіthub.com` (Cyrillic `і`) and `curl github。com` (U+3002 standing in for the hostname dot) still block.
 - **Private checkpoint storage:** checkpoint operations no longer fall back to the shared legacy `/tmp/tirith/checkpoints` path; they require a user-owned private state directory and validate its identity and permissions. `checkpoints_dir()` keeps its public `PathBuf` return type for source compatibility, while new code can use `try_checkpoints_dir()` for an explicit unavailable state. Existing legacy files are not migrated automatically: inspect and remove `/tmp/tirith/checkpoints` manually if an older release created it.
 
 ## [0.3.3] - 2026-06-19

--- a/crates/tirith-core/src/rules/terminal.rs
+++ b/crates/tirith-core/src/rules/terminal.rs
@@ -683,13 +683,18 @@ fn is_ascii_nearby(input: &[u8], offset: usize) -> bool {
 ///   confusable is isolated from `Rust`). Fixes #126.
 /// - `…/filename_Отсканированный_документ.pdf` → false (path/`_` separators
 ///   isolate the pure-Cyrillic segments). Fixes #134.
+/// - `あ。abc` → false (`。` is punctuation, so it ends the word instead of
+///   joining the following ASCII sentence to it). Fixes #196.
+/// - `curl github。com` → still true (`。` is a boundary, but the backward pass
+///   has already collected the ASCII `github` it was spliced into).
 ///
 /// Boundaries are script-aware: any non-alphanumeric ASCII byte (whitespace,
-/// punctuation, and identifier/path separators like `/ _ . -`), plus any
-/// character whose Unicode script is outside the confusable-bearing set
-/// {Latin, Cyrillic, Greek, Common, Inherited} — so Han/Hiragana/Katakana/
-/// Hangul/Thai/Arabic/… terminate a word. The word is suspicious only if, after
-/// trimming at those boundaries, it still contains an ASCII letter.
+/// punctuation, and identifier/path separators like `/ _ . -`), any non-ASCII
+/// punctuation, and any character whose Unicode script is outside the
+/// confusable-bearing set {Latin, Cyrillic, Greek, Common} — so Han/Hiragana/
+/// Katakana/Hangul/Thai/Arabic/… terminate a word, while combining marks stay
+/// word-internal. The word is suspicious only if, after trimming at those
+/// boundaries, it still contains an ASCII letter.
 fn is_same_word_as_ascii(input: &[u8], offset: usize) -> bool {
     use unicode_script::{Script, UnicodeScript};
 
@@ -699,10 +704,18 @@ fn is_same_word_as_ascii(input: &[u8], offset: usize) -> bool {
         if ch.is_ascii() {
             return ch.is_ascii_alphanumeric();
         }
-        matches!(
-            ch.script(),
-            Script::Latin | Script::Cyrillic | Script::Greek | Script::Common | Script::Inherited
-        )
+        // Combining marks attach to the preceding letter, so they never split it.
+        if ch.script() == Script::Inherited {
+            return true;
+        }
+        // Non-ASCII punctuation never sits inside a word even when its script is
+        // Common — U+3002 IDEOGRAPHIC FULL STOP would otherwise let the forward
+        // pass walk into the next sentence's ASCII word. Fixes #196.
+        ch.is_alphanumeric()
+            && matches!(
+                ch.script(),
+                Script::Latin | Script::Cyrillic | Script::Greek | Script::Common
+            )
     }
 
     let Ok(text) = std::str::from_utf8(input) else {

--- a/tests/fixtures/terminal.toml
+++ b/tests/fixtures/terminal.toml
@@ -481,6 +481,28 @@ context = "paste"
 expected_action = "allow"
 expected_rules = []
 
+# Regression for #196: the reverse of `confusable_text_benign_cjk_ascii_word` —
+# U+3002 closes a Japanese sentence and the next one opens with an ASCII word,
+# so U+3002 must terminate the word forwards too, not splice "Rust" onto it.
+[[fixture]]
+name = "confusable_text_benign_cjk_ascii_word_forward"
+min_milestone = 4
+input = "\u4F7F\u3046\u3002Rust"
+context = "paste"
+expected_action = "allow"
+expected_rules = []
+
+# Guard for #196: U+3002 standing in for the "." of a hostname is a real
+# homoglyph, and making it a word boundary must not suppress it — the backward
+# pass still collects the ASCII "github" it was spliced into.
+[[fixture]]
+name = "confusable_text_ideographic_period_in_host"
+min_milestone = 4
+input = "curl github\u3002com"
+context = "paste"
+expected_action = "block"
+expected_rules = ["confusable_text"]
+
 # Regression for #126: fullwidth Latin (U+FF21 A / U+FF30 P / U+FF29 I) inside
 # Japanese text ("Rust no API wo yobu"). The fullwidth letters are confusables,
 # but bounded by Hiragana they form their own non-ASCII word with no ASCII letter.


### PR DESCRIPTION
## Summary

- Treat non-ASCII punctuation as a word boundary in `is_same_word_as_ascii`: a non-ASCII character now stays word-internal only when it is alphanumeric, so a `Script::Common` punctuation mark can no longer join two words.
- Keep combining marks (`Script::Inherited`) word-internal as an explicit exception. They are not alphanumeric, so without it a decorated Latin letter would be split into two words and could hide a homoglyph.
- Add a forward-direction regression fixture (`使う。Rust`) and a guard fixture pinning that `curl github。com` still blocks.

## Problem

Reported in #196. `confusable_text` fires HIGH on ordinary Japanese prose whenever U+3002 IDEOGRAPHIC FULL STOP is immediately followed by an ASCII word, so a `tirith scan --ci` gate fails on a repository whose docs are written in Japanese — sentences routinely end with `。` and the next one starts with a Latin term.

`is_same_word_as_ascii` expands a word in both directions from the confusable's offset, and `is_word_char` accepted any `Script::Common` character as word-internal. U+3002 is `Common`, so the two directions behaved asymmetrically:

- `Rustを使う。` — the backward pass stops at the Hiragana and there is nothing to the right, so the word holds no ASCII letter. Already clean since #126.
- `あ。abc` — the backward pass stops at the Hiragana, but the forward pass runs *through* U+3002 and collects `abc`. The word now contains ASCII letters, so the finding fires.

#126 fixed only the trailing form, and the existing `confusable_text_benign_cjk_ascii_word` fixture covers only that direction, which left the forward pass untested.

Genuine homoglyphs are unaffected. Cyrillic and Greek lookalikes are letters rather than punctuation, so they stay word-internal and `curl gіthub.com` (Cyrillic `і`) still blocks. A punctuation homoglyph spliced into an ASCII word also still fires, because the backward pass has already collected the ASCII segment by the time it reaches the boundary — `curl github。com` (U+3002 standing in for the hostname dot) blocks, which the new guard fixture pins.

## Validation

macOS, stable toolchain, at this head:

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- `cargo test -p tirith-core --locked` — 4436 passed, 0 failed, 2 ignored in the lib suite, all integration suites green, 60 terminal golden fixtures (two new)
- `cargo test -p tirith --locked` — 1426 passed in the lib suite, integration suites green apart from the two pre-existing failures noted below
- `cargo test -p tirith-sign -p tirith-license-server --locked` — 38 and 9 passed
- `tirith scan --file` and `tirith paste` against the issue's reproducers — `あ。abc` and `oEmbedで本文を取得する。oEmbedは長文を省略する` are clean; `curl github。com` and `curl gіthub.com` still report HIGH `confusable_text`

The per-crate test runs above cover the workspace: `cargo test --workspace --locked` fail-fasts at `cli_integration`, where `install_npm_clean_package_no_exec_exits_zero` and `install_no_exec_json_is_well_formed_and_not_sandboxed` fail on my machine. Both read the real `~/.npmrc`, which selects a non-official registry, so `threat_suspicious_package` blocks before the assertion. Both fail identically at the base commit with this branch stashed, so they are unrelated to this change and should pass on a runner without a `~/.npmrc`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects `confusable_text` word-boundary handling so non-ASCII punctuation does not join Japanese prose to a following ASCII word, while preserving combining-mark and genuine homoglyph detection.

- Requires non-ASCII word characters to be alphanumeric and in a supported confusable-bearing script.
- Keeps inherited combining marks word-internal.
- Adds allow/block regression fixtures for Japanese punctuation and hostname-like substitutions.
- Documents the fix in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The revised predicate separates non-ASCII punctuation from adjacent words while retaining alphanumeric confusables and combining marks, and the added fixtures cover both the intended allow case and the principal detection guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/rules/terminal.rs | Narrows Unicode word expansion at non-ASCII punctuation while retaining supported letters and inherited combining marks; no actionable regression was established. |
| tests/fixtures/terminal.toml | Adds complementary fixtures proving the Japanese prose false positive is removed while an ideographic-period hostname substitution still blocks. |
| CHANGELOG.md | Accurately describes the boundary bug, its directional cause, and the preserved detection cases. |

<sub>Reviews (1): Last reviewed commit: ["fix(terminal): treat non-ASCII punctuati..."](https://github.com/sheeki03/tirith/commit/51554c2e2d2d34415276affd8e9e5402d8892cec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53938165)</sub>

**Context used:**

- Knowledge Base — [Rules Engine](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/rules-engine.md)

<!-- /greptile_comment -->