### PR TITLE
Security: bind MCP configuration and code identity

### DIFF
--- a/crates/tirith-core/src/mcp_lock.rs
+++ b/crates/tirith-core/src/mcp_lock.rs
@@ -320,8 +320,10 @@ pub struct McpServerEntry {
 impl McpServerEntry {
     /// A stable per-server content hash over name + transport (incl. a stdio
     /// server's `env`) + tools, so `mcp diff` can detect a changed server by hash
-    /// alone. `source_config` is excluded — moving an unchanged server between
-    /// configs must not drift.
+    /// alone. `source_config` is excluded from this content digest because it is
+    /// already an explicit part of the inventory and drift identity: moving an
+    /// otherwise unchanged server between configs is represented as an exact
+    /// `(name, source_config)` removal plus addition.
     ///
     /// **Collision-free framing:** every variable-length component is
     /// length-prefixed via [`hash_field`], not `\0`-joined — so `["a","b"]` and
@@ -1346,7 +1348,9 @@ pub enum RejectedReason {
     /// A regular file whose size exceeds `MCP_CONFIG_MAX_SIZE`; reading an
     /// unbounded JSON doc would be a DoS surface.
     Oversize {
-        /// The file's size in bytes (`fs::metadata().len()`).
+        /// A proven lower bound on the file size. The retained reader reports
+        /// `MCP_CONFIG_MAX_SIZE + 1` when the exact size cannot be recovered
+        /// without reopening an attacker-racy pathname.
         size_bytes: u64,
     },
     /// A regular file under the cap that could not be read.
@@ -1747,16 +1751,31 @@ pub(crate) const MCP_CONFIG_RELATIVE_PATHS: &[&str] = &[
     ".kiro/settings/mcp.json",
 ];
 
+/// One discovered MCP config bound to the exact retained repository/parent
+/// capabilities through which its bytes will be read. The public discovery API
+/// intentionally returns only the path projection; inventory construction keeps
+/// this authority alive through the capped, no-follow open and complete read.
+pub(crate) struct RetainedMcpConfig {
+    absolute_path: PathBuf,
+    relative_path: String,
+    file: crate::util::ContainedAtomicFile,
+}
+
 /// Discover the repo-local MCP config files under `repo_root`, returning
 /// `(absolute, repo_relative)` pairs sorted by the relative path. Only regular
 /// files reachable without crossing a symlink and resolving inside `repo_root`
 /// are returned — a probed path that is itself a symlink (or under a symlinked
 /// parent), or whose canonical form escapes the root, is rejected, so a
-/// `.mcp.json -> ~/.claude/mcp.json` can't pull a user config in. The symlink
-/// check uses `symlink_metadata` (no TOCTOU). Drops the rejection list — use
+/// `.mcp.json -> ~/.claude/mcp.json` can't pull a user config in. Inventory
+/// construction additionally retains a descriptor/handle-relative parent
+/// authority through the capped no-follow read. Drops the rejection list — use
 /// [`discover_mcp_configs_full`] for it.
 pub fn discover_mcp_configs(repo_root: &Path) -> Vec<(PathBuf, String)> {
-    discover_mcp_configs_full(repo_root).0
+    discover_mcp_configs_full(repo_root)
+        .0
+        .into_iter()
+        .map(|config| (config.absolute_path, config.relative_path))
+        .collect()
 }
 
 /// Like [`discover_mcp_configs`] but also returns the structured rejection list
@@ -1765,7 +1784,7 @@ pub fn discover_mcp_configs(repo_root: &Path) -> Vec<(PathBuf, String)> {
 /// in [`build_inventory`] when the file is read.
 pub(crate) fn discover_mcp_configs_full(
     repo_root: &Path,
-) -> (Vec<(PathBuf, String)>, Vec<RejectedConfig>) {
+) -> (Vec<RetainedMcpConfig>, Vec<RejectedConfig>) {
     // Canonicalize the root once for the containment check; if it doesn't exist,
     // no config under it can be discovered — return empty (nothing to reject).
     let canonical_root = match repo_root.canonicalize() {
@@ -1773,7 +1792,7 @@ pub(crate) fn discover_mcp_configs_full(
         Err(_) => return (Vec::new(), Vec::new()),
     };
 
-    let mut found: Vec<(PathBuf, String)> = Vec::new();
+    let mut found: Vec<RetainedMcpConfig> = Vec::new();
     let mut rejected: Vec<RejectedConfig> = Vec::new();
 
     for rel in MCP_CONFIG_RELATIVE_PATHS {
@@ -1828,9 +1847,40 @@ pub(crate) fn discover_mcp_configs_full(
             }
         }
 
-        found.push((abs, (*rel).to_string()));
+        // Bind the root, every directory component, and final name now; the
+        // retained capability is carried into `build_inventory` and performs
+        // the eventual open relative to this exact parent. A path swap after
+        // discovery therefore cannot redirect the read through a new parent,
+        // and a final-component symlink is refused both here and at read time.
+        let retained_path = canonical_root.join(rel);
+        let file =
+            match crate::util::ContainedAtomicFile::prepare(&canonical_root, &retained_path, false)
+            {
+                Ok(file) => file,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    let reason = if path_crosses_symlink(repo_root, rel) {
+                        RejectedReason::Symlink
+                    } else {
+                        RejectedReason::Unreadable {
+                            permission_denied: error.kind() == std::io::ErrorKind::PermissionDenied,
+                        }
+                    };
+                    rejected.push(RejectedConfig {
+                        path: (*rel).to_string(),
+                        reason,
+                    });
+                    continue;
+                }
+            };
+
+        found.push(RetainedMcpConfig {
+            absolute_path: abs,
+            relative_path: (*rel).to_string(),
+            file,
+        });
     }
-    found.sort_by(|a, b| a.1.cmp(&b.1));
+    found.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
     rejected.sort_by(|a, b| a.path.cmp(&b.path));
     (found, rejected)
 }
@@ -1868,83 +1918,70 @@ pub const MCP_CONFIG_MAX_SIZE: u64 = 1_048_576;
 ///
 /// Path-level rejections (from [`discover_mcp_configs_full`]) and file-level ones
 /// (oversize, permission) both flow into [`McpInventory::rejected_configs`] — one
-/// "present but skipped" list regardless of which gate tripped. Size is checked
-/// against [`MCP_CONFIG_MAX_SIZE`] before any read. IO errors are categorized:
+/// "present but skipped" list regardless of which gate tripped. The complete
+/// file is opened no-follow and read through the retained parent capability with
+/// a hard [`MCP_CONFIG_MAX_SIZE`] cap; growth after discovery is rejected after
+/// at most one byte beyond the cap. IO errors are categorized:
 /// `PermissionDenied`→`Unreadable{true}`; `NotFound`→silent (vanished mid-edit);
-/// `InvalidData`→malformed; else `Unreadable{false}`.
+/// non-UTF-8→malformed; else `Unreadable{false}`.
 pub fn build_inventory(repo_root: &Path) -> McpInventory {
     let (configs, rejected_from_discovery) = discover_mcp_configs_full(repo_root);
 
+    build_inventory_from_discovered(configs, rejected_from_discovery)
+}
+
+fn build_inventory_from_discovered(
+    configs: Vec<RetainedMcpConfig>,
+    rejected_from_discovery: Vec<RejectedConfig>,
+) -> McpInventory {
     let mut inventory = McpInventory {
         rejected_configs: rejected_from_discovery,
         ..McpInventory::default()
     };
 
-    for (abs_path, rel_path) in configs {
-        // Size pre-check. Discovery already rejected symlinks, so this is a real
-        // regular file; a metadata failure here folds into the unreadable bucket.
-        let size_bytes = match std::fs::metadata(&abs_path) {
-            Ok(m) => m.len(),
-            Err(e) => {
+    for config in configs {
+        let rel_path = config.relative_path;
+        let bytes = match config.file.read_capped(MCP_CONFIG_MAX_SIZE) {
+            Ok(bytes) => bytes,
+            Err(crate::util::OpenRegularError::NotFound) => continue,
+            Err(crate::util::OpenRegularError::NotRegularFile) => {
+                inventory.rejected_configs.push(RejectedConfig {
+                    path: rel_path.clone(),
+                    reason: RejectedReason::NotRegularFile,
+                });
+                continue;
+            }
+            Err(crate::util::OpenRegularError::TooLarge) => {
+                // The retained reader intentionally exposes no attacker-racy
+                // pathname metadata. Report the proven lower bound instead of
+                // reopening by path merely to recover an exact size.
+                inventory.rejected_configs.push(RejectedConfig {
+                    path: rel_path.clone(),
+                    reason: RejectedReason::Oversize {
+                        size_bytes: MCP_CONFIG_MAX_SIZE.saturating_add(1),
+                    },
+                });
+                continue;
+            }
+            Err(crate::util::OpenRegularError::Io(error)) => {
                 inventory.rejected_configs.push(RejectedConfig {
                     path: rel_path.clone(),
                     reason: RejectedReason::Unreadable {
-                        permission_denied: e.kind() == std::io::ErrorKind::PermissionDenied,
+                        permission_denied: error.kind() == std::io::ErrorKind::PermissionDenied,
                     },
                 });
                 continue;
             }
         };
 
-        if size_bytes > MCP_CONFIG_MAX_SIZE {
-            inventory.rejected_configs.push(RejectedConfig {
-                path: rel_path.clone(),
-                reason: RejectedReason::Oversize { size_bytes },
-            });
-            // Oversized: rejected at the gate, never a discovered config.
-            continue;
-        }
-
-        // Admitted: counts as a discovered config from here on, even if it later
-        // fails to read or parse.
+        // Admitted: counts as a discovered config from here on, even if it is
+        // later classified as malformed text or JSON.
         inventory.configs.push(rel_path.clone());
 
-        let content = match std::fs::read_to_string(&abs_path) {
-            Ok(c) => c,
-            Err(e) => {
-                // Categorize so the operator can tell "can't read" from "not UTF-8".
-                match e.kind() {
-                    std::io::ErrorKind::NotFound => {
-                        // Vanished between discovery and read (concurrent edit) —
-                        // pop it off `configs`, nothing to surface.
-                        inventory.configs.pop();
-                    }
-                    std::io::ErrorKind::PermissionDenied => {
-                        inventory.rejected_configs.push(RejectedConfig {
-                            path: rel_path.clone(),
-                            reason: RejectedReason::Unreadable {
-                                permission_denied: true,
-                            },
-                        });
-                        // Pop: discovered structurally, but unreadable; the
-                        // rejection list names it now.
-                        inventory.configs.pop();
-                    }
-                    std::io::ErrorKind::InvalidData => {
-                        // Non-UTF-8: present and attributable, just not text —
-                        // keep the legacy "malformed" path.
-                        inventory.malformed_configs.push(rel_path.clone());
-                    }
-                    _ => {
-                        inventory.rejected_configs.push(RejectedConfig {
-                            path: rel_path.clone(),
-                            reason: RejectedReason::Unreadable {
-                                permission_denied: false,
-                            },
-                        });
-                        inventory.configs.pop();
-                    }
-                }
+        let content = match String::from_utf8(bytes) {
+            Ok(content) => content,
+            Err(_) => {
+                inventory.malformed_configs.push(rel_path);
                 continue;
             }
         };
@@ -2379,6 +2416,7 @@ fn secret_key_name(value: &str) -> bool {
             | "awssecretaccesskey"
             | "authtoken"
             | "bearertoken"
+            | "gitlabtoken"
             | "token"
             | "sessiontoken"
             | "securitytoken"
@@ -2490,6 +2528,7 @@ fn looks_like_secret_literal(value: &str) -> bool {
         "ghs_",
         "ghr_",
         "github_pat_",
+        "glpat-",
         "npm_",
         "sk-proj-",
         "sk_live_",
@@ -3000,8 +3039,9 @@ impl McpDrift {
 /// nothing changed — empty drift, no per-server work. Slow path: a merge walk
 /// over the `(name, source_config)`-sorted sides emits `Added`/`Removed`, and
 /// `Changed` (via `compute_changed_entry`) when a per-server `content_hash`
-/// differs. `content_hash` excludes `source_config`, so moving an unchanged
-/// server between configs is a non-event.
+/// differs. `content_hash` excludes `source_config`, but the merge identity does
+/// not: moving an unchanged server between configs is an exact removal plus
+/// addition rather than a name-only cancellation.
 ///
 /// The result is sorted ([`McpDrift::sort_key`]). Privacy: entries carry only
 /// names (server / env-var / tool). V8 records only env names and URL-userinfo
@@ -3122,59 +3162,6 @@ fn compute_drift_static(current: &McpInventory, lock: &McpLockfile) -> Vec<McpDr
         j += 1;
     }
 
-    // repo-0459: `content_hash` excludes `source_config` BY DESIGN, so moving
-    // an unchanged server between config files must not drift. The
-    // `(name, source_config)`-keyed merge walk reports such a move as
-    // Removed+Added when unrelated drift forces this slow path — cancel pairs
-    // whose name AND content hash match (a true move), so fast and slow paths
-    // agree.
-    let mut kept: Vec<McpDrift> = Vec::with_capacity(drifts.len());
-    // (name, hash) for Added entries to match Removed against.
-    let add_keys: Vec<(String, String)> = drifts
-        .iter()
-        .filter_map(|d| match d {
-            McpDrift::Added { name, .. } => {
-                let hash = current_lock
-                    .servers
-                    .iter()
-                    .find(|s| &s.name == name)
-                    .map(|s| s.hash.clone())
-                    .unwrap_or_default();
-                Some((name.clone(), hash))
-            }
-            _ => None,
-        })
-        .collect();
-    let mut used_adds: Vec<bool> = vec![false; add_keys.len()];
-    for d in drifts {
-        if let McpDrift::Removed { name, .. } = &d {
-            let removed_hash = lock
-                .servers
-                .iter()
-                .find(|s| &s.name == name)
-                .map(|s| s.hash.clone())
-                .unwrap_or_default();
-            let matched = add_keys
-                .iter()
-                .enumerate()
-                .find(|(idx, (an, ah))| !used_adds[*idx] && an == name && *ah == removed_hash)
-                .map(|(idx, _)| idx);
-            if let Some(idx) = matched {
-                used_adds[idx] = true;
-                continue; // pure move: drop the Removed
-            }
-        }
-        kept.push(d);
-    }
-    // Drop the matched Adds too.
-    let mut drifts: Vec<McpDrift> = Vec::with_capacity(kept.len());
-    let mut add_iter = used_adds.iter();
-    for d in kept {
-        if matches!(d, McpDrift::Added { .. }) && add_iter.next() == Some(&true) {
-            continue;
-        }
-        drifts.push(d);
-    }
     drifts.sort_by_key(McpDrift::sort_key);
     drifts
 }
@@ -6041,10 +6028,9 @@ mod tests {
 
     #[test]
     fn drift_detects_unchanged_server_moving_between_config_principals() {
-        // repo-0459: `content_hash` excludes `source_config` BY DESIGN, so a
-        // pure move between config files is NOT drift — on the fast path (equal
-        // inventory) or the slow path (unrelated drift forcing the merge
-        // walk). Both paths must agree.
+        // Source config is part of the policy principal even though the
+        // transport/content digest excludes it. A move must therefore retain
+        // both exact identities as Removed(old source) + Added(new source).
         let prev = mk_inventory(vec![McpServerEntry {
             tools_declared: true,
             source_config: ".mcp.json".into(),
@@ -6058,43 +6044,59 @@ mod tests {
             ..stdio_server("s", "node")
         }]);
         let drifts = compute_drift(&cur, &lock);
-        // Fast path: pure move, equal inventory — no drift.
-        if drifts.is_empty() {
-            return;
-        }
-        // Slow path consistency: with an unrelated server added, the move must
-        // STILL not surface as Removed+Added.
-        let cur2 = mk_inventory(vec![
+        assert_eq!(drifts.len(), 2, "source move must preserve both identities");
+        assert!(matches!(
+            &drifts[0],
+            McpDrift::Removed { name, source_config }
+                if name == "s" && source_config == ".mcp.json"
+        ));
+        assert!(matches!(
+            &drifts[1],
+            McpDrift::Added { name, source_config, .. }
+                if name == "s" && source_config == ".vscode/mcp.json"
+        ));
+    }
+
+    #[test]
+    fn duplicate_names_cannot_cancel_exact_source_drift() {
+        // Regression for TIRITH-SEC-0072: the former cancellation pass looked
+        // up hashes by name alone. With duplicate names it could compare the
+        // first twin on each side and erase a Removed/Added pair belonging to
+        // a different source principal.
+        let prev = mk_inventory(vec![
             McpServerEntry {
-                tools_declared: true,
-                source_config: ".vscode/mcp.json".into(),
-                ..stdio_server("s", "node")
+                source_config: ".mcp.json".into(),
+                ..stdio_server("same", "node")
             },
-            stdio_server("other", "node"),
+            McpServerEntry {
+                source_config: ".vscode/mcp.json".into(),
+                ..stdio_server("same", "deno")
+            },
         ]);
-        let drifts2 = compute_drift(&cur2, &lock);
-        assert!(
-            !drifts2.iter().any(|drift| matches!(
-                drift,
-                McpDrift::Removed { name, .. } if name == "s"
-            )),
-            "a pure config-file move must not report removal: {drifts2:?}"
-        );
-        assert!(
-            !drifts2.iter().any(|drift| matches!(
-                drift,
-                McpDrift::Added { name, .. } if name == "s"
-            )),
-            "a pure config-file move must not report addition: {drifts2:?}"
-        );
-        // The genuinely new server IS reported.
-        assert!(
-            drifts2.iter().any(|drift| matches!(
-                drift,
-                McpDrift::Added { name, .. } if name == "other"
-            )),
-            "the new server must be reported: {drifts2:?}"
-        );
+        let lock = McpLockfile::from_inventory(&prev);
+        let cur = mk_inventory(vec![
+            McpServerEntry {
+                source_config: ".mcp.json".into(),
+                ..stdio_server("same", "node")
+            },
+            McpServerEntry {
+                source_config: ".cursor/mcp.json".into(),
+                ..stdio_server("same", "deno")
+            },
+        ]);
+
+        let drifts = compute_drift(&cur, &lock);
+        assert_eq!(drifts.len(), 2, "duplicate-name source move was erased");
+        assert!(drifts.iter().any(|drift| matches!(
+            drift,
+            McpDrift::Removed { name, source_config }
+                if name == "same" && source_config == ".vscode/mcp.json"
+        )));
+        assert!(drifts.iter().any(|drift| matches!(
+            drift,
+            McpDrift::Added { name, source_config, .. }
+                if name == "same" && source_config == ".cursor/mcp.json"
+        )));
     }
 
     #[test]
@@ -7005,6 +7007,98 @@ mod tests {
             }
             ref other => panic!("expected Oversize, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn retained_config_read_rejects_growth_after_discovery() {
+        let repo = tempdir().unwrap();
+        let config = repo.path().join(".mcp.json");
+        fs::write(&config, r#"{"mcpServers":{"safe":{"command":"node"}}}"#).unwrap();
+        let (configs, rejected) = discover_mcp_configs_full(repo.path());
+        assert_eq!(configs.len(), 1);
+        assert!(rejected.is_empty());
+
+        // Grow after discovery/retention. The read itself must enforce the cap;
+        // a pre-read pathname metadata check alone would miss this transition.
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&config)
+            .unwrap()
+            .set_len(MCP_CONFIG_MAX_SIZE + 1)
+            .unwrap();
+        let inventory = build_inventory_from_discovered(configs, rejected);
+        assert!(inventory.servers.is_empty());
+        assert!(inventory.configs.is_empty());
+        assert!(matches!(
+            inventory.rejected_configs.as_slice(),
+            [RejectedConfig {
+                path,
+                reason: RejectedReason::Oversize { size_bytes }
+            }] if path == ".mcp.json" && *size_bytes > MCP_CONFIG_MAX_SIZE
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_config_read_refuses_a_leaf_symlink_swap() {
+        use std::os::unix::fs::symlink;
+
+        let repo = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let config = repo.path().join(".mcp.json");
+        let outside_config = outside.path().join("outside.json");
+        fs::write(&config, r#"{"mcpServers":{"safe":{"command":"node"}}}"#).unwrap();
+        fs::write(
+            &outside_config,
+            r#"{"mcpServers":{"outside":{"command":"evil"}}}"#,
+        )
+        .unwrap();
+        let (configs, rejected) = discover_mcp_configs_full(repo.path());
+        assert_eq!(configs.len(), 1);
+        fs::rename(&config, repo.path().join("approved.json")).unwrap();
+        symlink(&outside_config, &config).unwrap();
+
+        let inventory = build_inventory_from_discovered(configs, rejected);
+        assert!(inventory.servers.is_empty());
+        assert!(inventory.configs.is_empty());
+        assert!(matches!(
+            inventory.rejected_configs.as_slice(),
+            [RejectedConfig {
+                path,
+                reason: RejectedReason::NotRegularFile
+            }] if path == ".mcp.json"
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_config_read_stays_on_the_discovered_parent() {
+        use std::os::unix::fs::symlink;
+
+        let repo = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let vscode = repo.path().join(".vscode");
+        fs::create_dir(&vscode).unwrap();
+        fs::write(
+            vscode.join("mcp.json"),
+            r#"{"mcpServers":{"safe":{"command":"node"}}}"#,
+        )
+        .unwrap();
+        fs::write(
+            outside.path().join("mcp.json"),
+            r#"{"mcpServers":{"outside":{"command":"evil"}}}"#,
+        )
+        .unwrap();
+        let (configs, rejected) = discover_mcp_configs_full(repo.path());
+        assert_eq!(configs.len(), 1);
+        fs::rename(&vscode, repo.path().join(".vscode-retained")).unwrap();
+        symlink(outside.path(), &vscode).unwrap();
+
+        let inventory = build_inventory_from_discovered(configs, rejected);
+        assert_eq!(inventory.servers.len(), 1);
+        assert_eq!(inventory.servers[0].name, "safe");
+        assert_eq!(inventory.servers[0].source_config, ".vscode/mcp.json");
+        assert!(inventory.rejected_configs.is_empty());
     }
 
     #[cfg(unix)]
@@ -8058,6 +8152,9 @@ mod tests {
 
         for args in [
             r#"["--api-key","ghp_12345678901234567890"]"#,
+            r#"["--gitlab-token","glpat-12345678901234567890"]"#,
+            r#"["--gitlab-token=glpat-12345678901234567890"]"#,
+            r#"["--opaque","glpat-12345678901234567890"]"#,
             r#"["--token=literal-secret"]"#,
             r#"["--foo=ghp_12345678901234567890"]"#,
             r#"["--mode=AKIA1234567890123456"]"#,
@@ -8097,8 +8194,34 @@ mod tests {
 
         // Explicit environment references and non-secret routing queries remain
         // lockable; the raw credential stays outside the committed document.
-        let safe = r#"{"mcpServers":{"s":{"command":"node","args":["--token","${env:MCP_TOKEN}","--header","Authorization: Bearer ${MCP_TOKEN}","--header=Accept: application/json","--mode=$MODE","--profile=%PROFILE%","--shell=$env:MCP_TOKEN","https://host.test/mcp?region=us"]}}}"#;
+        let safe = r#"{"mcpServers":{"s":{"command":"node","args":["--token","${env:MCP_TOKEN}","--gitlab-token","${env:GITLAB_TOKEN}","--header","Authorization: Bearer ${MCP_TOKEN}","--header=Accept: application/json","--mode=$MODE","--profile=%PROFILE%","--shell=$env:MCP_TOKEN","https://host.test/mcp?region=us"]}}}"#;
         assert!(parse_mcp_config(safe, ".mcp.json").is_some());
+    }
+
+    #[test]
+    fn gitlab_personal_access_tokens_never_reach_public_serialization() {
+        let secret = "glpat-12345678901234567890";
+        for args in [
+            vec!["--gitlab-token".to_string(), secret.to_string()],
+            vec![format!("--gitlab-token={secret}")],
+            vec!["--opaque".to_string(), secret.to_string()],
+        ] {
+            let transport = McpTransport::Stdio {
+                command: "gitlab-mcp".into(),
+                args,
+                env: vec![],
+            };
+            let error = serde_json::to_string(&transport)
+                .expect_err("GitLab PAT must be rejected before lock serialization");
+            assert!(!error.to_string().contains(secret));
+        }
+
+        let safe = McpTransport::Stdio {
+            command: "gitlab-mcp".into(),
+            args: vec!["--gitlab-token".into(), "${env:GITLAB_TOKEN}".into()],
+            env: vec![],
+        };
+        serde_json::to_string(&safe).expect("an explicit environment reference remains safe");
     }
 
     #[test]

--- a/crates/tirith/src/cli/gateway.rs
+++ b/crates/tirith/src/cli/gateway.rs
@@ -9118,6 +9118,14 @@ mod tests {
         );
     }
 
+    // `InterpretedCodeSnapshot::capture` goes through
+    // `ContainedAtomicFile::prepare`, which has no implementation outside Unix
+    // and Windows: the `cfg(all(not(unix), not(windows)))` platform module in
+    // contained_fs.rs returns `Unsupported`, so the `unwrap()` below would
+    // panic. The sibling limits test never reaches `prepare`, and
+    // `interpreted_snapshot_refuses_symlinked_dependencies` right after this is
+    // already gated the same way.
+    #[cfg(any(unix, windows))]
     #[test]
     fn interpreted_snapshot_excludes_self_referential_descriptor_lock() {
         let repo = tempfile::tempdir().unwrap();

--- a/crates/tirith/src/cli/gateway.rs
+++ b/crates/tirith/src/cli/gateway.rs
@@ -2423,20 +2423,11 @@ fn static_interpreted_entrypoint(
         &args[1]
     } else if let Some(first) = args.first().filter(|value| !value.starts_with('-')) {
         // A root-owned custom interpreter cannot be identified exhaustively by
-        // basename. If its leading operand names an existing repo file, treat
-        // that operand conservatively as interpreted code. Native servers that
-        // take only flags retain the ordinary executable-only binding.
-        let candidate = Path::new(first);
-        let candidate = if candidate.is_absolute() {
-            candidate.to_path_buf()
-        } else {
-            repo_root.join(candidate)
-        };
-        if candidate.is_file() {
-            first
-        } else {
-            return Ok(None);
-        }
+        // basename. Treat a leading positional operand as interpreted code
+        // without consulting its current existence: an absent path could be
+        // created after classification and otherwise escape the code binding.
+        // Native servers that take only flags retain executable-only binding.
+        first
     } else {
         return Ok(None);
     };
@@ -9110,6 +9101,37 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.contains("file limit"));
+    }
+
+    #[test]
+    fn custom_interpreter_classification_does_not_depend_on_path_existence() {
+        let repo = tempfile::tempdir().unwrap();
+        let entrypoint = static_interpreted_entrypoint(
+            Path::new("/usr/local/bin/custom-runtime"),
+            &["created-after-classification.script".to_string()],
+            repo.path(),
+        )
+        .unwrap();
+        assert_eq!(
+            entrypoint,
+            Some(PathBuf::from("created-after-classification.script"))
+        );
+    }
+
+    #[test]
+    fn interpreted_snapshot_excludes_self_referential_descriptor_lock() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("server.py"), b"pass\n").unwrap();
+        std::fs::create_dir(repo.path().join(".tirith")).unwrap();
+        let lock = repo
+            .path()
+            .join(".tirith")
+            .join(tirith_core::mcp_lock::MCP_LOCK_FILENAME);
+        std::fs::write(&lock, b"before approval\n").unwrap();
+        let before = InterpretedCodeSnapshot::capture(repo.path(), Path::new("server.py")).unwrap();
+        std::fs::write(&lock, b"after approval with launch fingerprint\n").unwrap();
+        let after = InterpretedCodeSnapshot::capture(repo.path(), Path::new("server.py")).unwrap();
+        assert_eq!(before, after);
     }
 
     #[cfg(unix)]

--- a/crates/tirith/src/cli/gateway.rs
+++ b/crates/tirith/src/cli/gateway.rs
@@ -2103,11 +2103,363 @@ fn spawn_upstream_capsuled(
 struct GatewayLaunchBinding {
     executable: tirith_core::trusted_child::TrustedExecutable,
     executable_digest: String,
+    interpreted_code: Option<InterpretedCodeSnapshot>,
     args: Vec<String>,
     cwd: PathBuf,
     environment: Vec<(String, String)>,
     capsule_spec: Option<tirith_core::capsule::CapsuleSpec>,
     fingerprint: String,
+}
+
+const MAX_INTERPRETED_SNAPSHOT_ENTRIES: usize = 8_192;
+const MAX_INTERPRETED_SNAPSHOT_FILES: usize = 4_096;
+const MAX_INTERPRETED_SNAPSHOT_PATH_BYTES: usize = 1024 * 1024;
+const MAX_INTERPRETED_SNAPSHOT_FILE_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_INTERPRETED_SNAPSHOT_TOTAL_BYTES: u64 = 128 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+struct InterpretedSnapshotLimits {
+    max_entries: usize,
+    max_files: usize,
+    max_path_bytes: usize,
+    max_file_bytes: u64,
+    max_total_bytes: u64,
+}
+
+impl Default for InterpretedSnapshotLimits {
+    fn default() -> Self {
+        Self {
+            max_entries: MAX_INTERPRETED_SNAPSHOT_ENTRIES,
+            max_files: MAX_INTERPRETED_SNAPSHOT_FILES,
+            max_path_bytes: MAX_INTERPRETED_SNAPSHOT_PATH_BYTES,
+            max_file_bytes: MAX_INTERPRETED_SNAPSHOT_FILE_BYTES,
+            max_total_bytes: MAX_INTERPRETED_SNAPSHOT_TOTAL_BYTES,
+        }
+    }
+}
+
+/// Bounded commitment to the mutable, repository-contained code and dependency
+/// tree of an interpreted MCP launch. Such launches are also required to use
+/// the capsule: the snapshot binds the writable repo closure while containment
+/// restricts all other reads to fixed system runtime roots. The committed lock
+/// stores only the outer launch fingerprint; raw paths and source bytes never
+/// enter it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InterpretedCodeSnapshot {
+    entrypoint: PathBuf,
+    digest: String,
+    file_count: u64,
+    total_bytes: u64,
+}
+
+impl InterpretedCodeSnapshot {
+    fn capture(repo_root: &Path, entrypoint: &Path) -> Result<Self, String> {
+        Self::capture_with_limits(repo_root, entrypoint, InterpretedSnapshotLimits::default())
+    }
+
+    fn capture_with_limits(
+        repo_root: &Path,
+        entrypoint: &Path,
+        limits: InterpretedSnapshotLimits,
+    ) -> Result<Self, String> {
+        let mut relative_files = Vec::new();
+        let mut entry_count = 0_usize;
+        let mut path_bytes = 0_usize;
+
+        for entry in walkdir::WalkDir::new(repo_root).follow_links(false) {
+            let entry = entry.map_err(|_| {
+                "interpreted dependency closure could not be enumerated safely".to_string()
+            })?;
+            if entry.depth() == 0 {
+                continue;
+            }
+            entry_count = entry_count
+                .checked_add(1)
+                .ok_or_else(|| "interpreted dependency entry count overflowed".to_string())?;
+            if entry_count > limits.max_entries {
+                return Err("interpreted dependency closure exceeds the entry limit".to_string());
+            }
+            let relative = entry
+                .path()
+                .strip_prefix(repo_root)
+                .map_err(|_| "interpreted dependency escaped the repository root".to_string())?;
+            if !safe_snapshot_relative_path(relative) {
+                return Err("interpreted dependency has a non-portable or unsafe path".to_string());
+            }
+            path_bytes = path_bytes
+                .checked_add(relative.as_os_str().as_encoded_bytes().len())
+                .ok_or_else(|| "interpreted dependency path budget overflowed".to_string())?;
+            if path_bytes > limits.max_path_bytes {
+                return Err("interpreted dependency paths exceed the byte limit".to_string());
+            }
+
+            let file_type = entry.file_type();
+            if file_type.is_symlink() {
+                return Err(
+                    "interpreted dependency closure contains a symlink; exact binding refused"
+                        .to_string(),
+                );
+            }
+            if file_type.is_dir() {
+                continue;
+            }
+            if !file_type.is_file() {
+                return Err(
+                    "interpreted dependency closure contains a non-regular entry".to_string(),
+                );
+            }
+            // The descriptor lock is the output that will receive this outer
+            // fingerprint. Including it would create a self-referential digest.
+            if is_descriptor_lock_control_file(relative) {
+                continue;
+            }
+            if relative_files.len() >= limits.max_files {
+                return Err("interpreted dependency closure exceeds the file limit".to_string());
+            }
+            relative_files.push(relative.to_path_buf());
+        }
+
+        relative_files.sort();
+        if !relative_files.iter().any(|path| path == entrypoint) {
+            return Err(
+                "interpreted entrypoint is not a regular repository-contained file".to_string(),
+            );
+        }
+
+        let mut hasher = Sha256::new();
+        launch_hash_field(&mut hasher, b"tirith-mcp-interpreted-closure-v1");
+        launch_hash_field(&mut hasher, entrypoint.as_os_str().as_encoded_bytes());
+        let mut total_bytes = 0_u64;
+        for relative in &relative_files {
+            let path = repo_root.join(relative);
+            let source = tirith_core::util::ContainedAtomicFile::prepare(repo_root, &path, false)
+                .map_err(|_| {
+                "interpreted dependency path could not be opened without symlinks".to_string()
+            })?;
+            let remaining = limits.max_total_bytes.saturating_sub(total_bytes);
+            let per_file_cap = limits.max_file_bytes.min(remaining);
+            let bytes = source
+                .read_capped(per_file_cap)
+                .map_err(|error| match error {
+                    tirith_core::util::OpenRegularError::TooLarge => {
+                        "interpreted dependency closure exceeds its byte limits".to_string()
+                    }
+                    tirith_core::util::OpenRegularError::NotRegularFile => {
+                        "interpreted dependency changed to a symlink or non-regular file"
+                            .to_string()
+                    }
+                    tirith_core::util::OpenRegularError::NotFound => {
+                        "interpreted dependency disappeared during capture".to_string()
+                    }
+                    tirith_core::util::OpenRegularError::Io(_) => {
+                        "interpreted dependency could not be read safely".to_string()
+                    }
+                })?;
+            total_bytes = total_bytes
+                .checked_add(bytes.len() as u64)
+                .ok_or_else(|| "interpreted dependency byte count overflowed".to_string())?;
+            if total_bytes > limits.max_total_bytes {
+                return Err(
+                    "interpreted dependency closure exceeds the total byte limit".to_string(),
+                );
+            }
+            launch_hash_field(&mut hasher, relative.as_os_str().as_encoded_bytes());
+            launch_hash_field(&mut hasher, &(bytes.len() as u64).to_le_bytes());
+            launch_hash_field(&mut hasher, &bytes);
+        }
+        launch_hash_field(&mut hasher, &(relative_files.len() as u64).to_le_bytes());
+        launch_hash_field(&mut hasher, &total_bytes.to_le_bytes());
+
+        Ok(Self {
+            entrypoint: entrypoint.to_path_buf(),
+            digest: format!("{:x}", hasher.finalize()),
+            file_count: relative_files.len() as u64,
+            total_bytes,
+        })
+    }
+}
+
+fn safe_snapshot_relative_path(path: &Path) -> bool {
+    !path.as_os_str().is_empty()
+        && path
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+}
+
+fn normalize_snapshot_relative_path(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(value) => normalized.push(value),
+            std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    (!normalized.as_os_str().is_empty()).then_some(normalized)
+}
+
+fn is_descriptor_lock_control_file(path: &Path) -> bool {
+    path == Path::new(".tirith").join(tirith_core::mcp_lock::MCP_LOCK_FILENAME)
+}
+
+fn versioned_interpreter_name(name: &str, prefix: &str) -> bool {
+    let Some(suffix) = name.strip_prefix(prefix) else {
+        return false;
+    };
+    let suffix = suffix.strip_prefix('-').unwrap_or(suffix);
+    suffix.is_empty()
+        || (suffix
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_digit())
+            && suffix
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || byte == b'.'))
+}
+
+fn static_interpreted_entrypoint(
+    executable: &Path,
+    args: &[String],
+    repo_root: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let executable_name = executable
+        .file_name()
+        .and_then(OsStr::to_str)
+        .ok_or_else(|| "upstream executable name is not valid UTF-8".to_string())?
+        .to_ascii_lowercase();
+    let executable_name = executable_name
+        .strip_suffix(".exe")
+        .unwrap_or(&executable_name);
+
+    if [
+        "env",
+        "npx",
+        "npm",
+        "pnpm",
+        "yarn",
+        "uv",
+        "uvx",
+        "poetry",
+        "pipenv",
+        "tsx",
+        "ts-node",
+        "jupyter",
+        "cargo",
+        "go",
+        "rust-script",
+        "dart",
+        "awk",
+        "gawk",
+        "php-cgi",
+    ]
+    .contains(&executable_name)
+    {
+        return Err(
+            "dynamic MCP launchers cannot establish an exact interpreted dependency closure; use an exact wrapper executable"
+                .to_string(),
+        );
+    }
+
+    let ordinary = [
+        "python",
+        "pypy",
+        "node",
+        "nodejs",
+        "ruby",
+        "perl",
+        "php",
+        "lua",
+        "luajit",
+        "bash",
+        "zsh",
+        "fish",
+        "pwsh",
+        "powershell",
+        "dotnet",
+        "tclsh",
+        "wish",
+        "julia",
+        "elixir",
+        "groovy",
+        "rscript",
+    ]
+    .iter()
+    .any(|prefix| versioned_interpreter_name(executable_name, prefix))
+        || matches!(
+            executable_name,
+            "sh" | "dash" | "ksh" | "csh" | "tcsh" | "qjs" | "quickjs" | "osascript"
+        );
+    let entrypoint = if ordinary {
+        let first = args
+            .first()
+            .ok_or_else(|| "interpreted MCP launch is missing a static entrypoint".to_string())?;
+        first
+    } else if executable_name == "deno" {
+        if args.first().map(String::as_str) != Some("run") || args.len() < 2 {
+            return Err(
+                "deno MCP launch must use `deno run <repo-contained-entrypoint>` without launcher flags"
+                    .to_string(),
+            );
+        }
+        &args[1]
+    } else if executable_name == "bun" {
+        let first = args
+            .first()
+            .ok_or_else(|| "interpreted MCP launch is missing a static entrypoint".to_string())?;
+        if first == "run" {
+            return Err(
+                "package-script MCP launchers have a dynamic dependency closure; use a static entrypoint"
+                    .to_string(),
+            );
+        }
+        first
+    } else if executable_name == "java" {
+        if args.first().map(String::as_str) != Some("-jar") || args.len() < 2 {
+            return Err(
+                "java MCP launch must use `java -jar <repo-contained-entrypoint>` without JVM launcher flags"
+                    .to_string(),
+            );
+        }
+        &args[1]
+    } else if let Some(first) = args.first().filter(|value| !value.starts_with('-')) {
+        // A root-owned custom interpreter cannot be identified exhaustively by
+        // basename. If its leading operand names an existing repo file, treat
+        // that operand conservatively as interpreted code. Native servers that
+        // take only flags retain the ordinary executable-only binding.
+        let candidate = Path::new(first);
+        let candidate = if candidate.is_absolute() {
+            candidate.to_path_buf()
+        } else {
+            repo_root.join(candidate)
+        };
+        if candidate.is_file() {
+            first
+        } else {
+            return Ok(None);
+        }
+    } else {
+        return Ok(None);
+    };
+
+    if entrypoint.is_empty()
+        || entrypoint.starts_with('-')
+        || entrypoint.contains("://")
+        || entrypoint.starts_with("data:")
+    {
+        return Err(
+            "interpreted MCP launch must name a static repository-contained entrypoint".to_string(),
+        );
+    }
+    let path = Path::new(entrypoint);
+    let relative = if path.is_absolute() {
+        path.strip_prefix(repo_root)
+            .map_err(|_| "interpreted MCP entrypoint is outside the repository root".to_string())?
+    } else {
+        path
+    };
+    normalize_snapshot_relative_path(relative)
+        .map(Some)
+        .ok_or_else(|| "interpreted MCP entrypoint has an unsafe path".to_string())
 }
 
 fn launch_hash_field(hasher: &mut Sha256, bytes: &[u8]) {
@@ -2258,6 +2610,16 @@ impl GatewayLaunchBinding {
             .to_str()
             .ok_or_else(|| "descriptor repository path is not valid UTF-8".to_string())?;
         let executable_digest = launch_executable_digest(executable.path())?;
+        let interpreted_entrypoint = static_interpreted_entrypoint(executable.path(), args, &cwd)?;
+        if interpreted_entrypoint.is_some() && !contained {
+            return Err(
+                "exact interpreted MCP binding requires the fail-closed capsule so code cannot load an out-of-root dependency"
+                    .to_string(),
+            );
+        }
+        let interpreted_code = interpreted_entrypoint
+            .map(|entrypoint| InterpretedCodeSnapshot::capture(&cwd, &entrypoint))
+            .transpose()?;
         let capsule_spec = contained.then(|| mcp_server_capsule_spec(&cwd));
         let containment = match &capsule_spec {
             Some(spec) => serde_json::to_string(spec)
@@ -2266,7 +2628,14 @@ impl GatewayLaunchBinding {
         };
 
         let mut hasher = Sha256::new();
-        launch_hash_field(&mut hasher, b"tirith-mcp-launch-v1");
+        launch_hash_field(
+            &mut hasher,
+            if interpreted_code.is_some() {
+                b"tirith-mcp-launch-v2-interpreted"
+            } else {
+                b"tirith-mcp-launch-v1"
+            },
+        );
         launch_hash_field(&mut hasher, executable_path.as_bytes());
         launch_hash_field(&mut hasher, executable_digest.as_bytes());
         launch_hash_field(&mut hasher, &(args.len() as u64).to_le_bytes());
@@ -2280,10 +2649,20 @@ impl GatewayLaunchBinding {
             launch_hash_field(&mut hasher, value.as_bytes());
         }
         launch_hash_field(&mut hasher, containment.as_bytes());
+        if let Some(snapshot) = &interpreted_code {
+            launch_hash_field(
+                &mut hasher,
+                snapshot.entrypoint.as_os_str().as_encoded_bytes(),
+            );
+            launch_hash_field(&mut hasher, snapshot.digest.as_bytes());
+            launch_hash_field(&mut hasher, &snapshot.file_count.to_le_bytes());
+            launch_hash_field(&mut hasher, &snapshot.total_bytes.to_le_bytes());
+        }
 
         Ok(Self {
             executable,
             executable_digest,
+            interpreted_code,
             args: args.to_vec(),
             cwd,
             environment,
@@ -2299,6 +2678,14 @@ impl GatewayLaunchBinding {
         let digest = launch_executable_digest(self.executable.path())?;
         if digest != self.executable_digest {
             return Err("upstream executable bytes changed before spawn".to_string());
+        }
+        if let Some(expected) = &self.interpreted_code {
+            let current = InterpretedCodeSnapshot::capture(&self.cwd, &expected.entrypoint)?;
+            if current != *expected {
+                return Err(
+                    "interpreted MCP code or dependency closure changed before spawn".to_string(),
+                );
+            }
         }
         Ok(())
     }
@@ -8615,6 +9002,129 @@ mod tests {
             GatewayLaunchBinding::build(command, &args, repo.path(), "1", true).unwrap();
         assert_ne!(first.fingerprint, contained.fingerprint);
         first.revalidate().unwrap();
+    }
+
+    #[cfg(unix)]
+    fn protected_test_interpreter(repo_root: &Path, entrypoint: &str) -> &'static str {
+        [
+            "/bin/sh",
+            "/usr/bin/sh",
+            "/bin/bash",
+            "/usr/bin/python3",
+            "/usr/bin/perl",
+        ]
+        .into_iter()
+        .find(|candidate| {
+            GatewayLaunchBinding::build(candidate, &[entrypoint.to_string()], repo_root, "1", true)
+                .is_ok()
+        })
+        .expect("a protected system interpreter is required for this Unix test")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exact_launch_fingerprint_binds_interpreted_repo_closure() {
+        let _lock = crate::cli::test_harness::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("server.sh"), b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::write(repo.path().join("dependency.inc"), b"stable-v1\n").unwrap();
+        let interpreter = protected_test_interpreter(repo.path(), "server.sh");
+        let args = vec!["server.sh".to_string()];
+
+        let first =
+            GatewayLaunchBinding::build(interpreter, &args, repo.path(), "1", true).unwrap();
+        let identical =
+            GatewayLaunchBinding::build(interpreter, &args, repo.path(), "1", true).unwrap();
+        assert_eq!(first.fingerprint, identical.fingerprint);
+        assert!(first.interpreted_code.is_some());
+
+        std::fs::write(repo.path().join("dependency.inc"), b"changed-v2\n").unwrap();
+        let error = first.revalidate().unwrap_err();
+        assert!(error.contains("code or dependency closure changed"));
+        let changed =
+            GatewayLaunchBinding::build(interpreter, &args, repo.path(), "1", true).unwrap();
+        assert_ne!(first.fingerprint, changed.fingerprint);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exact_launch_refuses_dynamic_or_out_of_root_interpreted_entrypoints() {
+        let _lock = crate::cli::test_harness::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("server.sh"), b"#!/bin/sh\nexit 0\n").unwrap();
+        let interpreter = protected_test_interpreter(repo.path(), "server.sh");
+
+        let uncontained = GatewayLaunchBinding::build(
+            interpreter,
+            &["server.sh".to_string()],
+            repo.path(),
+            "1",
+            false,
+        )
+        .unwrap_err();
+        assert!(uncontained.contains("requires the fail-closed capsule"));
+
+        let dynamic = GatewayLaunchBinding::build(
+            interpreter,
+            &["-c".to_string(), "exit 0".to_string()],
+            repo.path(),
+            "1",
+            true,
+        )
+        .unwrap_err();
+        assert!(dynamic.contains("static repository-contained entrypoint"));
+
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        let outside = GatewayLaunchBinding::build(
+            interpreter,
+            &[outside.path().display().to_string()],
+            repo.path(),
+            "1",
+            true,
+        )
+        .unwrap_err();
+        assert!(outside.contains("outside the repository root"));
+    }
+
+    #[test]
+    fn interpreted_snapshot_refuses_unbounded_closures() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("server.py"), b"pass\n").unwrap();
+        std::fs::write(repo.path().join("dependency.py"), b"pass\n").unwrap();
+        let limits = InterpretedSnapshotLimits {
+            max_entries: 8,
+            max_files: 1,
+            max_path_bytes: 1024,
+            max_file_bytes: 1024,
+            max_total_bytes: 2048,
+        };
+
+        let error = InterpretedCodeSnapshot::capture_with_limits(
+            repo.path(),
+            Path::new("server.py"),
+            limits,
+        )
+        .unwrap_err();
+        assert!(error.contains("file limit"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn interpreted_snapshot_refuses_symlinked_dependencies() {
+        use std::os::unix::fs::symlink;
+
+        let repo = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(repo.path().join("server.py"), b"pass\n").unwrap();
+        symlink(outside.path(), repo.path().join("dependency.py")).unwrap();
+
+        let error =
+            InterpretedCodeSnapshot::capture(repo.path(), Path::new("server.py")).unwrap_err();
+        assert!(error.contains("symlink"));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Stack PR 6 of 12. Exact MCP configuration and interpreted code identity binding. CI follow-up pending.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Sensitive credentials are no longer exposed through lockfile data or public configuration output.
  - Configuration files are safely read and protected against symlink swaps, directory changes, and unexpected growth.
  - GitLab token patterns are recognized and handled as secrets.

- **Bug Fixes**
  - Configuration changes involving moved servers are now detected accurately.
  - Unsupported lockfile versions produce a clear error.

- **Launch Validation**
  - Interpreted applications now require verified repository containment and are blocked if code or dependencies change before launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR binds MCP configuration reads to retained filesystem capabilities and incorporates interpreted repository contents into launch fingerprints.
- Reads discovered MCP configurations through capped, no-follow retained handles.
- Treats source configuration as part of server drift identity and expands GitLab-token detection.
- Captures and revalidates interpreted repository snapshots before capsule launches.

<h3>Confidence Score: 2/5</h3>

The PR does not yet appear safe to merge because interpreted launches can still reject valid repositories and can execute code changed after snapshot revalidation.

Snapshot capture still traverses and limits the entire repository rather than a precise dependency closure, and the child later opens interpreted code from mutable live paths after revalidation has completed.

**Files Needing Attention:** crates/tirith/src/cli/gateway.rs

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/mcp_lock.rs | Retains filesystem authority through MCP configuration reads, tightens drift identity, and extends GitLab-secret recognition. |
| crates/tirith/src/cli/gateway.rs | Adds interpreted-code snapshot binding and pre-spawn revalidation, while the previously reported launch-availability and live-path execution defects remain. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Gateway
    participant Repository
    participant Capsule
    participant Interpreter
    Gateway->>Repository: Capture and hash interpreted snapshot
    Gateway->>Repository: Revalidate live files
    Gateway->>Capsule: Spawn with repository read root
    Capsule->>Interpreter: Execute configured interpreter
    Interpreter->>Repository: Open entrypoint and dependencies by live path
```

<sub>Reviews (8): Last reviewed commit: ["test(gateway): gate the descriptor-lock ..."](https://github.com/sheeki03/tirith/commit/51091bfffcc2d5a53314353c9ddb06d82fce0a22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54708794)</sub>

**Context used:**

- Knowledge Base — [MCP Integration](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/mcp-integration.md)

<!-- /greptile_comment -->