### PR TITLE
Security: harden license and threat-data services

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,4 +10,8 @@
 # every /ObjStm compressed object stream (fail-closed on undecodable/over-cap), so
 # the compressed-stream bypass is closed too. Keep in sync with deny.toml; remove
 # when MSRV/lopdf move.
-ignore = ["RUSTSEC-2026-0009", "RUSTSEC-2026-0187"]
+#
+# RUSTSEC-2026-0119: hickory-proto 0.24.4 encoder DoS. Fix is 0.26.1 (API
+# break vs our 0.24 pin / MSRV 1.83). Tirith encodes only self-built DNS
+# queries, not untrusted messages. Keep in sync with deny.toml.
+ignore = ["RUSTSEC-2026-0009", "RUSTSEC-2026-0187", "RUSTSEC-2026-0119"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1251,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.7",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.7",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1567,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1785,15 @@ dependencies = [
  "rayon",
  "time",
  "weezl",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1817,7 +1902,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand",
+ "rand 0.9.3",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2274,7 +2359,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2317,12 +2402,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2493,6 +2599,12 @@ dependencies = [
  "web-sys",
  "webpki-roots",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -3125,6 +3237,7 @@ dependencies = [
  "fs2",
  "getrandom 0.3.4",
  "hex",
+ "hickory-resolver",
  "home",
  "is-terminal",
  "jsonschema",
@@ -3135,7 +3248,7 @@ dependencies = [
  "once_cell",
  "owo-colors",
  "percent-encoding",
- "rand",
+ "rand 0.9.3",
  "rand_core 0.6.4",
  "regex",
  "regex-syntax",
@@ -3148,6 +3261,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tirith-test-support",
+ "tokio",
  "toml",
  "unicode-normalization",
  "unicode-script",
@@ -3719,6 +3833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,6 +3950,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/crates/tirith-core/Cargo.toml
+++ b/crates/tirith-core/Cargo.toml
@@ -63,6 +63,12 @@ tempfile = "3"
 toml = "0.8"
 ed25519-dalek = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+# Socket-based DNS with cancellable async lookups. The resolver worker in
+# `network::dns` drives this on a private current-thread runtime so core callers
+# retain a synchronous API without using libc's non-interruptible resolver.
+# hickory-resolver 0.24.4 declares Rust 1.71.1, below workspace MSRV 1.83.
+hickory-resolver = { version = "0.24.4", default-features = false, features = ["system-config", "tokio-runtime"] }
+tokio = { workspace = true, features = ["net", "rt", "time"] }
 csv = { workspace = true }
 owo-colors = { workspace = true }
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/crates/tirith-core/src/dashboard.rs
+++ b/crates/tirith-core/src/dashboard.rs
@@ -393,7 +393,7 @@ fn policy_summary_error(path: String, error: String) -> PolicySummary {
 fn build_threatdb_summary() -> ThreatDbSummary {
     use crate::threatdb::ThreatDb;
 
-    let db_path = ThreatDb::default_path();
+    let db_path = ThreatDb::resolve_primary_path();
     let path_str = db_path.as_ref().map(|p| p.display().to_string());
 
     let exists = db_path.as_ref().map(|p| p.exists()).unwrap_or(false);
@@ -838,13 +838,14 @@ mod tests {
     /// Every env var that influences where `build_policy_summary` resolves
     /// config from (XDG / %APPDATA% / %LOCALAPPDATA% / HOME / USERPROFILE /
     /// TIRITH_*). A hermetic test must pin and restore EVERY one across OSes.
-    const ENV_KEYS: [&str; 8] = [
+    const ENV_KEYS: [&str; 9] = [
         "XDG_CONFIG_HOME",
         "APPDATA",
         "LOCALAPPDATA",
         "HOME",
         "USERPROFILE",
         "TIRITH_POLICY_ROOT",
+        "TIRITH_THREATDB_PATH",
         "TIRITH_SERVER_URL",
         "TIRITH_API_KEY",
     ];
@@ -1229,6 +1230,27 @@ mod tests {
             }
             other => panic!("isolated cwd with no policy file must be NoFile, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn threatdb_summary_reports_the_effective_v2_sibling() {
+        let state = tempfile::tempdir().unwrap();
+        let v1_path = state.path().join("primary.dat");
+        let v2_path = state.path().join("primary-v2.dat");
+        std::fs::write(
+            &v2_path,
+            include_bytes!("../../../tests/fixtures/test-threatdb.dat"),
+        )
+        .unwrap();
+        assert!(!v1_path.exists(), "the legacy path must remain absent");
+
+        let _env = dashboard_environment(&[("TIRITH_THREATDB_PATH", Some(v1_path.as_os_str()))]);
+        let summary = build_threatdb_summary();
+
+        assert!(summary.installed);
+        assert_eq!(summary.path.as_deref(), v2_path.to_str());
+        assert_eq!(summary.signature_valid, Some(true));
+        assert_eq!(summary.build_sequence, Some(42));
     }
 
     #[test]

--- a/crates/tirith-core/src/network/dns.rs
+++ b/crates/tirith-core/src/network/dns.rs
@@ -70,10 +70,14 @@ impl SystemDnsResolver {
                             return;
                         }
                     };
-                    let resolver = match {
+                    // The runtime guard has to stay alive across the constructor,
+                    // which registers IO/timer drivers, so scope it to the block
+                    // that builds the resolver and match on the result.
+                    let created = {
                         let _entered = runtime.enter();
                         hickory_resolver::TokioAsyncResolver::tokio_from_system_conf()
-                    } {
+                    };
+                    let resolver = match created {
                         Ok(resolver) => resolver,
                         Err(error) => {
                             let _ = initialized_tx

--- a/crates/tirith-core/src/network/dns.rs
+++ b/crates/tirith-core/src/network/dns.rs
@@ -268,7 +268,7 @@ pub fn check_dns_blocklist_with(
             let query = format!("{reversed}.{zone}");
             if budget
                 .resolve_query(resolver, &query)
-                .is_some_and(|addresses| !addresses.is_empty())
+                .is_some_and(|addresses| addresses.iter().any(is_dnsbl_listing))
                 && !matches.iter().any(|present| present == display_name)
             {
                 matches.push(display_name.to_string());
@@ -276,6 +276,24 @@ pub fn check_dns_blocklist_with(
         }
     }
     matches
+}
+
+/// A DNSBL reports a listing with a `127.0.0.0/8` answer, but the zones also
+/// answer in band with `127.255.255.0/24` for a query they refused: Spamhaus
+/// returns that range for a blocked or rate-limited querier, which is the
+/// normal response when the lookup comes from a public resolver. Treating any
+/// non-empty answer as a listing turns "we declined your query" into a
+/// High-severity blocklist finding against an innocent host.
+fn is_dnsbl_listing(address: &IpAddr) -> bool {
+    match address {
+        IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            octets[0] == 127 && !(octets[1] == 255 && octets[2] == 255)
+        }
+        // No zone in DNS_BLOCKLISTS publishes AAAA listings; an answer outside
+        // the documented response space is not evidence of one.
+        IpAddr::V6(_) => false,
+    }
 }
 
 fn reverse_ipv4(ip: std::net::Ipv4Addr) -> String {
@@ -331,6 +349,38 @@ mod tests {
             .resolve_subject(&resolver, "attacker.example")
             .is_none());
         assert!(resolver.calls().is_empty());
+    }
+
+    #[test]
+    fn a_reserved_dnsbl_answer_is_not_read_as_a_listing() {
+        // Spamhaus answers `127.255.255.x` when it refuses the query — a blocked
+        // or rate-limited querier, which is the normal reply when the lookup
+        // comes from a public resolver. That must not become a blocklist hit.
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let refused = FakeResolver::default()
+            .with_answer("host.example", vec!["192.0.2.10".parse().unwrap()])
+            .with_answer(
+                "10.2.0.192.zen.spamhaus.org",
+                vec!["127.255.255.254".parse().unwrap()],
+            );
+        let mut budget = DnsRequestBudget::new(deadline, 4, 8);
+        assert!(
+            check_dns_blocklist_with("host.example", &refused, &mut budget).is_empty(),
+            "an in-band refusal code is not evidence that the host is listed"
+        );
+
+        // A real listing code inside 127.0.0.0/8 still reports.
+        let listed = FakeResolver::default()
+            .with_answer("host.example", vec!["192.0.2.10".parse().unwrap()])
+            .with_answer(
+                "10.2.0.192.zen.spamhaus.org",
+                vec!["127.0.0.2".parse().unwrap()],
+            );
+        let mut budget = DnsRequestBudget::new(deadline, 4, 8);
+        assert_eq!(
+            check_dns_blocklist_with("host.example", &listed, &mut budget),
+            vec!["Spamhaus ZEN".to_string()]
+        );
     }
 
     #[test]

--- a/crates/tirith-core/src/network/dns.rs
+++ b/crates/tirith-core/src/network/dns.rs
@@ -1,4 +1,7 @@
-use std::net::ToSocketAddrs;
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 /// Known DNS-based blocklists for threat intelligence.
 const DNS_BLOCKLISTS: &[(&str, &str)] = &[
@@ -7,127 +10,359 @@ const DNS_BLOCKLISTS: &[(&str, &str)] = &[
     ("dnsbl.sorbs.net", "SORBS"),
 ];
 
-/// repo-0300: per-call work bounds — unique addresses queried and an overall
-/// wall-clock budget (system DNS has no per-query deadline).
+/// One daemon analysis shares this budget across every attacker-controlled host.
+const MAX_DNSBL_SUBJECTS: usize = 16;
+const MAX_DNSBL_QUERIES: usize = 32;
 const MAX_DNSBL_ADDRESSES: usize = 8;
-const MAX_DNSBL_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);
+const MAX_DNSBL_BUDGET: Duration = Duration::from_secs(8);
+const MAX_RESOLVED_ADDRESSES: usize = 32;
 
-/// Check if a domain appears in DNS-based blocklists (DNSBLs): resolve the
-/// domain to IPs, then query each DNSBL with the reversed-IP lookup format.
-/// Returns the matching blocklist display names (empty on no resolution/match).
+/// A resolver whose lookup is cancelled at `deadline`.
+///
+/// Implementations must not leave target DNS work running after returning. The
+/// production implementation drives Hickory's async socket resolver behind a
+/// fixed worker and drops the lookup future at the supplied deadline; it never
+/// calls the non-interruptible libc resolver.
+pub trait DnsResolver {
+    fn lookup_ips(&self, name: &str, deadline: Instant) -> Option<Vec<IpAddr>>;
+}
+
+struct LookupRequest {
+    name: String,
+    deadline: Instant,
+    reply: mpsc::SyncSender<Option<Vec<IpAddr>>>,
+}
+
+/// System-configured, cancellable DNS resolver.
+///
+/// A single worker owns the Tokio runtime and Hickory resolver. This keeps the
+/// public API synchronous for the core engine without nesting a runtime in a
+/// caller that may itself be async. Each request carries its absolute deadline;
+/// `tokio::time::timeout` cancels the socket lookup when that deadline wins.
+pub struct SystemDnsResolver {
+    requests: Option<mpsc::SyncSender<LookupRequest>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl SystemDnsResolver {
+    pub fn new() -> Result<Self, String> {
+        #[cfg(not(any(unix, target_os = "windows")))]
+        {
+            return Err("system DNS configuration is unsupported on this platform".to_string());
+        }
+
+        #[cfg(any(unix, target_os = "windows"))]
+        {
+            let (requests, receiver) = mpsc::sync_channel::<LookupRequest>(1);
+            let (initialized_tx, initialized_rx) = mpsc::sync_channel::<Result<(), String>>(1);
+            let worker = std::thread::Builder::new()
+                .name("tirith-dns-resolver".to_string())
+                .spawn(move || {
+                    let runtime = match tokio::runtime::Builder::new_current_thread()
+                        .enable_io()
+                        .enable_time()
+                        .build()
+                    {
+                        Ok(runtime) => runtime,
+                        Err(error) => {
+                            let _ = initialized_tx
+                                .send(Err(format!("failed to create DNS runtime: {error}")));
+                            return;
+                        }
+                    };
+                    let resolver = match {
+                        let _entered = runtime.enter();
+                        hickory_resolver::TokioAsyncResolver::tokio_from_system_conf()
+                    } {
+                        Ok(resolver) => resolver,
+                        Err(error) => {
+                            let _ = initialized_tx
+                                .send(Err(format!("failed to load system DNS config: {error}")));
+                            return;
+                        }
+                    };
+                    if initialized_tx.send(Ok(())).is_err() {
+                        return;
+                    }
+
+                    while let Ok(request) = receiver.recv() {
+                        let remaining = request.deadline.saturating_duration_since(Instant::now());
+                        if remaining.is_zero() {
+                            let _ = request.reply.send(None);
+                            continue;
+                        }
+                        // A trailing dot makes the attacker-controlled host an FQDN,
+                        // preventing resolver search-suffix expansion.
+                        let fqdn = format!("{}.", request.name.trim_end_matches('.'));
+                        let result = runtime.block_on(async {
+                            tokio::time::timeout(remaining, resolver.lookup_ip(fqdn.as_str()))
+                                .await
+                                .ok()?
+                                .ok()
+                                .map(|lookup| lookup.iter().take(MAX_RESOLVED_ADDRESSES).collect())
+                        });
+                        let _ = request.reply.send(result);
+                    }
+                })
+                .map_err(|error| format!("failed to spawn DNS resolver: {error}"))?;
+
+            match initialized_rx.recv() {
+                Ok(Ok(())) => Ok(Self {
+                    requests: Some(requests),
+                    worker: Some(worker),
+                }),
+                Ok(Err(error)) => {
+                    let _ = worker.join();
+                    Err(error)
+                }
+                Err(_) => {
+                    let _ = worker.join();
+                    Err("DNS resolver exited during initialization".to_string())
+                }
+            }
+        }
+    }
+}
+
+impl DnsResolver for SystemDnsResolver {
+    fn lookup_ips(&self, name: &str, deadline: Instant) -> Option<Vec<IpAddr>> {
+        let remaining = deadline.checked_duration_since(Instant::now())?;
+        if remaining.is_zero() {
+            return None;
+        }
+        let (reply, response) = mpsc::sync_channel(1);
+        self.requests
+            .as_ref()?
+            .try_send(LookupRequest {
+                name: name.to_string(),
+                deadline,
+                reply,
+            })
+            .ok()?;
+        response.recv_timeout(remaining).ok().flatten()
+    }
+}
+
+impl Drop for SystemDnsResolver {
+    fn drop(&mut self) {
+        // Disconnecting the bounded channel lets the worker finish without a
+        // sentinel. No lookup can remain in flight past its absolute deadline.
+        self.requests.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+/// Request-wide DNS accounting. Subject hosts and actual DNS queries have
+/// separate caps: generated DNSBL names consume query budget but cannot consume
+/// the allowance for attacker-controlled subjects.
+pub struct DnsRequestBudget {
+    deadline: Instant,
+    max_subjects: usize,
+    max_queries: usize,
+    subjects: HashSet<String>,
+    queries: usize,
+    cache: HashMap<String, Option<Vec<IpAddr>>>,
+}
+
+impl DnsRequestBudget {
+    /// Standard daemon DNSBL budget shared across the complete request.
+    pub fn dnsbl() -> Self {
+        Self::new(
+            Instant::now() + MAX_DNSBL_BUDGET,
+            MAX_DNSBL_SUBJECTS,
+            MAX_DNSBL_QUERIES,
+        )
+    }
+
+    /// Build a request budget with an existing deadline. Zero limits disable DNS.
+    pub fn new(deadline: Instant, max_subjects: usize, max_queries: usize) -> Self {
+        Self {
+            deadline,
+            max_subjects,
+            max_queries,
+            subjects: HashSet::new(),
+            queries: 0,
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Resolve one attacker-controlled subject under the shared request budget.
+    /// Repeated subjects use the cached result and do not consume another query.
+    pub fn resolve_subject(
+        &mut self,
+        resolver: &dyn DnsResolver,
+        subject: &str,
+    ) -> Option<Vec<IpAddr>> {
+        let normalized = normalize_dns_name(subject)?;
+        if !self.subjects.contains(&normalized) {
+            if self.subjects.len() >= self.max_subjects {
+                return None;
+            }
+            self.subjects.insert(normalized.clone());
+        }
+        self.resolve_query(resolver, &normalized)
+    }
+
+    fn resolve_query(&mut self, resolver: &dyn DnsResolver, name: &str) -> Option<Vec<IpAddr>> {
+        let normalized = normalize_dns_name(name)?;
+        if let Some(cached) = self.cache.get(&normalized) {
+            return cached.clone();
+        }
+        if self.queries >= self.max_queries || Instant::now() >= self.deadline {
+            return None;
+        }
+        self.queries += 1;
+        let result = resolver.lookup_ips(&normalized, self.deadline);
+        self.cache.insert(normalized, result.clone());
+        result
+    }
+}
+
+fn normalize_dns_name(name: &str) -> Option<String> {
+    let normalized = name.trim().trim_end_matches('.').to_ascii_lowercase();
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+/// Backwards-compatible per-call entry point.
 pub fn check_dns_blocklist(domain: &str) -> Vec<String> {
-    // repo-0300: attacker-controlled hosts reach this function through daemon
-    // enrichment. Bound the total work: one resolution, a capped number of
-    // unique addresses, and an overall deadline so a hostile domain cannot pin
-    // a blocking worker for an attacker-controlled duration.
-    let deadline = std::time::Instant::now() + MAX_DNSBL_BUDGET;
-    let mut ips = match resolve_domain_ips(domain) {
-        Some(ips) => ips,
+    let Ok(resolver) = SystemDnsResolver::new() else {
+        return Vec::new();
+    };
+    let mut budget = DnsRequestBudget::dnsbl();
+    check_dns_blocklist_with(domain, &resolver, &mut budget)
+}
+
+/// Check one domain while retaining a caller-owned resolver and request budget.
+pub fn check_dns_blocklist_with(
+    domain: &str,
+    resolver: &dyn DnsResolver,
+    budget: &mut DnsRequestBudget,
+) -> Vec<String> {
+    let mut ips: Vec<_> = match budget.resolve_subject(resolver, domain) {
+        Some(ips) => ips
+            .into_iter()
+            .filter_map(|ip| match ip {
+                IpAddr::V4(v4) => Some(v4),
+                IpAddr::V6(_) => None,
+            })
+            .collect(),
         None => return Vec::new(),
     };
     ips.sort();
     ips.dedup();
 
     let mut matches = Vec::new();
-
     for ip in ips.iter().take(MAX_DNSBL_ADDRESSES) {
-        if std::time::Instant::now() >= deadline {
-            break;
-        }
-        let reversed = reverse_ipv4(ip);
-        let reversed = match reversed {
-            Some(r) => r,
-            None => continue, // Skip non-IPv4 addresses
-        };
-
+        let reversed = reverse_ipv4(*ip);
         for &(zone, display_name) in DNS_BLOCKLISTS {
-            if std::time::Instant::now() >= deadline {
-                break;
-            }
             let query = format!("{reversed}.{zone}");
-            if dnsbl_lookup(&query) {
-                let entry = display_name.to_string();
-                if !matches.contains(&entry) {
-                    matches.push(entry);
-                }
+            if budget
+                .resolve_query(resolver, &query)
+                .is_some_and(|addresses| !addresses.is_empty())
+                && !matches.iter().any(|present| present == display_name)
+            {
+                matches.push(display_name.to_string());
             }
         }
     }
-
     matches
 }
 
-/// Resolve a domain to its IPv4 addresses via the system resolver.
-fn resolve_domain_ips(domain: &str) -> Option<Vec<String>> {
-    // ToSocketAddrs requires a port; 0 is a harmless placeholder.
-    let lookup = format!("{domain}:0");
-    let addrs: Vec<String> = lookup
-        .to_socket_addrs()
-        .ok()?
-        .filter_map(|addr| {
-            if addr.is_ipv4() {
-                Some(addr.ip().to_string())
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    if addrs.is_empty() {
-        None
-    } else {
-        Some(addrs)
-    }
-}
-
-/// Reverse the octets of an IPv4 address string.
-///
-/// `"1.2.3.4"` -> `Some("4.3.2.1")`
-fn reverse_ipv4(ip: &str) -> Option<String> {
-    let parts: Vec<&str> = ip.split('.').collect();
-    if parts.len() != 4 {
-        return None;
-    }
-    // Validate each octet is a number in range.
-    for part in &parts {
-        part.parse::<u8>().ok()?;
-    }
-    Some(format!(
-        "{}.{}.{}.{}",
-        parts[3], parts[2], parts[1], parts[0]
-    ))
-}
-
-/// A DNSBL lookup: a positive result is the query resolving to any address; a
-/// negative result is NXDOMAIN (resolution fails).
-fn dnsbl_lookup(query: &str) -> bool {
-    let lookup = format!("{query}:0");
-    lookup.to_socket_addrs().is_ok()
+fn reverse_ipv4(ip: std::net::Ipv4Addr) -> String {
+    let octets = ip.octets();
+    format!("{}.{}.{}.{}", octets[3], octets[2], octets[1], octets[0])
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct FakeResolver {
+        answers: HashMap<String, Option<Vec<IpAddr>>>,
+        calls: Mutex<Vec<(String, Instant)>>,
+    }
+
+    impl FakeResolver {
+        fn with_answer(mut self, name: &str, answers: Vec<IpAddr>) -> Self {
+            self.answers.insert(name.to_string(), Some(answers));
+            self
+        }
+
+        fn calls(&self) -> Vec<(String, Instant)> {
+            self.calls.lock().expect("calls lock").clone()
+        }
+    }
+
+    impl DnsResolver for FakeResolver {
+        fn lookup_ips(&self, name: &str, deadline: Instant) -> Option<Vec<IpAddr>> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push((name.to_string(), deadline));
+            self.answers.get(name).cloned().flatten()
+        }
+    }
 
     #[test]
-    fn test_reverse_ipv4_valid() {
-        assert_eq!(reverse_ipv4("1.2.3.4"), Some("4.3.2.1".to_string()));
+    fn reverse_ipv4_is_typed_and_infallible() {
         assert_eq!(
-            reverse_ipv4("192.168.1.100"),
-            Some("100.1.168.192".to_string())
+            reverse_ipv4(std::net::Ipv4Addr::new(192, 168, 1, 100)),
+            "100.1.168.192"
         );
-        assert_eq!(reverse_ipv4("10.0.0.1"), Some("1.0.0.10".to_string()));
     }
 
     #[test]
-    fn test_reverse_ipv4_invalid() {
-        assert_eq!(reverse_ipv4("not-an-ip"), None);
-        assert_eq!(reverse_ipv4("1.2.3"), None);
-        assert_eq!(reverse_ipv4("1.2.3.4.5"), None);
-        assert_eq!(reverse_ipv4("::1"), None);
-        assert_eq!(reverse_ipv4("256.1.2.3"), None);
+    fn expired_budget_performs_zero_resolver_calls() {
+        let resolver = FakeResolver::default();
+        let mut budget = DnsRequestBudget::new(Instant::now(), 4, 4);
+        assert!(budget
+            .resolve_subject(&resolver, "attacker.example")
+            .is_none());
+        assert!(resolver.calls().is_empty());
     }
 
-    // DNS resolution tests are network-dependent and skipped in CI.
-    // They should be run in integration test environments.
+    #[test]
+    fn shared_budget_caps_subjects_and_total_queries() {
+        let resolver = FakeResolver::default()
+            .with_answer("one.example", vec!["192.0.2.1".parse().unwrap()])
+            .with_answer("two.example", vec!["192.0.2.2".parse().unwrap()])
+            .with_answer("three.example", vec!["192.0.2.3".parse().unwrap()]);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let mut budget = DnsRequestBudget::new(deadline, 2, 3);
+
+        let _ = check_dns_blocklist_with("one.example", &resolver, &mut budget);
+        let _ = check_dns_blocklist_with("two.example", &resolver, &mut budget);
+        let _ = check_dns_blocklist_with("three.example", &resolver, &mut budget);
+
+        let calls = resolver.calls();
+        assert_eq!(calls.len(), 3, "one subject plus two DNSBL queries");
+        assert!(calls
+            .iter()
+            .all(|(_, call_deadline)| *call_deadline == deadline));
+        assert!(!calls.iter().any(|(name, _)| name == "two.example"));
+        assert!(!calls.iter().any(|(name, _)| name == "three.example"));
+    }
+
+    #[test]
+    fn repeated_subject_uses_cached_dns_result() {
+        let resolver = FakeResolver::default()
+            .with_answer("repeat.example", vec!["192.0.2.1".parse().unwrap()]);
+        let mut budget = DnsRequestBudget::new(Instant::now() + Duration::from_secs(1), 1, 4);
+
+        assert!(budget
+            .resolve_subject(&resolver, "REPEAT.example.")
+            .is_some());
+        assert!(budget
+            .resolve_subject(&resolver, "repeat.example")
+            .is_some());
+        assert_eq!(resolver.calls().len(), 1);
+    }
 }

--- a/crates/tirith-core/src/network/mod.rs
+++ b/crates/tirith-core/src/network/mod.rs
@@ -1,5 +1,7 @@
 pub mod dns;
 pub mod shorturl;
 
-pub use dns::check_dns_blocklist;
+pub use dns::{
+    check_dns_blocklist, check_dns_blocklist_with, DnsRequestBudget, DnsResolver, SystemDnsResolver,
+};
 pub use shorturl::resolve_shortened_url;

--- a/crates/tirith-core/src/threatdb_api.rs
+++ b/crates/tirith-core/src/threatdb_api.rs
@@ -250,6 +250,12 @@ pub fn enrich_command(
         // (repo-0348).
         let mut candidates: Vec<String> = Vec::new();
         let mut candidate_set: HashSet<String> = HashSet::new();
+        let dns_resolver = crate::network::SystemDnsResolver::new().ok();
+        // DNS classification shares the enrichment deadline and one lookup per
+        // candidate at most. If system DNS is unavailable or time is exhausted,
+        // dotted hostnames fail closed and are not disclosed to Google.
+        let mut dns_budget =
+            crate::network::DnsRequestBudget::new(deadline, MAX_ENRICH_URLS, MAX_ENRICH_URLS);
         // Same ordering as the package budget: the cap counts candidates that
         // will actually be looked up, so repeats cannot displace a distinct URL.
         for url_info in urls {
@@ -258,7 +264,14 @@ pub fn enrich_command(
                 url_budget_truncated = true;
                 break;
             }
-            if let Some(url) = safe_browsing_candidate_url(&url_info.parsed, &url_info.raw) {
+            if let Some(url) = safe_browsing_candidate_url(
+                &url_info.parsed,
+                &url_info.raw,
+                dns_resolver
+                    .as_ref()
+                    .map(|resolver| resolver as &dyn crate::network::DnsResolver),
+                &mut dns_budget,
+            ) {
                 if candidate_set.insert(url.clone()) {
                     candidates.push(url);
                 }
@@ -756,26 +769,54 @@ fn query_safe_browsing_batch(
     else {
         return out;
     };
-    let Some(mut parsed) = read_json_bounded::<SafeBrowsingResponse>(response, MAX_RESPONSE_BYTES)
+    let Some(parsed) = read_json_bounded::<SafeBrowsingResponse>(response, MAX_RESPONSE_BYTES)
     else {
         return out;
     };
+    out.extend(cache_successful_safe_browsing_batch(&missing, parsed));
+    out
+}
+
+/// Persist every outcome from one successfully parsed Safe Browsing response.
+/// The API omits clean entries, so each requested URL not present in a complete,
+/// fully mappable `matches` response receives an authenticated empty cache
+/// envelope. Transport, status, parse, truncation, or response-mapping failures
+/// are never cached as clean.
+fn cache_successful_safe_browsing_batch(
+    requested: &[&str],
+    mut parsed: SafeBrowsingResponse,
+) -> Vec<(String, String)> {
+    // If the decoded match list exceeds our cap, omitted entries are unknown,
+    // not confirmed clean. Positive entries within the cap remain actionable,
+    // but no negative cache entry may be synthesized from an incomplete view.
+    let response_complete = parsed.matches.len() <= MAX_DECODED_ITEMS;
     parsed.matches.truncate(MAX_DECODED_ITEMS);
-    // Cache the per-URL outcome (positive match or confirmed-clean empty
-    // response) so repeated scans of the same URL stay offline.
-    for m in parsed.matches.drain(..) {
-        let url = m.threat_entry.url.clone();
-        if url.is_empty() {
-            continue;
+    let requested_set: HashSet<&str> = requested.iter().copied().collect();
+    let mut by_url: std::collections::HashMap<String, Vec<SafeBrowsingMatch>> =
+        std::collections::HashMap::new();
+    let mut response_mappable = true;
+    for matched in parsed.matches {
+        let url = matched.threat_entry.url.clone();
+        // A compromised/malformed response cannot plant cache entries for URLs
+        // that were absent from this authenticated request batch.
+        if requested_set.contains(url.as_str()) {
+            by_url.entry(url).or_default().push(matched);
+        } else {
+            response_mappable = false;
         }
+    }
+
+    let mut out = Vec::new();
+    for &url in requested {
         let single = SafeBrowsingResponse {
-            matches: vec![SafeBrowsingMatch {
-                threat_type: m.threat_type.clone(),
-                threat_entry: m.threat_entry.clone(),
-            }],
+            matches: by_url.remove(url).unwrap_or_default(),
         };
-        store_cache("safe-browsing", &url, &single);
-        out.push((url, m.threat_type));
+        if let Some(matched) = single.matches.first() {
+            out.push((url.to_string(), matched.threat_type.clone()));
+            store_cache("safe-browsing", url, &single);
+        } else if response_complete && response_mappable {
+            store_cache("safe-browsing", url, &single);
+        }
     }
     out
 }
@@ -946,7 +987,12 @@ fn parse_rfc3339_secs(raw: &str) -> Option<i64> {
         .map(|dt| dt.timestamp())
 }
 
-fn safe_browsing_candidate_url(parsed: &UrlLike, raw: &str) -> Option<String> {
+fn safe_browsing_candidate_url(
+    parsed: &UrlLike,
+    raw: &str,
+    resolver: Option<&dyn crate::network::DnsResolver>,
+    dns_budget: &mut crate::network::DnsRequestBudget,
+) -> Option<String> {
     let candidate = match parsed {
         UrlLike::Standard { parsed, .. } if matches!(parsed.scheme(), "http" | "https") => {
             parsed.as_str()
@@ -956,19 +1002,24 @@ fn safe_browsing_candidate_url(parsed: &UrlLike, raw: &str) -> Option<String> {
         }
         _ => return None,
     };
-    privacy_scrub_url(candidate)
+    privacy_scrub_url(candidate, resolver, dns_budget)
 }
 
 /// Reduce a URL to the minimum form Safe Browsing can evaluate, and refuse
 /// URLs that must never leave the machine (repo-0346):
 ///
-///  * userinfo, query string, and fragment are stripped — presigned URLs,
-///    password-reset links, and bearer tokens must not be transmitted to a
-///    third party (or persisted in the on-disk cache);
+///  * userinfo, path, query string, and fragment are stripped — presigned URLs,
+///    password-reset links, route identifiers, and bearer tokens must not be
+///    transmitted to a third party (or persisted in the on-disk cache);
 ///  * private, loopback, link-local, and otherwise non-public destinations
-///    are excluded entirely via the server-URL validator;
+///    are excluded, including dotted split-DNS names that resolve to any
+///    non-public address;
 ///  * anything that does not parse as an http(s) URL is excluded.
-fn privacy_scrub_url(raw: &str) -> Option<String> {
+fn privacy_scrub_url(
+    raw: &str,
+    resolver: Option<&dyn crate::network::DnsResolver>,
+    dns_budget: &mut crate::network::DnsRequestBudget,
+) -> Option<String> {
     let mut parsed = url::Url::parse(raw).ok()?;
     if !matches!(parsed.scheme(), "http" | "https") {
         return None;
@@ -998,7 +1049,7 @@ fn privacy_scrub_url(raw: &str) -> Option<String> {
             }
         }
         url::Host::Domain(domain) => {
-            let lower = domain.to_ascii_lowercase();
+            let lower = domain.trim_end_matches('.').to_ascii_lowercase();
             let intranet = !lower.contains('.')
                 || lower == "localhost"
                 || lower.ends_with(".local")
@@ -1008,8 +1059,19 @@ fn privacy_scrub_url(raw: &str) -> Option<String> {
             if intranet {
                 return None;
             }
+            let addresses = dns_budget.resolve_subject(resolver?, &lower)?;
+            if addresses.is_empty()
+                || addresses.iter().any(|address| {
+                    !crate::url_validate::is_public_addr(&std::net::SocketAddr::new(*address, 0))
+                })
+            {
+                return None;
+            }
         }
     }
+    // Keep only the origin. Secrets embedded in path segments are as sensitive
+    // as query tokens, and Safe Browsing does not justify disclosing them.
+    parsed.set_path("/");
     Some(parsed.into())
 }
 
@@ -1098,17 +1160,70 @@ fn ecosystems_registry_name(ecosystem: Ecosystem) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::net::IpAddr;
+    use std::sync::Mutex;
     use url::Url;
+
+    #[derive(Default)]
+    struct FakeDns {
+        answers: HashMap<String, Option<Vec<IpAddr>>>,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl FakeDns {
+        fn public_for(names: &[&str]) -> Self {
+            let answers = names
+                .iter()
+                .map(|name| {
+                    (
+                        (*name).to_string(),
+                        Some(vec!["93.184.216.34".parse().expect("public IP")]),
+                    )
+                })
+                .collect();
+            Self {
+                answers,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_answer(mut self, name: &str, addresses: Option<Vec<IpAddr>>) -> Self {
+            self.answers.insert(name.to_string(), addresses);
+            self
+        }
+    }
+
+    impl crate::network::DnsResolver for FakeDns {
+        fn lookup_ips(&self, name: &str, _deadline: Instant) -> Option<Vec<IpAddr>> {
+            self.calls
+                .lock()
+                .expect("DNS calls lock")
+                .push(name.to_string());
+            self.answers.get(name).cloned().flatten()
+        }
+    }
+
+    fn dns_budget() -> crate::network::DnsRequestBudget {
+        crate::network::DnsRequestBudget::new(Instant::now() + Duration::from_secs(1), 64, 64)
+    }
 
     #[test]
     fn safe_browsing_filter_only_accepts_http_urls() {
+        let resolver = FakeDns::public_for(&["example.com", "phish.example"]);
+        let mut budget = dns_budget();
         let parsed = UrlLike::Standard {
             parsed: Url::parse("https://example.com/login").expect("url"),
             raw_host: "example.com".to_string(),
         };
         assert_eq!(
-            safe_browsing_candidate_url(&parsed, "https://example.com/login"),
-            Some("https://example.com/login".to_string())
+            safe_browsing_candidate_url(
+                &parsed,
+                "https://example.com/login",
+                Some(&resolver),
+                &mut budget,
+            ),
+            Some("https://example.com/".to_string())
         );
 
         let unparsed = UrlLike::Unparsed {
@@ -1117,7 +1232,12 @@ mod tests {
             raw_path: None,
         };
         assert_eq!(
-            safe_browsing_candidate_url(&unparsed, "http://phish.example"),
+            safe_browsing_candidate_url(
+                &unparsed,
+                "http://phish.example",
+                Some(&resolver),
+                &mut budget,
+            ),
             // The scrubber parses and re-serializes; an empty path normalizes
             // to `/`.
             Some("http://phish.example/".to_string())
@@ -1130,7 +1250,12 @@ mod tests {
             digest: None,
         };
         assert_eq!(
-            safe_browsing_candidate_url(&docker, "ghcr.io/owner/image"),
+            safe_browsing_candidate_url(
+                &docker,
+                "ghcr.io/owner/image",
+                Some(&resolver),
+                &mut budget,
+            ),
             None
         );
 
@@ -1140,23 +1265,37 @@ mod tests {
             path: "owner/repo.git".to_string(),
         };
         assert_eq!(
-            safe_browsing_candidate_url(&scp, "git@github.com:owner/repo.git"),
+            safe_browsing_candidate_url(
+                &scp,
+                "git@github.com:owner/repo.git",
+                Some(&resolver),
+                &mut budget,
+            ),
             None
         );
     }
 
     #[test]
     fn privacy_scrub_strips_secrets_and_rejects_internal_urls() {
-        // Userinfo, query, and fragment are removed before transmission.
+        let resolver =
+            FakeDns::public_for(&["example.com", "storage.example", "downloads.example.com"]);
+        let mut budget = dns_budget();
+        // Userinfo, path, query, and fragment are removed before transmission.
         assert_eq!(
-            privacy_scrub_url("https://user:pass@example.com/reset?token=secret123#frag"),
-            Some("https://example.com/reset".to_string())
+            privacy_scrub_url(
+                "https://user:pass@example.com/reset/secret123?token=secret123#frag",
+                Some(&resolver),
+                &mut budget,
+            ),
+            Some("https://example.com/".to_string())
         );
         assert_eq!(
             privacy_scrub_url(
-                "https://storage.example/x.tar.gz?X-Amz-Signature=abc&X-Amz-Expires=60"
+                "https://storage.example/x.tar.gz?X-Amz-Signature=abc&X-Amz-Expires=60",
+                Some(&resolver),
+                &mut budget,
             ),
-            Some("https://storage.example/x.tar.gz".to_string())
+            Some("https://storage.example/".to_string())
         );
         // Private / loopback / link-local literals and intranet names never leave.
         for raw in [
@@ -1169,12 +1308,124 @@ mod tests {
             "http://metadata.google.internal/computeMetadata/v1/",
             "http://intranet/hr",
         ] {
-            assert_eq!(privacy_scrub_url(raw), None, "must not transmit: {raw}");
+            assert_eq!(
+                privacy_scrub_url(raw, Some(&resolver), &mut budget),
+                None,
+                "must not transmit: {raw}"
+            );
         }
-        // Public destinations survive (with scheme/host intact).
+        // Public destinations survive as origins only.
         assert_eq!(
-            privacy_scrub_url("https://downloads.example.com/pkg.tar.gz"),
-            Some("https://downloads.example.com/pkg.tar.gz".to_string())
+            privacy_scrub_url(
+                "https://downloads.example.com/pkg.tar.gz",
+                Some(&resolver),
+                &mut budget,
+            ),
+            Some("https://downloads.example.com/".to_string())
+        );
+    }
+
+    #[test]
+    fn privacy_scrub_rejects_private_mixed_and_unresolved_dotted_names() {
+        let resolver = FakeDns::default()
+            .with_answer(
+                "private.example.com",
+                Some(vec!["10.0.0.7".parse().unwrap()]),
+            )
+            .with_answer(
+                "mixed.example.com",
+                Some(vec![
+                    "93.184.216.34".parse().unwrap(),
+                    "192.168.1.9".parse().unwrap(),
+                ]),
+            )
+            .with_answer("missing.example.com", None)
+            .with_answer(
+                "public.example.com",
+                Some(vec!["93.184.216.34".parse().unwrap()]),
+            );
+        let mut budget = dns_budget();
+
+        assert_eq!(
+            privacy_scrub_url(
+                "https://unclassified.example.com/private/path",
+                None,
+                &mut budget,
+            ),
+            None,
+            "a dotted hostname must not be disclosed when DNS classification is unavailable"
+        );
+
+        for host in [
+            "private.example.com",
+            "mixed.example.com",
+            "missing.example.com",
+        ] {
+            let raw = format!("https://{host}/internal/reset-token");
+            assert_eq!(
+                privacy_scrub_url(&raw, Some(&resolver), &mut budget),
+                None,
+                "must not disclose {host}"
+            );
+        }
+        assert_eq!(
+            privacy_scrub_url(
+                "https://public.example.com/private/path",
+                Some(&resolver),
+                &mut budget,
+            ),
+            Some("https://public.example.com/".to_string())
+        );
+        assert_eq!(
+            privacy_scrub_url("https://93.184.216.34/private/path", None, &mut budget),
+            Some("https://93.184.216.34/".to_string())
+        );
+    }
+
+    #[test]
+    fn successful_safe_browsing_batch_caches_clean_and_matched_results() {
+        let _guard = tirith_test_support::GlobalStateGuard::new().expect("isolated state");
+        let clean = "https://clean.example/";
+        let matched = "https://matched.example/";
+        let extraneous = "https://not-requested.example/";
+        let parsed = SafeBrowsingResponse {
+            matches: vec![SafeBrowsingMatch {
+                threat_type: "MALWARE".to_string(),
+                threat_entry: SafeBrowsingThreatEntry {
+                    url: matched.to_string(),
+                },
+            }],
+        };
+
+        let out = cache_successful_safe_browsing_batch(&[clean, matched], parsed);
+        assert_eq!(out, vec![(matched.to_string(), "MALWARE".to_string())]);
+
+        let clean_cache: SafeBrowsingResponse =
+            load_cache("safe-browsing", clean, CACHE_TTL_SECS).expect("clean cache entry");
+        assert!(clean_cache.matches.is_empty());
+        let matched_cache: SafeBrowsingResponse =
+            load_cache("safe-browsing", matched, CACHE_TTL_SECS).expect("matched cache entry");
+        assert_eq!(matched_cache.matches.len(), 1);
+
+        let ambiguous_clean = "https://ambiguous-clean.example/";
+        let malformed = SafeBrowsingResponse {
+            matches: vec![SafeBrowsingMatch {
+                threat_type: "SOCIAL_ENGINEERING".to_string(),
+                threat_entry: SafeBrowsingThreatEntry {
+                    url: extraneous.to_string(),
+                },
+            }],
+        };
+        assert!(cache_successful_safe_browsing_batch(&[ambiguous_clean], malformed).is_empty());
+        assert!(load_cache::<SafeBrowsingResponse>(
+            "safe-browsing",
+            ambiguous_clean,
+            CACHE_TTL_SECS
+        )
+        .is_none());
+        assert!(
+            load_cache::<SafeBrowsingResponse>("safe-browsing", extraneous, CACHE_TTL_SECS)
+                .is_none()
         );
     }
 

--- a/crates/tirith-core/src/threatdb_feeds.rs
+++ b/crates/tirith-core/src/threatdb_feeds.rs
@@ -1,7 +1,151 @@
-use std::io::{Read, Seek};
+use std::collections::BTreeSet;
+use std::io::{BufRead, Read, Seek};
 use std::net::Ipv4Addr;
 
 use crate::threatdb::BehaviorTag;
+
+/// Hard decoded-input ceiling for one remotely sourced threat-intelligence feed.
+/// Parsers enforce this while reading, so a missing or false Content-Length does
+/// not turn a feed into an unbounded allocation.
+pub const MAX_FEED_INPUT_BYTES: u64 = 64 * 1024 * 1024;
+/// Maximum logical records consumed from one feed.
+pub const MAX_FEED_RECORDS: usize = 1_000_000;
+/// Maximum columns accepted in one CSV record.
+pub const MAX_FEED_FIELDS: usize = 128;
+/// Maximum UTF-8 bytes accepted in one field/line.
+pub const MAX_FEED_FIELD_BYTES: usize = 16 * 1024;
+/// Maximum unique host/IP indicators returned by one parser or accumulated into
+/// the supplemental overlay.
+pub const MAX_FEED_ENTRIES: usize = 250_000;
+const MAX_FEED_ARCHIVE_MEMBERS: usize = 128;
+
+#[derive(Clone, Copy)]
+struct FeedLimits {
+    input_bytes: u64,
+    records: usize,
+    fields: usize,
+    field_bytes: usize,
+    entries: usize,
+}
+
+const DEFAULT_FEED_LIMITS: FeedLimits = FeedLimits {
+    input_bytes: MAX_FEED_INPUT_BYTES,
+    records: MAX_FEED_RECORDS,
+    fields: MAX_FEED_FIELDS,
+    field_bytes: MAX_FEED_FIELD_BYTES,
+    entries: MAX_FEED_ENTRIES,
+};
+
+/// Reader that permits at most `remaining` bytes and probes once at the
+/// boundary. Unlike `Read::take`, excess input is an error rather than a
+/// successful truncated EOF.
+struct CappedReader<R> {
+    inner: R,
+    remaining: u64,
+}
+
+impl<R> CappedReader<R> {
+    fn new(inner: R, remaining: u64) -> Self {
+        Self { inner, remaining }
+    }
+}
+
+impl<R: Read> Read for CappedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.remaining == 0 {
+            let mut probe = [0u8; 1];
+            return match self.inner.read(&mut probe)? {
+                0 => Ok(0),
+                _ => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "threat-intelligence feed exceeds decoded input limit",
+                )),
+            };
+        }
+        let allowed = usize::try_from(self.remaining.min(buf.len() as u64)).unwrap_or(buf.len());
+        let read = self.inner.read(&mut buf[..allowed])?;
+        self.remaining = self.remaining.saturating_sub(read as u64);
+        Ok(read)
+    }
+}
+
+#[derive(Default)]
+struct FeedAccumulator {
+    hostnames: BTreeSet<String>,
+    ips: BTreeSet<Ipv4Addr>,
+}
+
+impl FeedAccumulator {
+    fn len(&self) -> usize {
+        self.hostnames.len() + self.ips.len()
+    }
+
+    fn add_hostname(
+        &mut self,
+        hostname: String,
+        feed: &str,
+        limits: FeedLimits,
+    ) -> Result<(), String> {
+        if !self.hostnames.contains(&hostname) && self.len() >= limits.entries {
+            return Err(format!(
+                "{feed} exceeds the unique-indicator limit of {}",
+                limits.entries
+            ));
+        }
+        self.hostnames.insert(hostname);
+        Ok(())
+    }
+
+    fn add_ip(&mut self, ip: Ipv4Addr, feed: &str, limits: FeedLimits) -> Result<(), String> {
+        if !self.ips.contains(&ip) && self.len() >= limits.entries {
+            return Err(format!(
+                "{feed} exceeds the unique-indicator limit of {}",
+                limits.entries
+            ));
+        }
+        self.ips.insert(ip);
+        Ok(())
+    }
+
+    fn finish(self) -> FeedEntries {
+        FeedEntries {
+            hostnames: self.hostnames.into_iter().collect(),
+            ips: self.ips.into_iter().collect(),
+        }
+    }
+}
+
+fn validate_record(
+    feed: &str,
+    record_number: usize,
+    record: &csv::StringRecord,
+    limits: FeedLimits,
+) -> Result<(), String> {
+    if record_number > limits.records {
+        return Err(format!(
+            "{feed} exceeds the record limit of {}",
+            limits.records
+        ));
+    }
+    if record.len() > limits.fields {
+        return Err(format!(
+            "{feed} record {record_number} has {} fields (max {})",
+            record.len(),
+            limits.fields
+        ));
+    }
+    if let Some(field) = record.iter().find(|field| field.len() > limits.field_bytes) {
+        return Err(format!(
+            "{feed} record {record_number} has a {}-byte field (max {})",
+            field.len(),
+            limits.field_bytes
+        ));
+    }
+    Ok(())
+}
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FeedEntries {
@@ -24,54 +168,71 @@ pub fn extract_hostname_from_url(raw: &str) -> Option<String> {
 }
 
 pub fn parse_urlhaus_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
+    parse_urlhaus_csv_with_limits(reader, DEFAULT_FEED_LIMITS)
+}
+
+fn parse_urlhaus_csv_with_limits<R: Read>(
+    reader: R,
+    limits: FeedLimits,
+) -> Result<FeedEntries, String> {
     let mut csv = csv::ReaderBuilder::new()
         .has_headers(true)
         .flexible(false)
-        .from_reader(reader);
+        .from_reader(CappedReader::new(reader, limits.input_bytes));
     let headers = csv
         .headers()
         .map_err(|e| format!("URLhaus headers: {e}"))?
         .clone();
+    validate_record("URLhaus", 0, &headers, limits)?;
 
     let url_idx = headers
         .iter()
         .position(|header| matches!(header, "url" | "urlhaus_link"))
         .ok_or_else(|| format!("URLhaus schema error: no 'url' column in headers {headers:?}"))?;
 
-    let mut entries = FeedEntries::default();
-    for record in csv.records() {
+    let mut entries = FeedAccumulator::default();
+    for (index, record) in csv.records().enumerate() {
         let record = record.map_err(|e| format!("URLhaus record error: {e}"))?;
+        validate_record("URLhaus", index + 1, &record, limits)?;
         let raw = record.get(url_idx).or_else(|| {
             record
                 .iter()
                 .find(|value| value.starts_with("http://") || value.starts_with("https://"))
         });
         if let Some(host) = raw.and_then(extract_hostname_from_url) {
-            entries.hostnames.push(host);
+            entries.add_hostname(host, "URLhaus", limits)?;
         }
     }
-    entries.sort_and_dedup();
-    Ok(entries)
+    Ok(entries.finish())
 }
 
 pub fn parse_threatfox_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
+    parse_threatfox_csv_with_limits(reader, DEFAULT_FEED_LIMITS)
+}
+
+fn parse_threatfox_csv_with_limits<R: Read>(
+    reader: R,
+    limits: FeedLimits,
+) -> Result<FeedEntries, String> {
     let mut csv = csv::ReaderBuilder::new()
         .has_headers(true)
         .flexible(false)
-        .from_reader(reader);
+        .from_reader(CappedReader::new(reader, limits.input_bytes));
     let headers = csv
         .headers()
         .map_err(|e| format!("ThreatFox headers: {e}"))?
         .clone();
+    validate_record("ThreatFox", 0, &headers, limits)?;
 
     let ioc_idx = headers.iter().position(|header| header == "ioc");
     let ioc_type_idx = headers.iter().position(|header| header == "ioc_type");
     let ioc_idx = ioc_idx
         .ok_or_else(|| format!("ThreatFox schema error: no 'ioc' column in headers {headers:?}"))?;
 
-    let mut entries = FeedEntries::default();
-    for record in csv.records() {
+    let mut entries = FeedAccumulator::default();
+    for (index, record) in csv.records().enumerate() {
         let record = record.map_err(|e| format!("ThreatFox record error: {e}"))?;
+        validate_record("ThreatFox", index + 1, &record, limits)?;
 
         let raw_ioc = record.get(ioc_idx).or_else(|| {
             record.iter().find(|value| {
@@ -90,7 +251,7 @@ pub fn parse_threatfox_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
 
         if raw_ioc.starts_with("http://") || raw_ioc.starts_with("https://") {
             if let Some(host) = extract_hostname_from_url(raw_ioc) {
-                entries.hostnames.push(host);
+                entries.add_hostname(host, "ThreatFox", limits)?;
             }
             continue;
         }
@@ -98,79 +259,86 @@ pub fn parse_threatfox_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
         if matches!(ioc_type.as_str(), "ip:port" | "ip_port") {
             let ip_part = raw_ioc.split(':').next().unwrap_or(raw_ioc);
             if let Ok(ip) = ip_part.parse::<Ipv4Addr>() {
-                entries.ips.push(ip);
+                entries.add_ip(ip, "ThreatFox", limits)?;
             }
             continue;
         }
 
         if let Ok(ip) = raw_ioc.parse::<Ipv4Addr>() {
-            entries.ips.push(ip);
+            entries.add_ip(ip, "ThreatFox", limits)?;
             continue;
         }
 
         if !raw_ioc.contains('/') && raw_ioc.contains('.') {
-            entries.hostnames.push(raw_ioc.to_ascii_lowercase());
+            entries.add_hostname(raw_ioc.to_ascii_lowercase(), "ThreatFox", limits)?;
         }
     }
 
-    entries.sort_and_dedup();
-    Ok(entries)
+    Ok(entries.finish())
 }
 
 pub fn parse_threatfox_zip<R: Read + Seek>(reader: R) -> Result<FeedEntries, String> {
     let mut archive =
         zip::ZipArchive::new(reader).map_err(|e| format!("ThreatFox ZIP open failed: {e}"))?;
+    if archive.len() > MAX_FEED_ARCHIVE_MEMBERS {
+        return Err(format!(
+            "ThreatFox ZIP contains {} members (max {MAX_FEED_ARCHIVE_MEMBERS})",
+            archive.len()
+        ));
+    }
     for idx in 0..archive.len() {
-        let mut file = archive
+        let file = archive
             .by_index(idx)
             .map_err(|e| format!("ThreatFox ZIP read failed: {e}"))?;
         if !file.name().ends_with(".csv") {
             continue;
         }
 
-        // Cap decompressed size to prevent zip bombs.
-        const MAX_DECOMPRESSED: u64 = 512 * 1024 * 1024;
-        let mut csv_bytes = Vec::new();
-        file.by_ref()
-            .take(MAX_DECOMPRESSED + 1)
-            .read_to_end(&mut csv_bytes)
-            .map_err(|e| format!("ThreatFox ZIP extraction failed: {e}"))?;
-        if csv_bytes.len() as u64 > MAX_DECOMPRESSED {
+        // Stream the decompressed member directly into the bounded CSV parser;
+        // never materialize a second 512 MiB buffer.
+        if file.size() > MAX_FEED_INPUT_BYTES {
             return Err(format!(
                 "ThreatFox CSV exceeds {} MiB decompressed size limit",
-                MAX_DECOMPRESSED / (1024 * 1024)
+                MAX_FEED_INPUT_BYTES / (1024 * 1024)
             ));
         }
-        return parse_threatfox_csv(std::io::Cursor::new(csv_bytes))
-            .map_err(|e| format!("ThreatFox CSV parse failed: {e}"));
+        return parse_threatfox_csv(file).map_err(|e| format!("ThreatFox CSV parse failed: {e}"));
     }
 
     Err("ThreatFox ZIP did not contain a CSV payload".to_string())
 }
 
 pub fn parse_phishtank_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
+    parse_phishtank_csv_with_limits(reader, DEFAULT_FEED_LIMITS)
+}
+
+fn parse_phishtank_csv_with_limits<R: Read>(
+    reader: R,
+    limits: FeedLimits,
+) -> Result<FeedEntries, String> {
     let mut csv = csv::ReaderBuilder::new()
         .has_headers(true)
         .flexible(false)
-        .from_reader(reader);
+        .from_reader(CappedReader::new(reader, limits.input_bytes));
     let headers = csv
         .headers()
         .map_err(|e| format!("PhishTank headers: {e}"))?
         .clone();
+    validate_record("PhishTank", 0, &headers, limits)?;
     let url_idx = headers
         .iter()
         .position(|header| header == "url")
         .ok_or_else(|| format!("PhishTank schema error: no 'url' column in headers {headers:?}"))?;
 
-    let mut entries = FeedEntries::default();
-    for record in csv.records() {
+    let mut entries = FeedAccumulator::default();
+    for (index, record) in csv.records().enumerate() {
         let record = record.map_err(|e| format!("PhishTank record error: {e}"))?;
+        validate_record("PhishTank", index + 1, &record, limits)?;
         if let Some(host) = record.get(url_idx).and_then(extract_hostname_from_url) {
-            entries.hostnames.push(host);
+            entries.add_hostname(host, "PhishTank", limits)?;
         }
     }
-    entries.sort_and_dedup();
-    Ok(entries)
+    Ok(entries.finish())
 }
 
 /// Parse a DigitalSide Threat-Intel MISP-style CSV export.
@@ -199,13 +367,20 @@ pub fn parse_phishtank_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
 /// plus IPv4; file-hash ingestion is deferred to a follow-up (the
 /// `CuratedFileHashes` path).
 pub fn parse_digitalside_csv<R: Read>(reader: R) -> Result<FeedEntries, String> {
+    parse_digitalside_csv_with_limits(reader, DEFAULT_FEED_LIMITS)
+}
+
+fn parse_digitalside_csv_with_limits<R: Read>(
+    reader: R,
+    limits: FeedLimits,
+) -> Result<FeedEntries, String> {
     // has_headers(false) so we detect the header ourselves. has_headers(true)
     // would consume the first row of a headerless export as the header and drop
     // that indicator.
     let mut rdr = csv::ReaderBuilder::new()
         .has_headers(false)
         .flexible(false)
-        .from_reader(reader);
+        .from_reader(CappedReader::new(reader, limits.input_bytes));
     let mut records = rdr.records();
 
     let first = match records.next() {
@@ -213,6 +388,7 @@ pub fn parse_digitalside_csv<R: Read>(reader: R) -> Result<FeedEntries, String> 
         Some(Err(e)) => return Err(format!("DigitalSide first record: {e}")),
         None => return Ok(FeedEntries::default()),
     };
+    validate_record("DigitalSide", 1, &first, limits)?;
     let has_header = first.iter().any(|field| field == "type")
         && first.iter().any(|field| field == "value")
         && first.iter().any(|field| field == "to_ids");
@@ -234,9 +410,13 @@ pub fn parse_digitalside_csv<R: Read>(reader: R) -> Result<FeedEntries, String> 
     // row is a real indicator and is ingested with the rest.
     let leading = if has_header { None } else { Some(Ok(first)) };
 
-    let mut entries = FeedEntries::default();
-    for record in leading.into_iter().chain(records) {
+    let mut entries = FeedAccumulator::default();
+    for (index, record) in leading.into_iter().chain(records).enumerate() {
         let record = record.map_err(|e| format!("DigitalSide record error: {e}"))?;
+        // `index == 0` may be the already-validated leading record for a
+        // headerless export; validating it twice is harmless and keeps the
+        // logical-record budget uniform.
+        validate_record("DigitalSide", index + 1, &record, limits)?;
 
         // MISP `to_ids` gate: ingest only analyst-flagged detectable indicators.
         if record.get(to_ids_idx).map(str::trim) != Some("1") {
@@ -258,17 +438,17 @@ pub fn parse_digitalside_csv<R: Read>(reader: R) -> Result<FeedEntries, String> 
         match ioc_type.as_str() {
             "url" => {
                 if let Some(host) = extract_hostname_from_url(value) {
-                    entries.hostnames.push(host);
+                    entries.add_hostname(host, "DigitalSide", limits)?;
                 }
             }
             // A domain/hostname attribute is a bare host; the guard rejects a
             // stray URL sneaking into the field before it is stored.
             "domain" | "hostname" if !value.contains('/') => {
-                entries.hostnames.push(value.to_ascii_lowercase());
+                entries.add_hostname(value.to_ascii_lowercase(), "DigitalSide", limits)?;
             }
             "ip-src" | "ip-dst" => {
                 if let Ok(ip) = value.parse::<Ipv4Addr>() {
-                    entries.ips.push(ip);
+                    entries.add_ip(ip, "DigitalSide", limits)?;
                 }
             }
             // filename, md5/sha*, mime-type, comment, and every other type are
@@ -277,8 +457,7 @@ pub fn parse_digitalside_csv<R: Read>(reader: R) -> Result<FeedEntries, String> 
         }
     }
 
-    entries.sort_and_dedup();
-    Ok(entries)
+    Ok(entries.finish())
 }
 
 pub fn parse_domain_blocklist(contents: &str) -> FeedEntries {
@@ -307,6 +486,57 @@ pub fn parse_domain_blocklist(contents: &str) -> FeedEntries {
     }
     entries.sort_and_dedup();
     entries
+}
+
+/// Streaming, fail-closed form of [`parse_domain_blocklist`] for remote feeds.
+/// The compatibility wrapper above remains infallible for curated local files;
+/// network consumers must use this entry point so excess records/fields/input
+/// preserve the last-known-good overlay instead of publishing a prefix.
+pub fn parse_domain_blocklist_reader<R: Read>(reader: R) -> Result<FeedEntries, String> {
+    parse_domain_blocklist_reader_with_limits(reader, DEFAULT_FEED_LIMITS)
+}
+
+fn parse_domain_blocklist_reader_with_limits<R: Read>(
+    reader: R,
+    limits: FeedLimits,
+) -> Result<FeedEntries, String> {
+    let reader = std::io::BufReader::new(CappedReader::new(reader, limits.input_bytes));
+    let mut entries = FeedAccumulator::default();
+    for (index, line) in reader.split(b'\n').enumerate() {
+        let line = line.map_err(|error| format!("domain blocklist read failed: {error}"))?;
+        let record_number = index + 1;
+        if record_number > limits.records {
+            return Err(format!(
+                "domain blocklist exceeds the record limit of {}",
+                limits.records
+            ));
+        }
+        if line.len() > limits.field_bytes {
+            return Err(format!(
+                "domain blocklist record {record_number} has a {}-byte field (max {})",
+                line.len(),
+                limits.field_bytes
+            ));
+        }
+        let line = std::str::from_utf8(&line)
+            .map_err(|error| format!("domain blocklist is not UTF-8: {error}"))?
+            .trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let token = line
+            .split_whitespace()
+            .take_while(|value| !value.starts_with('#'))
+            .last()
+            .unwrap_or(line);
+        if token.eq_ignore_ascii_case("localhost") || token.starts_with("127.") {
+            continue;
+        }
+        if token.contains('.') && !token.contains('/') {
+            entries.add_hostname(token.to_ascii_lowercase(), "domain blocklist", limits)?;
+        }
+    }
+    Ok(entries.finish())
 }
 
 /// Parse a curated exfiltration-endpoint / webhook-catcher hostname list.
@@ -479,6 +709,46 @@ pub fn parse_tor_exit_list(contents: &str) -> FeedEntries {
     }
     entries.sort_and_dedup();
     entries
+}
+
+/// Streaming, bounded Tor-exit parser for remote supplemental updates.
+pub fn parse_tor_exit_list_reader<R: Read>(reader: R) -> Result<FeedEntries, String> {
+    parse_tor_exit_list_reader_with_limits(reader, DEFAULT_FEED_LIMITS)
+}
+
+fn parse_tor_exit_list_reader_with_limits<R: Read>(
+    reader: R,
+    limits: FeedLimits,
+) -> Result<FeedEntries, String> {
+    let reader = std::io::BufReader::new(CappedReader::new(reader, limits.input_bytes));
+    let mut entries = FeedAccumulator::default();
+    for (index, line) in reader.split(b'\n').enumerate() {
+        let line = line.map_err(|error| format!("Tor exit feed read failed: {error}"))?;
+        let record_number = index + 1;
+        if record_number > limits.records {
+            return Err(format!(
+                "Tor exit feed exceeds the record limit of {}",
+                limits.records
+            ));
+        }
+        if line.len() > limits.field_bytes {
+            return Err(format!(
+                "Tor exit record {record_number} has a {}-byte field (max {})",
+                line.len(),
+                limits.field_bytes
+            ));
+        }
+        let line = std::str::from_utf8(&line)
+            .map_err(|error| format!("Tor exit feed is not UTF-8: {error}"))?
+            .trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Ok(ip) = line.parse::<Ipv4Addr>() {
+            entries.add_ip(ip, "Tor exit feed", limits)?;
+        }
+    }
+    Ok(entries.finish())
 }
 
 #[cfg(test)]
@@ -771,5 +1041,104 @@ mod tests {
 
         let csv = "ioc,ioc_type\nbad.example,domain\n\"unclosed,domain\n";
         assert!(parse_threatfox_csv(csv.as_bytes()).is_err());
+    }
+
+    fn tiny_limits() -> FeedLimits {
+        FeedLimits {
+            input_bytes: 1024,
+            records: 2,
+            fields: 4,
+            field_bytes: 64,
+            entries: 2,
+        }
+    }
+
+    #[test]
+    fn csv_limits_fail_closed_for_records_fields_and_aggregate_entries() {
+        let mut limits = tiny_limits();
+        limits.records = 1;
+        let two_rows = "url\nhttps://one.example/\nhttps://two.example/\n";
+        let error = parse_urlhaus_csv_with_limits(two_rows.as_bytes(), limits).unwrap_err();
+        assert!(error.contains("record limit"), "{error}");
+
+        let mut limits = tiny_limits();
+        limits.field_bytes = 8;
+        let wide = "url\nhttps://wide.example/\n";
+        let error = parse_urlhaus_csv_with_limits(wide.as_bytes(), limits).unwrap_err();
+        assert!(error.contains("byte field"), "{error}");
+
+        let mut limits = tiny_limits();
+        limits.fields = 1;
+        let wide_record = "url,other\nhttps://one.example/,x\n";
+        let error = parse_urlhaus_csv_with_limits(wide_record.as_bytes(), limits).unwrap_err();
+        assert!(error.contains("fields"), "{error}");
+
+        let mut limits = tiny_limits();
+        limits.entries = 1;
+        let two_unique = "url\nhttps://one.example/\nhttps://two.example/\n";
+        let error = parse_urlhaus_csv_with_limits(two_unique.as_bytes(), limits).unwrap_err();
+        assert!(error.contains("unique-indicator limit"), "{error}");
+
+        let duplicate = "url\nhttps://one.example/\nhttps://one.example/\n";
+        let parsed = parse_urlhaus_csv_with_limits(duplicate.as_bytes(), limits).unwrap();
+        assert_eq!(parsed.hostnames, vec!["one.example"]);
+    }
+
+    #[test]
+    fn decoded_input_cap_is_enforced_during_streaming_read() {
+        let mut limits = tiny_limits();
+        limits.input_bytes = 24;
+        let input = "url\nhttps://one.example/\n";
+        let error = parse_urlhaus_csv_with_limits(input.as_bytes(), limits).unwrap_err();
+        assert!(error.contains("decoded input limit"), "{error}");
+
+        limits.input_bytes = input.len() as u64;
+        let parsed = parse_urlhaus_csv_with_limits(input.as_bytes(), limits).unwrap();
+        assert_eq!(parsed.hostnames, vec!["one.example"]);
+    }
+
+    #[test]
+    fn streaming_line_feeds_refuse_partial_prefixes_at_every_budget() {
+        let mut limits = tiny_limits();
+        limits.records = 1;
+        let error = parse_domain_blocklist_reader_with_limits(
+            "one.example\ntwo.example\n".as_bytes(),
+            limits,
+        )
+        .unwrap_err();
+        assert!(error.contains("record limit"), "{error}");
+
+        let mut limits = tiny_limits();
+        limits.field_bytes = 4;
+        let error = parse_domain_blocklist_reader_with_limits("wide.example\n".as_bytes(), limits)
+            .unwrap_err();
+        assert!(error.contains("byte field"), "{error}");
+
+        let mut limits = tiny_limits();
+        limits.entries = 1;
+        let error =
+            parse_tor_exit_list_reader_with_limits("203.0.113.1\n203.0.113.2\n".as_bytes(), limits)
+                .unwrap_err();
+        assert!(error.contains("unique-indicator limit"), "{error}");
+    }
+
+    #[test]
+    fn threatfox_zip_rejects_excess_member_table() {
+        let mut cursor = Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut cursor);
+            for index in 0..=MAX_FEED_ARCHIVE_MEMBERS {
+                zip.start_file(
+                    format!("member-{index}.txt"),
+                    zip::write::SimpleFileOptions::default(),
+                )
+                .unwrap();
+                zip.write_all(b"x").unwrap();
+            }
+            zip.finish().unwrap();
+        }
+        cursor.set_position(0);
+        let error = parse_threatfox_zip(cursor).unwrap_err();
+        assert!(error.contains("members"), "{error}");
     }
 }

--- a/crates/tirith-core/tests/generate_test_fixtures.rs
+++ b/crates/tirith-core/tests/generate_test_fixtures.rs
@@ -7,12 +7,13 @@
 //! `<repo>/tests/fixtures/test-threatdb.dat` (signed test DB).
 
 use std::net::Ipv4Addr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ed25519_dalek::SigningKey;
 use rand_core::OsRng;
 
 use tirith_core::threatdb::{Confidence, Ecosystem, ThreatDbWriter, ThreatSource};
+use tirith_core::util::ContainedAtomicFile;
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -25,6 +26,18 @@ fn repo_root() -> PathBuf {
 
 fn crate_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn write_private_key(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "private key path has no parent",
+        )
+    })?;
+    let destination = ContainedAtomicFile::prepare(parent, path, false)?;
+    let mut reader = bytes;
+    destination.write_atomic_from_reader(&mut reader, true, Some(0o600))
 }
 
 /// Generate a fresh Ed25519 keypair: write the public key to assets (embedded
@@ -40,7 +53,7 @@ fn generate_keypair() -> SigningKey {
     use base64::Engine;
     let b64 = base64::engine::general_purpose::STANDARD.encode(signing_key.to_bytes());
     let key_path = repo_root().join("threatdb-signing.key");
-    std::fs::write(&key_path, &b64)
+    write_private_key(&key_path, b64.as_bytes())
         .unwrap_or_else(|e| panic!("Failed to write {}: {}", key_path.display(), e));
     eprintln!("Wrote private key to {}", key_path.display());
 
@@ -118,4 +131,43 @@ fn generate_keypair_and_test_db() {
     let key = generate_keypair();
     build_test_db(&key);
     eprintln!("Done. Now rebuild tirith-core to embed the new public key.");
+}
+
+#[cfg(unix)]
+#[test]
+fn private_key_create_and_update_are_exactly_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().unwrap();
+    let key_path = directory.path().join("threatdb-signing.key");
+
+    write_private_key(&key_path, b"first key").unwrap();
+    let created_mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o7777;
+    assert_eq!(created_mode, 0o600);
+
+    std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    write_private_key(&key_path, b"replacement key").unwrap();
+    let updated_mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o7777;
+    assert_eq!(updated_mode, 0o600);
+    assert_eq!(std::fs::read(&key_path).unwrap(), b"replacement key");
+}
+
+#[cfg(unix)]
+#[test]
+fn private_key_write_refuses_a_symlink_destination() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let victim = directory.path().join("victim");
+    let key_path = directory.path().join("threatdb-signing.key");
+    std::fs::write(&victim, b"preserve me").unwrap();
+    symlink(&victim, &key_path).unwrap();
+
+    write_private_key(&key_path, b"replacement key").unwrap_err();
+
+    assert_eq!(std::fs::read(&victim).unwrap(), b"preserve me");
+    assert!(std::fs::symlink_metadata(&key_path)
+        .unwrap()
+        .file_type()
+        .is_symlink());
 }

--- a/crates/tirith/src/cli/daemon.rs
+++ b/crates/tirith/src/cli/daemon.rs
@@ -593,6 +593,12 @@ fn handle_request(req: &DaemonRequest) -> DaemonResponse {
 #[cfg(unix)]
 fn enrich_with_network_checks(findings: &mut Vec<Finding>) {
     let mut new_findings = Vec::new();
+    // One cancellable resolver and one absolute budget cover every host in this
+    // daemon request. Distinct attacker-controlled findings cannot each reset
+    // the DNS deadline/query allowance.
+    let mut dns = network::SystemDnsResolver::new()
+        .ok()
+        .map(|resolver| (resolver, network::DnsRequestBudget::dnsbl()));
 
     // Resolve shortened URLs and surface blocklist hits on destinations.
     for finding in findings.iter_mut() {
@@ -612,7 +618,12 @@ fn enrich_with_network_checks(findings: &mut Vec<Finding>) {
 
                 // DNS blocklist on the resolved destination's host.
                 if let Some(host) = extract_host_from_url(&resolved) {
-                    let blocklist_hits = network::check_dns_blocklist(&host);
+                    let blocklist_hits = dns
+                        .as_mut()
+                        .map(|(resolver, budget)| {
+                            network::check_dns_blocklist_with(&host, resolver, budget)
+                        })
+                        .unwrap_or_default();
                     if !blocklist_hits.is_empty() {
                         new_findings.push(Finding {
                             rule_id: RuleId::ShortenedUrl,
@@ -642,7 +653,12 @@ fn enrich_with_network_checks(findings: &mut Vec<Finding>) {
             if let Evidence::Url { raw } = evidence {
                 if let Some(host) = extract_host_from_url(raw) {
                     if checked_hosts.insert(host.clone()) {
-                        let hits = network::check_dns_blocklist(&host);
+                        let hits = dns
+                            .as_mut()
+                            .map(|(resolver, budget)| {
+                                network::check_dns_blocklist_with(&host, resolver, budget)
+                            })
+                            .unwrap_or_default();
                         if !hits.is_empty() {
                             new_findings.push(Finding {
                                 rule_id: finding.rule_id,

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -12,8 +12,8 @@ use tirith_core::policy;
 use tirith_core::selfupdate::SemVer;
 use tirith_core::threatdb::{ThreatDb, ThreatDbWriter, ThreatSource, MAX_FORMAT_VERSION};
 use tirith_core::threatdb_feeds::{
-    parse_domain_blocklist, parse_phishtank_csv, parse_threatfox_zip, parse_tor_exit_list,
-    parse_urlhaus_csv,
+    parse_domain_blocklist_reader, parse_phishtank_csv, parse_threatfox_zip,
+    parse_tor_exit_list_reader, parse_urlhaus_csv, MAX_FEED_ENTRIES, MAX_FEED_INPUT_BYTES,
 };
 
 /// Pinned Ed25519 manifest-verify key. MUST stay in sync with
@@ -44,7 +44,7 @@ const MANIFEST_TIMEOUT_SECS: u64 = 15;
 const DB_DOWNLOAD_TIMEOUT_SECS: u64 = 120;
 const SUPPLEMENTAL_DOWNLOAD_TIMEOUT_SECS: u64 = 120;
 /// Max bytes read from any single supplemental feed response.
-const MAX_SUPPLEMENTAL_FEED_SIZE: u64 = 256 * 1024 * 1024;
+const MAX_SUPPLEMENTAL_FEED_SIZE: u64 = MAX_FEED_INPUT_BYTES;
 
 const LOCKFILE_NAME: &str = "threatdb-update.lock";
 const NEXT_CHECK_FILE: &str = "threatdb-next-check-at";
@@ -76,7 +76,7 @@ fn validate_remote_url(url: &str, purpose: &str) -> Result<(), String> {
         .map_err(|reason| format!("refusing unsafe {purpose} URL: {reason}"))
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 struct Manifest {
     sha256: String,
     size: u64,
@@ -99,6 +99,12 @@ impl Manifest {
 
     /// Verify the manifest signature against the pinned public key.
     fn verify_signature(&self) -> Result<(), String> {
+        let verify_key = VerifyingKey::from_bytes(VERIFY_KEY_BYTES)
+            .map_err(|e| format!("invalid embedded public key: {e}"))?;
+        self.verify_signature_with_key(&verify_key)
+    }
+
+    fn verify_signature_with_key(&self, verify_key: &VerifyingKey) -> Result<(), String> {
         let sig_bytes =
             base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &self.signature)
                 .map_err(|e| format!("invalid manifest signature encoding: {e}"))?;
@@ -113,9 +119,6 @@ impl Manifest {
 
         let signature = Signature::from_slice(&sig_bytes)
             .map_err(|e| format!("invalid manifest signature: {e}"))?;
-
-        let verify_key = VerifyingKey::from_bytes(VERIFY_KEY_BYTES)
-            .map_err(|e| format!("invalid embedded public key: {e}"))?;
 
         let payload = self.canonical_payload();
         use ed25519_dalek::Verifier;
@@ -357,7 +360,7 @@ pub fn update(force: bool, background: bool) -> i32 {
 }
 
 /// Outcome of a primary-DB update attempt.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UpdateOutcome {
     /// A new primary DB was downloaded, verified, and installed.
     Installed,
@@ -390,16 +393,32 @@ fn do_update(force: bool) -> Result<(), String> {
         }
     };
 
-    // Refresh the cache, then run the supplemental update ONLY when a new primary
-    // was actually installed (matching the pre-DB-B behavior: an already-current
-    // DB does not trigger a supplemental refresh).
+    // Primary currentness and supplemental currentness are independent. Enabling,
+    // retrying, or disabling an opt-in feed must reconcile the overlay even when
+    // the signed primary DB was already current.
     ThreatDb::refresh_cache();
-    if outcome == UpdateOutcome::Installed {
-        if let Err(e) = update_supplemental_db(&policy::Policy::discover(None)) {
-            eprintln!("tirith: warning: supplemental threat DB update failed: {e}");
-        }
+    if let Err(e) = reconcile_supplemental_after_primary(outcome, || {
+        update_supplemental_db(&policy::Policy::discover(None))
+    }) {
+        eprintln!("tirith: warning: supplemental threat DB update failed: {e}");
     }
     Ok(())
+}
+
+fn reconcile_supplemental_after_primary<F>(
+    outcome: UpdateOutcome,
+    reconcile: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    match outcome {
+        UpdateOutcome::Installed | UpdateOutcome::AlreadyCurrent => reconcile(),
+        UpdateOutcome::NoCompatibleAsset => Err(
+            "internal error: supplemental reconciliation reached before primary selection"
+                .to_string(),
+        ),
+    }
 }
 
 /// Attempt the v2-index update path. Returns:
@@ -672,13 +691,39 @@ impl SupplementalEntries {
         &mut self,
         entries: tirith_core::threatdb_feeds::FeedEntries,
         source: ThreatSource,
-    ) -> usize {
-        let count = entries.hostnames.len() + entries.ips.len();
+    ) -> Result<usize, String> {
+        self.ingest_with_limit(entries, source, MAX_FEED_ENTRIES)
+    }
+
+    fn ingest_with_limit(
+        &mut self,
+        entries: tirith_core::threatdb_feeds::FeedEntries,
+        source: ThreatSource,
+        limit: usize,
+    ) -> Result<usize, String> {
+        let count = entries
+            .hostnames
+            .len()
+            .checked_add(entries.ips.len())
+            .ok_or_else(|| "supplemental feed entry count overflow".to_string())?;
+        let current = self
+            .hostnames
+            .len()
+            .checked_add(self.ips.len())
+            .ok_or_else(|| "supplemental aggregate entry count overflow".to_string())?;
+        let projected = current
+            .checked_add(count)
+            .ok_or_else(|| "supplemental aggregate entry count overflow".to_string())?;
+        if projected > limit {
+            return Err(format!(
+                "supplemental feeds exceed the aggregate indicator limit of {limit}"
+            ));
+        }
         self.hostnames
             .extend(entries.hostnames.into_iter().map(|h| (h, source)));
         self.ips
             .extend(entries.ips.into_iter().map(|ip| (ip, source)));
-        count
+        Ok(count)
     }
 }
 
@@ -696,7 +741,7 @@ fn update_supplemental_db(policy: &policy::Policy) -> Result<(), String> {
     let phishing_enabled = policy.threat_intel.phishing_army_enabled;
 
     if !abusech_enabled && !phishing_enabled {
-        let _ = std::fs::remove_file(&supplemental_path);
+        remove_disabled_supplemental(&supplemental_path)?;
         ThreatDb::refresh_cache();
         return Ok(());
     }
@@ -794,6 +839,17 @@ fn update_supplemental_db(policy: &policy::Policy) -> Result<(), String> {
     Ok(())
 }
 
+fn remove_disabled_supplemental(path: &std::path::Path) -> Result<(), String> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "failed to remove disabled supplemental threat DB {}: {error}",
+            path.display()
+        )),
+    }
+}
+
 /// Log a feed outcome; `true` when the feed genuinely produced entries.
 /// repo-0441: an EMPTY successful response is treated as a failure for
 /// publication purposes — a wiped/zero-answer upstream must not shrink the DB.
@@ -817,10 +873,9 @@ fn fetch_urlhaus_feed(
     supplemental: &mut SupplementalEntries,
 ) -> Result<usize, String> {
     let url = URLHAUS_EXPORT_TEMPLATE.replace("{auth_key}", auth_key);
-    let body = fetch_text(client, &url)?;
-    let entries = parse_urlhaus_csv(Cursor::new(body.into_bytes()))
-        .map_err(|e| format!("URLhaus parse failed: {e}"))?;
-    Ok(supplemental.ingest(entries, ThreatSource::Urlhaus))
+    let response = fetch_feed_response(client, &url)?;
+    let entries = parse_urlhaus_csv(response).map_err(|e| format!("URLhaus parse failed: {e}"))?;
+    supplemental.ingest(entries, ThreatSource::Urlhaus)
 }
 
 fn fetch_threatfox_feed(
@@ -831,35 +886,37 @@ fn fetch_threatfox_feed(
     let url = THREATFOX_EXPORT_TEMPLATE.replace("{auth_key}", auth_key);
     let zip_bytes = fetch_bytes(client, &url)?;
     let entries = parse_threatfox_zip(Cursor::new(zip_bytes))?;
-    Ok(supplemental.ingest(entries, ThreatSource::ThreatFoxIoc))
+    supplemental.ingest(entries, ThreatSource::ThreatFoxIoc)
 }
 
 fn fetch_phishing_army_feed(
     client: &reqwest::blocking::Client,
     supplemental: &mut SupplementalEntries,
 ) -> Result<usize, String> {
-    let body = fetch_text(client, PHISHING_ARMY_URL)?;
-    let entries = parse_domain_blocklist(&body);
-    Ok(supplemental.ingest(entries, ThreatSource::PhishingArmy))
+    let response = fetch_feed_response(client, PHISHING_ARMY_URL)?;
+    let entries = parse_domain_blocklist_reader(response)
+        .map_err(|e| format!("Phishing Army parse failed: {e}"))?;
+    supplemental.ingest(entries, ThreatSource::PhishingArmy)
 }
 
 fn fetch_phishtank_feed(
     client: &reqwest::blocking::Client,
     supplemental: &mut SupplementalEntries,
 ) -> Result<usize, String> {
-    let body = fetch_text(client, PHISHTANK_URL)?;
-    let entries = parse_phishtank_csv(Cursor::new(body.into_bytes()))
-        .map_err(|e| format!("PhishTank parse failed: {e}"))?;
-    Ok(supplemental.ingest(entries, ThreatSource::PhishTank))
+    let response = fetch_feed_response(client, PHISHTANK_URL)?;
+    let entries =
+        parse_phishtank_csv(response).map_err(|e| format!("PhishTank parse failed: {e}"))?;
+    supplemental.ingest(entries, ThreatSource::PhishTank)
 }
 
 fn fetch_tor_exit_feed(
     client: &reqwest::blocking::Client,
     supplemental: &mut SupplementalEntries,
 ) -> Result<usize, String> {
-    let body = fetch_text(client, TOR_EXIT_URL)?;
-    let entries = parse_tor_exit_list(&body);
-    Ok(supplemental.ingest(entries, ThreatSource::TorExit))
+    let response = fetch_feed_response(client, TOR_EXIT_URL)?;
+    let entries =
+        parse_tor_exit_list_reader(response).map_err(|e| format!("Tor exit parse failed: {e}"))?;
+    supplemental.ingest(entries, ThreatSource::TorExit)
 }
 
 /// Redact query-string secrets (e.g. `?auth-key=...`) from a URL for log/error use.
@@ -871,14 +928,10 @@ fn redact_url(url: &str) -> String {
     }
 }
 
-fn fetch_text(client: &reqwest::blocking::Client, url: &str) -> Result<String, String> {
-    let bytes = fetch_bytes(client, url)?;
-    let safe = redact_url(url);
-    String::from_utf8(bytes)
-        .map_err(|e| format!("failed to decode UTF-8 response body for {safe}: {e}"))
-}
-
-fn fetch_bytes(client: &reqwest::blocking::Client, url: &str) -> Result<Vec<u8>, String> {
+fn fetch_feed_response(
+    client: &reqwest::blocking::Client,
+    url: &str,
+) -> Result<reqwest::blocking::Response, String> {
     let safe = redact_url(url);
     validate_remote_url(url, "supplemental feed")?;
     let response = client
@@ -904,6 +957,21 @@ fn fetch_bytes(client: &reqwest::blocking::Client, url: &str) -> Result<Vec<u8>,
             format!("fetch failed for {safe}: {reason}")
         })?;
 
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_SUPPLEMENTAL_FEED_SIZE)
+    {
+        return Err(format!(
+            "response body for {safe} exceeds {} bytes",
+            MAX_SUPPLEMENTAL_FEED_SIZE
+        ));
+    }
+    Ok(response)
+}
+
+fn fetch_bytes(client: &reqwest::blocking::Client, url: &str) -> Result<Vec<u8>, String> {
+    let safe = redact_url(url);
+    let response = fetch_feed_response(client, url)?;
     let content_length = response.content_length();
     read_bounded_bytes(response, &safe, content_length, MAX_SUPPLEMENTAL_FEED_SIZE)
 }
@@ -1297,34 +1365,64 @@ pub fn maybe_background_update(offline_flag: bool) {
     }
 }
 
-/// Fetch the manifest from the primary URL, falling back to the release asset URL
-/// when the primary fetch fails OR the primary manifest is older than the current
-/// DB (e.g. manifest PR not yet merged).
+/// Fetch and authenticate both independently published legacy manifests, then
+/// select the newest verified candidate. Selection cannot run on merely parsed
+/// JSON: an invalid primary must not suppress a valid fallback, and an older
+/// replayed primary must not beat a newer signed release candidate.
 fn fetch_manifest() -> Result<Manifest, String> {
-    match fetch_manifest_from(MANIFEST_URL_PRIMARY) {
-        Ok(m) => {
-            // If the primary version is at or below the installed DB, try the
-            // fallback in case it's ahead (releases can lag the raw path).
-            if let Some(db) = ThreatDb::cached() {
-                if m.version <= db.build_sequence() {
-                    eprintln!("tirith: primary manifest is stale (v{} <= current v{}), trying fallback...",
-                        m.version, db.build_sequence());
-                    match fetch_manifest_from(MANIFEST_URL_FALLBACK) {
-                        Ok(fallback) if fallback.version > db.build_sequence() => {
-                            return Ok(fallback)
-                        }
-                        _ => {}
-                    }
+    let verify_key = VerifyingKey::from_bytes(VERIFY_KEY_BYTES)
+        .map_err(|error| format!("invalid embedded public key: {error}"))?;
+    fetch_manifest_with(fetch_manifest_from, &verify_key)
+}
+
+fn fetch_verified_manifest_candidate<F>(
+    fetch: &mut F,
+    url: &str,
+    verify_key: &VerifyingKey,
+) -> Result<Manifest, String>
+where
+    F: FnMut(&str) -> Result<Manifest, String>,
+{
+    let manifest = fetch(url)?;
+    manifest.verify_signature_with_key(verify_key)?;
+    Ok(manifest)
+}
+
+fn fetch_manifest_with<F>(mut fetch: F, verify_key: &VerifyingKey) -> Result<Manifest, String>
+where
+    F: FnMut(&str) -> Result<Manifest, String>,
+{
+    let primary = fetch_verified_manifest_candidate(&mut fetch, MANIFEST_URL_PRIMARY, verify_key);
+    let fallback = fetch_verified_manifest_candidate(&mut fetch, MANIFEST_URL_FALLBACK, verify_key);
+    match (primary, fallback) {
+        (Ok(primary), Ok(fallback)) => match primary.version.cmp(&fallback.version) {
+            std::cmp::Ordering::Greater => Ok(primary),
+            std::cmp::Ordering::Less => Ok(fallback),
+            std::cmp::Ordering::Equal => {
+                if primary.canonical_payload() != fallback.canonical_payload() {
+                    return Err(format!(
+                        "legacy manifest equivocation: primary and fallback both claim version {} with different signed payloads",
+                        primary.version
+                    ));
                 }
+                Ok(primary)
             }
-            Ok(m)
+        },
+        (Ok(primary), Err(fallback_error)) => {
+            eprintln!(
+                "tirith: legacy manifest fallback unavailable or invalid ({fallback_error}); using verified primary"
+            );
+            Ok(primary)
         }
-        Err(primary_err) => {
-            eprintln!("tirith: primary manifest unavailable ({primary_err}), trying fallback...");
-            fetch_manifest_from(MANIFEST_URL_FALLBACK).map_err(|fallback_err| {
-                format!("manifest fetch failed: primary: {primary_err}; fallback: {fallback_err}")
-            })
+        (Err(primary_error), Ok(fallback)) => {
+            eprintln!(
+                "tirith: legacy manifest primary unavailable or invalid ({primary_error}); using verified fallback"
+            );
+            Ok(fallback)
         }
+        (Err(primary_error), Err(fallback_error)) => Err(format!(
+            "legacy manifest fetch/verification failed: primary: {primary_error}; fallback: {fallback_error}"
+        )),
     }
 }
 
@@ -2945,6 +3043,168 @@ mod tests {
             size: 1024,
             min_tirith_version: min.map(str::to_string),
         }
+    }
+
+    fn signed_manifest(version: u64, url: &str, sha256: &str, key: &SigningKey) -> Manifest {
+        let mut manifest = Manifest {
+            sha256: sha256.to_string(),
+            size: 1024,
+            url: url.to_string(),
+            version,
+            signature: String::new(),
+        };
+        use ed25519_dalek::Signer;
+        let signature = key.sign(manifest.canonical_payload().as_bytes());
+        manifest.signature = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            signature.to_bytes(),
+        );
+        manifest
+    }
+
+    #[test]
+    fn already_current_primary_still_reconciles_supplemental_state() {
+        for outcome in [UpdateOutcome::Installed, UpdateOutcome::AlreadyCurrent] {
+            let mut calls = 0usize;
+            reconcile_supplemental_after_primary(outcome, || {
+                calls += 1;
+                Ok(())
+            })
+            .unwrap();
+            assert_eq!(calls, 1, "{outcome:?} must reconcile exactly once");
+        }
+        let mut calls = 0usize;
+        assert!(
+            reconcile_supplemental_after_primary(UpdateOutcome::NoCompatibleAsset, || {
+                calls += 1;
+                Ok(())
+            })
+            .is_err()
+        );
+        assert_eq!(
+            calls, 0,
+            "an unresolved primary must not publish an overlay"
+        );
+    }
+
+    #[test]
+    fn disabled_supplemental_removal_is_idempotent_and_reports_real_failures() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("supplemental.dat");
+        std::fs::write(&path, b"stale overlay").unwrap();
+        remove_disabled_supplemental(&path).unwrap();
+        assert!(!path.exists());
+        remove_disabled_supplemental(&path).unwrap();
+
+        let directory = root.path().join("not-a-file");
+        std::fs::create_dir(&directory).unwrap();
+        let error = remove_disabled_supplemental(&directory).unwrap_err();
+        assert!(error.contains("failed to remove"), "{error}");
+        assert!(directory.is_dir());
+    }
+
+    #[test]
+    fn supplemental_aggregate_limit_is_atomic() {
+        let mut supplemental = SupplementalEntries::default();
+        let first = tirith_core::threatdb_feeds::FeedEntries {
+            hostnames: vec!["one.example".to_string()],
+            ips: vec![],
+        };
+        assert_eq!(
+            supplemental
+                .ingest_with_limit(first, ThreatSource::Urlhaus, 1)
+                .unwrap(),
+            1
+        );
+        let second = tirith_core::threatdb_feeds::FeedEntries {
+            hostnames: vec!["two.example".to_string()],
+            ips: vec![],
+        };
+        let error = supplemental
+            .ingest_with_limit(second, ThreatSource::PhishingArmy, 1)
+            .unwrap_err();
+        assert!(error.contains("aggregate indicator limit"), "{error}");
+        assert_eq!(supplemental.hostnames.len(), 1);
+        assert_eq!(supplemental.hostnames[0].0, "one.example");
+    }
+
+    #[test]
+    fn legacy_invalid_primary_uses_valid_signed_fallback() {
+        let key = SigningKey::from_bytes(&[0x31; 32]);
+        let fallback = signed_manifest(
+            12,
+            "https://example.com/fallback.dat",
+            &"b".repeat(64),
+            &key,
+        );
+        let mut invalid_primary =
+            signed_manifest(13, "https://example.com/primary.dat", &"a".repeat(64), &key);
+        invalid_primary.version = 14;
+
+        let selected = fetch_manifest_with(
+            |url| {
+                if url == MANIFEST_URL_PRIMARY {
+                    Ok(invalid_primary.clone())
+                } else {
+                    Ok(fallback.clone())
+                }
+            },
+            &key.verifying_key(),
+        )
+        .expect("valid fallback must survive an unauthenticated primary");
+        assert_eq!(selected.version, 12);
+        assert!(selected
+            .verify_signature_with_key(&key.verifying_key())
+            .is_ok());
+    }
+
+    #[test]
+    fn legacy_selection_chooses_newest_only_after_both_verify() {
+        let key = SigningKey::from_bytes(&[0x32; 32]);
+        let primary = signed_manifest(11, "https://example.com/primary.dat", &"a".repeat(64), &key);
+        let fallback = signed_manifest(
+            12,
+            "https://example.com/fallback.dat",
+            &"b".repeat(64),
+            &key,
+        );
+        let selected = fetch_manifest_with(
+            |url| {
+                if url == MANIFEST_URL_PRIMARY {
+                    Ok(primary.clone())
+                } else {
+                    Ok(fallback.clone())
+                }
+            },
+            &key.verifying_key(),
+        )
+        .unwrap();
+        assert_eq!(selected.version, 12);
+        assert_eq!(selected.url, fallback.url);
+    }
+
+    #[test]
+    fn legacy_equal_version_signed_equivocation_fails_closed() {
+        let key = SigningKey::from_bytes(&[0x33; 32]);
+        let primary = signed_manifest(12, "https://example.com/primary.dat", &"a".repeat(64), &key);
+        let fallback = signed_manifest(
+            12,
+            "https://example.com/fallback.dat",
+            &"b".repeat(64),
+            &key,
+        );
+        let error = fetch_manifest_with(
+            |url| {
+                if url == MANIFEST_URL_PRIMARY {
+                    Ok(primary.clone())
+                } else {
+                    Ok(fallback.clone())
+                }
+            },
+            &key.verifying_key(),
+        )
+        .unwrap_err();
+        assert!(error.contains("equivocation"), "{error}");
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,14 @@ ignore = [
     # preflight was bypassable via /ObjStm). Remove this ignore
     # (and the .cargo/audit.toml twin) once MSRV/lopdf can move.
     "RUSTSEC-2026-0187",
+    # hickory-proto 0.24.4 BinEncoder name-compression DoS (O(n²) on a
+    # malicious message with many labels). The fixed line is 0.26.1; that
+    # resolver series is a different API than the 0.24 pin in
+    # crates/tirith-core/Cargo.toml (MSRV 1.83). Tirith only encodes DNS
+    # queries it constructs for hostnames already extracted from policy or
+    # command text; it does not re-encode untrusted DNS messages. Remove
+    # this ignore when the resolver can move to >=0.26.1.
+    "RUSTSEC-2026-0119",
 ]
 
 [licenses]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -73,6 +73,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +455,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +743,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +759,51 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.7",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.7",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "home"
@@ -977,6 +1051,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,7 +1151,7 @@ checksum = "4cca98e95f35b29d469dade6724c6f96cec9236640f745a0e99b0334ec320ab1"
 dependencies = [
  "enumflags2",
  "libc",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1088,6 +1175,12 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1134,6 +1227,15 @@ dependencies = [
  "rayon",
  "time",
  "weezl",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1446,6 +1548,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,7 +1579,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -1483,14 +1594,14 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1533,6 +1644,17 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -1540,6 +1662,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1706,6 +1838,12 @@ dependencies = [
  "web-sys",
  "webpki-roots",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -1931,6 +2069,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,11 +2200,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2140,6 +2308,7 @@ dependencies = [
  "fs2",
  "getrandom 0.3.4",
  "hex",
+ "hickory-resolver",
  "home",
  "is-terminal",
  "jsonschema",
@@ -2159,7 +2328,8 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.20",
+ "tokio",
  "toml",
  "unicode-normalization",
  "unicode-script",
@@ -2190,8 +2360,21 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2297,7 +2480,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2536,6 +2731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2848,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3061,7 +3273,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.20",
  "zopfli",
 ]
 

--- a/tools/license-server/src/db.rs
+++ b/tools/license-server/src/db.rs
@@ -466,6 +466,40 @@ impl Db {
                         ?reason,
                         "subscription.revoked did not carry a provably newer timestamp; state unchanged"
                     );
+                    // `Stale` is an ordinary non-advance: the stored state is
+                    // already at or past this event, so declining it is right.
+                    // The other variants mean the event could not be ordered at
+                    // all, and marking it processed below is what makes that
+                    // terminal — the handler answers 200, Polar never
+                    // redelivers, and the subscription stays active with its API
+                    // key unrevoked. Revocation is the one action where silently
+                    // declining keeps paid access open, so record those for the
+                    // dead-letter retry tooling instead of only warning.
+                    if !matches!(reason, EventTimestampError::Stale) {
+                        tx.execute(
+                            "INSERT OR IGNORE INTO dead_letter \
+                             (event_id, subscription_id, event_type, reason, occurred_at, payload) \
+                             VALUES (?1, ?2, 'subscription.revoked', ?3, ?4, ?5)",
+                            params![
+                                data.event_id,
+                                data.subscription_id,
+                                format!("unorderable revoked timestamp: {reason:?}"),
+                                data.occurred_at,
+                                serde_json::json!({
+                                    "subscription_id": data.subscription_id,
+                                    "customer_id": data.customer_id,
+                                    "email": data.email,
+                                    "tier": data.tier,
+                                    "product_id": data.product_id,
+                                    "occurred_at": data.occurred_at,
+                                })
+                                .to_string(),
+                            ],
+                        )
+                        .map_err(|e| {
+                            AppError::Internal(format!("db dead-letter revoked: {e}"))
+                        })?;
+                    }
                     tx.execute(
                         "INSERT INTO webhook_events (event_id, event_type) VALUES (?1, 'subscription.revoked')",
                         params![data.event_id],

--- a/tools/license-server/src/db.rs
+++ b/tools/license-server/src/db.rs
@@ -108,6 +108,37 @@ fn normalize_event_ts(raw: Option<&str>) -> Option<String> {
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EventTimestampError {
+    Missing,
+    InvalidIncoming,
+    InvalidStored,
+    Stale,
+}
+
+/// Validate an event timestamp and compare it to the row version observed in
+/// the same transaction. A missing or unparseable timestamp is never allowed to
+/// carry a lifecycle side effect, and an unparseable legacy row fails closed
+/// until it is repaired deliberately.
+fn ordered_event_timestamp(
+    incoming: Option<&str>,
+    previous: Option<&str>,
+) -> Result<String, EventTimestampError> {
+    let incoming = incoming.ok_or(EventTimestampError::Missing)?;
+    let incoming = chrono::DateTime::parse_from_rfc3339(incoming)
+        .map_err(|_| EventTimestampError::InvalidIncoming)?;
+    if let Some(previous) = previous {
+        let previous = chrono::DateTime::parse_from_rfc3339(previous)
+            .map_err(|_| EventTimestampError::InvalidStored)?;
+        if incoming < previous {
+            return Err(EventTimestampError::Stale);
+        }
+    }
+    Ok(incoming
+        .to_utc()
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
+}
+
 impl Db {
     pub fn open(path: &str) -> Result<Self, AppError> {
         let conn =
@@ -415,6 +446,37 @@ impl Db {
                 return Ok(false);
             }
 
+            let previous_event_at: Option<String> = tx
+                .query_row(
+                    "SELECT last_event_at FROM subscriptions WHERE id=?1",
+                    params![data.subscription_id],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .optional()
+                .map_err(|e| AppError::Internal(format!("db read revoked order: {e}")))?
+                .flatten();
+            let occurred_at = match ordered_event_timestamp(
+                data.occurred_at.as_deref(),
+                previous_event_at.as_deref(),
+            ) {
+                Ok(occurred_at) => occurred_at,
+                Err(reason) => {
+                    tracing::warn!(
+                        event_id = %data.event_id,
+                        ?reason,
+                        "subscription.revoked did not carry a provably newer timestamp; state unchanged"
+                    );
+                    tx.execute(
+                        "INSERT INTO webhook_events (event_id, event_type) VALUES (?1, 'subscription.revoked')",
+                        params![data.event_id],
+                    )
+                    .map_err(|e| AppError::Internal(format!("db mark rejected revoked: {e}")))?;
+                    tx.commit()
+                        .map_err(|e| AppError::Internal(format!("db commit: {e}")))?;
+                    return Ok(false);
+                }
+            };
+
             tx.execute(
                 "INSERT INTO subscriptions (id, customer_id, email, tier, status, product_id, last_event_at)
                  VALUES (?1, ?2, ?3, ?4, 'revoked', ?5, ?6)
@@ -432,7 +494,7 @@ impl Db {
                     data.email.as_deref().unwrap_or("unknown"),
                     data.tier.as_deref().unwrap_or("unknown"),
                     data.product_id.as_deref().unwrap_or("unknown"),
-                    normalize_event_ts(data.occurred_at.as_deref()),
+                    occurred_at,
                 ],
             )
             .map_err(|e| AppError::Internal(format!("db upsert revoked: {e}")))?;
@@ -516,6 +578,32 @@ impl Db {
             let prev_status = prev_row.as_ref().map(|(s, _)| s.as_str());
             let prev_last_event_at = prev_row.as_ref().and_then(|(_, t)| t.as_deref());
 
+            // Missing, malformed, and stale timestamps are all non-advances.
+            // This check runs before the terminal-state branch so every update
+            // has one ordering contract, including events targeting a revoked
+            // row and `revoked` updates routed through this generic seam.
+            let occurred_at = match ordered_event_timestamp(
+                data.occurred_at.as_deref(),
+                prev_last_event_at,
+            ) {
+                Ok(occurred_at) => occurred_at,
+                Err(reason) => {
+                    tracing::warn!(
+                        event_id = %data.event_id,
+                        ?reason,
+                        "subscription update did not carry a provably newer timestamp; state unchanged"
+                    );
+                    tx.execute(
+                        "INSERT INTO webhook_events (event_id, event_type) VALUES (?1, ?2)",
+                        params![data.event_id, data.event_type],
+                    )
+                    .map_err(|e| AppError::Internal(format!("db mark rejected update: {e}")))?;
+                    tx.commit()
+                        .map_err(|e| AppError::Internal(format!("db commit: {e}")))?;
+                    return Ok(UpdatedOutcome::StaleIgnored);
+                }
+            };
+
             // revoked absorbs every non-revoked transition.
             if prev_status == Some("revoked") && data.new_status != "revoked" {
                 tx.execute(
@@ -525,66 +613,6 @@ impl Db {
                 .map_err(|e| AppError::Internal(format!("db mark event: {e}")))?;
                 tx.commit().map_err(|e| AppError::Internal(format!("db commit: {e}")))?;
                 return Ok(UpdatedOutcome::TerminalIgnored);
-            }
-
-            // Out-of-order guard: a stale/reordered genuine event whose
-            // occurred_at predates the row's last_event_at must not overwrite
-            // the status or touch the `revoked` flag. Without this, an older
-            // `active` arriving after `past_due`/`revoked` would re-enable a
-            // key that was correctly disabled by the newer event.
-            //
-            // Both sides carry a Polar event's `created_at`, but
-            // last_event_at is persisted verbatim from the payload, so an
-            // equivalent-or-older instant may be encoded with a different UTC
-            // offset (e.g. `+02:00` vs `Z`) or fractional-second format. A raw
-            // string compare sorts those incorrectly and would let a stale
-            // event through, so parse BOTH to a normalized instant first and
-            // compare the instants.
-            //
-            // Fail-safe policy: a parse failure must never let a stale event
-            // re-apply status side effects. If the incoming occurred_at is
-            // unparseable we cannot trust it is newer, so we reject it as a
-            // non-advance (StaleIgnored). If prev_last_event_at is unparseable
-            // (e.g. a malformed legacy value) we likewise cannot prove the
-            // incoming event is newer, so we conservatively treat the incoming
-            // event as stale. Only a successful parse of BOTH with
-            // occurred >= prev advances the row.
-            if let (Some(occurred), Some(prev_at)) =
-                (data.occurred_at.as_deref(), prev_last_event_at)
-            {
-                let is_stale = match (
-                    chrono::DateTime::parse_from_rfc3339(occurred),
-                    chrono::DateTime::parse_from_rfc3339(prev_at),
-                ) {
-                    (Ok(occurred_ts), Ok(prev_ts)) => occurred_ts < prev_ts,
-                    (Err(e), _) => {
-                        tracing::warn!(
-                            event_id = %data.event_id,
-                            occurred_at = %occurred,
-                            error = %e,
-                            "unparseable incoming occurred_at; rejecting as stale (non-advance)"
-                        );
-                        true
-                    }
-                    (Ok(_), Err(e)) => {
-                        tracing::warn!(
-                            event_id = %data.event_id,
-                            last_event_at = %prev_at,
-                            error = %e,
-                            "unparseable stored last_event_at; conservatively treating incoming event as stale"
-                        );
-                        true
-                    }
-                };
-                if is_stale {
-                    tx.execute(
-                        "INSERT INTO webhook_events (event_id, event_type) VALUES (?1, ?2)",
-                        params![data.event_id, data.event_type],
-                    )
-                    .map_err(|e| AppError::Internal(format!("db mark event: {e}")))?;
-                    tx.commit().map_err(|e| AppError::Internal(format!("db commit: {e}")))?;
-                    return Ok(UpdatedOutcome::StaleIgnored);
-                }
             }
 
             tx.execute(
@@ -603,7 +631,7 @@ impl Db {
                     data.tier.as_deref().unwrap_or("unknown"),
                     data.new_status,
                     data.product_id.as_deref().unwrap_or("unknown"),
-                    normalize_event_ts(data.occurred_at.as_deref()),
+                    occurred_at,
                 ],
             )
             .map_err(|e| AppError::Internal(format!("db upsert updated: {e}")))?;
@@ -706,10 +734,28 @@ impl Db {
         .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
     }
 
-    /// Atomic consume — DELETE … RETURNING ensures exactly one request
-    /// receives the row.
-    /// repo-0237: non-destructive read of a pending receipt. `receipt_view`
-    /// peeks, decrypts/validates, and only then calls [`Self::receipt_consume`]
+    /// Non-destructive availability check for confirmation pages. This avoids
+    /// loading encrypted credentials for safe GET/HEAD requests.
+    pub async fn receipt_available(&self, receipt_secret: &str) -> Result<bool, AppError> {
+        let conn = self.conn.clone();
+        let secret = receipt_secret.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = acquire_db(&conn);
+            let exists: i64 = conn
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM pending_receipts WHERE receipt_secret=?1 AND expires_at > datetime('now'))",
+                    params![secret],
+                    |row| row.get(0),
+                )
+                .map_err(|e| AppError::Internal(format!("db receipt availability: {e}")))?;
+            Ok(exists != 0)
+        })
+        .await
+        .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
+    }
+
+    /// repo-0237: non-destructive read of a pending receipt. `receipt_consume`
+    /// peeks, decrypts/validates, and only then calls the atomic consume below
     /// — a decryption/validation failure must not destroy the only recoverable
     /// encrypted API key.
     pub async fn receipt_peek(&self, receipt_secret: &str) -> Result<Option<ReceiptRow>, AppError> {
@@ -739,6 +785,8 @@ impl Db {
         .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
     }
 
+    /// Atomic consume — DELETE … RETURNING ensures exactly one request
+    /// receives the row.
     pub async fn receipt_consume(
         &self,
         receipt_secret: &str,
@@ -813,44 +861,60 @@ impl Db {
         .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
     }
 
-    pub async fn insert_token(
+    /// Atomically publish a refresh token only when this subscription has not
+    /// received one inside `min_interval_secs`. The decision and INSERT share
+    /// one SQLite statement while the connection mutex is held, so parallel
+    /// refresh requests cannot all observe an old token and then all win.
+    pub async fn insert_refresh_token_if_due(
         &self,
         sub_id: &str,
         token: &str,
         expires_at: i64,
-    ) -> Result<(), AppError> {
+        min_interval_secs: i64,
+    ) -> Result<bool, AppError> {
         let conn = self.conn.clone();
         let sid = sub_id.to_string();
         let tok = token.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = acquire_db(&conn);
-            conn.execute(
-                "INSERT INTO tokens (subscription_id, token, expires_at) VALUES (?1, ?2, ?3)",
-                params![sid, tok, expires_at],
-            )
-            .map_err(|e| AppError::Internal(format!("db insert token: {e}")))?;
-            Ok(())
+            let inserted = conn
+                .execute(
+                    "INSERT INTO tokens (subscription_id, token, expires_at)
+                     SELECT ?1, ?2, ?3
+                     WHERE NOT EXISTS (
+                       SELECT 1 FROM tokens
+                       WHERE subscription_id=?1
+                         AND CAST(strftime('%s', created_at) AS INTEGER)
+                             > unixepoch('now') - ?4
+                     )",
+                    params![sid, tok, expires_at, min_interval_secs],
+                )
+                .map_err(|e| AppError::Internal(format!("db insert refresh token: {e}")))?;
+            Ok(inserted == 1)
         })
         .await
         .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
     }
 
-    /// Seconds since the most recent token issuance for `sub_id` (`None` when
-    /// never issued). Drives the repo-0449 per-subscription refresh interval.
-    pub async fn seconds_since_last_token(&self, sub_id: &str) -> Result<Option<i64>, AppError> {
-        let conn = self.conn.clone();
-        let sid = sub_id.to_string();
-        tokio::task::spawn_blocking(move || {
-            let conn = acquire_db(&conn);
-            conn.query_row(
-                "SELECT CAST(strftime('%s','now') AS INTEGER) - CAST(strftime('%s', MAX(created_at)) AS INTEGER) FROM tokens WHERE subscription_id=?1",
-                params![sid],
-                |row| row.get::<_, Option<i64>>(0),
-            )
-            .map_err(|e| AppError::Internal(format!("db token age: {e}")))
-        })
-        .await
-        .map_err(|e| AppError::Internal(format!("spawn_blocking: {e}")))?
+    #[cfg(test)]
+    fn count_tokens_for_subscription(&self, sub_id: &str) -> i64 {
+        let conn = acquire_db(&self.conn);
+        conn.query_row(
+            "SELECT COUNT(*) FROM tokens WHERE subscription_id=?1",
+            params![sub_id],
+            |row| row.get(0),
+        )
+        .expect("count tokens")
+    }
+
+    #[cfg(test)]
+    fn delete_tokens_for_subscription(&self, sub_id: &str) {
+        let conn = acquire_db(&self.conn);
+        conn.execute(
+            "DELETE FROM tokens WHERE subscription_id=?1",
+            params![sub_id],
+        )
+        .expect("delete tokens");
     }
 
     pub async fn insert_dead_letter(&self, dl: DeadLetterData) -> Result<(), AppError> {
@@ -1189,6 +1253,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn parallel_refreshes_have_exactly_one_atomic_winner() {
+        let db = test_db();
+        db.process_subscription_created(make_created("evt_1", "sub_1", "team"))
+            .await
+            .unwrap();
+        db.delete_tokens_for_subscription("sub_1");
+
+        let contestants = 16;
+        let barrier = Arc::new(tokio::sync::Barrier::new(contestants));
+        let mut tasks = Vec::new();
+        for index in 0..contestants {
+            let db = db.clone();
+            let barrier = Arc::clone(&barrier);
+            tasks.push(tokio::spawn(async move {
+                barrier.wait().await;
+                db.insert_refresh_token_if_due(
+                    "sub_1",
+                    &format!("refresh-token-{index}"),
+                    9_999_999_999,
+                    60,
+                )
+                .await
+                .unwrap()
+            }));
+        }
+
+        let mut winners = 0;
+        for task in tasks {
+            winners += usize::from(task.await.unwrap());
+        }
+        assert_eq!(winners, 1, "parallel refreshes must have one winner");
+        assert_eq!(db.count_tokens_for_subscription("sub_1"), 1);
+    }
+
+    #[tokio::test]
     async fn test_provision_duplicate_event() {
         let db = test_db();
         let data1 = make_created("evt_1", "sub_1", "team");
@@ -1263,6 +1362,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_receipt_availability_is_non_consuming_until_atomic_consume() {
+        let db = test_db();
+        let mut data = make_created("evt_1", "sub_1", "team");
+        data.checkout_id = Some("checkout_real".to_string());
+        db.process_subscription_created(data).await.unwrap();
+
+        assert!(db.receipt_available("receipt_evt_1").await.unwrap());
+        assert!(db.receipt_available("receipt_evt_1").await.unwrap());
+        assert!(db.receipt_consume("receipt_evt_1").await.unwrap().is_some());
+        assert!(!db.receipt_available("receipt_evt_1").await.unwrap());
+        assert!(db.receipt_consume("receipt_evt_1").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn test_provision_skipped_if_revoked() {
         let db = test_db();
         {
@@ -1323,6 +1436,86 @@ mod tests {
         let (status, revoked) = read_state(&db, "sub_1");
         assert_eq!(status, "revoked");
         assert_eq!(revoked, Some(true));
+    }
+
+    #[tokio::test]
+    async fn stale_revoked_event_cannot_override_newer_active_state() {
+        let db = test_db();
+        db.process_subscription_created(make_created("evt_1", "sub_1", "team"))
+            .await
+            .unwrap();
+
+        let mut newer_active = make_updated("evt_2", "sub_1", "active");
+        newer_active.occurred_at = Some("2024-03-01T00:00:00Z".to_string());
+        assert_eq!(
+            db.process_subscription_updated(newer_active).await.unwrap(),
+            UpdatedOutcome::Unrevoked
+        );
+
+        let mut stale_revoked = make_revoked("evt_3", "sub_1");
+        stale_revoked.occurred_at = Some("2024-02-01T00:00:00Z".to_string());
+        assert!(!db
+            .process_subscription_revoked(stale_revoked)
+            .await
+            .unwrap());
+        let (status, revoked) = read_state(&db, "sub_1");
+        assert_eq!(status, "active");
+        assert_eq!(revoked, Some(false));
+
+        let mut newer_revoked = make_revoked("evt_4", "sub_1");
+        newer_revoked.occurred_at = Some("2024-04-01T00:00:00Z".to_string());
+        assert!(db
+            .process_subscription_revoked(newer_revoked)
+            .await
+            .unwrap());
+        let (status, revoked) = read_state(&db, "sub_1");
+        assert_eq!(status, "revoked");
+        assert_eq!(revoked, Some(true));
+    }
+
+    #[tokio::test]
+    async fn missing_update_timestamp_cannot_reenable_key() {
+        let db = test_db();
+        db.process_subscription_created(make_created("evt_1", "sub_1", "team"))
+            .await
+            .unwrap();
+
+        let mut past_due = make_updated("evt_2", "sub_1", "past_due");
+        past_due.occurred_at = Some("2024-03-01T00:00:00Z".to_string());
+        assert_eq!(
+            db.process_subscription_updated(past_due).await.unwrap(),
+            UpdatedOutcome::Revoked
+        );
+
+        let mut missing_timestamp = make_updated("evt_3", "sub_1", "active");
+        missing_timestamp.occurred_at = None;
+        assert_eq!(
+            db.process_subscription_updated(missing_timestamp)
+                .await
+                .unwrap(),
+            UpdatedOutcome::StaleIgnored
+        );
+        let (status, revoked) = read_state(&db, "sub_1");
+        assert_eq!(status, "past_due");
+        assert_eq!(revoked, Some(true));
+    }
+
+    #[tokio::test]
+    async fn missing_revoked_timestamp_cannot_change_state() {
+        let db = test_db();
+        db.process_subscription_created(make_created("evt_1", "sub_1", "team"))
+            .await
+            .unwrap();
+
+        let mut revoked_event = make_revoked("evt_2", "sub_1");
+        revoked_event.occurred_at = None;
+        assert!(!db
+            .process_subscription_revoked(revoked_event)
+            .await
+            .unwrap());
+        let (status, revoked) = read_state(&db, "sub_1");
+        assert_eq!(status, "active");
+        assert_eq!(revoked, Some(false));
     }
 
     #[tokio::test]

--- a/tools/license-server/src/error.rs
+++ b/tools/license-server/src/error.rs
@@ -12,8 +12,6 @@ pub enum AppError {
     /// Rate limit exceeded (used by rate-limiting middleware)
     #[allow(dead_code)]
     RateLimited,
-    /// Not found (receipt expired, etc.)
-    NotFound(String),
     /// Internal server error (DB, signing, transient)
     Internal(String),
 }
@@ -25,7 +23,6 @@ impl std::fmt::Display for AppError {
             Self::BadWebhook(msg) => write!(f, "bad webhook: {msg}"),
             Self::PaymentRequired(msg) => write!(f, "payment required: {msg}"),
             Self::RateLimited => write!(f, "rate limited"),
-            Self::NotFound(msg) => write!(f, "not found: {msg}"),
             Self::Internal(msg) => write!(f, "internal error: {msg}"),
         }
     }
@@ -38,7 +35,6 @@ impl IntoResponse for AppError {
             Self::BadWebhook(_) => (StatusCode::BAD_REQUEST, "Bad request"),
             Self::PaymentRequired(msg) => (StatusCode::PAYMENT_REQUIRED, msg.as_str()),
             Self::RateLimited => (StatusCode::TOO_MANY_REQUESTS, "Too many requests"),
-            Self::NotFound(msg) => (StatusCode::NOT_FOUND, msg.as_str()),
             Self::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error"),
         };
         (status, body.to_string()).into_response()

--- a/tools/license-server/src/routes/mod.rs
+++ b/tools/license-server/src/routes/mod.rs
@@ -13,6 +13,11 @@ pub fn router() -> Router<AppState> {
         .route("/health", get(health::health))
         .route("/api/polar/webhook", post(webhook::webhook))
         .route("/receipt/lookup", get(receipt::receipt_lookup))
-        .route("/receipt/{receipt_secret}", get(receipt::receipt_view))
+        // `get` also handles HEAD in axum. Both methods only confirm that the
+        // receipt is available; the explicit POST is the sole consuming route.
+        .route(
+            "/receipt/{receipt_secret}",
+            get(receipt::receipt_confirmation).post(receipt::receipt_consume),
+        )
         .route("/api/license/refresh", post(refresh::refresh))
 }

--- a/tools/license-server/src/routes/receipt.rs
+++ b/tools/license-server/src/routes/receipt.rs
@@ -1,7 +1,7 @@
 use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{Method, StatusCode};
 use axum::response::{IntoResponse, Redirect, Response};
 use serde::Deserialize;
 use tracing::error;
@@ -13,8 +13,7 @@ use crate::state::AppState;
 pub struct LookupQuery {
     pub checkout: String,
     /// `1` when the not-ready page polls via fetch (repo-0235): returns JSON
-    /// instead of a redirect so the one-time receipt is not consumed by the
-    /// poller.
+    /// instead of following a redirect into the human confirmation page.
     #[serde(default)]
     pub poll: Option<String>,
 }
@@ -29,10 +28,9 @@ pub async fn receipt_lookup(
 
     let secret = state.db.receipt_lookup(&query.checkout).await?;
 
-    // repo-0235: the not-ready poller must NOT follow the redirect — fetch()
-    // auto-follows into /receipt/{secret}, consuming the one-time row, and the
-    // discarded body leaves the customer at a perpetual "not ready". Polling
-    // with `poll=1` returns the URL as JSON; the script navigates top-level.
+    // repo-0235: the not-ready poller must not follow the redirect into HTML it
+    // cannot interpret. Polling with `poll=1` returns the confirmation URL as
+    // JSON; the script then navigates there at top level.
     if query.poll.as_deref() == Some("1") {
         let body = match &secret {
             Some(s) => format!(
@@ -55,7 +53,9 @@ pub async fn receipt_lookup(
     match secret {
         Some(s) => {
             let redirect_url = format!("/receipt/{s}");
-            Ok(Redirect::to(&redirect_url).into_response())
+            let mut response = Redirect::to(&redirect_url).into_response();
+            set_no_store_headers(&mut response);
+            Ok(response)
         }
         None => {
             // Redirect arrived before the webhook finished processing.
@@ -74,18 +74,49 @@ pub async fn receipt_lookup(
     }
 }
 
-pub async fn receipt_view(
+/// Confirm that a one-time receipt is available without consuming it. Browsers,
+/// mail clients, security scanners, and link-preview bots routinely issue GET or
+/// HEAD requests automatically, so neither safe method may reveal credentials or
+/// delete the row. Axum's `get` router also directs HEAD here.
+pub async fn receipt_confirmation(
+    method: Method,
+    State(state): State<AppState>,
+    Path(receipt_secret): Path<String>,
+) -> Result<Response, AppError> {
+    if !state.db.receipt_available(&receipt_secret).await? {
+        return Ok(receipt_not_found_response());
+    }
+
+    // Return no representation for HEAD even when this handler is called
+    // directly; axum also strips GET-handler bodies for implicit HEAD requests.
+    let body = if method == Method::HEAD {
+        String::new()
+    } else {
+        receipt_confirmation_page()
+    };
+    let mut response = (
+        StatusCode::OK,
+        [("content-type", "text/html; charset=utf-8")],
+        body,
+    )
+        .into_response();
+    set_no_store_headers(&mut response);
+    Ok(response)
+}
+
+/// Reveal and atomically consume a one-time receipt. This handler is mounted
+/// only on POST; a second concurrent or repeated POST loses the atomic DELETE
+/// race and receives NotFound.
+pub async fn receipt_consume(
     State(state): State<AppState>,
     Path(receipt_secret): Path<String>,
 ) -> Result<Response, AppError> {
     // repo-0237: peek first and decrypt/validate BEFORE the destructive
     // consume — a key-rotation mismatch or corrupt row must not delete the
     // only recoverable copy of the customer's API key.
-    let row = state
-        .db
-        .receipt_peek(&receipt_secret)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Receipt expired or already viewed".into()))?;
+    let Some(row) = state.db.receipt_peek(&receipt_secret).await? else {
+        return Ok(receipt_not_found_response());
+    };
 
     let cipher = Aes256Gcm::new_from_slice(&state.config.receipt_encryption_key).map_err(|e| {
         error!("AES-GCM key init failed: {e}");
@@ -121,15 +152,11 @@ pub async fn receipt_view(
 
     // Everything validated — NOW consume atomically. If another request won
     // the race, the row is gone and we report it as already viewed.
-    let consumed = state
-        .db
-        .receipt_consume(&receipt_secret)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Receipt expired or already viewed".into()))?;
+    let Some(consumed) = state.db.receipt_consume(&receipt_secret).await? else {
+        return Ok(receipt_not_found_response());
+    };
     if consumed.subscription_id != row.subscription_id {
-        return Err(AppError::NotFound(
-            "Receipt expired or already viewed".into(),
-        ));
+        return Ok(receipt_not_found_response());
     }
 
     let server_url = state
@@ -143,17 +170,61 @@ pub async fn receipt_view(
         None => receipt_partial_page(&api_key, server_url),
     };
 
-    Ok((
+    let mut response = (
         StatusCode::OK,
-        [
-            ("content-type", "text/html; charset=utf-8"),
-            ("cache-control", "no-store"),
-            ("pragma", "no-cache"),
-            ("x-content-type-options", "nosniff"),
-        ],
+        [("content-type", "text/html; charset=utf-8")],
         html,
     )
-        .into_response())
+        .into_response();
+    set_no_store_headers(&mut response);
+    Ok(response)
+}
+
+fn set_no_store_headers(response: &mut Response) {
+    use axum::http::header::{CACHE_CONTROL, PRAGMA, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS};
+    use axum::http::HeaderValue;
+
+    let headers = response.headers_mut();
+    headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    headers.insert(PRAGMA, HeaderValue::from_static("no-cache"));
+    headers.insert(REFERRER_POLICY, HeaderValue::from_static("no-referrer"));
+    headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
+}
+
+fn receipt_not_found_response() -> Response {
+    let mut response = (
+        StatusCode::NOT_FOUND,
+        "Receipt expired or already viewed".to_string(),
+    )
+        .into_response();
+    set_no_store_headers(&mut response);
+    response
+}
+
+fn receipt_confirmation_page() -> String {
+    r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Tirith — Reveal Your License</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 60px auto; padding: 0 20px; color: #333; }
+  .warning { background: #fff3cd; border: 1px solid #ffc107; padding: 12px; border-radius: 6px; margin: 20px 0; }
+  button { background: #333; color: #fff; border: none; padding: 10px 18px; border-radius: 4px; cursor: pointer; font-size: 15px; }
+  button:hover { background: #555; }
+</style>
+</head>
+<body>
+<h1>Your Tirith License Is Ready</h1>
+<div class="warning">
+  Continue only when you are ready to save your credentials. Submitting this form reveals and consumes the one-time receipt.
+</div>
+<form method="post">
+  <button type="submit">Reveal my license</button>
+</form>
+</body>
+</html>"#
+        .to_string()
 }
 
 fn receipt_not_ready_page(checkout_id: &str) -> String {
@@ -184,8 +255,8 @@ fn receipt_not_ready_page(checkout_id: &str) -> String {
       return;
     }}
     try {{
-      // Poll the JSON endpoint: following the redirect with fetch() would
-      // CONSUME the one-time receipt before the page navigates (repo-0235).
+      // Poll the JSON endpoint: following the redirect with fetch() would return
+      // the human confirmation HTML rather than a machine-readable status.
       const u = new URL(location.href);
       u.searchParams.set('poll', '1');
       const r = await fetch(u, {{ redirect: 'manual' }});
@@ -326,4 +397,218 @@ export TIRITH_API_KEY="{api_key}"</pre>
 </body>
 </html>"#
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aes_gcm::aead::Aead as _;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use crate::config::Config;
+    use crate::db::{CreatedData, CreatedOutcome, Db};
+    use crate::sign::TokenSigner;
+
+    const RECEIPT_SECRET: &str = "receipt-route-test-secret";
+    const API_KEY: &str = "tirith_api_key_route_test";
+    const TOKEN: &str = "route.test.token";
+
+    async fn test_state() -> AppState {
+        let encryption_key = [0x42; 32];
+        let nonce = [0x24; 12];
+        let cipher = Aes256Gcm::new_from_slice(&encryption_key).unwrap();
+        let api_key_enc = cipher
+            .encrypt(Nonce::from_slice(&nonce), API_KEY.as_bytes())
+            .unwrap();
+
+        let db = Db::open(":memory:").unwrap();
+        let outcome = db
+            .process_subscription_created(CreatedData {
+                event_id: "evt_receipt_route".to_string(),
+                event_type: "subscription.active".to_string(),
+                subscription_id: "sub_receipt_route".to_string(),
+                customer_id: "customer_receipt_route".to_string(),
+                email: "receipt-route@example.invalid".to_string(),
+                tier: "pro".to_string(),
+                product_id: "product_receipt_route".to_string(),
+                occurred_at: Some("2026-08-19T00:00:00Z".to_string()),
+                checkout_id: Some("checkout_receipt_route".to_string()),
+                key_hash: "route-test-key-hash".to_string(),
+                token: Some(TOKEN.to_string()),
+                token_expires_at: 4_102_444_800,
+                receipt_secret: RECEIPT_SECRET.to_string(),
+                api_key_enc,
+                api_key_nonce: nonce.to_vec(),
+            })
+            .await
+            .unwrap();
+        assert!(matches!(outcome, CreatedOutcome::Provisioned));
+
+        let config = Config {
+            ed25519_seed_hex: "00".repeat(32),
+            polar_webhook_secret: "whsec_test".to_string(),
+            polar_api_key: "polar_test".to_string(),
+            receipt_encryption_key: encryption_key,
+            product_tier_map: HashMap::new(),
+            kid: "test".to_string(),
+            token_ttl_days: 30,
+            port: 0,
+            database_url: ":memory:".to_string(),
+            receipt_base_url: Some("https://license.example.invalid".to_string()),
+            trusted_proxy: false,
+            backup_r2_endpoint: None,
+            backup_r2_bucket: None,
+            backup_r2_access_key_id: None,
+            backup_r2_secret_access_key: None,
+        };
+
+        AppState {
+            db,
+            signer: Arc::new(
+                TokenSigner::from_hex_seed(&config.ed25519_seed_hex, config.kid.clone()).unwrap(),
+            ),
+            config: Arc::new(config),
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    fn assert_no_store(response: &Response) {
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-store")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::REFERRER_POLICY)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-referrer")
+        );
+    }
+
+    async fn body_text(response: Response) -> String {
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn get_and_head_confirm_without_consuming_or_revealing_credentials() {
+        let state = test_state().await;
+
+        let get = receipt_confirmation(
+            Method::GET,
+            State(state.clone()),
+            Path(RECEIPT_SECRET.to_string()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(get.status(), StatusCode::OK);
+        assert_no_store(&get);
+        let get_body = body_text(get).await;
+        assert!(get_body.contains("<form method=\"post\">"));
+        assert!(!get_body.contains(API_KEY));
+        assert!(!get_body.contains(TOKEN));
+        assert!(state
+            .db
+            .receipt_peek(RECEIPT_SECRET)
+            .await
+            .unwrap()
+            .is_some());
+
+        let head = receipt_confirmation(
+            Method::HEAD,
+            State(state.clone()),
+            Path(RECEIPT_SECRET.to_string()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(head.status(), StatusCode::OK);
+        assert_no_store(&head);
+        assert!(body_text(head).await.is_empty());
+        assert!(state
+            .db
+            .receipt_peek(RECEIPT_SECRET)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn lookup_redirect_is_no_store_and_does_not_consume() {
+        let state = test_state().await;
+        let response = receipt_lookup(
+            State(state.clone()),
+            Query(LookupQuery {
+                checkout: "checkout_receipt_route".to_string(),
+                poll: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_no_store(&response);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::LOCATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("/receipt/receipt-route-test-secret")
+        );
+        assert!(state
+            .db
+            .receipt_peek(RECEIPT_SECRET)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn concurrent_posts_reveal_and_consume_exactly_once() {
+        let state = test_state().await;
+        let left = receipt_consume(State(state.clone()), Path(RECEIPT_SECRET.to_string()));
+        let right = receipt_consume(State(state.clone()), Path(RECEIPT_SECRET.to_string()));
+        let (left, right) = tokio::join!(left, right);
+        let responses = [left.unwrap(), right.unwrap()];
+
+        assert_eq!(
+            responses
+                .iter()
+                .filter(|response| response.status() == StatusCode::OK)
+                .count(),
+            1
+        );
+        assert_eq!(
+            responses
+                .iter()
+                .filter(|response| response.status() == StatusCode::NOT_FOUND)
+                .count(),
+            1
+        );
+        for response in &responses {
+            assert_no_store(response);
+        }
+
+        let mut bodies = Vec::new();
+        for response in responses {
+            bodies.push(body_text(response).await);
+        }
+        assert_eq!(
+            bodies.iter().filter(|body| body.contains(API_KEY)).count(),
+            1
+        );
+        assert_eq!(bodies.iter().filter(|body| body.contains(TOKEN)).count(), 1);
+        assert!(state
+            .db
+            .receipt_peek(RECEIPT_SECRET)
+            .await
+            .unwrap()
+            .is_none());
+    }
 }

--- a/tools/license-server/src/routes/receipt.rs
+++ b/tools/license-server/src/routes/receipt.rs
@@ -106,7 +106,7 @@ pub async fn receipt_confirmation(
 
 /// Reveal and atomically consume a one-time receipt. This handler is mounted
 /// only on POST; a second concurrent or repeated POST loses the atomic DELETE
-/// race and receives NotFound.
+/// race and receives the not-found response.
 pub async fn receipt_consume(
     State(state): State<AppState>,
     Path(receipt_secret): Path<String>,
@@ -402,7 +402,6 @@ export TIRITH_API_KEY="{api_key}"</pre>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aes_gcm::aead::Aead as _;
     use std::collections::HashMap;
     use std::sync::Arc;
 

--- a/tools/license-server/src/routes/refresh.rs
+++ b/tools/license-server/src/routes/refresh.rs
@@ -61,16 +61,19 @@ pub async fn refresh(
     // unthrottled loop could exhaust disk and contend on the DB mutex. 60s is
     // far below any legitimate CLI refresh cadence.
     const MIN_REFRESH_INTERVAL_SECS: i64 = 60;
-    if let Some(age) = state.db.seconds_since_last_token(&sub.id).await? {
-        if age < MIN_REFRESH_INTERVAL_SECS {
-            return Err(AppError::RateLimited);
-        }
-    }
-
     let exp_ts = chrono::Utc::now().timestamp() + (state.config.token_ttl_days * 86400);
     let token = state.signer.sign_token(&sub.tier, exp_ts);
 
-    state.db.insert_token(&sub.id, &token, exp_ts).await?;
+    // The throttle check and token publication are one atomic database
+    // operation. Signing can happen speculatively, but only the single winner
+    // is persisted and returned; every parallel loser is rate-limited.
+    if !state
+        .db
+        .insert_refresh_token_if_due(&sub.id, &token, exp_ts, MIN_REFRESH_INTERVAL_SECS)
+        .await?
+    {
+        return Err(AppError::RateLimited);
+    }
 
     Ok((
         StatusCode::OK,

--- a/tools/license-server/src/routes/webhook.rs
+++ b/tools/license-server/src/routes/webhook.rs
@@ -46,6 +46,13 @@ pub async fn webhook(
 
     let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
+    // Enforce the ordering prerequisite at the dispatcher as well as inside
+    // each state-changing handler. That keeps a newly added subscription event
+    // from accidentally bypassing the fail-closed timestamp contract.
+    if event_type.starts_with("subscription.") {
+        let _ = required_event_created_at(&event)?;
+    }
+
     // Polar does not include event_id in the body; the webhook-id header
     // is the authoritative identifier.
     let event_id = msg_id.to_string();
@@ -115,10 +122,7 @@ async fn handle_order_paid(
     let checkout_id = json_str(data, "checkout_id")
         .ok_or_else(|| AppError::BadWebhook("missing checkout_id".into()))?;
 
-    let created_at = event
-        .get("created_at")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    let created_at = required_event_created_at(event)?;
 
     let product_id = json_str(data, "product_id")
         .ok_or_else(|| AppError::BadWebhook("missing product_id".into()))?;
@@ -149,7 +153,7 @@ async fn handle_order_paid(
         email,
         tier,
         product_id,
-        occurred_at: created_at,
+        occurred_at: Some(created_at),
         // order.paid always carries a checkout_id (enforced above).
         checkout_id: Some(checkout_id),
         key_hash: creds.key_hash,
@@ -189,10 +193,7 @@ async fn handle_sub_active(
     let product_id = json_str(data, "product_id");
     let checkout_id = json_str(data, "checkout_id");
 
-    let created_at = event
-        .get("created_at")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    let created_at = required_event_created_at(event)?;
 
     let (tier, tier_unknown) = resolve_tier(
         state,
@@ -200,7 +201,7 @@ async fn handle_sub_active(
         product_id.as_deref(),
         event_id,
         "subscription.active",
-        &created_at,
+        &Some(created_at.clone()),
         event,
     )
     .await;
@@ -218,7 +219,7 @@ async fn handle_sub_active(
             email: Some(email),
             tier: tier.clone(),
             product_id: product_id.clone(),
-            occurred_at: created_at,
+            occurred_at: Some(created_at),
             resolved_tier: tier.clone(),
             tier_unknown,
         };
@@ -265,7 +266,7 @@ async fn handle_sub_active(
                         subscription_id: Some(sub_id.clone()),
                         event_type: "subscription.active".to_string(),
                         reason: "unresolvable_product".to_string(),
-                        occurred_at: created_at.clone(),
+                        occurred_at: Some(created_at.clone()),
                         payload: redact_event(event),
                     })
                     .await;
@@ -283,7 +284,7 @@ async fn handle_sub_active(
             email,
             tier: tier_str,
             product_id: product_id.unwrap_or_default(),
-            occurred_at: created_at,
+            occurred_at: Some(created_at),
             // None for checkout-less subscriptions — process_subscription_created
             // then skips the pending_receipts row instead of keying it by a
             // guessable id that /receipt/lookup could race.
@@ -336,10 +337,7 @@ async fn handle_sub_canceled(
         }
     };
 
-    let created_at = event
-        .get("created_at")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    let created_at = required_event_created_at(event)?;
 
     let customer_id = json_str(data, "customer_id");
     let email = data
@@ -358,7 +356,7 @@ async fn handle_sub_canceled(
         email,
         tier,
         product_id,
-        occurred_at: created_at,
+        occurred_at: Some(created_at),
     };
 
     let processed = state
@@ -406,10 +404,7 @@ async fn handle_sub_revoked(
         }
     };
 
-    let created_at = event
-        .get("created_at")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    let created_at = required_event_created_at(event)?;
 
     let customer_id = json_str(data, "customer_id");
     let email = data
@@ -428,7 +423,7 @@ async fn handle_sub_revoked(
         email,
         tier,
         product_id,
-        occurred_at: created_at,
+        occurred_at: Some(created_at),
     };
 
     let processed = state.db.process_subscription_revoked(revoked_data).await?;
@@ -459,10 +454,7 @@ async fn handle_sub_past_due(
         }
     };
 
-    let created_at = event
-        .get("created_at")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    let created_at = required_event_created_at(event)?;
 
     let product_id = json_str(data, "product_id");
     let (tier, tier_unknown) = resolve_tier(
@@ -471,7 +463,7 @@ async fn handle_sub_past_due(
         product_id.as_deref(),
         event_id,
         "subscription.past_due",
-        &created_at,
+        &Some(created_at.clone()),
         event,
     )
     .await;
@@ -488,7 +480,7 @@ async fn handle_sub_past_due(
             .map(|s| s.to_string()),
         tier: tier.clone(),
         product_id,
-        occurred_at: created_at,
+        occurred_at: Some(created_at),
         resolved_tier: tier,
         tier_unknown,
     };
@@ -534,10 +526,7 @@ async fn handle_sub_uncanceled(
         }
     };
 
-    let created_at = event
-        .get("created_at")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    let created_at = required_event_created_at(event)?;
 
     let product_id = json_str(data, "product_id");
     let (tier, tier_unknown) = resolve_tier(
@@ -546,7 +535,7 @@ async fn handle_sub_uncanceled(
         product_id.as_deref(),
         event_id,
         "subscription.uncanceled",
-        &created_at,
+        &Some(created_at.clone()),
         event,
     )
     .await;
@@ -563,7 +552,7 @@ async fn handle_sub_uncanceled(
             .map(|s| s.to_string()),
         tier: tier.clone(),
         product_id,
-        occurred_at: created_at,
+        occurred_at: Some(created_at),
         resolved_tier: tier,
         tier_unknown,
     };
@@ -602,6 +591,25 @@ fn json_str(val: &serde_json::Value, key: &str) -> Option<String> {
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
+}
+
+/// Lifecycle ordering is only safe when Polar supplies a parseable event
+/// creation instant. The signed delivery timestamp proves freshness of the
+/// HTTP message, not ordering of the underlying subscription event, so it
+/// cannot substitute for this payload field.
+fn required_event_created_at(event: &serde_json::Value) -> Result<String, AppError> {
+    let raw = event
+        .get("created_at")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| AppError::BadWebhook("missing created_at".into()))?;
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|timestamp| {
+            timestamp
+                .to_utc()
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        })
+        .map_err(|_| AppError::BadWebhook("invalid created_at".into()))
 }
 
 /// Resolve product_id → tier. On unknown product, insert dead-letter and return None.
@@ -755,4 +763,36 @@ fn redact_event(event: &serde_json::Value) -> String {
     }
 
     serde_json::to_string(&redacted).unwrap_or_else(|_| "{}".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_timestamp_is_required_and_must_be_rfc3339() {
+        for event in [
+            serde_json::json!({"type": "subscription.active"}),
+            serde_json::json!({"type": "subscription.active", "created_at": null}),
+            serde_json::json!({"type": "subscription.active", "created_at": ""}),
+            serde_json::json!({"type": "subscription.active", "created_at": "not-a-time"}),
+        ] {
+            assert!(matches!(
+                required_event_created_at(&event),
+                Err(AppError::BadWebhook(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn lifecycle_timestamp_is_normalized_to_one_utc_encoding() {
+        let event = serde_json::json!({
+            "type": "subscription.active",
+            "created_at": "2024-03-01T13:30:00+02:00"
+        });
+        assert_eq!(
+            required_event_created_at(&event).unwrap(),
+            "2024-03-01T11:30:00.000Z"
+        );
+    }
 }


### PR DESCRIPTION
Stack PR 7 of 12. License, DNS, Safe Browsing, and ThreatDB hardening. CI follow-up pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * DNS checks are cancellable, time-bounded, cached, and consistently applied across network requests.
  * URL enrichment validates public addresses and reports only origin-level URLs.
  * Threat-feed downloads enforce size and content limits with safer streaming and fail-closed handling.
  * Threat database updates verify signed assets, support v2 databases, and preserve existing data when updates are incomplete.

* **License & Receipt Handling**
  * Receipt confirmation no longer consumes receipts; consumption occurs explicitly via POST.
  * Refresh-token issuance is atomic, preventing duplicate tokens during concurrent requests.
  * Subscription events require valid, consistently ordered timestamps.
  * Receipt responses use safer no-store protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens DNS and Safe Browsing handling, threat-feed ingestion and signed database updates, and license-server receipt, refresh-token, and webhook processing.
- Adds cancellable, request-budgeted DNS resolution and stricter URL privacy projection.
- Enforces bounded, fail-closed supplemental-feed parsing and atomic ThreatDB replacement.
- Strengthens receipt consumption, refresh-token issuance, and subscription-event validation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith/src/cli/threatdb_cmd.rs | Adds bounded supplemental-feed aggregation and preserves the installed database when any enabled feed fails. |
| crates/tirith-core/src/threatdb_feeds.rs | Introduces decoded-size, record, field, archive-member, and unique-entry limits for remote threat feeds. |
| crates/tirith-core/src/network/dns.rs | Replaces blocking system resolution with cancellable Hickory lookups, shared request budgets, caching, and DNSBL response validation. |
| crates/tirith-core/src/threatdb_api.rs | Applies DNS-based public-address validation, origin-only URL projection, and safer per-URL Safe Browsing caching. |
| tools/license-server/src/routes/refresh.rs | Makes refresh-token issuance atomic to prevent concurrent duplicate issuance. |
| tools/license-server/src/routes/receipt.rs | Separates receipt confirmation from explicit consumption. |
| tools/license-server/src/routes/webhook.rs | Adds stricter subscription timestamp validation and ordering. |

<sub>Reviews (8): Last reviewed commit: ["fix(license-server): dead-letter an unor..."](https://github.com/sheeki03/tirith/commit/2d23349def0bc733f70285463b096bd8c5ddc7f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54708799)</sub>

**Context used:**

- Knowledge Base — [ThreatDB: compilation, versioning, and update flow](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/threatdb.md)

<!-- /greptile_comment -->