### PR TITLE
Security: converge release and supply-chain gates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
         tirith scan "$INPUT_PATH" --ci --fail-on "$INPUT_FAIL_ON" "${IGNORE_ARGS[@]}"
     - name: Upload SARIF
       if: always() && inputs.sarif == 'true'
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
       with:
         sarif_file: results.sarif
       continue-on-error: true

--- a/crates/tirith/tests/release_security.rs
+++ b/crates/tirith/tests/release_security.rs
@@ -55,6 +55,69 @@ fn yaml_key<'a>(mapping: &'a serde_yaml::Mapping, key: &str) -> &'a serde_yaml::
         .unwrap_or_else(|| panic!("release workflow is missing {key:?}"))
 }
 
+fn uses_is_immutably_pinned(uses: &str) -> bool {
+    if uses.starts_with("./") {
+        return true;
+    }
+    if let Some(image) = uses.strip_prefix("docker://") {
+        let digest = image
+            .rsplit_once("@sha256:")
+            .map(|(_, digest)| digest)
+            .unwrap_or_default();
+        return digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit());
+    }
+    let revision = uses
+        .rsplit_once('@')
+        .map(|(_, revision)| revision)
+        .unwrap_or_default();
+    revision.len() == 40 && revision.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[test]
+fn composite_action_keeps_third_party_actions_pinned_to_full_commit_shas() {
+    let action_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("action.yml");
+    let action = std::fs::read_to_string(&action_path).expect("read composite action");
+    let document: serde_yaml::Value =
+        serde_yaml::from_str(&action).expect("composite action must be valid YAML");
+    let root = document
+        .as_mapping()
+        .expect("composite action root mapping");
+    let runs = yaml_key(root, "runs")
+        .as_mapping()
+        .expect("composite action runs mapping");
+    let steps = yaml_key(runs, "steps")
+        .as_sequence()
+        .expect("composite action steps sequence");
+
+    for step in steps {
+        let step = step.as_mapping().expect("composite action step mapping");
+        let Some(uses) = step
+            .get(serde_yaml::Value::String("uses".to_string()))
+            .and_then(serde_yaml::Value::as_str)
+        else {
+            continue;
+        };
+        assert!(
+            uses_is_immutably_pinned(uses),
+            "composite-action reference {uses:?} must be a local path, a full commit SHA, or a sha256-digest container"
+        );
+    }
+}
+
+#[test]
+fn mutable_docker_tags_are_not_immutable_pins() {
+    assert!(!uses_is_immutably_pinned("docker://ghcr.io/example/tool:latest"));
+    assert!(uses_is_immutably_pinned(&format!(
+        "docker://ghcr.io/example/tool@sha256:{}",
+        "ab".repeat(32)
+    )));
+    assert!(uses_is_immutably_pinned(
+        "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+    ));
+}
+
 #[test]
 fn release_workflow_keeps_manual_dispatch_non_publishing() {
     let workflow_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/tirith/tests/release_security.rs
+++ b/crates/tirith/tests/release_security.rs
@@ -108,7 +108,9 @@ fn composite_action_keeps_third_party_actions_pinned_to_full_commit_shas() {
 
 #[test]
 fn mutable_docker_tags_are_not_immutable_pins() {
-    assert!(!uses_is_immutably_pinned("docker://ghcr.io/example/tool:latest"));
+    assert!(!uses_is_immutably_pinned(
+        "docker://ghcr.io/example/tool:latest"
+    ));
     assert!(uses_is_immutably_pinned(&format!(
         "docker://ghcr.io/example/tool@sha256:{}",
         "ab".repeat(32)

--- a/crates/tirith/tests/release_security.rs
+++ b/crates/tirith/tests/release_security.rs
@@ -93,12 +93,14 @@ fn composite_action_keeps_third_party_actions_pinned_to_full_commit_shas() {
 
     for step in steps {
         let step = step.as_mapping().expect("composite action step mapping");
-        let Some(uses) = step
-            .get(serde_yaml::Value::String("uses".to_string()))
-            .and_then(serde_yaml::Value::as_str)
-        else {
+        // Skip only when the key is absent. Folding a non-string value into the
+        // same `continue` would let `uses: 123` pass the pinning gate unchecked.
+        let Some(value) = step.get(serde_yaml::Value::String("uses".to_string())) else {
             continue;
         };
+        let uses = value
+            .as_str()
+            .unwrap_or_else(|| panic!("composite-action `uses` must be a string, got {value:?}"));
         assert!(
             uses_is_immutably_pinned(uses),
             "composite-action reference {uses:?} must be a local path, a full commit SHA, or a sha256-digest container"


### PR DESCRIPTION
## Summary
- pin the composite SARIF upload action to its immutable upstream commit
- add structural enforcement against mutable third-party action refs
- establish the final release-convergence layer for tag identity, self-update, data generation, and publication gates

## Stack
This is PR 12 of 12 and is based on `codex/poststack-containment-daemon`. Additional scoped release-convergence commits will follow while CodeRabbit and Greptile review the stack.

## Validation
YAML, SHA provenance, formatting, and diff checks pass. CI follow-up is intentionally pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved SARIF upload security by locking the analysis action to a specific immutable version.
  * Added safeguards requiring third-party actions to use immutable references, reducing unexpected changes during releases.
  * Added validation for container-based actions to ensure they use secure, immutable image digests.
  * Expanded security checks to help detect mutable action or container references before release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR pins SARIF upload to an immutable upstream commit and adds structural tests that reject mutable third-party action references.
- Replaces the mutable CodeQL upload tag with a full commit SHA.
- Allows repository-local composite actions while requiring external actions to use full commit SHAs.
- Requires container actions to use 64-character SHA-256 digests and includes regression coverage for mutable tags.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current helper rejects mutable container tags and accepts only SHA-256-digest container references.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| action.yml | Pins the SARIF upload action to an immutable CodeQL Action commit without changing its inputs or execution condition. |
| crates/tirith/tests/release_security.rs | Adds structural enforcement for immutable composite-action references and fully addresses the previously reported unconditional container-reference exemption. |

<sub>Reviews (8): Last reviewed commit: ["test(release): fail on a non-string comp..."](https://github.com/sheeki03/tirith/commit/390b781d9d568ba14fbc8def224dbeb655a4e280) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54710591)</sub>

**Context used:**

- Knowledge Base — [Packaging and Distribution](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/packaging-and-distribution.md)

<!-- /greptile_comment -->