### PR TITLE
fix(docs): restore broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,4 +1066,4 @@ Third-party data attributions in [NOTICE](NOTICE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sheeki03/tirith&type=Date)](https://star-history.com/#sheeki03/tirith&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sheeki03/tirith&type=Date)](https://star-history.dera.page/#sheeki03/tirith&Date)


### PR DESCRIPTION
The Star History chart in the README is currently broken, so the repository's stars no longer render. This change repoints the chart at a maintained alternative that uses the same data source and requires no API token, restoring the chart to working order.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the README to restore the Star History chart using a maintained, token-free mirror.
- Repoints the embedded SVG from `api.star-history.com` to `star-history.dera.page`.
- Repoints the chart hyperlink to the same mirror while preserving the repository and date parameters.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The replacement URLs retain the existing repository identifier, chart type, and supported endpoint structure, and no repository rule or validation contract is violated.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Replaces the broken Star History image and destination hosts while preserving the existing repository identifier and chart type. |

<sub>Reviews (1): Last reviewed commit: ["fix(docs): point Star History chart at w..."](https://github.com/sheeki03/tirith/commit/0bb05747c886fae6679ed71315f5e6b8a9d829c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54753522)</sub>

<!-- /greptile_comment -->