### PR TITLE
fix(threatdb): calibrate pinned OpenSSF snapshot bounds

### DIFF
--- a/.github/scripts/fetch-threatdb-sources.sh
+++ b/.github/scripts/fetch-threatdb-sources.sh
@@ -28,8 +28,11 @@ CURL_CONNECT_TIMEOUT_SECONDS=15
 CURL_MAX_TIME_SECONDS=120
 FEODO_MAX_BYTES=$((16 * 1024 * 1024))
 CISA_KEV_MAX_BYTES=$((64 * 1024 * 1024))
-OSSF_MAX_FILES=50000
-OSSF_MAX_BYTES=$((256 * 1024 * 1024))
+# The reviewed immutable OpenSSF revision above materializes to 235,293 files
+# and 441,674,789 bytes (verified by the 2026-08-24 main build). Keep bounded
+# headroom for filesystem accounting while still rejecting an unexpected tree.
+OSSF_MAX_FILES=250000
+OSSF_MAX_BYTES=$((512 * 1024 * 1024))
 DATADOG_MANIFEST_MAX_BYTES=$((64 * 1024 * 1024))
 TYPOSQUAT_MAX_BYTES=$((4 * 1024 * 1024))
 

--- a/.github/scripts/test-fetch-threatdb-sources.sh
+++ b/.github/scripts/test-fetch-threatdb-sources.sh
@@ -16,6 +16,12 @@ FAKE_BIN="$TEST_ROOT/bin"
 OUTPUT_ROOT="$TEST_ROOT/output"
 mkdir -p -- "$FAKE_BIN" "$OUTPUT_ROOT"
 
+# The immutable OpenSSF revision currently contains 235,293 files totaling
+# 441,674,789 bytes. Guard the calibrated defaults so the reviewed snapshot
+# cannot silently become unbuildable again while both resource limits remain.
+grep -Fq 'OSSF_MAX_FILES=250000' "$FETCH_SCRIPT"
+grep -Fq 'OSSF_MAX_BYTES=$((512 * 1024 * 1024))' "$FETCH_SCRIPT"
+
 cat > "$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Summary

- raise the fail-closed OpenSSF snapshot limits from 50,000 files / 256 MiB to 250,000 files / 512 MiB
- calibrate those bounds against the reviewed immutable revision, measured by the live main run at 235,293 files and 441,674,789 bytes
- lock the calibrated defaults into the deterministic source-fetch regression

This is a follow-up to #213 and #214. The first post-merge live rebuild passed the corrected Feodo/CISA fetch path and exposed this previously masked bound mismatch. The OpenSSF revision remains immutable and verified; the resource checks remain enforced.

## Validation

- `git diff --check`
- `bash -n .github/scripts/fetch-threatdb-sources.sh`
- `bash -n .github/scripts/test-fetch-threatdb-sources.sh`
- `bash .github/scripts/test-fetch-threatdb-sources.sh`
- live failure evidence: https://github.com/sheeki03/tirith/actions/runs/32720481854

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Raises the fail-closed OpenSSF snapshot limits to accommodate the measured contents of the pinned immutable revision while retaining bounded resource checks.

- Increases the OpenSSF file limit from 50,000 to 250,000.
- Increases the OpenSSF byte limit from 256 MiB to 512 MiB.
- Adds deterministic regression assertions for both calibrated defaults.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the immutable OpenSSF revision remains pinned and verified while both resource bounds remain enforced above its measured size.

The changed constants provide bounded headroom for the known snapshot, and the accompanying regression assertions keep those calibrated defaults synchronized with the fetch script.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/scripts/fetch-threatdb-sources.sh | Calibrates the OpenSSF snapshot limits above the pinned revision’s measured file count and logical byte size without removing either fail-closed check. |
| .github/scripts/test-fetch-threatdb-sources.sh | Locks the calibrated file and byte defaults into the deterministic source-fetch regression test. |

<sub>Reviews (1): Last reviewed commit: ["fix(threatdb): calibrate OpenSSF snapsho..."](https://github.com/sheeki03/tirith/commit/1e531a7393395b2e9d7506d723983fa369a154a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56212488)</sub>

<!-- /greptile_comment -->