### PR TITLE
fix(threatdb): parse the pinned OpenSSF corpus and restore publication

### DIFF
--- a/.github/scripts/fetch-threatdb-sources.sh
+++ b/.github/scripts/fetch-threatdb-sources.sh
@@ -82,6 +82,19 @@ case "$TRANSACTION_TIMEOUT_SECONDS" in
     exit 1
     ;;
 esac
+# The bounded registry snapshot is the last networked step and, unlike one git
+# or curl fetch, it is a sequence of up to 1,000 metadata requests: the
+# reviewed 156-package pinned set measured 148 s end to end on a residential
+# link. Give that step its own ceiling inside the transaction deadline instead
+# of the per-fetch bound, so one slow registry day cannot fail publication by
+# itself. The transaction deadline still fail-closes it.
+REGISTRY_TIMEOUT_SECONDS=${THREATDB_REGISTRY_TIMEOUT_SECONDS:-420}
+case "$REGISTRY_TIMEOUT_SECONDS" in
+  ''|*[!0-9]*|0)
+    echo "::error::THREATDB_REGISTRY_TIMEOUT_SECONDS must be a positive integer" >&2
+    exit 1
+    ;;
+esac
 THREATDB_TRANSACTION_DEADLINE_EPOCH=$(($(date +%s) + TRANSACTION_TIMEOUT_SECONDS))
 
 TIMEOUT_BIN=${THREATDB_FETCH_TIMEOUT_BIN:-}
@@ -98,22 +111,29 @@ fi
 # fetch child, which then keeps writing into a staging tree cleanup just removed.
 # `$!` set here is visible to the caller.
 remaining_timeout_seconds() {
+  local ceiling=${1:-$FETCH_TIMEOUT_SECONDS}
   local remaining
   remaining=$((THREATDB_TRANSACTION_DEADLINE_EPOCH - $(date +%s)))
   if (( remaining <= 0 )); then
     echo "::error::threatdb source transaction exceeded ${TRANSACTION_TIMEOUT_SECONDS}s deadline" >&2
     return 1
   fi
-  if (( remaining < FETCH_TIMEOUT_SECONDS )); then
+  if (( remaining < ceiling )); then
     printf '%s\n' "$remaining"
   else
-    printf '%s\n' "$FETCH_TIMEOUT_SECONDS"
+    printf '%s\n' "$ceiling"
   fi
 }
 
 run_bounded() {
   local timeout_seconds
   timeout_seconds=$(remaining_timeout_seconds) || return 1
+  "$TIMEOUT_BIN" --signal=TERM --kill-after=10s "${timeout_seconds}s" "$@"
+}
+
+run_bounded_registry() {
+  local timeout_seconds
+  timeout_seconds=$(remaining_timeout_seconds "$REGISTRY_TIMEOUT_SECONDS") || return 1
   "$TIMEOUT_BIN" --signal=TERM --kill-after=10s "${timeout_seconds}s" "$@"
 }
 
@@ -316,8 +336,10 @@ fi
 
 # The compiler owns OSV shape classification. It requests registry versions only
 # for unique bounded claims and writes one atomic capped snapshot; direct
-# introduced:0-without-close claims never trigger a request.
-run_bounded "$COMPILER_BIN" fetch-registry-snapshots \
+# introduced:0-without-close claims never trigger a request. This step runs
+# under the registry ceiling (see REGISTRY_TIMEOUT_SECONDS), not the per-fetch
+# bound.
+run_bounded_registry "$COMPILER_BIN" fetch-registry-snapshots \
   --ossf "$STAGED_SOURCES/ossf-mp" \
   --ossf-commit "$OSSF_MP_SHA" \
   --output "$STAGED_SOURCES/registry-versions.json"
@@ -337,9 +359,17 @@ for package in packages:
     assert isinstance(package.get("source_url"), str) and package["source_url"].startswith("https://")
     assert isinstance(package.get("response_sha256"), str) and len(package["response_sha256"]) == 64
     assert package["response_sha256"] != "0" * 64
-    assert isinstance(package.get("response_bytes"), int) and 0 < package["response_bytes"] <= 8 * 1024 * 1024
-    assert isinstance(package.get("versions"), list) and package["versions"]
-    assert len(package["versions"]) <= 20000
+    assert isinstance(package.get("response_bytes"), int) and 0 <= package["response_bytes"] <= 16 * 1024 * 1024
+    versions = package.get("versions")
+    assert isinstance(versions, list) and len(versions) <= 20000
+    resolution = package.get("resolution")
+    status = package.get("http_status")
+    if resolution == "registry_versions":
+        assert status == 200 and package["response_bytes"] > 0 and versions
+    else:
+        assert resolution == "package_not_found"
+        assert status == 404 and not versions
+assert sum(package["response_bytes"] for package in packages) <= 128 * 1024 * 1024
 PY
 
 FEODO_SHA=$(sha256sum "$STAGED_SOURCES/feodo.txt" | cut -d' ' -f1)

--- a/.github/scripts/test-fetch-threatdb-sources.sh
+++ b/.github/scripts/test-fetch-threatdb-sources.sh
@@ -200,7 +200,9 @@ child=$!
 (
   sleep "$duration"
   kill -TERM "$child" 2>/dev/null || exit 0
-  sleep 0.2
+  # Give the fake worker's TERM trap time to record graceful termination even
+  # on loaded macOS runners before exercising the hard-kill fallback.
+  sleep 1
   kill -KILL "$child" 2>/dev/null || true
 ) &
 watchdog=$!
@@ -251,6 +253,30 @@ if [ -e "$compile_reached" ] || [ -e "$OUTPUT_ROOT/tirith-threatdb-sources" ]; t
 fi
 if compgen -G "$OUTPUT_ROOT/.tirith-threatdb-fetch.*" >/dev/null; then
   echo "invalid fetch timeout left private staging state" >&2
+  exit 1
+fi
+
+status=0
+if PATH="$FAKE_BIN:$PATH" \
+   THREATDB_FETCH_OUTPUT_DIR="$OUTPUT_ROOT" \
+   THREATDB_COMPILER_BIN="$FAKE_BIN/tirith-threatdb-compile" \
+   THREATDB_FETCH_TIMEOUT_BIN="$FAKE_BIN/timeout" \
+   THREATDB_REGISTRY_TIMEOUT_SECONDS=0 \
+   bash "$FETCH_SCRIPT"; then
+  touch "$compile_reached"
+else
+  status=$?
+fi
+if (( status == 0 )); then
+  echo "expected an invalid registry timeout to fail preflight" >&2
+  exit 1
+fi
+if [ -e "$compile_reached" ] || [ -e "$OUTPUT_ROOT/tirith-threatdb-sources" ]; then
+  echo "invalid registry timeout reached compile/publication" >&2
+  exit 1
+fi
+if compgen -G "$OUTPUT_ROOT/.tirith-threatdb-fetch.*" >/dev/null; then
+  echo "invalid registry timeout left private staging state" >&2
   exit 1
 fi
 
@@ -389,6 +415,9 @@ else
   status=$?
 fi
 if (( status == 0 )) || [ ! -s "$sparse_started" ] || [ ! -s "$sparse_terminated" ]; then
+  printf 'status=%s started=%s terminated=%s\n' "$status" \
+    "$([ -s "$sparse_started" ] && echo yes || echo no)" \
+    "$([ -s "$sparse_terminated" ] && echo yes || echo no)" >&2
   echo "expected per-source timeout to start and terminate sparse materialization" >&2
   exit 1
 fi

--- a/crates/tirith/src/bin/tirith_threatdb_compile.rs
+++ b/crates/tirith/src/bin/tirith_threatdb_compile.rs
@@ -190,14 +190,23 @@ type FeedResult<T> = Result<T, String>;
 // supplemental feed must contribute at least one record.
 const MIN_OSSF_PACKAGES: usize = 100;
 const MIN_DATADOG_PACKAGES: usize = 100;
-const MIN_FEODO_IPS: usize = 10;
+// abuse.ch Feodo Tracker has listed exactly 5 C2 IPs since its 2026-03-04
+// update, and the 2026-08-12 production build shipped those 5. A floor of 10
+// therefore rejects the real feed outright; require a non-empty feed instead,
+// which still fails an empty or comment-only fetch.
+const MIN_FEODO_IPS: usize = 1;
 const MIN_CISA_KEV_RECORDS: usize = 100;
 const MIN_TYPOSQUAT_RECORDS: usize = 100;
 const MAX_BASELINE_DROP_PERCENT: u64 = 50;
 const MAX_OSV_VALUE_BYTES: usize = 256;
 const MAX_BOUNDED_PACKAGE_REQUESTS: usize = 1_000;
-const MAX_REGISTRY_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
-const MAX_REGISTRY_AGGREGATE_BYTES: usize = 64 * 1024 * 1024;
+// The pinned bounded set includes @solana/web3.js metadata at 11,975,695
+// uncompressed bytes. Keep a finite per-package ceiling above that reviewed
+// response while the aggregate cap still bounds the complete transaction.
+const MAX_REGISTRY_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+// The reviewed 142-package snapshot totals 92,111,058 response bytes. Keep a
+// bounded 128 MiB transaction ceiling rather than the obsolete 64 MiB limit.
+const MAX_REGISTRY_AGGREGATE_BYTES: usize = 128 * 1024 * 1024;
 const MAX_REGISTRY_VERSIONS_PER_PACKAGE: usize = 20_000;
 const MAX_SOURCE_PROVENANCE_BYTES: usize = 1024 * 1024;
 
@@ -411,7 +420,7 @@ struct OsvDatabaseSpecific {
     #[serde(default)]
     iocs: Option<OsvIocs>,
     #[serde(default, rename = "malicious-packages-origins")]
-    malicious_packages_origins: Vec<OsvOrigin>,
+    malicious_packages_origins: Option<Vec<OsvOrigin>>,
 }
 
 /// Indicators of compromise carried at the entry level by current records.
@@ -496,7 +505,7 @@ impl OssfIndicators {
         let Some(ds) = ds else {
             return out;
         };
-        for origin in &ds.malicious_packages_origins {
+        for origin in ds.malicious_packages_origins.as_deref().unwrap_or_default() {
             if let Some(sha) = &origin.sha256 {
                 // Only accept a real 64-char hex SHA-256: a malformed value would
                 // poison the artifact-hash index DB-B builds from these indicators.
@@ -586,6 +595,9 @@ struct OssfStats {
     parsed_packages: usize,
     direct_whole_package_claims: usize,
     bounded_intervals_materialized: usize,
+    empty_registry_intervals_projected: usize,
+    open_ended_boundaries_emitted: usize,
+    registry_not_found_whole_claims: usize,
     exact_versions_emitted: usize,
     unsupported_confirmed_shapes: usize,
     snapshot_failures: usize,
@@ -621,7 +633,10 @@ struct OsvInterval {
 enum RangeProjection {
     None,
     WholePackage,
-    Bounded(Vec<OsvInterval>),
+    Bounded {
+        intervals: Vec<OsvInterval>,
+        open_boundaries: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -633,8 +648,14 @@ struct PendingOssfClaim {
     reference: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+enum RegistryVersionSet {
+    Versions(Vec<String>),
+    PackageNotFound,
+}
+
 trait RegistryVersionProvider {
-    fn versions_for(&mut self, key: &RegistryPackageKey) -> FeedResult<Vec<String>>;
+    fn versions_for(&mut self, key: &RegistryPackageKey) -> FeedResult<RegistryVersionSet>;
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -652,14 +673,30 @@ struct RegistrySnapshotPackage {
     ecosystem: String,
     name: String,
     source_url: String,
+    #[serde(default = "registry_http_ok")]
+    http_status: u16,
+    #[serde(default)]
+    resolution: RegistrySnapshotResolution,
     response_sha256: String,
     response_bytes: usize,
     versions: Vec<String>,
 }
 
+fn registry_http_ok() -> u16 {
+    200
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RegistrySnapshotResolution {
+    #[default]
+    RegistryVersions,
+    PackageNotFound,
+}
+
 #[derive(Debug)]
 struct RegistrySnapshotStore {
-    packages: BTreeMap<RegistryPackageKey, Vec<String>>,
+    packages: BTreeMap<RegistryPackageKey, RegistryVersionSet>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -818,15 +855,16 @@ fn canonical_source_summary(
     if relative_paths.is_empty() {
         return Err("source summary has no files".to_string());
     }
-    let mut paths = relative_paths.to_vec();
-    paths.sort();
-    paths.dedup();
-    if paths.len() != relative_paths.len() {
-        return Err("source summary contains duplicate paths".to_string());
-    }
-    let mut digest = Sha256::new();
-    let mut total_bytes = 0usize;
-    for relative in &paths {
+    // The fetch script digests `find … -print0 | LC_ALL=C sort -z`, i.e. the
+    // NUL-delimited relative path BYTES in ascending order. `PathBuf`'s `Ord`
+    // is component-wise instead: it places `osv/pkg/…` before `osv/pkg-x/…`,
+    // whereas a byte sort places `osv/pkg-x/…` first because '-' (0x2d) sorts
+    // below '/' (0x2f). A 100-file fixture never hits that; the 235k-file
+    // OpenSSF tree hits it constantly, and the two digests then disagree and
+    // fail publication. Sort the normalized string form so both sides of the
+    // provenance binding order any tree identically.
+    let mut entries = Vec::with_capacity(relative_paths.len());
+    for relative in relative_paths {
         if relative.is_absolute()
             || relative
                 .components()
@@ -841,6 +879,16 @@ fn canonical_source_summary(
             .to_str()
             .ok_or_else(|| format!("source summary path {} is not UTF-8", relative.display()))?
             .replace('\\', "/");
+        entries.push((normalized, relative.clone()));
+    }
+    entries.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
+    entries.dedup_by(|left, right| left.0 == right.0);
+    if entries.len() != relative_paths.len() {
+        return Err("source summary contains duplicate paths".to_string());
+    }
+    let mut digest = Sha256::new();
+    let mut total_bytes = 0usize;
+    for (normalized, relative) in &entries {
         let path = root.join(relative);
         let metadata = std::fs::symlink_metadata(&path)
             .map_err(|error| format!("cannot inspect source input {}: {error}", path.display()))?;
@@ -861,7 +909,7 @@ fn canonical_source_summary(
         digest.update([0]);
     }
     Ok(CanonicalSourceSummary {
-        files: paths.len(),
+        files: entries.len(),
         bytes: total_bytes,
         content_sha256: format!("{:x}", digest.finalize()),
     })
@@ -1297,8 +1345,6 @@ impl RegistrySnapshotStore {
                 &format!("registry response SHA-256 for {}", key.name),
             )?;
             if package.response_bytes > MAX_REGISTRY_RESPONSE_BYTES
-                || package.response_bytes == 0
-                || package.versions.is_empty()
                 || package.versions.len() > MAX_REGISTRY_VERSIONS_PER_PACKAGE
             {
                 return Err(format!(
@@ -1307,6 +1353,29 @@ impl RegistrySnapshotStore {
                 ));
             }
             let versions = package.versions;
+            let version_set = match package.resolution {
+                RegistrySnapshotResolution::RegistryVersions => {
+                    if package.http_status != 200
+                        || package.response_bytes == 0
+                        || versions.is_empty()
+                    {
+                        return Err(format!(
+                            "registry snapshot entry for {} has inconsistent available-package metadata",
+                            key.name
+                        ));
+                    }
+                    RegistryVersionSet::Versions(versions.clone())
+                }
+                RegistrySnapshotResolution::PackageNotFound => {
+                    if package.http_status != 404 || !versions.is_empty() {
+                        return Err(format!(
+                            "registry snapshot entry for {} has inconsistent not-found metadata",
+                            key.name
+                        ));
+                    }
+                    RegistryVersionSet::PackageNotFound
+                }
+            };
             for version in &versions {
                 validate_osv_value(version, "registry version")?;
             }
@@ -1316,7 +1385,7 @@ impl RegistrySnapshotStore {
                     key.name
                 ));
             }
-            if packages.insert(key.clone(), versions).is_some() {
+            if packages.insert(key.clone(), version_set).is_some() {
                 return Err(format!(
                     "duplicate registry snapshot entry for {}",
                     key.name
@@ -1339,7 +1408,7 @@ impl RegistrySnapshotStore {
 }
 
 impl RegistryVersionProvider for RegistrySnapshotStore {
-    fn versions_for(&mut self, key: &RegistryPackageKey) -> FeedResult<Vec<String>> {
+    fn versions_for(&mut self, key: &RegistryPackageKey) -> FeedResult<RegistryVersionSet> {
         self.packages.remove(key).ok_or_else(|| {
             format!(
                 "registry snapshot is missing {}:{}",
@@ -1368,6 +1437,8 @@ fn parse_range_projection(
         return Ok(RangeProjection::None);
     }
     let mut intervals = Vec::new();
+    let mut open_boundaries = Vec::new();
+    let mut whole_package = false;
     for range in ranges {
         if !range.extra.is_empty() {
             return Err(format!(
@@ -1376,7 +1447,13 @@ fn parse_range_projection(
                 range.extra.keys().collect::<Vec<_>>()
             ));
         }
-        if range.range_type != "ECOSYSTEM" {
+        let supported_range_type = range.range_type == "ECOSYSTEM"
+            || (range.range_type == "SEMVER"
+                && matches!(
+                    ecosystem,
+                    Ecosystem::Npm | Ecosystem::Crates | Ecosystem::Go
+                ));
+        if !supported_range_type {
             return Err(format!(
                 "{} uses unsupported confirmed OSV range type {:?}",
                 path.display(),
@@ -1446,16 +1523,17 @@ fn parse_range_projection(
             });
         }
         if let Some(introduced) = open {
-            if introduced != "0" {
-                return Err(format!(
-                    "{} has an unrepresentable non-zero open-ended confirmed interval",
-                    path.display()
-                ));
+            if introduced == "0" {
+                whole_package = true;
+            } else {
+                // The signed database has no open-ended range encoding. Emit the
+                // validated introduced boundary as an exact known-bad version;
+                // do not silently broaden it into a whole-package claim. Closed
+                // siblings are still materialized from the audited registry
+                // snapshot below.
+                compare_versions(ecosystem, &introduced, &introduced)?;
+                open_boundaries.push(introduced);
             }
-            intervals.push(OsvInterval {
-                introduced,
-                end: None,
-            });
         }
     }
     // A package-wide interval changes only the aggregate projection. It must
@@ -1464,16 +1542,16 @@ fn parse_range_projection(
     for interval in &intervals {
         validate_interval_order(ecosystem, interval)?;
     }
-    if intervals
-        .iter()
-        .any(|interval| interval.introduced == "0" && interval.end.is_none())
-    {
+    if whole_package {
         return Ok(RangeProjection::WholePackage);
     }
-    if intervals.is_empty() {
+    if intervals.is_empty() && open_boundaries.is_empty() {
         return Err(format!("{} produced no OSV intervals", path.display()));
     }
-    Ok(RangeProjection::Bounded(intervals))
+    Ok(RangeProjection::Bounded {
+        intervals,
+        open_boundaries,
+    })
 }
 
 fn collect_ossf(
@@ -1490,12 +1568,31 @@ fn collect_ossf(
         return Err(format!("root {} is not a directory", root.display()));
     }
 
+    // A repository checkout contains active, withdrawn, and intentionally
+    // unmergeable OSV trees. Only `osv/malicious` is an active package feed;
+    // parsing the sibling quarantine/archive trees can turn known-invalid or
+    // retired records into publication blockers. Unit fixtures retain the
+    // historical direct-root layout.
+    let osv_root = root.join("osv");
+    let records_root = if osv_root.exists() {
+        let malicious_root = osv_root.join("malicious");
+        if !malicious_root.is_dir() {
+            return Err(format!(
+                "OpenSSF source {} is missing the active osv/malicious tree",
+                root.display()
+            ));
+        }
+        malicious_root
+    } else {
+        root.to_path_buf()
+    };
+
     let mut entries = Vec::new();
     let mut pending = Vec::new();
     let mut all_indicators = OssfIndicators::default();
     let mut stats = OssfStats::default();
     let mut paths = Vec::new();
-    for entry in walkdir::WalkDir::new(root) {
+    for entry in walkdir::WalkDir::new(&records_root) {
         let entry = entry.map_err(|e| format!("root traversal failed: {e}"))?;
         if entry.path().extension().is_some_and(|ext| ext == "json")
             && entry.file_type().is_file()
@@ -1575,12 +1672,25 @@ fn collect_ossf(
         let reference = osv.references.first().map(|record| record.url.clone());
 
         for affected in &osv.affected {
-            let package = affected.package.as_ref().ok_or_else(|| {
-                format!(
+            let Some(package) = affected.package.as_ref() else {
+                // OSV GIT ranges identify repositories/commits rather than a
+                // package ecosystem and cannot enter the package-name index.
+                // Count and exclude that unsupported shape, but retain any
+                // explicit record-level IOCs collected above.
+                if !affected.ranges.is_empty()
+                    && affected
+                        .ranges
+                        .iter()
+                        .all(|range| range.range_type == "GIT")
+                {
+                    stats.skipped_unknown_ecosystem += 1;
+                    continue;
+                }
+                return Err(format!(
                     "{} has an affected record without a package",
                     path.display()
-                )
-            })?;
+                ));
+            };
             if package.ecosystem.trim().is_empty() || package.name.trim().is_empty() {
                 return Err(format!(
                     "{} has an affected package with an empty ecosystem or name",
@@ -1588,11 +1698,8 @@ fn collect_ossf(
                 ));
             }
             let Some(ecosystem) = Ecosystem::from_name(&package.ecosystem) else {
-                return Err(format!(
-                    "unsupported_confirmed_shapes=1: {} has unsupported confirmed ecosystem {:?}",
-                    path.display(),
-                    package.ecosystem
-                ));
+                stats.skipped_unknown_ecosystem += 1;
+                continue;
             };
             let key = RegistryPackageKey {
                 ecosystem,
@@ -1621,13 +1728,35 @@ fn collect_ossf(
                         reference: reference.clone(),
                     });
                 }
-                RangeProjection::Bounded(intervals) => pending.push(PendingOssfClaim {
-                    key,
-                    explicit_versions,
+                RangeProjection::Bounded {
                     intervals,
-                    confidence,
-                    reference: reference.clone(),
-                }),
+                    open_boundaries,
+                } => {
+                    stats.open_ended_boundaries_emitted += open_boundaries.len();
+                    explicit_versions.extend(open_boundaries);
+                    explicit_versions.sort();
+                    explicit_versions.dedup();
+                    if intervals.is_empty() {
+                        stats.exact_versions_emitted += explicit_versions.len();
+                        entries.push(PackageEntry {
+                            ecosystem,
+                            name: key.name,
+                            affected_versions: explicit_versions,
+                            all_versions_malicious: false,
+                            source: ThreatSource::OssfMalicious,
+                            confidence,
+                            reference: reference.clone(),
+                        });
+                    } else {
+                        pending.push(PendingOssfClaim {
+                            key,
+                            explicit_versions,
+                            intervals,
+                            confidence,
+                            reference: reference.clone(),
+                        });
+                    }
+                }
                 RangeProjection::None if !explicit_versions.is_empty() => {
                     stats.exact_versions_emitted += explicit_versions.len();
                     entries.push(PackageEntry {
@@ -1753,8 +1882,8 @@ fn parse_ossf_with_provider(
             })?
             .versions_for(&key);
         match result {
-            Ok(versions) => {
-                universes.insert(key, versions);
+            Ok(version_set) => {
+                universes.insert(key, version_set);
             }
             Err(error) => {
                 return Err(format!("snapshot_failures=1: {error}"));
@@ -1763,12 +1892,35 @@ fn parse_ossf_with_provider(
     }
 
     for claim in pending {
-        let versions = universes.get(&claim.key).ok_or_else(|| {
+        let version_set = universes.get(&claim.key).ok_or_else(|| {
             format!(
                 "registry snapshot missing materialization key {}",
                 claim.key.name
             )
         })?;
+        if matches!(version_set, RegistryVersionSet::PackageNotFound) {
+            // The exact registry endpoint returned a provenance-bound 404.
+            // With no available universe from which to enumerate a bounded
+            // interval, preserve protection by blocking this confirmed
+            // malicious package identity as a whole. This can only broaden a
+            // package that is absent at snapshot time; a future publication
+            // will reevaluate it if the name reappears.
+            stats.registry_not_found_whole_claims += 1;
+            stats.exact_versions_emitted += claim.explicit_versions.len();
+            entries.push(PackageEntry {
+                ecosystem: claim.key.ecosystem,
+                name: claim.key.name,
+                affected_versions: claim.explicit_versions,
+                all_versions_malicious: true,
+                source: ThreatSource::OssfMalicious,
+                confidence: claim.confidence,
+                reference: claim.reference,
+            });
+            continue;
+        }
+        let RegistryVersionSet::Versions(versions) = version_set else {
+            unreachable!("package-not-found registry snapshots return above")
+        };
         let mut affected = claim.explicit_versions;
         for interval in &claim.intervals {
             validate_interval_order(claim.key.ecosystem, interval)?;
@@ -1780,10 +1932,28 @@ fn parse_ossf_with_provider(
                 }
             }
             if interval_matches == 0 {
-                return Err(format!(
-                    "bounded interval for {}:{} materialized to no registry versions",
-                    claim.key.ecosystem, claim.key.name
-                ));
+                // Registries can omit versions after an incident (for example,
+                // npm unpublishes). Preserve the exact source claim without
+                // turning the package into a false whole-package block: an
+                // introduced boundary is affected, and a `last_affected` close
+                // is affected as well. `fixed`/`limit` closes are excluded by
+                // OSV semantics and must never be emitted as malicious.
+                let mut projected_boundary = false;
+                if interval.introduced != "0" {
+                    affected.push(interval.introduced.clone());
+                    projected_boundary = true;
+                }
+                if let Some((RangeEndKind::LastAffected, end)) = &interval.end {
+                    affected.push(end.clone());
+                    projected_boundary = true;
+                }
+                if !projected_boundary {
+                    return Err(format!(
+                        "bounded interval for {}:{} has no registry versions or exact affected boundary",
+                        claim.key.ecosystem, claim.key.name
+                    ));
+                }
+                stats.empty_registry_intervals_projected += 1;
             }
         }
         affected.sort();
@@ -3702,7 +3872,8 @@ fn fetch_registry_snapshots(root: &Path, ossf_commit: &str, output: &Path) -> Fe
         let response = client.get(url.clone()).send().map_err(|error| {
             format!("registry snapshot request for {} failed: {error}", key.name)
         })?;
-        if !response.status().is_success() {
+        let http_status = response.status().as_u16();
+        if http_status != 200 && http_status != 404 {
             return Err(format!(
                 "registry snapshot request for {} returned {}",
                 key.name,
@@ -3729,11 +3900,20 @@ fn fetch_registry_snapshots(root: &Path, ossf_commit: &str, output: &Path) -> Fe
         if aggregate_bytes > MAX_REGISTRY_AGGREGATE_BYTES {
             return Err("registry responses exceed aggregate byte cap".to_string());
         }
-        let versions = extract_registry_versions(&key, &bytes)?;
+        let (resolution, versions) = if http_status == 404 {
+            (RegistrySnapshotResolution::PackageNotFound, Vec::new())
+        } else {
+            (
+                RegistrySnapshotResolution::RegistryVersions,
+                extract_registry_versions(&key, &bytes)?,
+            )
+        };
         packages.push(RegistrySnapshotPackage {
             ecosystem: key.ecosystem.to_string(),
             name: key.name,
             source_url: url.to_string(),
+            http_status,
+            resolution,
             response_sha256: format!("{:x}", Sha256::digest(&bytes)),
             response_bytes: bytes.len(),
             versions,
@@ -3891,12 +4071,15 @@ fn main() {
             require_minimum("OSSF", unique_packages, MIN_OSSF_PACKAGES),
         );
         eprintln!(
-            "    {} entries scanned, {} unique packages ({} parsed claims), {} whole-package claims, {} bounded intervals, {} exact versions, {} withdrawn, {} non-malicious, {} unknown ecosystem, {} unsupported shapes, {} snapshot failures",
+            "    {} entries scanned, {} unique packages ({} parsed claims), {} whole-package claims, {} bounded intervals, {} empty-registry intervals projected exactly, {} open boundaries emitted exactly, {} registry-404 whole-package fallbacks, {} exact versions, {} withdrawn, {} non-malicious, {} unknown ecosystem, {} unsupported shapes, {} snapshot failures",
             stats.total_entries,
             unique_packages,
             stats.parsed_packages,
             stats.direct_whole_package_claims,
             stats.bounded_intervals_materialized,
+            stats.empty_registry_intervals_projected,
+            stats.open_ended_boundaries_emitted,
+            stats.registry_not_found_whole_claims,
             stats.exact_versions_emitted,
             stats.skipped_withdrawn,
             stats.skipped_non_malicious,
@@ -4329,6 +4512,18 @@ fn main() {
                     ossf_stats.bounded_intervals_materialized,
                 ),
                 (
+                    "empty_registry_intervals_projected".to_string(),
+                    ossf_stats.empty_registry_intervals_projected,
+                ),
+                (
+                    "open_ended_boundaries_emitted".to_string(),
+                    ossf_stats.open_ended_boundaries_emitted,
+                ),
+                (
+                    "registry_not_found_whole_claims".to_string(),
+                    ossf_stats.registry_not_found_whole_claims,
+                ),
+                (
                     "exact_versions_emitted".to_string(),
                     ossf_stats.exact_versions_emitted,
                 ),
@@ -4336,6 +4531,10 @@ fn main() {
                 (
                     "non_malicious".to_string(),
                     ossf_stats.skipped_non_malicious,
+                ),
+                (
+                    "unknown_ecosystem".to_string(),
+                    ossf_stats.skipped_unknown_ecosystem,
                 ),
                 (
                     "unsupported_confirmed_shapes".to_string(),
@@ -4802,14 +5001,19 @@ mod tests {
     struct SpyRegistryVersions {
         calls: Vec<RegistryPackageKey>,
         versions: BTreeMap<RegistryPackageKey, Vec<String>>,
+        not_found: BTreeSet<RegistryPackageKey>,
     }
 
     impl RegistryVersionProvider for SpyRegistryVersions {
-        fn versions_for(&mut self, key: &RegistryPackageKey) -> FeedResult<Vec<String>> {
+        fn versions_for(&mut self, key: &RegistryPackageKey) -> FeedResult<RegistryVersionSet> {
             self.calls.push(key.clone());
+            if self.not_found.contains(key) {
+                return Ok(RegistryVersionSet::PackageNotFound);
+            }
             self.versions
                 .get(key)
                 .cloned()
+                .map(RegistryVersionSet::Versions)
                 .ok_or_else(|| format!("missing spy universe for {}", key.name))
         }
     }
@@ -5157,6 +5361,69 @@ mod tests {
     const C01_REGISTRY_VERSIONS: &str =
         include_str!("fixtures/threatdb-c01/registry-versions.json");
 
+    #[test]
+    fn canonical_source_summary_orders_paths_by_bytes_like_the_fetch_script() {
+        // `find -print0 | LC_ALL=C sort -z` orders whole relative paths by
+        // bytes, so `osv/pkg-x/…` and `osv/pkg.x/…` sort BEFORE `osv/pkg/…`
+        // ('-' and '.' are below '/'), and `osv/pkg0/…` after it. Component
+        // ordering puts `osv/pkg/…` first and produces a different digest.
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let files = [
+            ("osv/pkg/MAL-2099-0001.json", "a"),
+            ("osv/pkg-x/MAL-2099-0002.json", "b"),
+            ("osv/pkg.x/MAL-2099-0003.json", "c"),
+            ("osv/pkg0/MAL-2099-0004.json", "d"),
+        ];
+        for (relative, content) in files {
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, content).unwrap();
+        }
+
+        // Independent replica of the shell pipeline's digest.
+        let mut byte_sorted: Vec<&str> = files.iter().map(|(relative, _)| *relative).collect();
+        byte_sorted.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+        assert_eq!(
+            byte_sorted,
+            [
+                "osv/pkg-x/MAL-2099-0002.json",
+                "osv/pkg.x/MAL-2099-0003.json",
+                "osv/pkg/MAL-2099-0001.json",
+                "osv/pkg0/MAL-2099-0004.json",
+            ]
+        );
+        let mut expected = Sha256::new();
+        for relative in &byte_sorted {
+            expected.update(relative.as_bytes());
+            expected.update([0]);
+            expected.update(sha256_hex(&std::fs::read(root.join(relative)).unwrap()).as_bytes());
+            expected.update([0]);
+        }
+        let expected = format!("{:x}", expected.finalize());
+
+        // The fixture must actually exercise the divergence.
+        let mut component_sorted: Vec<PathBuf> = files
+            .iter()
+            .map(|(relative, _)| PathBuf::from(relative))
+            .collect();
+        component_sorted.sort();
+        assert_ne!(
+            component_sorted
+                .iter()
+                .map(|path| path.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            byte_sorted
+        );
+
+        let summary =
+            canonical_source_summary(root, &collect_tree_source_paths(root, "osv").unwrap())
+                .unwrap();
+        assert_eq!(summary.files, 4);
+        assert_eq!(summary.bytes, 4);
+        assert_eq!(summary.content_sha256, expected);
+    }
+
     fn fixture_snapshot_binding(snapshot_path: &Path) -> SourceTransactionBinding {
         let bytes = std::fs::read(snapshot_path).unwrap();
         let document: RegistrySnapshotDocument = serde_json::from_slice(&bytes).unwrap();
@@ -5248,6 +5515,14 @@ mod tests {
     }
 
     #[test]
+    fn nullable_ossf_origins_are_treated_as_no_indicators() {
+        let database_specific: OsvDatabaseSpecific =
+            serde_json::from_str(r#"{"malicious-packages-origins":null}"#).unwrap();
+        let indicators = OssfIndicators::from_database_specific(Some(&database_specific));
+        assert!(indicators.is_empty());
+    }
+
+    #[test]
     fn whole_package_range_bypasses_registry_provider() {
         let directory = tempfile::tempdir().unwrap();
         write_mal(directory.path(), "MAL-2099-0001.json", C01_WHOLE_PACKAGE);
@@ -5259,6 +5534,195 @@ mod tests {
         assert_eq!(stats.bounded_intervals_materialized, 0);
         assert_eq!(entries.len(), 1);
         assert!(entries[0].all_versions_malicious);
+    }
+
+    #[test]
+    fn standard_semver_whole_package_ranges_need_no_registry_snapshot() {
+        let directory = tempfile::tempdir().unwrap();
+        for (index, ecosystem) in [(20, "npm"), (21, "crates.io"), (22, "Go")] {
+            let id = format!("MAL-2099-{index:04}");
+            write_mal(
+                directory.path(),
+                &format!("{id}.json"),
+                &format!(
+                    r#"{{
+                        "id":"{id}",
+                        "affected":[{{
+                            "package":{{"ecosystem":"{ecosystem}","name":"whole-{index}"}},
+                            "ranges":[{{"type":"SEMVER","events":[{{"introduced":"0"}}]}}]
+                        }}]
+                    }}"#
+                ),
+            );
+        }
+        let mut spy = SpyRegistryVersions::default();
+        let (entries, stats, _) =
+            parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap();
+        assert!(spy.calls.is_empty());
+        assert_eq!(entries.len(), 3);
+        assert!(entries.iter().all(|entry| entry.all_versions_malicious));
+        assert_eq!(stats.direct_whole_package_claims, 3);
+    }
+
+    #[test]
+    fn nonzero_open_range_emits_known_versions_without_broadening() {
+        let directory = tempfile::tempdir().unwrap();
+        write_mal(
+            directory.path(),
+            "MAL-2099-0023.json",
+            r#"{
+                "id":"MAL-2099-0023",
+                "affected":[{
+                    "package":{"ecosystem":"npm","name":"open-package"},
+                    "versions":["1.0.2"],
+                    "ranges":[{"type":"SEMVER","events":[{"introduced":"1.0.1"}]}]
+                }]
+            }"#,
+        );
+        let mut spy = SpyRegistryVersions::default();
+        let (entries, stats, _) =
+            parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap();
+        assert!(
+            spy.calls.is_empty(),
+            "an open tail must not trigger live expansion"
+        );
+        assert_eq!(entries.len(), 1);
+        assert!(!entries[0].all_versions_malicious);
+        assert_eq!(entries[0].affected_versions, ["1.0.1", "1.0.2"]);
+        assert_eq!(stats.open_ended_boundaries_emitted, 1);
+        assert_eq!(stats.bounded_intervals_materialized, 0);
+    }
+
+    #[test]
+    fn registry_not_found_preserves_a_confirmed_bounded_package_block() {
+        let directory = tempfile::tempdir().unwrap();
+        write_mal(
+            directory.path(),
+            "MAL-2099-0030.json",
+            r#"{
+                "id":"MAL-2099-0030",
+                "affected":[{
+                    "package":{"ecosystem":"npm","name":"removed-package"},
+                    "ranges":[{"type":"SEMVER","events":[
+                        {"introduced":"0"},{"fixed":"2.0.0"}
+                    ]}]
+                }]
+            }"#,
+        );
+        let key = RegistryPackageKey {
+            ecosystem: Ecosystem::Npm,
+            name: "removed-package".to_string(),
+        };
+        let mut spy = SpyRegistryVersions::default();
+        spy.not_found.insert(key.clone());
+
+        let (entries, stats, _) =
+            parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap();
+        assert_eq!(spy.calls, [key]);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].all_versions_malicious);
+        assert_eq!(stats.registry_not_found_whole_claims, 1);
+        assert_eq!(stats.bounded_intervals_materialized, 0);
+    }
+
+    #[test]
+    fn unpublished_interval_uses_only_exact_affected_boundaries() {
+        let directory = tempfile::tempdir().unwrap();
+        write_mal(
+            directory.path(),
+            "MAL-2099-0031.json",
+            r#"{
+                "id":"MAL-2099-0031",
+                "affected":[{
+                    "package":{"ecosystem":"npm","name":"partly-unpublished"},
+                    "versions":["2.0.22"],
+                    "ranges":[{"type":"SEMVER","events":[
+                        {"introduced":"2.0.27"},{"last_affected":"2.0.28"}
+                    ]}]
+                }]
+            }"#,
+        );
+        let key = RegistryPackageKey {
+            ecosystem: Ecosystem::Npm,
+            name: "partly-unpublished".to_string(),
+        };
+        let mut spy = SpyRegistryVersions::default();
+        spy.versions.insert(
+            key.clone(),
+            vec!["2.0.24".to_string(), "2.0.41".to_string()],
+        );
+
+        let (entries, stats, _) =
+            parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap();
+        assert_eq!(spy.calls, [key]);
+        assert_eq!(entries.len(), 1);
+        assert!(!entries[0].all_versions_malicious);
+        assert_eq!(entries[0].affected_versions, ["2.0.22", "2.0.27", "2.0.28"]);
+        assert_eq!(stats.empty_registry_intervals_projected, 1);
+        assert_eq!(stats.bounded_intervals_materialized, 1);
+    }
+
+    #[test]
+    fn repository_layout_reads_only_the_active_malicious_tree() {
+        let directory = tempfile::tempdir().unwrap();
+        let osv = directory.path().join("osv");
+        write_mal(
+            &osv.join("malicious/npm/active"),
+            "MAL-2099-0024.json",
+            r#"{
+                "id":"MAL-2099-0024",
+                "affected":[{"package":{"ecosystem":"npm","name":"active"}}]
+            }"#,
+        );
+        write_mal(
+            &osv.join("unmergable/npm/quarantined"),
+            "MAL-2099-0025.json",
+            r#"{"id":"MAL-WRONG","affected":[]}"#,
+        );
+        write_mal(
+            &osv.join("withdrawn/npm/retired"),
+            "MAL-2099-0026.json",
+            "{not json",
+        );
+
+        let (entries, stats, _) = parse_ossf(directory.path()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "active");
+        assert_eq!(stats.total_entries, 1);
+    }
+
+    #[test]
+    fn unsupported_package_ecosystems_are_counted_and_excluded() {
+        let directory = tempfile::tempdir().unwrap();
+        write_mal(
+            directory.path(),
+            "MAL-2099-0027.json",
+            r#"{
+                "id":"MAL-2099-0027",
+                "affected":[{"package":{"ecosystem":"npm","name":"supported"}}]
+            }"#,
+        );
+        write_mal(
+            directory.path(),
+            "MAL-2099-0028.json",
+            r#"{
+                "id":"MAL-2099-0028",
+                "affected":[{"package":{"ecosystem":"VSCode","name":"unsupported.extension"}}]
+            }"#,
+        );
+        write_mal(
+            directory.path(),
+            "MAL-2099-0029.json",
+            r#"{
+                "id":"MAL-2099-0029",
+                "affected":[{"ranges":[{"type":"GIT","repo":"https://example.invalid/repo.git","events":[{"introduced":"0"}]}]}]
+            }"#,
+        );
+
+        let (entries, stats, _) = parse_ossf(directory.path()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "supported");
+        assert_eq!(stats.skipped_unknown_ecosystem, 2);
     }
 
     #[test]
@@ -5449,7 +5913,6 @@ mod tests {
     #[test]
     fn confirmed_unrepresentable_range_shapes_fail_publication() {
         for events_or_range in [
-            r#"{"type":"ECOSYSTEM","events":[{"introduced":"1.0.0"}]}"#,
             r#"{"type":"GIT","events":[{"introduced":"0"},{"fixed":"abc"}]}"#,
             r#"{"type":"ECOSYSTEM","events":[{"fixed":"1.0.0"}]}"#,
             r#"{"type":"ECOSYSTEM","events":[{"introduced":"0","fixed":"1.0.0"}]}"#,
@@ -5645,7 +6108,35 @@ mod tests {
         let binding = fixture_snapshot_binding(&snapshot_path);
         assert!(RegistrySnapshotStore::load(&snapshot_path, &binding)
             .unwrap_err()
-            .contains("outside caps"));
+            .contains("inconsistent available-package metadata"));
+    }
+
+    #[test]
+    fn registry_snapshot_authenticates_package_not_found_resolution() {
+        let directory = tempfile::tempdir().unwrap();
+        let snapshot_path = directory.path().join("registry-versions.json");
+        let mut document: serde_json::Value = serde_json::from_str(C01_REGISTRY_VERSIONS).unwrap();
+        document["packages"][0]["resolution"] = serde_json::json!("package_not_found");
+        document["packages"][0]["http_status"] = serde_json::json!(404);
+        document["packages"][0]["versions"] = serde_json::json!([]);
+        std::fs::write(&snapshot_path, serde_json::to_vec(&document).unwrap()).unwrap();
+        let binding = fixture_snapshot_binding(&snapshot_path);
+        let mut store = RegistrySnapshotStore::load(&snapshot_path, &binding).unwrap();
+        let key = RegistryPackageKey {
+            ecosystem: Ecosystem::Npm,
+            name: "@solana/web3.js".to_string(),
+        };
+        assert!(matches!(
+            store.versions_for(&key).unwrap(),
+            RegistryVersionSet::PackageNotFound
+        ));
+
+        document["packages"][0]["http_status"] = serde_json::json!(200);
+        std::fs::write(&snapshot_path, serde_json::to_vec(&document).unwrap()).unwrap();
+        let binding = fixture_snapshot_binding(&snapshot_path);
+        assert!(RegistrySnapshotStore::load(&snapshot_path, &binding)
+            .unwrap_err()
+            .contains("inconsistent not-found metadata"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Restores daily Threat DB publication. Every scheduled build since 2026-08-13 has failed, and the last database that actually published (run 31567484525, 2026-08-12) was compiled by the pre-#212 parser, whose own log reads `31557 packages extracted, 203819 skipped (range-only)`. Clients are running a 13-day-old database that silently drops ~204k confirmed OpenSSF records.

After #214 (client update path) and #215 (OpenSSF snapshot caps), the production workflow surfaced the next chain of blockers in the compiler, one per run. Run 32724280499 died at the first valid `SEMVER` record:

```text
crates.io/rustdecimal/MAL-2022-1.json uses unsupported confirmed OSV range type "SEMVER"
```

This PR fixes that chain end to end against the exact pinned corpus (`1ea2762d`, 234,933 active records), including three blockers that only show up on the full tree or the live feeds and that no CI run had reached yet (content-hash ordering, registry step timing, Feodo floor).

## What changes

- **Valid OSV `SEMVER` ranges** are accepted for npm, crates.io, and Go. Whole-package `{"introduced":"0"}` ranges no longer abort publication. Malformed, contradictory, or genuinely unsupported confirmed ranges still fail closed.
- **Active tree only.** The compiler reads `osv/malicious` from a repository checkout and no longer treats the sibling `withdrawn` / `unmergable` trees as active input. Filename-to-record-ID binding stays strict. Unit fixtures keep the direct-root layout.
- **Nullable origins.** `"malicious-packages-origins": null` (present in real records) parses as no indicators instead of a deserialization failure.
- **Unsupported ecosystems** (about 20 VS Code / OpenVSX extension records and one repository-level `GIT` record with no package identity) are counted under `unknown_ecosystem` in compiler metadata and excluded, instead of aborting.
- **Registry 404s are provenance-bound, not fatal.** The pinned bounded set is 156 packages (150 npm, 6 PyPI): 134 return 200, 22 return an authenticated 404 (confirmed-malicious packages npm has removed). The snapshot now records exact URL, HTTP status, `resolution`, response hash, and byte count for both. A 404 on a confirmed-malicious package yields a conservative whole-package claim; a future daily snapshot reevaluates if the name reappears.
- **Registry caps recalibrated to measurements.** The pinned set needs 92,942,474 raw response bytes with a largest response of 11,975,695 bytes (`@solana/web3.js`). Per-response cap 8 MiB -> 16 MiB, aggregate 64 MiB -> 128 MiB, enforced identically by the compiler and the shell validator.
- **Unpublished affected versions.** When a closed interval matches zero currently visible registry versions (npm unpublished them, e.g. `@art-ws/common` `introduced 2.0.27` / `last_affected 2.0.28`), the compiler emits only the exact malicious boundaries (`introduced`, `last_affected`) plus explicit versions. `fixed` / `limit` closes are never emitted as malicious, and the package is not broadened to all versions.
- **Open-ended non-zero ranges** (`introduced: X`, no close) emit `X` plus any explicit versions as exact claims and are counted under `open_ended_boundaries_emitted`. See "Known limitation" below.
- **OpenSSF content hash ordering (full-tree blocker).** The fetch script digests `find -print0 | LC_ALL=C sort -z`, i.e. relative path bytes. The compiler sorted `PathBuf`s, whose `Ord` is component-wise: `osv/pkg/` sorts before `osv/pkg-x/`, while a byte sort puts `osv/pkg-x/` first (`-` is 0x2d, `/` is 0x2f). The 100-file fixture never diverges; the 235,293-file pinned tree diverges at path index 66, so every full compile failed with `OpenSSF staged files changed after provenance` even though file and byte counts matched. The compiler now sorts the normalized path strings by bytes. New test builds a tree with `pkg/`, `pkg-x/`, `pkg.x/`, `pkg0/` and checks the digest against an in-test replica of the shell pipeline.
- **Registry step ceiling (timing blocker).** `run_bounded` gives every step `min(remaining, 180 s)`. The registry snapshot is not one fetch but a sequence of up to 1,000 metadata requests, and the pinned 156-package set measured **148 s sequential** on a residential link. It now runs under its own `THREATDB_REGISTRY_TIMEOUT_SECONDS` (default 420 s) inside the unchanged 600 s transaction deadline, validated like the other timeouts, with a preflight regression case.
- **Feodo floor (live-feed blocker).** `MIN_FEODO_IPS` was 10. abuse.ch's Feodo Tracker has listed exactly 5 C2 IPs since its 2026-03-04 update, and the 2026-08-12 production build shipped those 5 (`IPs (Feodo): 5` in its log). The floor arrived with #179 later that day and had never executed against the live feed, so the very next full compile fails with `Feodo produced 5 records, below the fail-closed minimum of 10`. It is now 1: an empty or comment-only fetch still fails closed.
- The fetch-orchestration test's fake-timeout window grows from 0.2 s to 1 s so the `TERM` handler is not racy on loaded macOS runners, and it prints the missing state on failure.

## Known limitation, measured (follow-up PR)

The signed database has no range encoding (a package claim is `all_versions_malicious` plus an explicit version list), so an open tail cannot be stored as `>= X` without materializing it from the registry. This PR does not add those requests. Measured on the pinned corpus:

- 854 npm records have this shape (all single-affected, 851 from 2025, all `SEMVER`); 517 carry no explicit versions and **0** of those carry origin `versions`, so OpenSSF origin metadata cannot close the gap.
- Fetching abbreviated npm metadata (`application/vnd.npm.install-v1+json`) for all 854 at concurrency 8 took 53.8 s wall and 1.0 MiB total (largest 390 KB); sequentially it would take about 7 minutes.
- 808 are live, 46 are gone. Of the live ones, 733 have **zero** registry versions at or above `introduced` (npm already removed the bad version; the legitimate lower versions remain, e.g. `@dydxprotocol/solo`). Registry materialization would add coverage for exactly **10 packages / 15 versions** today, plus whole-package claims for the 46 removed names.

That is the follow-up: bounded-parallel abbreviated fetch for open tails, media type bound into snapshot provenance, `MAX_BOUNDED_PACKAGE_REQUESTS` raised from 1,000 (156 + 854 = 1,010 already exceeds it). It is deliberately separate so publication resumes now; this PR is a strict coverage improvement over the published database for every one of those 854 packages.

## Verification

- `cargo test -p tirith --bin tirith-threatdb-compile`: 71 passed.
- `.github/scripts/test-fetch-threatdb-sources.sh` and `test-threatdb-manifest-transition.sh`: passed.
- `cargo fmt --all -- --check`, `cargo clippy -p tirith --bin tirith-threatdb-compile --all-targets -- -D warnings`, `cargo +1.83 check`, `git diff --check`, `bash -n` on both scripts: clean.
- CI-faithful local rehearsal: the real `fetch-threatdb-sources.sh` against the pinned OpenSSF commit and live registries (156 packages, 92,942,474 bytes, registry step 148 s sequential), then a full v1 compile with the rebuilt binary:
  - OSSF: `234933 entries scanned, 234911 unique packages (234912 parsed claims), 211269 whole-package claims, 138 bounded intervals, 134 empty-registry intervals projected exactly, 854 open boundaries emitted exactly, 22 registry-404 whole-package fallbacks, 66833 exact versions, 21 unknown ecosystem, 0 unsupported shapes, 0 snapshot failures`
  - Datadog 49,138 packages; projection `284050 claims -> 239013 v1 keys`; Feodo 5 IPs; CISA KEV 1,675; typosquats 137 accepted
  - Output: 11,727,894 bytes, 239,013 v1 packages, signed, format v1 (same header version as the published Aug-12 file), compile wall 112 s
  - The three full-tree / live-feed blockers above were each found by this rehearsal (each one masked the next), and each is fixed in this PR.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved threat database updates with configurable time limits and safer handling of slow or unavailable registries.
  - Added support for additional OpenSSF repository layouts, package metadata, version ranges, and missing-package responses.
  - Improved source provenance consistency and boundary detection for more accurate compiled results.
  - Added clearer diagnostics for unsupported, incomplete, or fallback data scenarios.

- **Bug Fixes**
  - Prevented invalid timeout configurations from continuing partial publication.
  - Improved cleanup and graceful termination during interrupted updates.
  - Added stronger validation for registry responses and aggregate download sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores ThreatDB publication against the pinned OpenSSF corpus by extending OSV parsing, preserving registry provenance for removed packages, and correcting source validation and orchestration limits.

- Accepts supported SEMVER records, nullable origins, active-tree repository layouts, and unsupported ecosystems without aborting the entire build.
- Adds provenance-bound registry 404 handling and recalibrates snapshot byte and execution-time limits.
- Aligns compiler content-hash ordering with the shell pipeline and lowers the Feodo non-empty floor to match the live feed.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith/src/bin/tirith_threatdb_compile.rs | Extends OpenSSF range parsing and registry snapshot semantics, limits input to the active corpus tree, and aligns source digest ordering with the fetch pipeline. |
| .github/scripts/fetch-threatdb-sources.sh | Adds a registry-specific timeout, validates 404 snapshot provenance fields, and raises bounded response-size ceilings to fit the pinned corpus. |
| .github/scripts/test-fetch-threatdb-sources.sh | Covers registry-timeout preflight validation and makes timeout-worker termination assertions less timing-sensitive. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  O[OpenSSF active OSV tree] --> P[Parse and classify claims]
  P -->|Whole-package claims| C[ThreatDB claim collection]
  P -->|Bounded claims| R[Bounded registry snapshot]
  R -->|HTTP 200 versions| M[Materialize affected versions]
  R -->|Authenticated HTTP 404| W[Conservative whole-package fallback]
  M --> C
  W --> C
  D[Datadog feed] --> C
  F[Feodo and CISA feeds] --> C
  C --> V[Validate provenance and anti-drop constraints]
  V --> S[Sign and publish ThreatDB]
```

<sub>Reviews (2): Last reviewed commit: ["fix(threatdb): parse the pinned OpenSSF ..."](https://github.com/sheeki03/tirith/commit/6dc81a97c38c97cfeb9b93b98f2978306b14a184) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56448346)</sub>

**Context used:**

- Knowledge Base — [Threat intelligence and registry correlation](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/threat-intelligence-and-registry-correlation.md)

<!-- /greptile_comment -->