### PR TITLE
fix(threatdb): materialize open-ended OpenSSF ranges from the registry

### DIFF
--- a/.github/scripts/fetch-threatdb-sources.sh
+++ b/.github/scripts/fetch-threatdb-sources.sh
@@ -349,14 +349,19 @@ import json
 import pathlib
 import sys
 document = json.loads(pathlib.Path(sys.argv[1]).read_text())
-assert document.get("schema_version") == 1
+assert document.get("schema_version") == 2
 assert document.get("ossf_commit") == sys.argv[2]
 packages = document.get("packages")
-assert isinstance(packages, list) and len(packages) <= 1000
+assert isinstance(packages, list) and len(packages) <= 2000
+expected_media_type = {
+    "npm": "application/vnd.npm.install-v1+json",
+    "pypi": "application/json",
+}
 for package in packages:
     assert package.get("ecosystem") in {"npm", "pypi"}
     assert isinstance(package.get("name"), str) and package["name"]
     assert isinstance(package.get("source_url"), str) and package["source_url"].startswith("https://")
+    assert package.get("media_type") == expected_media_type[package["ecosystem"]]
     assert isinstance(package.get("response_sha256"), str) and len(package["response_sha256"]) == 64
     assert package["response_sha256"] != "0" * 64
     assert isinstance(package.get("response_bytes"), int) and 0 <= package["response_bytes"] <= 16 * 1024 * 1024
@@ -366,6 +371,8 @@ for package in packages:
     status = package.get("http_status")
     if resolution == "registry_versions":
         assert status == 200 and package["response_bytes"] > 0 and versions
+    elif resolution == "package_unpublished":
+        assert status == 200 and package["response_bytes"] > 0 and not versions
     else:
         assert resolution == "package_not_found"
         assert status == 404 and not versions

--- a/.github/scripts/test-fetch-threatdb-sources.sh
+++ b/.github/scripts/test-fetch-threatdb-sources.sh
@@ -113,7 +113,7 @@ while (( $# > 0 )); do
 done
 test -n "$output"
 retrieved_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-printf '{"schema_version":1,"ossf_commit":"1ea2762d5fb415aef003a244d5aa83c5fc48cc6e","retrieved_at":"%s","packages":[]}\n' "$retrieved_at" > "$output"
+printf '{"schema_version":2,"ossf_commit":"1ea2762d5fb415aef003a244d5aa83c5fc48cc6e","retrieved_at":"%s","packages":[]}\n' "$retrieved_at" > "$output"
 EOF
 
 cat > "$FAKE_BIN/curl" <<'EOF'

--- a/crates/tirith/src/bin/fixtures/threatdb-c01/registry-versions.json
+++ b/crates/tirith/src/bin/fixtures/threatdb-c01/registry-versions.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "ossf_commit": "1ea2762d5fb415aef003a244d5aa83c5fc48cc6e",
   "retrieved_at": "2026-08-08T00:00:00Z",
   "packages": [
@@ -7,6 +7,7 @@
       "ecosystem": "npm",
       "name": "@solana/web3.js",
       "source_url": "https://registry.npmjs.org/@solana%2Fweb3.js",
+      "media_type": "application/vnd.npm.install-v1+json",
       "response_sha256": "3cb47fe9e2db9ff023241a2f3089d8076da380094c6eb14385c127b59a76b6d3",
       "response_bytes": 128,
       "versions": ["1.95.5", "1.95.6", "1.95.7", "1.95.8"]

--- a/crates/tirith/src/bin/tirith_threatdb_compile.rs
+++ b/crates/tirith/src/bin/tirith_threatdb_compile.rs
@@ -199,10 +199,27 @@ const MIN_CISA_KEV_RECORDS: usize = 100;
 const MIN_TYPOSQUAT_RECORDS: usize = 100;
 const MAX_BASELINE_DROP_PERCENT: u64 = 50;
 const MAX_OSV_VALUE_BYTES: usize = 256;
-const MAX_BOUNDED_PACKAGE_REQUESTS: usize = 1_000;
-// The pinned bounded set includes @solana/web3.js metadata at 11,975,695
-// uncompressed bytes. Keep a finite per-package ceiling above that reviewed
-// response while the aggregate cap still bounds the complete transaction.
+// Pinned corpus 1ea2762d needs 156 closed-range keys plus 854 non-zero open
+// tails (`introduced: X`, no close) that are materialized from the registry as
+// well: 1,010 unique packages. Keep a finite ceiling with growth headroom.
+const MAX_BOUNDED_PACKAGE_REQUESTS: usize = 2_000;
+// Bounded registry fetches run on this many worker threads. The 854 open-tail
+// npm documents measured 53.8 s wall at 8 workers and about 7 minutes
+// sequentially, against the 420 s registry ceiling in
+// fetch-threatdb-sources.sh.
+const REGISTRY_FETCH_CONCURRENCY: usize = 8;
+// npm's abbreviated metadata keeps every `versions` key while dropping READMEs
+// and per-version manifests (@solana/web3.js: 11,975,695 -> 4,688,592 bytes).
+// PyPI has no abbreviated representation. The requested media type is recorded
+// per package in the snapshot and verified on load, so the reviewed response
+// shape is part of the provenance rather than an ambient client default.
+const NPM_REGISTRY_MEDIA_TYPE: &str = "application/vnd.npm.install-v1+json";
+const PYPI_REGISTRY_MEDIA_TYPE: &str = "application/json";
+const REGISTRY_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
+// The largest reviewed response was @solana/web3.js at 11,975,695 bytes as a
+// full document (4,688,592 abbreviated). Keep a finite per-package ceiling
+// above the full-document size while the aggregate cap still bounds the
+// complete transaction.
 const MAX_REGISTRY_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 // The reviewed 142-package snapshot totals 92,111,058 response bytes. Keep a
 // bounded 128 MiB transaction ceiling rather than the obsolete 64 MiB limit.
@@ -596,8 +613,9 @@ struct OssfStats {
     direct_whole_package_claims: usize,
     bounded_intervals_materialized: usize,
     empty_registry_intervals_projected: usize,
-    open_ended_boundaries_emitted: usize,
+    open_ended_intervals_materialized: usize,
     registry_not_found_whole_claims: usize,
+    registry_unpublished_whole_claims: usize,
     exact_versions_emitted: usize,
     unsupported_confirmed_shapes: usize,
     snapshot_failures: usize,
@@ -633,10 +651,9 @@ struct OsvInterval {
 enum RangeProjection {
     None,
     WholePackage,
-    Bounded {
-        intervals: Vec<OsvInterval>,
-        open_boundaries: Vec<String>,
-    },
+    /// Closed intervals and non-zero open tails (`introduced: X`, no close),
+    /// every one of which is materialized against the registry snapshot.
+    Bounded(Vec<OsvInterval>),
 }
 
 #[derive(Debug, Clone)]
@@ -652,6 +669,7 @@ struct PendingOssfClaim {
 enum RegistryVersionSet {
     Versions(Vec<String>),
     PackageNotFound,
+    PackageUnpublished,
 }
 
 trait RegistryVersionProvider {
@@ -673,6 +691,7 @@ struct RegistrySnapshotPackage {
     ecosystem: String,
     name: String,
     source_url: String,
+    media_type: String,
     #[serde(default = "registry_http_ok")]
     http_status: u16,
     #[serde(default)]
@@ -691,7 +710,13 @@ fn registry_http_ok() -> u16 {
 enum RegistrySnapshotResolution {
     #[default]
     RegistryVersions,
+    /// The exact metadata endpoint returned an authenticated HTTP 404.
     PackageNotFound,
+    /// HTTP 200 with no installable version: npm serves a stub document
+    /// (`{"name":…,"modified":…}`, `time.unpublished` in the full form) for a
+    /// fully unpublished package. 374 of the 854 open-tail packages in the
+    /// pinned corpus look like this.
+    PackageUnpublished,
 }
 
 #[derive(Debug)]
@@ -1292,7 +1317,7 @@ impl RegistrySnapshotStore {
         }
         let document: RegistrySnapshotDocument = serde_json::from_slice(&bytes)
             .map_err(|error| format!("invalid registry snapshot JSON: {error}"))?;
-        if document.schema_version != 1 {
+        if document.schema_version != REGISTRY_SNAPSHOT_SCHEMA_VERSION {
             return Err(format!(
                 "unsupported registry snapshot schema {}",
                 document.schema_version
@@ -1339,6 +1364,12 @@ impl RegistrySnapshotStore {
                     key.name
                 ));
             }
+            if package.media_type != registry_media_type(key.ecosystem)? {
+                return Err(format!(
+                    "registry snapshot entry for {} has unexpected media type {:?}",
+                    key.name, package.media_type
+                ));
+            }
             validate_lower_hex(
                 &package.response_sha256,
                 32,
@@ -1374,6 +1405,18 @@ impl RegistrySnapshotStore {
                         ));
                     }
                     RegistryVersionSet::PackageNotFound
+                }
+                RegistrySnapshotResolution::PackageUnpublished => {
+                    if package.http_status != 200
+                        || package.response_bytes == 0
+                        || !versions.is_empty()
+                    {
+                        return Err(format!(
+                            "registry snapshot entry for {} has inconsistent unpublished-package metadata",
+                            key.name
+                        ));
+                    }
+                    RegistryVersionSet::PackageUnpublished
                 }
             };
             for version in &versions {
@@ -1437,7 +1480,6 @@ fn parse_range_projection(
         return Ok(RangeProjection::None);
     }
     let mut intervals = Vec::new();
-    let mut open_boundaries = Vec::new();
     let mut whole_package = false;
     for range in ranges {
         if !range.extra.is_empty() {
@@ -1526,13 +1568,17 @@ fn parse_range_projection(
             if introduced == "0" {
                 whole_package = true;
             } else {
-                // The signed database has no open-ended range encoding. Emit the
-                // validated introduced boundary as an exact known-bad version;
-                // do not silently broaden it into a whole-package claim. Closed
-                // siblings are still materialized from the audited registry
-                // snapshot below.
-                compare_versions(ecosystem, &introduced, &introduced)?;
-                open_boundaries.push(introduced);
+                // The signed database has no open-ended range encoding, so
+                // `>= introduced` is materialized against the audited registry
+                // snapshot like a closed interval: every currently published
+                // version at or above the boundary becomes an exact claim, a
+                // registry 404 becomes a whole-package claim, and a boundary
+                // the registry no longer lists is still emitted exactly. It is
+                // never silently broadened to all versions.
+                intervals.push(OsvInterval {
+                    introduced,
+                    end: None,
+                });
             }
         }
     }
@@ -1545,13 +1591,10 @@ fn parse_range_projection(
     if whole_package {
         return Ok(RangeProjection::WholePackage);
     }
-    if intervals.is_empty() && open_boundaries.is_empty() {
+    if intervals.is_empty() {
         return Err(format!("{} produced no OSV intervals", path.display()));
     }
-    Ok(RangeProjection::Bounded {
-        intervals,
-        open_boundaries,
-    })
+    Ok(RangeProjection::Bounded(intervals))
 }
 
 fn collect_ossf(
@@ -1728,35 +1771,16 @@ fn collect_ossf(
                         reference: reference.clone(),
                     });
                 }
-                RangeProjection::Bounded {
+                // Only ecosystems with a pinned comparator reach here
+                // (parse_range_projection fails closed for the others), and
+                // those are exactly the ecosystems with a registry fetcher.
+                RangeProjection::Bounded(intervals) => pending.push(PendingOssfClaim {
+                    key,
+                    explicit_versions,
                     intervals,
-                    open_boundaries,
-                } => {
-                    stats.open_ended_boundaries_emitted += open_boundaries.len();
-                    explicit_versions.extend(open_boundaries);
-                    explicit_versions.sort();
-                    explicit_versions.dedup();
-                    if intervals.is_empty() {
-                        stats.exact_versions_emitted += explicit_versions.len();
-                        entries.push(PackageEntry {
-                            ecosystem,
-                            name: key.name,
-                            affected_versions: explicit_versions,
-                            all_versions_malicious: false,
-                            source: ThreatSource::OssfMalicious,
-                            confidence,
-                            reference: reference.clone(),
-                        });
-                    } else {
-                        pending.push(PendingOssfClaim {
-                            key,
-                            explicit_versions,
-                            intervals,
-                            confidence,
-                            reference: reference.clone(),
-                        });
-                    }
-                }
+                    confidence,
+                    reference: reference.clone(),
+                }),
                 RangeProjection::None if !explicit_versions.is_empty() => {
                     stats.exact_versions_emitted += explicit_versions.len();
                     entries.push(PackageEntry {
@@ -1819,7 +1843,8 @@ fn interval_contains(
         return Ok(false);
     }
     let Some((kind, end)) = &interval.end else {
-        return Err("non-zero open interval reached materialization".to_string());
+        // An open tail is affected from `introduced` onward (OSV semantics).
+        return Ok(true);
     };
     let ordering = compare_versions(ecosystem, version, end)?;
     Ok(match kind {
@@ -1840,7 +1865,10 @@ fn validate_interval_order(ecosystem: Ecosystem, interval: &OsvInterval) -> Feed
         return Ok(());
     }
     let Some((kind, end)) = &interval.end else {
-        return Err("non-zero open interval is unrepresentable".to_string());
+        // A non-zero open tail has no close to order against; its boundary
+        // must still be a parseable ecosystem version.
+        compare_versions(ecosystem, &interval.introduced, &interval.introduced)?;
+        return Ok(());
     };
     let ordering = compare_versions(ecosystem, &interval.introduced, end)?;
     let valid = match kind {
@@ -1898,28 +1926,38 @@ fn parse_ossf_with_provider(
                 claim.key.name
             )
         })?;
-        if matches!(version_set, RegistryVersionSet::PackageNotFound) {
-            // The exact registry endpoint returned a provenance-bound 404.
-            // With no available universe from which to enumerate a bounded
-            // interval, preserve protection by blocking this confirmed
-            // malicious package identity as a whole. This can only broaden a
-            // package that is absent at snapshot time; a future publication
-            // will reevaluate it if the name reappears.
-            stats.registry_not_found_whole_claims += 1;
-            stats.exact_versions_emitted += claim.explicit_versions.len();
-            entries.push(PackageEntry {
-                ecosystem: claim.key.ecosystem,
-                name: claim.key.name,
-                affected_versions: claim.explicit_versions,
-                all_versions_malicious: true,
-                source: ThreatSource::OssfMalicious,
-                confidence: claim.confidence,
-                reference: claim.reference,
-            });
-            continue;
-        }
-        let RegistryVersionSet::Versions(versions) = version_set else {
-            unreachable!("package-not-found registry snapshots return above")
+        stats.open_ended_intervals_materialized += claim
+            .intervals
+            .iter()
+            .filter(|interval| interval.end.is_none())
+            .count();
+        let versions = match version_set {
+            RegistryVersionSet::Versions(versions) => versions,
+            RegistryVersionSet::PackageNotFound | RegistryVersionSet::PackageUnpublished => {
+                // The exact registry endpoint returned a provenance-bound 404,
+                // or a 200 with no installable version (fully unpublished).
+                // With no available universe from which to enumerate a bounded
+                // interval, preserve protection by blocking this confirmed
+                // malicious package identity as a whole. Nothing installable
+                // exists to block wrongly today; a future publication will
+                // reevaluate it if the name reappears with versions.
+                if matches!(version_set, RegistryVersionSet::PackageNotFound) {
+                    stats.registry_not_found_whole_claims += 1;
+                } else {
+                    stats.registry_unpublished_whole_claims += 1;
+                }
+                stats.exact_versions_emitted += claim.explicit_versions.len();
+                entries.push(PackageEntry {
+                    ecosystem: claim.key.ecosystem,
+                    name: claim.key.name,
+                    affected_versions: claim.explicit_versions,
+                    all_versions_malicious: true,
+                    source: ThreatSource::OssfMalicious,
+                    confidence: claim.confidence,
+                    reference: claim.reference,
+                });
+                continue;
+            }
         };
         let mut affected = claim.explicit_versions;
         for interval in &claim.intervals {
@@ -3807,7 +3845,26 @@ fn registry_metadata_url(key: &RegistryPackageKey) -> FeedResult<url::Url> {
     Ok(url)
 }
 
-fn extract_registry_versions(key: &RegistryPackageKey, bytes: &[u8]) -> FeedResult<Vec<String>> {
+/// The exact `Accept` value sent for one ecosystem's metadata request. It is
+/// recorded in the snapshot and verified on load so the reviewed response
+/// shape is bound into provenance.
+fn registry_media_type(ecosystem: Ecosystem) -> FeedResult<&'static str> {
+    match ecosystem {
+        Ecosystem::Npm => Ok(NPM_REGISTRY_MEDIA_TYPE),
+        Ecosystem::PyPI => Ok(PYPI_REGISTRY_MEDIA_TYPE),
+        ecosystem => Err(format!(
+            "bounded registry snapshots are unsupported for {ecosystem}"
+        )),
+    }
+}
+
+/// The installable version keys of one HTTP 200 metadata document, or `None`
+/// when the document carries no version object at all or an empty one: npm
+/// answers a fully unpublished package with a stub that has no `versions`.
+fn extract_registry_versions(
+    key: &RegistryPackageKey,
+    bytes: &[u8],
+) -> FeedResult<Option<Vec<String>>> {
     let document: serde_json::Value = serde_json::from_slice(bytes)
         .map_err(|error| format!("invalid registry response for {}: {error}", key.name))?;
     let field = match key.ecosystem {
@@ -3815,13 +3872,24 @@ fn extract_registry_versions(key: &RegistryPackageKey, bytes: &[u8]) -> FeedResu
         Ecosystem::PyPI => "releases",
         _ => return Err(format!("unsupported registry ecosystem {}", key.ecosystem)),
     };
-    let versions = document
-        .get(field)
-        .and_then(serde_json::Value::as_object)
-        .ok_or_else(|| format!("registry response for {} has no {field} object", key.name))?;
-    if versions.is_empty() || versions.len() > MAX_REGISTRY_VERSIONS_PER_PACKAGE {
+    let document = document
+        .as_object()
+        .ok_or_else(|| format!("registry response for {} is not a JSON object", key.name))?;
+    let versions = match document.get(field) {
+        None => return Ok(None),
+        Some(value) => value.as_object().ok_or_else(|| {
+            format!(
+                "registry response for {} has a non-object {field} field",
+                key.name
+            )
+        })?,
+    };
+    if versions.is_empty() {
+        return Ok(None);
+    }
+    if versions.len() > MAX_REGISTRY_VERSIONS_PER_PACKAGE {
         return Err(format!(
-            "registry response for {} contains {} versions, outside 1..={} cap",
+            "registry response for {} contains {} versions, above the {} cap",
             key.name,
             versions.len(),
             MAX_REGISTRY_VERSIONS_PER_PACKAGE
@@ -3833,7 +3901,139 @@ fn extract_registry_versions(key: &RegistryPackageKey, bytes: &[u8]) -> FeedResu
     }
     output.sort();
     output.dedup();
-    Ok(output)
+    Ok(Some(output))
+}
+
+/// One bounded metadata request: exact URL, exact `Accept`, no redirects,
+/// per-response byte cap, HTTP 200 or an authenticated 404 only. The
+/// aggregate byte cap is enforced across workers by [`fetch_all_bounded`].
+fn fetch_registry_snapshot_package(
+    client: &reqwest::blocking::Client,
+    key: &RegistryPackageKey,
+) -> FeedResult<RegistrySnapshotPackage> {
+    let url = registry_metadata_url(key)?;
+    let media_type = registry_media_type(key.ecosystem)?;
+    let response = client
+        .get(url.clone())
+        .header(reqwest::header::ACCEPT, media_type)
+        .send()
+        .map_err(|error| format!("registry snapshot request for {} failed: {error}", key.name))?;
+    let http_status = response.status().as_u16();
+    if http_status != 200 && http_status != 404 {
+        return Err(format!(
+            "registry snapshot request for {} returned {}",
+            key.name,
+            response.status()
+        ));
+    }
+    if response.url() != &url {
+        return Err(format!("registry request for {} redirected", key.name));
+    }
+    let mut bytes = Vec::new();
+    response
+        .take((MAX_REGISTRY_RESPONSE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("cannot read registry response for {}: {error}", key.name))?;
+    if bytes.len() > MAX_REGISTRY_RESPONSE_BYTES {
+        return Err(format!(
+            "registry response for {} exceeds byte cap",
+            key.name
+        ));
+    }
+    let (resolution, versions) = if http_status == 404 {
+        (RegistrySnapshotResolution::PackageNotFound, Vec::new())
+    } else {
+        match extract_registry_versions(key, &bytes)? {
+            Some(versions) => (RegistrySnapshotResolution::RegistryVersions, versions),
+            None => (RegistrySnapshotResolution::PackageUnpublished, Vec::new()),
+        }
+    };
+    Ok(RegistrySnapshotPackage {
+        ecosystem: key.ecosystem.to_string(),
+        name: key.name.clone(),
+        source_url: url.to_string(),
+        media_type: media_type.to_string(),
+        http_status,
+        resolution,
+        response_sha256: format!("{:x}", Sha256::digest(&bytes)),
+        response_bytes: bytes.len(),
+        versions,
+    })
+}
+
+/// Run `fetch_one` over `requests` on up to `concurrency` worker threads.
+/// Results keep the input order, the aggregate response byte cap is enforced
+/// across every worker, and the first failure stops all workers before they
+/// take another request. Errors are reported lowest input index first, so the
+/// outcome for a given request set does not depend on scheduling.
+fn fetch_all_bounded<F>(
+    requests: Vec<RegistryPackageKey>,
+    concurrency: usize,
+    fetch_one: F,
+) -> FeedResult<Vec<RegistrySnapshotPackage>>
+where
+    F: Fn(&RegistryPackageKey) -> FeedResult<RegistrySnapshotPackage> + Sync,
+{
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::Mutex;
+
+    let concurrency = concurrency.clamp(1, requests.len().max(1));
+    let next = AtomicUsize::new(0);
+    let aggregate_bytes = AtomicUsize::new(0);
+    let stop = AtomicBool::new(false);
+    let slots: Mutex<Vec<Option<FeedResult<RegistrySnapshotPackage>>>> =
+        Mutex::new((0..requests.len()).map(|_| None).collect());
+    let requests = &requests;
+    let fetch_one = &fetch_one;
+    let record = |index: usize, result: FeedResult<RegistrySnapshotPackage>| {
+        if result.is_err() {
+            stop.store(true, AtomicOrdering::SeqCst);
+        }
+        slots
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())[index] = Some(result);
+    };
+    std::thread::scope(|scope| {
+        for _ in 0..concurrency {
+            scope.spawn(|| loop {
+                if stop.load(AtomicOrdering::SeqCst) {
+                    break;
+                }
+                let index = next.fetch_add(1, AtomicOrdering::SeqCst);
+                if index >= requests.len() {
+                    break;
+                }
+                let result = fetch_one(&requests[index]).and_then(|package| {
+                    let total = aggregate_bytes
+                        .fetch_add(package.response_bytes, AtomicOrdering::SeqCst)
+                        .checked_add(package.response_bytes)
+                        .ok_or_else(|| "registry aggregate byte count overflow".to_string())?;
+                    if total > MAX_REGISTRY_AGGREGATE_BYTES {
+                        return Err("registry responses exceed aggregate byte cap".to_string());
+                    }
+                    Ok(package)
+                });
+                record(index, result);
+            });
+        }
+    });
+    let slots = slots
+        .into_inner()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut packages = Vec::with_capacity(slots.len());
+    for (index, slot) in slots.into_iter().enumerate() {
+        match slot {
+            Some(Ok(package)) => packages.push(package),
+            Some(Err(error)) => return Err(error),
+            None => {
+                return Err(format!(
+                    "registry snapshot request for {} was not completed",
+                    requests[index].name
+                ))
+            }
+        }
+    }
+    Ok(packages)
 }
 
 fn fetch_registry_snapshots(root: &Path, ossf_commit: &str, output: &Path) -> FeedResult<()> {
@@ -3865,62 +4065,13 @@ fn fetch_registry_snapshots(root: &Path, ossf_commit: &str, output: &Path) -> Fe
         ))
         .build()
         .map_err(|error| format!("cannot build bounded registry client: {error}"))?;
-    let mut aggregate_bytes = 0usize;
-    let mut packages = Vec::with_capacity(requests.len());
-    for key in requests {
-        let url = registry_metadata_url(&key)?;
-        let response = client.get(url.clone()).send().map_err(|error| {
-            format!("registry snapshot request for {} failed: {error}", key.name)
-        })?;
-        let http_status = response.status().as_u16();
-        if http_status != 200 && http_status != 404 {
-            return Err(format!(
-                "registry snapshot request for {} returned {}",
-                key.name,
-                response.status()
-            ));
-        }
-        if response.url() != &url {
-            return Err(format!("registry request for {} redirected", key.name));
-        }
-        let mut bytes = Vec::new();
-        response
-            .take((MAX_REGISTRY_RESPONSE_BYTES + 1) as u64)
-            .read_to_end(&mut bytes)
-            .map_err(|error| format!("cannot read registry response for {}: {error}", key.name))?;
-        if bytes.len() > MAX_REGISTRY_RESPONSE_BYTES {
-            return Err(format!(
-                "registry response for {} exceeds byte cap",
-                key.name
-            ));
-        }
-        aggregate_bytes = aggregate_bytes
-            .checked_add(bytes.len())
-            .ok_or_else(|| "registry aggregate byte count overflow".to_string())?;
-        if aggregate_bytes > MAX_REGISTRY_AGGREGATE_BYTES {
-            return Err("registry responses exceed aggregate byte cap".to_string());
-        }
-        let (resolution, versions) = if http_status == 404 {
-            (RegistrySnapshotResolution::PackageNotFound, Vec::new())
-        } else {
-            (
-                RegistrySnapshotResolution::RegistryVersions,
-                extract_registry_versions(&key, &bytes)?,
-            )
-        };
-        packages.push(RegistrySnapshotPackage {
-            ecosystem: key.ecosystem.to_string(),
-            name: key.name,
-            source_url: url.to_string(),
-            http_status,
-            resolution,
-            response_sha256: format!("{:x}", Sha256::digest(&bytes)),
-            response_bytes: bytes.len(),
-            versions,
-        });
-    }
+    let packages = fetch_all_bounded(
+        requests.into_iter().collect(),
+        REGISTRY_FETCH_CONCURRENCY,
+        |key| fetch_registry_snapshot_package(&client, key),
+    )?;
     let document = RegistrySnapshotDocument {
-        schema_version: 1,
+        schema_version: REGISTRY_SNAPSHOT_SCHEMA_VERSION,
         ossf_commit: ossf_commit.to_string(),
         retrieved_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         packages,
@@ -4071,15 +4222,16 @@ fn main() {
             require_minimum("OSSF", unique_packages, MIN_OSSF_PACKAGES),
         );
         eprintln!(
-            "    {} entries scanned, {} unique packages ({} parsed claims), {} whole-package claims, {} bounded intervals, {} empty-registry intervals projected exactly, {} open boundaries emitted exactly, {} registry-404 whole-package fallbacks, {} exact versions, {} withdrawn, {} non-malicious, {} unknown ecosystem, {} unsupported shapes, {} snapshot failures",
+            "    {} entries scanned, {} unique packages ({} parsed claims), {} whole-package claims, {} bounded intervals, {} empty-registry intervals projected exactly, {} open-ended intervals materialized, {} registry-404 whole-package fallbacks, {} registry-unpublished whole-package fallbacks, {} exact versions, {} withdrawn, {} non-malicious, {} unknown ecosystem, {} unsupported shapes, {} snapshot failures",
             stats.total_entries,
             unique_packages,
             stats.parsed_packages,
             stats.direct_whole_package_claims,
             stats.bounded_intervals_materialized,
             stats.empty_registry_intervals_projected,
-            stats.open_ended_boundaries_emitted,
+            stats.open_ended_intervals_materialized,
             stats.registry_not_found_whole_claims,
+            stats.registry_unpublished_whole_claims,
             stats.exact_versions_emitted,
             stats.skipped_withdrawn,
             stats.skipped_non_malicious,
@@ -4516,12 +4668,16 @@ fn main() {
                     ossf_stats.empty_registry_intervals_projected,
                 ),
                 (
-                    "open_ended_boundaries_emitted".to_string(),
-                    ossf_stats.open_ended_boundaries_emitted,
+                    "open_ended_intervals_materialized".to_string(),
+                    ossf_stats.open_ended_intervals_materialized,
                 ),
                 (
                     "registry_not_found_whole_claims".to_string(),
                     ossf_stats.registry_not_found_whole_claims,
+                ),
+                (
+                    "registry_unpublished_whole_claims".to_string(),
+                    ossf_stats.registry_unpublished_whole_claims,
                 ),
                 (
                     "exact_versions_emitted".to_string(),
@@ -5002,6 +5158,7 @@ mod tests {
         calls: Vec<RegistryPackageKey>,
         versions: BTreeMap<RegistryPackageKey, Vec<String>>,
         not_found: BTreeSet<RegistryPackageKey>,
+        unpublished: BTreeSet<RegistryPackageKey>,
     }
 
     impl RegistryVersionProvider for SpyRegistryVersions {
@@ -5009,6 +5166,9 @@ mod tests {
             self.calls.push(key.clone());
             if self.not_found.contains(key) {
                 return Ok(RegistryVersionSet::PackageNotFound);
+            }
+            if self.unpublished.contains(key) {
+                return Ok(RegistryVersionSet::PackageUnpublished);
             }
             self.versions
                 .get(key)
@@ -5424,6 +5584,160 @@ mod tests {
         assert_eq!(summary.content_sha256, expected);
     }
 
+    fn synthetic_snapshot_package(
+        key: &RegistryPackageKey,
+        bytes: usize,
+    ) -> RegistrySnapshotPackage {
+        RegistrySnapshotPackage {
+            ecosystem: key.ecosystem.to_string(),
+            name: key.name.clone(),
+            source_url: registry_metadata_url(key).unwrap().to_string(),
+            media_type: registry_media_type(key.ecosystem).unwrap().to_string(),
+            http_status: 200,
+            resolution: RegistrySnapshotResolution::RegistryVersions,
+            response_sha256: "ab".repeat(32),
+            response_bytes: bytes,
+            versions: vec!["1.0.0".to_string()],
+        }
+    }
+
+    fn synthetic_request_keys(count: usize) -> Vec<RegistryPackageKey> {
+        (0..count)
+            .map(|index| RegistryPackageKey {
+                ecosystem: Ecosystem::Npm,
+                name: format!("pkg-{index:03}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn parallel_bounded_fetch_preserves_request_order() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        let requests = synthetic_request_keys(23);
+        let in_flight = AtomicUsize::new(0);
+        let peak = AtomicUsize::new(0);
+        let packages = fetch_all_bounded(requests.clone(), 8, |key| {
+            let now = in_flight.fetch_add(1, AtomicOrdering::SeqCst) + 1;
+            peak.fetch_max(now, AtomicOrdering::SeqCst);
+            // Later requests finish first so ordering cannot come from timing.
+            let index: u64 = key.name.trim_start_matches("pkg-").parse().unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(30 - index));
+            in_flight.fetch_sub(1, AtomicOrdering::SeqCst);
+            Ok(synthetic_snapshot_package(key, 10))
+        })
+        .unwrap();
+        assert_eq!(
+            packages.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(),
+            requests.iter().map(|k| k.name.as_str()).collect::<Vec<_>>()
+        );
+        assert!(
+            peak.load(AtomicOrdering::SeqCst) > 1,
+            "workers must overlap"
+        );
+        assert!(peak.load(AtomicOrdering::SeqCst) <= 8);
+    }
+
+    #[test]
+    fn parallel_bounded_fetch_reports_the_lowest_failure_and_stops_taking_work() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+        let requests = synthetic_request_keys(200);
+        let attempted = AtomicUsize::new(0);
+        let error = fetch_all_bounded(requests, 4, |key| {
+            attempted.fetch_add(1, AtomicOrdering::SeqCst);
+            if key.name == "pkg-005" {
+                return Err("boom for pkg-005".to_string());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            Ok(synthetic_snapshot_package(key, 1))
+        })
+        .unwrap_err();
+        assert_eq!(error, "boom for pkg-005");
+        assert!(
+            attempted.load(AtomicOrdering::SeqCst) < 200,
+            "a failure must stop workers from taking every remaining request"
+        );
+    }
+
+    #[test]
+    fn parallel_bounded_fetch_enforces_the_aggregate_byte_cap_across_workers() {
+        let requests = synthetic_request_keys(16);
+        let per_response = MAX_REGISTRY_AGGREGATE_BYTES / 10;
+        let error = fetch_all_bounded(requests.clone(), 8, |key| {
+            Ok(synthetic_snapshot_package(key, per_response))
+        })
+        .unwrap_err();
+        assert!(error.contains("aggregate byte cap"), "{error}");
+        let packages = fetch_all_bounded(requests, 8, |key| {
+            Ok(synthetic_snapshot_package(
+                key,
+                MAX_REGISTRY_AGGREGATE_BYTES / 16,
+            ))
+        })
+        .unwrap();
+        assert_eq!(packages.len(), 16);
+    }
+
+    #[test]
+    fn parallel_bounded_fetch_handles_an_empty_request_set() {
+        let packages =
+            fetch_all_bounded(Vec::new(), 8, |key| Ok(synthetic_snapshot_package(key, 1))).unwrap();
+        assert!(packages.is_empty());
+    }
+
+    #[test]
+    fn registry_snapshot_binds_the_requested_media_type_and_schema() {
+        let directory = tempfile::tempdir().unwrap();
+        let snapshot_path = directory.path().join("registry-versions.json");
+        let mut document: serde_json::Value = serde_json::from_str(C01_REGISTRY_VERSIONS).unwrap();
+        assert_eq!(
+            document["packages"][0]["media_type"],
+            NPM_REGISTRY_MEDIA_TYPE
+        );
+
+        document["packages"][0]["media_type"] = serde_json::json!("application/json");
+        std::fs::write(&snapshot_path, serde_json::to_vec(&document).unwrap()).unwrap();
+        let binding = fixture_snapshot_binding(&snapshot_path);
+        assert!(RegistrySnapshotStore::load(&snapshot_path, &binding)
+            .unwrap_err()
+            .contains("unexpected media type"));
+
+        document["packages"][0]["media_type"] = serde_json::json!(NPM_REGISTRY_MEDIA_TYPE);
+        document["schema_version"] = serde_json::json!(1);
+        std::fs::write(&snapshot_path, serde_json::to_vec(&document).unwrap()).unwrap();
+        let binding = fixture_snapshot_binding(&snapshot_path);
+        assert!(RegistrySnapshotStore::load(&snapshot_path, &binding)
+            .unwrap_err()
+            .contains("unsupported registry snapshot schema 1"));
+
+        let mut without_media_type = document.clone();
+        without_media_type["schema_version"] = serde_json::json!(REGISTRY_SNAPSHOT_SCHEMA_VERSION);
+        without_media_type["packages"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("media_type");
+        let bytes = serde_json::to_vec(&without_media_type).unwrap();
+        std::fs::write(&snapshot_path, &bytes).unwrap();
+        // The fixture helper parses the document itself, so bind by hand here.
+        let binding = SourceTransactionBinding {
+            provenance_sha256: "11".repeat(32),
+            registry_snapshot_sha256: sha256_hex(&bytes),
+            ossf_commit: without_media_type["ossf_commit"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+            registry_retrieved_at: without_media_type["retrieved_at"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+            registry_packages: 1,
+        };
+        let error = RegistrySnapshotStore::load(&snapshot_path, &binding).unwrap_err();
+        assert!(
+            error.contains("invalid registry snapshot JSON") && error.contains("media_type"),
+            "{error}"
+        );
+    }
+
     fn fixture_snapshot_binding(snapshot_path: &Path) -> SourceTransactionBinding {
         let bytes = std::fs::read(snapshot_path).unwrap();
         let document: RegistrySnapshotDocument = serde_json::from_slice(&bytes).unwrap();
@@ -5564,11 +5878,9 @@ mod tests {
         assert_eq!(stats.direct_whole_package_claims, 3);
     }
 
-    #[test]
-    fn nonzero_open_range_emits_known_versions_without_broadening() {
-        let directory = tempfile::tempdir().unwrap();
+    fn write_open_tail_record(directory: &Path) -> RegistryPackageKey {
         write_mal(
-            directory.path(),
+            directory,
             "MAL-2099-0023.json",
             r#"{
                 "id":"MAL-2099-0023",
@@ -5579,18 +5891,201 @@ mod tests {
                 }]
             }"#,
         );
+        RegistryPackageKey {
+            ecosystem: Ecosystem::Npm,
+            name: "open-package".to_string(),
+        }
+    }
+
+    #[test]
+    fn nonzero_open_range_materializes_every_registry_version_at_or_above_introduced() {
+        let directory = tempfile::tempdir().unwrap();
+        let key = write_open_tail_record(directory.path());
         let mut spy = SpyRegistryVersions::default();
+        spy.versions.insert(
+            key.clone(),
+            ["0.9.0", "1.0.0", "1.0.1", "1.0.3", "2.0.0-beta.1", "2.0.0"]
+                .iter()
+                .map(|v| v.to_string())
+                .collect(),
+        );
         let (entries, stats, _) =
             parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap();
+        assert_eq!(spy.calls, [key]);
+        assert_eq!(entries.len(), 1);
         assert!(
-            spy.calls.is_empty(),
-            "an open tail must not trigger live expansion"
+            !entries[0].all_versions_malicious,
+            "an open tail must not broaden to versions below introduced"
         );
+        assert_eq!(
+            entries[0].affected_versions,
+            ["1.0.1", "1.0.2", "1.0.3", "2.0.0", "2.0.0-beta.1"]
+        );
+        assert_eq!(stats.open_ended_intervals_materialized, 1);
+        assert_eq!(stats.bounded_intervals_materialized, 1);
+        assert_eq!(stats.empty_registry_intervals_projected, 0);
+    }
+
+    #[test]
+    fn nonzero_open_range_with_no_registry_version_at_or_above_introduced_keeps_exact_boundary() {
+        // The dependency-confusion shape: npm removed the attacker's version and
+        // the legitimate lower releases remain. Only the exact boundary and
+        // explicit versions may be claimed.
+        let directory = tempfile::tempdir().unwrap();
+        let key = write_open_tail_record(directory.path());
+        let mut spy = SpyRegistryVersions::default();
+        spy.versions
+            .insert(key.clone(), vec!["0.9.0".to_string(), "1.0.0".to_string()]);
+        let (entries, stats, _) =
+            parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap();
+        assert_eq!(spy.calls, [key]);
         assert_eq!(entries.len(), 1);
         assert!(!entries[0].all_versions_malicious);
         assert_eq!(entries[0].affected_versions, ["1.0.1", "1.0.2"]);
-        assert_eq!(stats.open_ended_boundaries_emitted, 1);
-        assert_eq!(stats.bounded_intervals_materialized, 0);
+        assert_eq!(stats.open_ended_intervals_materialized, 1);
+        assert_eq!(stats.empty_registry_intervals_projected, 1);
+    }
+
+    #[test]
+    fn nonzero_open_range_on_a_removed_package_becomes_a_whole_package_claim() {
+        let directory = tempfile::tempdir().unwrap();
+        let key = write_open_tail_record(directory.path());
+        let mut spy = SpyRegistryVersions::default();
+        spy.not_found.insert(key.clone());
+        let (entries, stats, _) =
+            parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap();
+        assert_eq!(spy.calls, [key]);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].all_versions_malicious);
+        assert_eq!(entries[0].affected_versions, ["1.0.2"]);
+        assert_eq!(stats.open_ended_intervals_materialized, 1);
+        assert_eq!(stats.registry_not_found_whole_claims, 1);
+    }
+
+    #[test]
+    fn nonzero_open_range_on_an_unpublished_package_becomes_a_whole_package_claim() {
+        let directory = tempfile::tempdir().unwrap();
+        let key = write_open_tail_record(directory.path());
+        let mut spy = SpyRegistryVersions::default();
+        spy.unpublished.insert(key.clone());
+        let (entries, stats, _) =
+            parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap();
+        assert_eq!(spy.calls, [key]);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].all_versions_malicious);
+        assert_eq!(stats.registry_unpublished_whole_claims, 1);
+        assert_eq!(stats.registry_not_found_whole_claims, 0);
+    }
+
+    #[test]
+    fn registry_documents_without_installable_versions_resolve_as_unpublished() {
+        let key = RegistryPackageKey {
+            ecosystem: Ecosystem::Npm,
+            name: "ab-test-wordpress".to_string(),
+        };
+        // npm's abbreviated stub for a fully unpublished package.
+        assert_eq!(
+            extract_registry_versions(
+                &key,
+                br#"{"name":"ab-test-wordpress","modified":"2025-10-10T10:44:23.849Z"}"#
+            )
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            extract_registry_versions(&key, br#"{"name":"x","versions":{}}"#).unwrap(),
+            None
+        );
+        assert_eq!(
+            extract_registry_versions(&key, br#"{"versions":{"1.0.0":{},"0.9.0":{}}}"#).unwrap(),
+            Some(vec!["0.9.0".to_string(), "1.0.0".to_string()])
+        );
+        assert!(extract_registry_versions(&key, br#"{"versions":[]}"#)
+            .unwrap_err()
+            .contains("non-object"));
+        assert!(extract_registry_versions(&key, br#"[]"#)
+            .unwrap_err()
+            .contains("not a JSON object"));
+    }
+
+    #[test]
+    fn registry_snapshot_authenticates_package_unpublished_resolution() {
+        let directory = tempfile::tempdir().unwrap();
+        let snapshot_path = directory.path().join("registry-versions.json");
+        let mut document: serde_json::Value = serde_json::from_str(C01_REGISTRY_VERSIONS).unwrap();
+        document["packages"][0]["resolution"] = serde_json::json!("package_unpublished");
+        document["packages"][0]["http_status"] = serde_json::json!(200);
+        document["packages"][0]["versions"] = serde_json::json!([]);
+        std::fs::write(&snapshot_path, serde_json::to_vec(&document).unwrap()).unwrap();
+        let binding = fixture_snapshot_binding(&snapshot_path);
+        let mut store = RegistrySnapshotStore::load(&snapshot_path, &binding).unwrap();
+        let key = RegistryPackageKey {
+            ecosystem: Ecosystem::Npm,
+            name: "@solana/web3.js".to_string(),
+        };
+        assert!(matches!(
+            store.versions_for(&key).unwrap(),
+            RegistryVersionSet::PackageUnpublished
+        ));
+
+        for (field, value) in [
+            ("http_status", serde_json::json!(404)),
+            ("response_bytes", serde_json::json!(0)),
+            ("versions", serde_json::json!(["1.0.0"])),
+        ] {
+            let mut altered = document.clone();
+            altered["packages"][0][field] = value;
+            std::fs::write(&snapshot_path, serde_json::to_vec(&altered).unwrap()).unwrap();
+            let binding = fixture_snapshot_binding(&snapshot_path);
+            let error = RegistrySnapshotStore::load(&snapshot_path, &binding).unwrap_err();
+            assert!(
+                error.contains("inconsistent unpublished-package metadata")
+                    || error.contains("not strictly sorted"),
+                "{field}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn nonzero_open_range_without_a_pinned_comparator_fails_closed_before_any_request() {
+        // crates.io and Go have no pinned comparator and no registry fetcher.
+        // A non-zero open tail there must keep failing closed at projection
+        // time (as in the parent commit), never reaching the registry path.
+        for ecosystem in ["crates.io", "Go"] {
+            let directory = tempfile::tempdir().unwrap();
+            write_mal(
+                directory.path(),
+                "MAL-2099-0040.json",
+                &format!(
+                    r#"{{
+                        "id":"MAL-2099-0040",
+                        "affected":[{{
+                            "package":{{"ecosystem":"{ecosystem}","name":"open-package"}},
+                            "ranges":[{{"type":"SEMVER","events":[{{"introduced":"1.2.0"}}]}}]
+                        }}]
+                    }}"#
+                ),
+            );
+            let mut spy = SpyRegistryVersions::default();
+            let error = parse_ossf_with_provider(directory.path(), Some(&mut spy)).unwrap_err();
+            assert!(
+                error.contains("unsupported_confirmed_shapes=1")
+                    && error.contains("not safely representable"),
+                "{ecosystem}: {error}"
+            );
+            assert!(
+                spy.calls.is_empty(),
+                "{ecosystem}: no registry request may be attempted"
+            );
+        }
+    }
+
+    #[test]
+    fn nonzero_open_range_requires_a_registry_snapshot() {
+        let directory = tempfile::tempdir().unwrap();
+        write_open_tail_record(directory.path());
+        let error = parse_ossf(directory.path()).unwrap_err();
+        assert!(error.contains("requires --registry-snapshots"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #216, which restored publication but deliberately left one measured gap: a confirmed record with `introduced: X` and no close (OSV semantics: X and every later version are malicious) was emitted as the single exact version X, because the signed database has no range encoding. A later attacker-published version resolved to `NoRecord`.

This PR materializes those open tails from the registry snapshot the same way closed intervals already are, and makes the registry step fast enough to afford it.

## Measured on the pinned corpus (`1ea2762d`)

- 854 npm records have the open-tail shape (851 from 2025, all `SEMVER`, all single-affected). 517 carry no explicit versions and none of those carry origin `versions`, so origin metadata could not close the gap.
- Abbreviated npm metadata for all 854 at concurrency 8: 53.8 s wall, 1.0 MiB total, largest 390 KB. Sequentially it takes about 7 minutes.
- 808 are live, 46 are gone. Of the live ones, 733 have **zero** registry versions at or above X (dependency-confusion shape: npm removed the attacker's version and the legitimate lower releases remain, e.g. `@dydxprotocol/solo`). Materialization adds coverage for 10 packages / 15 versions today plus whole-package claims for the 46 removed names, and it keeps every future daily snapshot self-correcting when an attacker publishes more versions.

## What changes

- **Open tails are materialized.** A non-zero `introduced: X` with no close becomes an `OsvInterval` with no end and goes through the registry path: every currently published version at or above X is an exact claim; a provenance-bound 404 becomes a whole-package claim (the package is gone, nothing legitimate is blocked); a boundary the registry no longer lists is still emitted exactly (`empty_registry_intervals_projected`). It is never broadened to versions below X. Metadata renames `open_ended_boundaries_emitted` to `open_ended_intervals_materialized`.
- **Unpublished packages are a third provenance-bound resolution.** npm answers a fully unpublished package with HTTP 200 and a stub document (`{"name":…,"modified":…}`; the full form carries `time.unpublished`). 374 of the 854 open tails look like this, and the previous code failed closed on the first one (`has no versions object`). `extract_registry_versions` now returns `None` for a missing or empty version object, the snapshot records `resolution: package_unpublished` (status 200, non-empty body, no versions, checked for consistency on load and by the shell validator), and materialization treats it like a 404: a whole-package claim counted under `registry_unpublished_whole_claims`. Nothing installable exists to block wrongly; a later republish is reevaluated by the next daily snapshot.
- **Unchanged fail-closed behavior for crates.io / Go.** Those ecosystems have no pinned comparator, so a non-zero open tail there still fails closed at projection time exactly as in #216 (`not safely representable by the current pinned comparator`); a new test pins that and that no registry request is attempted. The pinned corpus has none (all 854 open tails are npm).
- **Bounded-parallel registry fetch.** `fetch_all_bounded` runs the per-package request on 8 worker threads: input order preserved (the snapshot is deterministic), aggregate byte cap enforced across workers, the first failure stops workers from taking more requests and is reported lowest-index first. The per-request function is unchanged apart from the `Accept` header. Four unit tests cover ordering under adversarial timing, failure propagation, the aggregate cap across workers, and the empty set.
- **Abbreviated npm metadata, bound into provenance.** npm requests send `Accept: application/vnd.npm.install-v1+json` (all `versions` keys, no READMEs or per-version manifests; `@solana/web3.js` 11,975,695 -> 4,688,592 bytes). PyPI stays `application/json`. The media type is recorded per package in the snapshot (`schema_version` 2, field required, `deny_unknown_fields` kept) and verified against the ecosystem on load; a wrong media type, a missing field, or schema 1 is rejected.
- **`MAX_BOUNDED_PACKAGE_REQUESTS` 1,000 -> 2,000.** The pinned corpus needs 156 closed-range keys plus 854 open tails: 1,010. The shell validator, the compiler cap, and the provenance check all move together.
- Fetch script validator: `schema_version == 2`, per-ecosystem `media_type`, 2,000-package cap. The orchestration test's fake compiler emits schema 2.

## Verification

- `cargo test -p tirith --bin tirith-threatdb-compile`: 83 passed.
- `.github/scripts/test-fetch-threatdb-sources.sh`: passed.
- `cargo fmt --all -- --check`, `cargo clippy -p tirith --bin tirith-threatdb-compile --all-targets -- -D warnings`, `cargo +1.83 check`, `bash -n`: clean.
- Rehearsal against the sources materialized for #216 (pinned OpenSSF commit, live registries, provenance rebound exactly as the fetch script does after the registry step), then a full compile:
  - Registry step: **1,010 packages in 102 s** (8 workers, abbreviated npm; the 156-package sequential step in #216 measured 148 s), 40,592,450 bytes total (92,942,474 before with full documents), largest 5,551,875 (`@things-factory/shell`); 936 npm 200, 68 npm 404, 6 PyPI 200; validator passed.
  - OSSF: `234933 entries scanned, 234911 unique packages, 211269 whole-package claims, 572 bounded intervals, 493 empty-registry intervals projected exactly, 854 open-ended intervals materialized, 68 registry-404 whole-package fallbacks, 374 registry-unpublished whole-package fallbacks, 66603 exact versions, 21 unknown ecosystem, 0 unsupported shapes, 0 snapshot failures`
  - Accounting matches the pre-measurement exactly: 68 = 22 closed-range 404s + 46 open-tail 404s; 493 = 134 closed + 359 open tails whose live package has no version at or above X (733 zero-match live packages minus 374 unpublished).
  - Output: 11,726,384 bytes, 239,013 v1 packages, signed, compile wall 115 s.
