### PR TITLE
chore(release): prepare Tirith v0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -840,10 +840,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          notes_file="docs/release-notes-${GITHUB_REF_NAME#v}.md"
+          if [[ -f "$notes_file" ]]; then
+            notes_args=(--notes-file "$notes_file")
+          else
+            notes_args=(--generate-notes)
+          fi
           gh release create "$GITHUB_REF_NAME" artifacts/* \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
-            --generate-notes
+            "${notes_args[@]}"
 
   publish-crates:
     name: Publish to crates.io
@@ -1688,7 +1694,6 @@ jobs:
 
       - name: Push to Chocolatey
         shell: pwsh
-        continue-on-error: true  # Chocolatey moderation can block pushes; don't fail the release
         env:
           # Reach the secret through the environment. Interpolating `${{ }}` into
           # a run: body splices the value into the script before the shell sees
@@ -1696,17 +1701,16 @@ jobs:
           # lands in the process command line.
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
         run: |
-          # `continue-on-error` keeps a moderation hold from failing a release,
-          # but it also let the v0.3.3 push fail with a 403 that nobody saw: the
-          # step went red inside a green job and the version never reached
-          # Chocolatey. Every outcome here is therefore written to the run
-          # summary and raised as an annotation, so the job page says what
-          # happened without anyone opening a log.
+          # The v0.3.3 push failed with a 403 that was hidden by
+          # continue-on-error, so Chocolatey authentication/submission failures
+          # now keep the release workflow red and can be retried after the key
+          # or package ownership is fixed. A successful push may still wait for
+          # community moderation; that state is recorded in the run summary.
           $summary = $env:GITHUB_STEP_SUMMARY
           if ([string]::IsNullOrWhiteSpace($env:CHOCOLATEY_API_KEY)) {
-            Write-Output "::warning title=Chocolatey push skipped::CHOCOLATEY_API_KEY is not configured; the release was not pushed to Chocolatey"
-            Add-Content -Path $summary -Value "## Chocolatey`n`n**Skipped**: CHOCOLATEY_API_KEY is not configured."
-            exit 0
+            Write-Output "::error title=Chocolatey push blocked::CHOCOLATEY_API_KEY is not configured; the release was not pushed to Chocolatey"
+            Add-Content -Path $summary -Value "## Chocolatey`n`n**Blocked**: CHOCOLATEY_API_KEY is not configured."
+            exit 1
           }
           $nupkg = Get-ChildItem -Path ${{ github.workspace }} -Filter "tirith.*.nupkg" | Select-Object -First 1
           if (-not $nupkg) {
@@ -1720,7 +1724,7 @@ jobs:
           if ($code -ne 0) {
             $detail = ($output -split "`n" | Where-Object { $_ -match "status code|forbidden|unauthorized|conflict|moderation|exists" } | Select-Object -First 3) -join "; "
             if ([string]::IsNullOrWhiteSpace($detail)) { $detail = "exit $code" }
-            Write-Output "::error title=Chocolatey push failed::$($nupkg.Name): $detail. A 403 means the API key is invalid or not authorized for this package; a 409 means the version already exists; a moderation hold on the previous version can also refuse a push. The release itself is unaffected."
+            Write-Output "::error title=Chocolatey push failed::$($nupkg.Name): $detail. A 403 means the API key is invalid or not authorized for this package; a 409 means the version already exists; a moderation hold on the previous version can also refuse a push. The release workflow remains failed until submission succeeds."
             Add-Content -Path $summary -Value "## Chocolatey`n`n**Failed** to push ``$($nupkg.Name)``: $detail`n`nThe package must be pushed by hand, or the key rotated, before the next tag. See the step log for the full response."
             exit $code
           }

--- a/.github/workflows/threatdb.yml
+++ b/.github/workflows/threatdb.yml
@@ -756,7 +756,7 @@ jobs:
           # manifest. This is the floor introduced with DB-B/DB-C. It MUST equal
           # the tag of the release that first ships the DB-B reader: a client at
           # exactly v${V2_MIN_VERSION} is expected to be able to read the v2 asset.
-          V2_MIN_VERSION="0.3.4"
+          V2_MIN_VERSION="0.4.0"
 
           # Pre-flight: refuse to publish a v2 index whose min_tirith_version
           # points at a release tag that does not exist. Without this a typo (or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Target release: 0.4.0.** This section combines the changes merged after
-> 0.3.3 with the current integration stack. It remains unreleased until that
-> stack is rebased onto the final default-branch tip, the platform matrix and
-> release gates pass on the resulting tree, and the release date is known. See
-> the [draft 0.4.0 release guide](docs/release-notes-0.4.0.md).
+## [0.4.0] - 2026-08-25
 
 ### Added
 
@@ -76,6 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **License and release boundaries:** revocation-like webhook events that cannot be ordered are dead-lettered rather than dropped, dead-letter failures and internal server errors are logged, and an unparseable refresh-token timestamp fails closed. Release actions, images, runners, and package inputs are immutably pinned; validation and publication are separated; crates, npm packages, containers, checksums, signatures, and provenance are treated as single-use release artifacts.
 
 ### Known issues
+
+The following limitations are explicitly deferred from 0.4.0. They remain
+documented release constraints rather than claims of complete enforcement.
 
 - **Broad custom-DLP patterns can rewrite generated machine fields.** Several JSON/MCP projections recursively redact every string value after construction. Keys, booleans, and numbers survive, but generated enum labels, receipt types, content identifiers, hashes, and other protocol-owned strings can match an operator regex and be replaced, producing schema-valid JSON whose semantics or later signature/receipt verification no longer match. Custom DLP needs field classification so only untrusted/sensitive values are mutable.
 - **`tirith install --yes` is an unattended task-policy approval.** At the package-manager execution boundary, an explicit `--yes` mints the typed `unattended_package_manager` approval required by `action_incomplete_analysis: require_approval`; it does not require a TTY or a separate human. Do not use `require_approval` there as a human-in-the-loop guarantee. Use a blocking task policy or omit `--yes` until unattended acknowledgement is separated from policy approval.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,7 +3181,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tirith"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "tirith-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "base64",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "tirith-license-server"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "tirith-sign"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "tirith-test-support"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 rust-version = "1.83"
 
 [workspace.dependencies]
-tirith-core = { version = "0.3.3", path = "crates/tirith-core" }
+tirith-core = { version = "0.4.0", path = "crates/tirith-core" }
 tirith-test-support = { path = "crates/tirith-test-support" }
 clap = { version = "4", features = ["derive"] }
 url = "2"

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ documented native authority, a newly dedicated target directory, and an
 enrolled fully static native `uv`. Every unsupported platform fails closed
 before pip starts; it never falls back to an ordinary install. npm and Cargo
 remain non-enforcing evidence surfaces. See the
-[0.4.0 release guide](docs/release-notes-0.4.0.md) and
+[0.4.0 release notes](docs/release-notes-0.4.0.md) and
 [command reference](docs/commands.md).
 
 **Attack families tirith is built for** (illustrative, not a caught-by-current-code claim):
@@ -822,7 +822,7 @@ plugins=(... tirith)
 
 Use `tirith setup <tool>` for one-command configuration. This is the complete
 named setup surface, including both the earlier integrations and the additions
-targeted for 0.4.0:
+released in 0.4.0:
 
 | Host | Setup | Protection layer installed by setup | Scope |
 |---|---|---|---|
@@ -1232,7 +1232,7 @@ Disable: `export TIRITH_LOG=0`
 - [Cookbook](docs/cookbook.md), policy examples for common setups
 - [Troubleshooting](docs/troubleshooting.md), shell quirks, latency, false positives
 - [Compatibility](docs/compatibility.md), stable vs experimental surface
-- [Draft 0.4.0 release guide](docs/release-notes-0.4.0.md), release highlights, upgrade notes, limitations, and final gates
+- [0.4.0 release notes](docs/release-notes-0.4.0.md), release highlights, upgrade notes, limitations, and publication contract
 - [Release checklist](docs/release-checklist.md), protected publication sequence and registry verification
 - [Security policy](SECURITY.md), vulnerability reporting
 - [Uninstall](docs/uninstall.md), clean removal per shell and package manager

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,6 +89,5 @@ lines receive best-effort support only; upgrade before reporting a result as a
 current-version vulnerability. Code on an unreleased branch or integration
 stack is not a supported release until its protected tag and artifacts exist.
 
-For the planned 0.4.0 release, 0.3.x remains the supported published line until
-0.4.0 is actually available. After publication, 0.4.x becomes the supported
-line.
+Beginning with v0.4.0, 0.4.x is the supported release line. The 0.3.x line now
+receives best-effort support only.

--- a/TIRITH.md
+++ b/TIRITH.md
@@ -7,7 +7,7 @@
 > capability contract. Use the [README](README.md),
 > [changelog](CHANGELOG.md), [capability matrix](docs/capability-matrix.md),
 > [enforcement coverage](docs/enforcement-coverage.md), and
-> [draft 0.4.0 release guide](docs/release-notes-0.4.0.md) for current behavior.
+> [0.4.0 release notes](docs/release-notes-0.4.0.md) for current behavior.
 
 > Browsers solved homograph attacks years ago. Terminals haven't. tirith is the browser-equivalent safety net for the terminal.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,9 +1,8 @@
 # Compatibility and Stability
 
-This matrix describes the current 0.4.0 integration tree. Until 0.4.0 is
-tagged, the latest published package may expose a smaller surface. The
-[draft release guide](release-notes-0.4.0.md) separates target capabilities
-from released artifacts.
+This matrix describes Tirith 0.4.0. The
+[0.4.0 release notes](release-notes-0.4.0.md) summarize the published
+capabilities, compatibility boundaries, and remaining limitations.
 
 ## Stability Tiers
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,10 +1,10 @@
 # Release Checklist
 
-## 0.4.0 preparation
+## 0.4.0 release sequence
 
-The current changelog and release guide describe **target** 0.4.0 behavior; the
-package version remains 0.3.3 until the final integration tree is known. Before
-creating the release commit:
+The changelog and release notes describe the final 0.4.0 tree. The workspace
+version stays on the previous release until the integration tree is known, then
+the release commit performs the version and documentation transition below:
 
 1. Rebase or merge the complete integration stack onto the final default-branch
    tip and review the resulting tree, not only each stacked diff.
@@ -17,7 +17,7 @@ creating the release commit:
    every package template is materialized from the tag as designed. Do not
    hand-edit generated capability or evidence files.
 6. Move the changelog content from `[Unreleased]` to
-   `[0.4.0] - YYYY-MM-DD`, remove the draft banner from the release guide, and
+   `[0.4.0] - YYYY-MM-DD`, remove the draft banner from the release notes, and
    ensure README installation text does not claim a registry has 0.4.0 before
    that registry actually does.
 7. Run package assembly and the full release-validation workflow before pushing

--- a/docs/release-notes-0.4.0.md
+++ b/docs/release-notes-0.4.0.md
@@ -1,10 +1,7 @@
-# Tirith 0.4.0 release guide
+# Tirith 0.4.0 release notes
 
-> **Draft, not a release announcement.** Version 0.4.0 is the target for the
-> changes merged after 0.3.3 plus the current integration stack. Do not describe
-> these capabilities as released until the stack is integrated onto the final
-> default-branch tree, all required release gates pass there, and the 0.4.0 tag
-> and artifacts exist.
+Released 2026-08-25. This release integrates the work merged after 0.3.3 and
+publishes it through Tirith's protected, single-use release pipeline.
 
 ## Why 0.4.0
 
@@ -177,9 +174,7 @@ times out; run each host's verification step after setup and upgrades.
 
 ## Upgrade and installation
 
-Do not run these as 0.4.0-specific instructions until the 0.4.0 artifacts are
-published. Once released, use the same package manager that owns the current
-installation:
+Use the same package manager that owns the current installation:
 
 ```bash
 brew upgrade tirith
@@ -260,22 +255,11 @@ agent matrix.
 - Host hooks and MCP registrations require effective-host verification; config
   presence alone does not prove that a host loaded or honored them.
 
-## Release-owner gates
+## Publication and verification
 
-Before changing `[Unreleased]` to `[0.4.0]`:
-
-1. Integrate the full stack onto the final default-branch tip and review the
-   conflict resolutions and resulting tree.
-2. Close or explicitly defer every item in the changelog's known-issues list.
-3. Run the full required Linux, macOS, and Windows matrices on that exact tree,
-   including host-shaped hook fixtures and native Linux containment tests.
-4. Complete the Web3/task and ThreatDB v2 rollout playbooks.
-5. Set every workspace/package version to `0.4.0`, regenerate locked/generated
-   artifacts, and run package assembly before tagging.
-6. Verify that 0.4.0 is absent from every destination, then publish through the
-   protected tag workflow without replacing any existing artifact.
-7. Verify GitHub assets, signatures, provenance, crates.io, npm, Homebrew,
-   Scoop, GHCR, Chocolatey submission status, and AUR after publication.
-
-The operational sequence and authority requirements live in the
+0.4.0 is published only from the protected `v0.4.0` tag after the Linux,
+macOS, Windows, package-assembly, compatibility, and provenance gates pass on
+the exact tagged tree. The limitations above are the release's explicit
+deferrals. Registry availability, public artifact checksums, signatures,
+provenance, and package-manager state are verified using the
 [release checklist](release-checklist.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@ records what each command inspects and whether policy fully governs that
 surface. It is generated from the versioned
 [`capability-manifest.toml`](capability-manifest.toml) and guarded by a CI test.
 
-## Published: 0.3.3
+## Published foundation: 0.3.3
 
 The latest published release line established the current shell, CLI, policy,
 and threat-intelligence foundation:
@@ -31,10 +31,9 @@ and threat-intelligence foundation:
 See the historical [0.3.3 changelog](../CHANGELOG.md#033---2026-06-19) for the
 exact release contents.
 
-## Merged after 0.3.3
+## Published: 0.4.0
 
-These capabilities are on the default branch but have not yet appeared in a
-new tagged release:
+These capabilities shipped in 0.4.0:
 
 - **Python artifact pipeline:** typed coverage outcomes, byte/magic
   classification, a hardened streaming wheel reader, RECORD/ownership
@@ -55,10 +54,9 @@ new tagged release:
   network/feed/MCP/artifact work, centralized redaction, private audit/receipt
   state, license-event ordering, and immutable release inputs.
 
-## Targeted for 0.4.0
+### Additional 0.4.0 capabilities
 
-These capabilities are present on the current integration stack and are
-planned for 0.4.0 after final integration and release verification:
+The release also includes:
 
 - bounded Web3 command grammar and `web3_guard` policy for Cast, Forge,
   Hardhat, Solana, and Anchor;
@@ -79,23 +77,17 @@ planned for 0.4.0 after final integration and release verification:
 - GLIBC 2.28 Linux release compatibility, canonical Debian/RPM bytes, and
   expanded crates/npm/container/Chocolatey/AUR publication gates.
 
-The [draft 0.4.0 release guide](release-notes-0.4.0.md) is the detailed feature
-and upgrade inventory.
+The [0.4.0 release notes](release-notes-0.4.0.md) are the detailed feature,
+upgrade, compatibility, and limitation inventory.
 
-## Required before tagging 0.4.0
+## 0.4.0 publication contract
 
-- Integrate the entire stack onto the final default-branch tip and review the
-  resulting tree and conflict resolutions.
-- Resolve or explicitly defer every changelog known issue, including the
-  nested-shell, `forge create`, inert Web3 policy, command-card authoring,
-  task-audit, and full/read-only temporary-directory gaps.
-- Run the required Linux, macOS, and Windows matrix on the exact release tree,
-  including native Linux containment and real-host-shaped integration checks.
-- Complete the Web3/task and ThreatDB v2 rollout playbooks.
-- Make the 0.4.0 release commit, package the workspace, and publish only through
-  the protected single-use tag workflow.
-- Verify every public registry and artifact after publication. Chocolatey and
-  Homebrew core may lag the GitHub release and must be described honestly.
+0.4.0 is cut only from the final default-branch tree after the cross-platform
+and package-assembly gates pass on that exact commit. Its known issues are
+explicitly deferred in the changelog, and publication uses the protected,
+single-use tag workflow. Registry state is verified independently after the
+workflow completes; Chocolatey moderation and Homebrew core bottle publication
+may lag and are reported separately.
 
 ## Later
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2295,7 +2295,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tirith-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "base64",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -181,7 +181,7 @@ resolve_latest_version() {
   workdir="$1"
   if [ -n "$VERSION" ]; then
     validate_release_tag "$VERSION" \
-      || err "TIRITH_VERSION must be a complete semantic version (for example 0.3.3)"
+      || err "TIRITH_VERSION must be a complete semantic version (for example 0.4.0)"
     return 0
   fi
 


### PR DESCRIPTION
## Summary

- bump every Cargo workspace package and the `tirith-core` registry dependency to `0.4.0`
- move the complete post-0.3.3 changelog into `[0.4.0] - 2026-08-25` and explicitly defer the documented known limitations
- finalize the 0.4.0 release notes, compatibility/support/roadmap text, and README links
- publish curated 0.4.0 notes in the GitHub Release when present instead of an unbounded generated commit list
- set the staged ThreatDB v2 compatibility floor to the real first v2-capable release, `0.4.0`; v2 publication remains disabled
- make missing/invalid Chocolatey credentials or a rejected submission fail the release workflow so the job is retryable instead of silently green

## Release authority and destination preflight

- created the required `release` environment with a required maintainer review and a `v*` tag-only deployment policy
- created an active tag ruleset restricting creation, update, and deletion of `v*` tags to the release maintainer
- confirmed `v0.4.0` is absent from GitHub Releases/tags, crates.io, all six npm packages, Homebrew tap, Scoop, AUR, and Chocolatey
- confirmed all registry secrets are configured by name; no secret values were read
- confirmed `ENABLE_THREATDB_V2` is unset and both v2 discovery indexes return 404
- confirmed the latest deliberate ThreatDB build and subsequent scheduled build succeeded with signed source provenance

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --release --locked -p tirith --test release_security` (12 passed)
- release-tag enforcement guard with `RELEASE_TAG=v0.4.0` (passed)
- `@solana/web3.js` 1.95.5/1.95.6/1.95.7/1.95.8 boundary regression (passed)
- frozen default MCP tool-list contract (passed)
- command-category exhaustiveness contract (passed)
- ThreatDB fetch, manifest-transition, manifest-shape, shell-syntax, and workflow-YAML checks (passed)
- `cargo package -p tirith-core --allow-dirty` (passed; 224 files)
- `cargo package -p tirith --allow-dirty --list` (201 files)
- full isolated workspace run reached 1,736 passing main-binary tests; seven macOS environment/PATH-sensitive tests failed only under the synthetic HOME, then all seven passed serially under the normal account HOME. Hosted Linux/macOS/Windows CI and release dry-run are the merge gate.

`tirith` package verification is intentionally deferred until `tirith-core 0.4.0` is visible on crates.io, matching the enforced publish order.

## Post-merge publication

After every required CI and release dry-run job is green, tag the exact current `main` commit as protected `v0.4.0`, approve the `release` environment deployment, supervise all downstream publications, and independently verify public bytes and registries. Homebrew core is a separate follow-up PR; Chocolatey availability may remain pending community moderation after a successful push.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the v0.4.0 release by updating workspace versions and release documentation while tightening publication behavior.
- Uses curated release notes when creating the GitHub Release, with generated notes as a fallback.
- Makes missing credentials and rejected Chocolatey submissions fail the release workflow.
- Sets the ThreatDB v2 compatibility floor to v0.4.0.
- Finalizes the changelog, compatibility guidance, roadmap, security-support text, and release notes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no changed-code defects or security regressions identified.

The workflow changes fail closed on Chocolatey publication errors, release-note selection has a valid fallback, version metadata is synchronized, and advisory-affected third-party dependency paths identified during review are unchanged from the base revision.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Selects curated release notes when available and makes Chocolatey credential or submission failures fail the workflow. |
| .github/workflows/threatdb.yml | Updates the staged ThreatDB v2 minimum compatible Tirith version from 0.3.4 to 0.4.0. |
| Cargo.toml | Bumps the workspace and tirith-core dependency versions to 0.4.0. |
| Cargo.lock | Synchronizes workspace package versions with the 0.4.0 release without changing third-party dependency versions. |
| CHANGELOG.md | Moves post-0.3.3 changes into the dated 0.4.0 section and explicitly records deferred limitations. |
| docs/release-notes-0.4.0.md | Converts the draft release guide into finalized release notes and publication guidance. |
| SECURITY.md | Marks 0.4.x as the supported release line and moves 0.3.x to best-effort support. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Tag[Protected v0.4.0 tag] --> Gates[Release validation gates]
  Gates --> Release[GitHub Release]
  Notes{Curated notes file exists?} -->|Yes| Curated[Use 0.4.0 release notes]
  Notes -->|No| Generated[Generate release notes]
  Curated --> Release
  Generated --> Release
  Gates --> Registries[Registry publication jobs]
  Registries --> Chocolatey[Chocolatey submission]
  Chocolatey -->|Accepted| Success[Successful workflow]
  Chocolatey -->|Missing key or rejected| Failed[Failed, retryable workflow]
```

<sub>Reviews (1): Last reviewed commit: ["chore(release): prepare v0.4.0"](https://github.com/sheeki03/tirith/commit/adbefbbed1a0037650df42308cbb4af33d632f87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56762298)</sub>

<!-- /greptile_comment -->