### PR TITLE
fix: migrate rolling ThreatDB release channel

### DIFF
--- a/.github/scripts/check-threatdb-manifest-transition.py
+++ b/.github/scripts/check-threatdb-manifest-transition.py
@@ -16,7 +16,8 @@ from typing import Any
 EXPECTED_KEYS = {"version", "sha256", "size", "url", "signature"}
 ASSET_URL = re.compile(
     r"https://github\.com/sheeki03/tirith/releases/download/"
-    r"threatdb-latest/tirith-threatdb-[1-9][0-9]*-[1-9][0-9]*\.dat\Z"
+    r"(?:threatdb-latest|threatdb-current)/"
+    r"tirith-threatdb-[1-9][0-9]*-[1-9][0-9]*\.dat\Z"
 )
 LOWER_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 MAX_SAFE_SEQUENCE = 9_007_199_254_740_990

--- a/.github/scripts/test-threatdb-manifest-transition.sh
+++ b/.github/scripts/test-threatdb-manifest-transition.sh
@@ -13,7 +13,7 @@ cat > "$TEST_ROOT/base.json" <<EOF
 {"version":100,"sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":1000,"url":"https://github.com/sheeki03/tirith/releases/download/threatdb-latest/tirith-threatdb-100-1.dat","signature":"$SIGNATURE"}
 EOF
 cat > "$TEST_ROOT/forward.json" <<EOF
-{"version":101,"sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","size":1001,"url":"https://github.com/sheeki03/tirith/releases/download/threatdb-latest/tirith-threatdb-101-1.dat","signature":"$SIGNATURE"}
+{"version":101,"sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","size":1001,"url":"https://github.com/sheeki03/tirith/releases/download/threatdb-current/tirith-threatdb-101-1.dat","signature":"$SIGNATURE"}
 EOF
 cat > "$TEST_ROOT/regression.json" <<EOF
 {"version":99,"sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","size":999,"url":"https://github.com/sheeki03/tirith/releases/download/threatdb-latest/tirith-threatdb-99-1.dat","signature":"$SIGNATURE"}
@@ -23,6 +23,9 @@ cat > "$TEST_ROOT/equivocation.json" <<EOF
 EOF
 cat > "$TEST_ROOT/duplicate.json" <<EOF
 {"version":101,"version":102,"sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","size":1001,"url":"https://github.com/sheeki03/tirith/releases/download/threatdb-latest/tirith-threatdb-101-1.dat","signature":"$SIGNATURE"}
+EOF
+cat > "$TEST_ROOT/foreign-release.json" <<EOF
+{"version":101,"sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","size":1001,"url":"https://github.com/sheeki03/tirith/releases/download/untrusted/tirith-threatdb-101-1.dat","signature":"$SIGNATURE"}
 EOF
 
 python3 "$CHECK_SCRIPT" "$TEST_ROOT/base.json"
@@ -48,5 +51,13 @@ if python3 "$CHECK_SCRIPT" "$TEST_ROOT/duplicate.json" \
   exit 1
 fi
 grep -Fq 'duplicate JSON key: version' "$TEST_ROOT/duplicate.log"
+
+if python3 "$CHECK_SCRIPT" "$TEST_ROOT/foreign-release.json" \
+    > "$TEST_ROOT/foreign-release.log" 2>&1; then
+  echo "expected an untrusted release URL to fail" >&2
+  exit 1
+fi
+grep -Fq 'URL is outside the rolling ThreatDB release' \
+  "$TEST_ROOT/foreign-release.log"
 
 echo "threatdb manifest transition regression passed"

--- a/.github/workflows/threatdb.yml
+++ b/.github/workflows/threatdb.yml
@@ -16,6 +16,11 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # `threatdb-latest` was sealed by GitHub release immutability and cannot be
+  # updated. Keep it intact as a legacy client fallback; all new rolling state
+  # is published through this replacement tag.
+  THREATDB_RELEASE_TAG: threatdb-current
+  THREATDB_LEGACY_RELEASE_TAG: threatdb-latest
   # Reviewed immutable source revisions consumed and verified by the atomic
   # fetch transaction. Updating any pin is a source-review event.
   THREATDB_OSSF_MP_REF: 1ea2762d5fb415aef003a244d5aa83c5fc48cc6e
@@ -324,15 +329,34 @@ jobs:
 
           # The rolling release is a second publication surface. It can be ahead
           # of main after a push failure, so both copies participate in the max.
-          if gh release view threatdb-latest --repo "$GITHUB_REPOSITORY" \
+          # On the first run after the immutable-release migration, bootstrap
+          # only from the sealed legacy channel. Once the replacement exists,
+          # every later run must allocate from it.
+          ROLLING_STATE_TAG="$THREATDB_RELEASE_TAG"
+          if ! gh release view "$ROLLING_STATE_TAG" --repo "$GITHUB_REPOSITORY" \
               --json assets > "$STATE_DIR/release.json"; then
+            if git ls-remote --exit-code --tags origin \
+                "refs/tags/$THREATDB_RELEASE_TAG" >/dev/null 2>&1; then
+              echo "::error::$THREATDB_RELEASE_TAG tag exists but its release could not be inspected; refusing legacy bootstrap"
+              exit 1
+            fi
+            ROLLING_STATE_TAG="$THREATDB_LEGACY_RELEASE_TAG"
+            if ! gh release view "$ROLLING_STATE_TAG" --repo "$GITHUB_REPOSITORY" \
+                --json assets > "$STATE_DIR/release.json"; then
+              echo "::error::failed to inspect either rolling release; refusing to allocate from incomplete state"
+              exit 1
+            fi
+            echo "Bootstrapping $THREATDB_RELEASE_TAG from sealed $ROLLING_STATE_TAG"
+          fi
+
+          if [ -s "$STATE_DIR/release.json" ]; then
             if ! jq -e '.assets | any(.name == "threatdb-manifest.json")' \
                 "$STATE_DIR/release.json" >/dev/null; then
               echo "::error::rolling release exists without threatdb-manifest.json"
               exit 1
             fi
             mkdir -p "$STATE_DIR/release"
-            gh release download threatdb-latest --repo "$GITHUB_REPOSITORY" \
+            gh release download "$ROLLING_STATE_TAG" --repo "$GITHUB_REPOSITORY" \
               --pattern threatdb-manifest.json --dir "$STATE_DIR/release" --clobber
             consider_signed_document \
               "$STATE_DIR/release/threatdb-manifest.json" manifest \
@@ -340,7 +364,7 @@ jobs:
 
             if jq -e '.assets | any(.name == "threatdb-index-v2.json")' \
                 "$STATE_DIR/release.json" >/dev/null; then
-              gh release download threatdb-latest --repo "$GITHUB_REPOSITORY" \
+              gh release download "$ROLLING_STATE_TAG" --repo "$GITHUB_REPOSITORY" \
                 --pattern threatdb-index-v2.json --dir "$STATE_DIR/release" --clobber
               consider_signed_document \
                 "$STATE_DIR/release/threatdb-index-v2.json" index \
@@ -348,18 +372,12 @@ jobs:
             fi
             if jq -e '.assets | any(.name == "threatdb-baseline-v2.json")' \
                 "$STATE_DIR/release.json" >/dev/null; then
-              gh release download threatdb-latest --repo "$GITHUB_REPOSITORY" \
+              gh release download "$ROLLING_STATE_TAG" --repo "$GITHUB_REPOSITORY" \
                 --pattern threatdb-baseline-v2.json --dir "$STATE_DIR/release" --clobber
               consider_signed_document \
                 "$STATE_DIR/release/threatdb-baseline-v2.json" index \
                 "retained non-discovery v2 baseline"
             fi
-          else
-            # Do not mistake an API/network failure (or a deleted release) for a
-            # clean bootstrap. This repository already has a rolling channel;
-            # recovering it requires an explicit operator action.
-            echo "::error::failed to inspect the rolling release; refusing to allocate from incomplete state"
-            exit 1
           fi
 
           NOW_MILLIS=$(date +%s%3N)
@@ -456,7 +474,7 @@ jobs:
             V2_ARGS+=(--output-v2 "tirith-threatdb-v2-${RUN_ID}-${RUN_ATTEMPT}.dat")
             GENERATION_ARGS+=(
               --generation-manifest threatdb-index-v2.json
-              --generation-base-url https://github.com/sheeki03/tirith/releases/download/threatdb-latest
+              --generation-base-url "https://github.com/sheeki03/tirith/releases/download/${THREATDB_RELEASE_TAG}"
               --source-integrity-manifest "threatdb-source-integrity-${RUN_ID}-${RUN_ATTEMPT}.json"
             )
           fi
@@ -586,7 +604,7 @@ jobs:
           DB_ASSET="tirith-threatdb-${RUN_ID}-${RUN_ATTEMPT}.dat"
           SHA=$(sha256sum "$DB_ASSET" | cut -d' ' -f1)
           SIZE=$(stat -c%s "$DB_ASSET")
-          URL="https://github.com/sheeki03/tirith/releases/download/threatdb-latest/${DB_ASSET}"
+          URL="https://github.com/sheeki03/tirith/releases/download/${THREATDB_RELEASE_TAG}/${DB_ASSET}"
           # PAYLOAD MUST stay byte-identical to the client's canonical_payload() in
           # crates/tirith/src/cli/threatdb_cmd.rs (alphabetical keys, compact, no
           # spaces) — only the $URL value differs from older versions. The signature
@@ -611,7 +629,7 @@ jobs:
       - name: Publish release (v1 + legacy manifest)
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: threatdb-latest
+          tag_name: ${{ env.THREATDB_RELEASE_TAG }}
           prerelease: true
           make_latest: false
           overwrite_files: true
@@ -654,15 +672,15 @@ jobs:
           set -euo pipefail
           STATE_DIR=$(mktemp -d)
           trap 'rm -rf "$STATE_DIR"' EXIT
-          if ! gh release view threatdb-latest --repo "${{ github.repository }}" \
+          if ! gh release view "$THREATDB_RELEASE_TAG" --repo "${{ github.repository }}" \
               --json assets > "$STATE_DIR/assets.json"; then
             echo "::error::cannot inspect rolling release before v2-index retirement"
             exit 1
           fi
           if [ -f threatdb-baseline-v2.json ]; then
-            gh release upload threatdb-latest threatdb-baseline-v2.json \
+            gh release upload "$THREATDB_RELEASE_TAG" threatdb-baseline-v2.json \
               --repo "${{ github.repository }}" --clobber
-            if ! gh release view threatdb-latest --repo "${{ github.repository }}" \
+            if ! gh release view "$THREATDB_RELEASE_TAG" --repo "${{ github.repository }}" \
                 --json assets > "$STATE_DIR/assets-with-baseline.json"; then
               echo "::error::cannot verify retained v2 baseline publication"
               exit 1
@@ -673,7 +691,7 @@ jobs:
               exit 1
             fi
             mkdir -p "$STATE_DIR/verify-baseline"
-            if ! gh release download threatdb-latest --repo "${{ github.repository }}" \
+            if ! gh release download "$THREATDB_RELEASE_TAG" --repo "${{ github.repository }}" \
                 --pattern threatdb-baseline-v2.json \
                 --dir "$STATE_DIR/verify-baseline" --clobber; then
               echo "::error::cannot read back retained v2 baseline"
@@ -687,9 +705,9 @@ jobs:
           fi
           if jq -e '.assets | any(.name == "threatdb-index-v2.json")' \
               "$STATE_DIR/assets.json" >/dev/null; then
-            gh release delete-asset threatdb-latest threatdb-index-v2.json \
+            gh release delete-asset "$THREATDB_RELEASE_TAG" threatdb-index-v2.json \
               --repo "${{ github.repository }}" --yes
-            if ! gh release view threatdb-latest --repo "${{ github.repository }}" \
+            if ! gh release view "$THREATDB_RELEASE_TAG" --repo "${{ github.repository }}" \
                 --json assets > "$STATE_DIR/assets-after.json"; then
               echo "::error::cannot verify rolling-release v2-index retirement"
               exit 1
@@ -745,8 +763,8 @@ jobs:
           V2_SHA=$(sha256sum "$V2_ASSET" | cut -d' ' -f1)
           V1_SIZE=$(stat -c%s "$V1_ASSET")
           V2_SIZE=$(stat -c%s "$V2_ASSET")
-          V1_URL="https://github.com/sheeki03/tirith/releases/download/threatdb-latest/${V1_ASSET}"
-          V2_URL="https://github.com/sheeki03/tirith/releases/download/threatdb-latest/${V2_ASSET}"
+          V1_URL="https://github.com/sheeki03/tirith/releases/download/${THREATDB_RELEASE_TAG}/${V1_ASSET}"
+          V2_URL="https://github.com/sheeki03/tirith/releases/download/${THREATDB_RELEASE_TAG}/${V2_ASSET}"
           SOURCE_PROVENANCE="threatdb-source-provenance-${RUN_ID}-${RUN_ATTEMPT}.json"
           SOURCE_TRANSACTION_SHA=$(jq -er '.integrity_bindings.source_transaction_sha256' "$SOURCE_PROVENANCE")
           REGISTRY_SNAPSHOT_SHA=$(jq -er '.integrity_bindings.registry_snapshot_sha256' "$SOURCE_PROVENANCE")
@@ -885,7 +903,7 @@ jobs:
         if: ${{ env.ENABLE_THREATDB_V2 == 'true' }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: threatdb-latest
+          tag_name: ${{ env.THREATDB_RELEASE_TAG }}
           prerelease: true
           make_latest: false
           overwrite_files: true
@@ -902,7 +920,7 @@ jobs:
         if: ${{ env.ENABLE_THREATDB_V2 == 'true' }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: threatdb-latest
+          tag_name: ${{ env.THREATDB_RELEASE_TAG }}
           prerelease: true
           make_latest: false
           overwrite_files: true
@@ -917,7 +935,7 @@ jobs:
         if: ${{ env.ENABLE_THREATDB_V2 == 'true' }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: threatdb-latest
+          tag_name: ${{ env.THREATDB_RELEASE_TAG }}
           prerelease: true
           make_latest: false
           overwrite_files: true
@@ -983,7 +1001,7 @@ jobs:
           STATE_DIR="$(mktemp -d)"
           ASSETS_JSON="$STATE_DIR/assets.json"
           trap 'rm -rf "$STATE_DIR"' EXIT
-          if ! gh release view threatdb-latest --repo "${{ github.repository }}" \
+          if ! gh release view "$THREATDB_RELEASE_TAG" --repo "${{ github.repository }}" \
               --json assets > "$ASSETS_JSON"; then
             echo "::error::prune: failed to fetch release assets via gh release view"
             exit 1
@@ -999,7 +1017,7 @@ jobs:
             exit 1
           fi
           mkdir -p "$STATE_DIR/published/release" "$STATE_DIR/published/main"
-          if ! gh release download threatdb-latest \
+          if ! gh release download "$THREATDB_RELEASE_TAG" \
               --repo "${{ github.repository }}" \
               --pattern threatdb-manifest.json \
               --dir "$STATE_DIR/published/release" --clobber; then
@@ -1097,7 +1115,7 @@ jobs:
           # verify bytes and apply v2-only anti-drop floors.
           if jq -e '.assets | any(.name == "threatdb-baseline-v2.json")' \
               "$ASSETS_JSON" >/dev/null; then
-            if ! gh release download threatdb-latest \
+            if ! gh release download "$THREATDB_RELEASE_TAG" \
                 --repo "${{ github.repository }}" \
                 --pattern threatdb-baseline-v2.json \
                 --dir "$STATE_DIR/published/release" --clobber; then
@@ -1114,7 +1132,7 @@ jobs:
           # protect the referenced asset; malformed disagreement fails closed.
           if jq -e '.assets | any(.name == "threatdb-index-v2.json")' \
               "$ASSETS_JSON" >/dev/null; then
-            if ! gh release download threatdb-latest \
+            if ! gh release download "$THREATDB_RELEASE_TAG" \
                 --repo "${{ github.repository }}" \
                 --pattern threatdb-index-v2.json \
                 --dir "$STATE_DIR/published/release" --clobber; then
@@ -1161,6 +1179,6 @@ jobs:
           fi
           for asset in "${STALE[@]}"; do
             echo "Pruning stale asset: $asset"
-            gh release delete-asset threatdb-latest "$asset" \
+            gh release delete-asset "$THREATDB_RELEASE_TAG" "$asset" \
               --repo "${{ github.repository }}" --yes
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Migrated the mutable ThreatDB publication channel to `threatdb-current` after
+  GitHub sealed the former `threatdb-latest` rolling release. The signed legacy
+  channel remains intact as a last-known-good fallback, while new manifests,
+  assets, pruning, and v2 rollback operations use the replacement channel.
+
 ## [0.4.0] - 2026-08-25
 
 ### Added

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -24,7 +24,7 @@ static VERIFY_KEY_BYTES: &[u8; PUBLIC_KEY_LENGTH] =
 const MANIFEST_URL_PRIMARY: &str =
     "https://raw.githubusercontent.com/sheeki03/tirith/main/threatdb-manifest.json";
 const MANIFEST_URL_FALLBACK: &str =
-    "https://github.com/sheeki03/tirith/releases/download/threatdb-latest/threatdb-manifest.json";
+    "https://github.com/sheeki03/tirith/releases/download/threatdb-current/threatdb-manifest.json";
 
 /// Signed multi-asset v2 index. A new (v2-capable) client fetches this first,
 /// verifies its signature, and selects the highest compatible asset; on any
@@ -33,7 +33,7 @@ const MANIFEST_URL_FALLBACK: &str =
 const INDEX_V2_URL_PRIMARY: &str =
     "https://raw.githubusercontent.com/sheeki03/tirith/main/threatdb-index-v2.json";
 const INDEX_V2_URL_FALLBACK: &str =
-    "https://github.com/sheeki03/tirith/releases/download/threatdb-latest/threatdb-index-v2.json";
+    "https://github.com/sheeki03/tirith/releases/download/threatdb-current/threatdb-index-v2.json";
 
 const MAX_MANIFEST_SIZE: u64 = 64 * 1024;
 const MAX_DB_SIZE: u64 = 256 * 1024 * 1024;

--- a/docs/threatdb-v2-rollout.md
+++ b/docs/threatdb-v2-rollout.md
@@ -7,6 +7,10 @@ DB-backed detection silently stops). So the v2 migration is staged so that no
 client is ever served data it cannot read, and the v1 path is never removed until
 adoption is high enough.
 
+The mutable rolling channel is `threatdb-current`. The former
+`threatdb-latest` release is sealed and retained as a last-known-good fallback;
+it must not be deleted or reused.
+
 This runbook covers the rollout sequence, the safety properties that make it
 safe, and how the cutover is gated without any client telemetry.
 
@@ -91,7 +95,7 @@ then remove unreferenced data:
 3. Dispatch `threatdb.yml` after the variable change and wait for it to complete.
    A disabled run publishes the next signed v1 generation, preserves the newest
    authenticated generation as the non-discovery `threatdb-baseline-v2.json`,
-   deletes the fallback `threatdb-index-v2.json` asset from `threatdb-latest`, and
+   deletes the fallback `threatdb-index-v2.json` asset from `threatdb-current`, and
    commits deletion of the primary `threatdb-index-v2.json` on main, in that order.
    Confirm the release index is absent and the raw-main URL returns 404 before
    proceeding. If an emergency manual retirement is necessary, preserve the
@@ -108,7 +112,7 @@ then remove unreferenced data:
    set -euo pipefail
    state=$(mktemp -d)
    trap 'rm -rf -- "$state"' EXIT
-   gh release download threatdb-latest --repo <owner>/<repo> \
+   gh release download threatdb-current --repo <owner>/<repo> \
      --pattern threatdb-baseline-v2.json --dir "$state"
    protected=$(jq -er '.assets[] | select(.format == 2) | .filename' \
      "$state/threatdb-baseline-v2.json")
@@ -116,7 +120,7 @@ then remove unreferenced data:
      echo "invalid protected v2 baseline asset: $protected" >&2
      exit 1
    fi
-   gh release view threatdb-latest --repo <owner>/<repo> --json assets \
+   gh release view threatdb-current --repo <owner>/<repo> --json assets \
      > "$state/assets.json"
    jq -e --arg protected "$protected" \
      '.assets | any(.name == $protected)' "$state/assets.json" >/dev/null
@@ -125,7 +129,7 @@ then remove unreferenced data:
      "$state/assets.json" > "$state/candidates.txt"
    while IFS= read -r asset; do
      if [ "$asset" != "$protected" ]; then
-       gh release delete-asset threatdb-latest "$asset" --repo <owner>/<repo> --yes
+       gh release delete-asset threatdb-current "$asset" --repo <owner>/<repo> --yes
      fi
    done < "$state/candidates.txt"
    ```


### PR DESCRIPTION
## Summary

- migrate mutable ThreatDB publication from the now-sealed `threatdb-latest` release to `threatdb-current`
- bootstrap the replacement exactly once from the authenticated legacy release, while failing closed if the replacement tag already exists but cannot be inspected
- retain `threatdb-latest` unchanged as a last-known-good fallback and update future client fallback URLs, validation, tests, runbook, and changelog

## Why

Repository release immutability was briefly enabled during the v0.4.0 release verification. A subsequent rolling ThreatDB update caused GitHub to seal the existing `threatdb-latest` release. GitHub does not allow its assets to be replaced after that point, so the rolling channel needs a new tag. The stable v0.4.0 release and all package-manager artifacts are unaffected.

## Verification

- `bash .github/scripts/test-threatdb-manifest-transition.sh`
- `python3 .github/scripts/check-threatdb-manifest-transition.py threatdb-manifest.json`
- `python3 -m py_compile .github/scripts/check-threatdb-manifest-transition.py`
- `shellcheck .github/scripts/test-threatdb-manifest-transition.sh`
- `cargo fmt --all -- --check`
- `cargo test -p tirith --bin tirith threatdb` (118 passed)
- workflow YAML parsed successfully
- live bootstrap preconditions verified: `threatdb-current` tag/release absent; sealed `threatdb-latest` present with signed manifest


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates mutable ThreatDB publication and client fallbacks from the sealed `threatdb-latest` release to `threatdb-current`, retaining the legacy release as bootstrap and last-known-good state.

- Adds one-time authenticated bootstrap logic for the replacement rolling release.
- Retargets v1/v2 publication, retirement, pruning, and client fallback URLs.
- Expands manifest validation and regression coverage for both trusted release tags.
- Updates the rollout runbook and changelog.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until replacement-tag absence is distinguished from a failed remote lookup, which can otherwise bootstrap publication from stale legacy state.

The new bootstrap branch fails open to the sealed release when both current-release inspection and the remote tag lookup error, despite requiring incomplete-state inspection failures to stop publication.

**Files Needing Attention:** .github/workflows/threatdb.yml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/threatdb.yml | Migrates the complete publication lifecycle, but the bootstrap tag check can mistake a failed lookup for confirmed absence and select stale legacy state. |
| crates/tirith/src/cli/threatdb_cmd.rs | Consistently redirects v1 and v2 client release fallbacks to `threatdb-current`. |
| .github/scripts/check-threatdb-manifest-transition.py | Extends the strict trusted-asset URL allowlist to the legacy and replacement rolling tags. |
| .github/scripts/test-threatdb-manifest-transition.sh | Covers valid cross-channel progression and rejection of an unrelated release URL. |
| docs/threatdb-v2-rollout.md | Updates rollback operations and documents preservation of the sealed legacy release. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  M[Main signed documents] --> A[Sequence and baseline allocator]
  C[threatdb-current] -->|normal state| A
  L[sealed threatdb-latest] -->|first-run bootstrap only| A
  A --> B[Compile and sign next generation]
  B --> P[Publish assets and pointers to threatdb-current]
  P --> R[Protect referenced assets and prune stale assets]
  P --> U[Clients fetch raw-main primary]
  P --> F[Clients fetch threatdb-current fallback]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20sheeki03%2Ftirith%20PR%20%23220%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=sheeki03%2Ftirith&pr=220&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fthreatdb.yml%3A337-342%0A**Failed%20lookup%20enables%20stale%20bootstrap**%0A%0AWhen%20%60gh%20release%20view%60%20and%20the%20subsequent%20remote%20tag%20lookup%20both%20fail%20transiently%2C%20every%20nonzero%20%60git%20ls-remote%60%20result%20is%20treated%20as%20proof%20that%20%60threatdb-current%60%20is%20absent.%20The%20workflow%20then%20bootstraps%20from%20%60threatdb-latest%60%2C%20omitting%20newer%20signed%20state%20from%20sequence%20and%20baseline%20allocation%20and%20allowing%20publication%20based%20on%20stale%20legacy%20state.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=sheeki03%2Ftirith&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: migrate rolling ThreatDB release ch..."](https://github.com/sheeki03/tirith/commit/3d45d5f151b77e73a1e51d597818f869db234bc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56810713)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Threat intelligence and registry correlation](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/threat-intelligence-and-registry-correlation.md)

<!-- /greptile_comment -->