### PR TITLE
fix(receipts): canonicalize the launch path before the O_NOFOLLOW identity open

### DIFF
--- a/crates/tirith-core/src/execution_state/shell_receipt.rs
+++ b/crates/tirith-core/src/execution_state/shell_receipt.rs
@@ -646,14 +646,30 @@ fn shell_process_identity(
 
 #[cfg(unix)]
 fn current_tirith_executable_identity() -> Result<TirithExecutableIdentity, String> {
-    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
-
     let path = std::env::current_exe()
         .map_err(|error| format!("resolve current Tirith executable: {error}"))?;
+    identity_for_launch_path(&path)
+}
+
+/// On macOS `current_exe` returns the launch path unresolved, so a symlinked
+/// launch path (Homebrew's `/opt/homebrew/bin/tirith`, npm wrappers) would fail
+/// the O_NOFOLLOW open below with ELOOP. Canonicalize first; a symlink swapped
+/// in after canonicalization still fails closed on O_NOFOLLOW.
+#[cfg(unix)]
+fn identity_for_launch_path(path: &Path) -> Result<TirithExecutableIdentity, String> {
+    let path = fs::canonicalize(path)
+        .map_err(|error| format!("resolve current Tirith executable: {error}"))?;
+    executable_identity_at(&path)
+}
+
+#[cfg(unix)]
+fn executable_identity_at(path: &Path) -> Result<TirithExecutableIdentity, String> {
+    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+
     let file = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK)
-        .open(&path)
+        .open(path)
         .map_err(|error| format!("open current Tirith executable: {error}"))?;
     let metadata = file
         .metadata()
@@ -670,7 +686,7 @@ fn current_tirith_executable_identity() -> Result<TirithExecutableIdentity, Stri
             "current Tirith executable is writable by group/other or is not executable".to_string(),
         );
     }
-    let path_metadata = fs::symlink_metadata(&path)
+    let path_metadata = fs::symlink_metadata(path)
         .map_err(|error| format!("inspect current Tirith executable path: {error}"))?;
     if path_metadata.file_type().is_symlink()
         || !path_metadata.is_file()
@@ -5262,5 +5278,43 @@ mod tests {
                 "unexpected error: {reconcile_error}"
             );
         });
+    }
+
+    fn fake_executable(dir: &Path) -> PathBuf {
+        let target = dir.join("tirith-real");
+        fs::write(&target, b"#!/bin/sh\n").expect("write fake executable");
+        let mut permissions = fs::metadata(&target)
+            .expect("inspect fake executable")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&target, permissions).expect("mark fake executable executable");
+        target
+    }
+
+    #[test]
+    fn identity_for_launch_path_resolves_symlinked_launch_paths() {
+        let temporary = tempfile::tempdir().expect("temp dir");
+        let target = fake_executable(temporary.path());
+        let link = temporary.path().join("tirith-link");
+        symlink(&target, &link).expect("create launch-path symlink");
+
+        let via_link = identity_for_launch_path(&link).expect("symlinked launch path must resolve");
+        let direct = identity_for_launch_path(&target).expect("direct launch path must resolve");
+        assert_eq!(via_link, direct);
+    }
+
+    #[test]
+    fn executable_identity_at_still_refuses_symlinks() {
+        let temporary = tempfile::tempdir().expect("temp dir");
+        let target = fake_executable(temporary.path());
+        let link = temporary.path().join("tirith-link");
+        symlink(&target, &link).expect("create launch-path symlink");
+
+        let error = executable_identity_at(&link)
+            .expect_err("O_NOFOLLOW open must reject an unresolved symlink");
+        assert!(
+            error.contains("open current Tirith executable"),
+            "unexpected error: {error}"
+        );
     }
 }


### PR DESCRIPTION
std::env::current_exe returns the launch path unresolved on macOS, so
registering or validating the receipt capability through a symlinked
launch path (Homebrew /opt/homebrew/bin/tirith, npm wrappers) failed
with ELOOP and silently degraded the shell to legacy mode. Resolve the
path first; O_NOFOLLOW stays on the open of the resolved path, so a
symlink swapped in after canonicalization still fails closed.

Refs #221 (finding 2).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Tirith launched through symbolic links on Unix systems.
  - Valid symbolic links are now resolved correctly, allowing the executable to be identified and inspected as expected.
  - Unresolved or invalid symbolic links continue to be rejected.
  - Preserved protections against executable path substitution during inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR resolves Unix launch paths before obtaining Tirith’s executable identity, allowing shell receipt registration and validation through macOS package-manager symlinks while retaining the no-follow open on the resolved file.
- Extracts launch-path resolution into `identity_for_launch_path`.
- Keeps executable metadata and path identity validation in `executable_identity_at`.
- Adds coverage for accepted symlinked launch paths and rejection of unresolved symlinks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/execution_state/shell_receipt.rs | Canonicalizes the current executable’s launch path before the existing identity checks and adds focused Unix symlink regression tests. |

<sub>Reviews (3): Last reviewed commit: ["fix(receipts): canonicalize the launch p..."](https://github.com/sheeki03/tirith/commit/7584b985a1f15134a70f41ed3999e30c7be797c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58726077)</sub>

<!-- /greptile_comment -->