### PR TITLE
fix(shell): register execution receipts as a direct child of the shell

### DIFF
--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -1273,7 +1273,7 @@ _tirith_preexec_receipt_check() {
     _TIRITH_RECEIPT_FAMILY="$_TIRITH_RECEIPT_FAMILY" \
     builtin command "$_TIRITH_BIN" check --approval-check --execution-receipt bash-preexec \
     --non-interactive --interactive --shell posix "${render_args[@]}" -- "$scan_target" \
-    >"$stdout_file"
+    >|"$stdout_file"
   rc=$?
 
   local parse_rc token
@@ -1770,7 +1770,7 @@ _TIRITH_DEBUG_CAPTURE_FILE=""
 _TIRITH_DEBUG_OWNERSHIP_FILE=""
 _TIRITH_DEBUG_TRAP_OWNERSHIP_OK=0
 _TIRITH_PREEXEC_ENFORCE_PENDING=0
-_TIRITH_PREEXEC_BOOTSTRAP_COMMAND='if [[ "${_TIRITH_DEBUG_TRAP_CAPTURE_READY:-0}" == "0" ]]; then builtin trap -p DEBUG >"$_TIRITH_DEBUG_CAPTURE_FILE" 2>/dev/null; _tirith_finalize_debug_trap_capture; fi; if [[ "${_TIRITH_DEBUG_TRAP_INSTALLED:-0}" == "1" ]]; then builtin trap -p DEBUG >"$_TIRITH_DEBUG_OWNERSHIP_FILE" 2>/dev/null; _tirith_verify_debug_trap_ownership; fi; _tirith_restore_prompt_status'
+_TIRITH_PREEXEC_BOOTSTRAP_COMMAND='if [[ "${_TIRITH_DEBUG_TRAP_CAPTURE_READY:-0}" == "0" ]]; then builtin trap -p DEBUG >|"$_TIRITH_DEBUG_CAPTURE_FILE" 2>/dev/null; _tirith_finalize_debug_trap_capture; fi; if [[ "${_TIRITH_DEBUG_TRAP_INSTALLED:-0}" == "1" ]]; then builtin trap -p DEBUG >|"$_TIRITH_DEBUG_OWNERSHIP_FILE" 2>/dev/null; _tirith_verify_debug_trap_ownership; fi; _tirith_restore_prompt_status'
 
 
 if [[ -n "${TIRITH_BASH_MODE:-}" ]]; then
@@ -2096,7 +2096,7 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         _TIRITH_RECEIPT_SHELL_PID="$_TIRITH_RECEIPT_SHELL_PID" \
         _TIRITH_RECEIPT_FAMILY="$_TIRITH_RECEIPT_FAMILY" \
         builtin command "$_TIRITH_BIN" check --approval-check --non-interactive --interactive --shell posix \
-        "${receipt_args[@]}" -- "$READLINE_LINE" >"$stdout_file" 2>"$errfile"
+        "${receipt_args[@]}" -- "$READLINE_LINE" >|"$stdout_file" 2>|"$errfile"
       rc=$?
       _TIRITH_BASH_INTERNAL="$_tirith_prev_internal"
       local output
@@ -2339,7 +2339,7 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         }
         local _tirith_prev_internal="${_TIRITH_BASH_INTERNAL:-0}"
         _TIRITH_BASH_INTERNAL=1
-        printf '%s' "$pasted" | builtin command "$_TIRITH_BIN" paste --shell posix --interactive >"$tmpfile" 2>&1
+        printf '%s' "$pasted" | builtin command "$_TIRITH_BIN" paste --shell posix --interactive >|"$tmpfile" 2>&1
         local rc=$?
         _TIRITH_BASH_INTERNAL="$_tirith_prev_internal"
         local output=$(<"$tmpfile")

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -300,13 +300,13 @@ if [[ $- == *i* ]]; then
   _tirith_receipt_error_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_error_file=""
   if [[ -n "$_tirith_receipt_capture_file" && -n "$_tirith_receipt_error_file" ]] \
      && builtin command "$_TIRITH_BIN" __execution-receipt capability \
-          >"$_tirith_receipt_capture_file" 2>/dev/null \
+          >|"$_tirith_receipt_capture_file" 2>/dev/null \
      && _tirith_read_single_capture_line "$_tirith_receipt_capture_file" \
      && [[ "$_TIRITH_CAPTURE_LINE" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
-    : > "$_tirith_receipt_capture_file"
+    : >| "$_tirith_receipt_capture_file"
     if builtin command "$_TIRITH_BIN" __execution-receipt register \
          --family bash --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-         >"$_tirith_receipt_capture_file" 2>"$_tirith_receipt_error_file" \
+         >|"$_tirith_receipt_capture_file" 2>|"$_tirith_receipt_error_file" \
        && _tirith_read_single_capture_line "$_tirith_receipt_capture_file"; then
       _TIRITH_RECEIPT_INSTANCE="$_TIRITH_CAPTURE_LINE"
     fi

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -293,9 +293,12 @@ _tirith_receipt_parent_context_is_valid() {
 }
 
 _tirith_receipt_capture_file=""
+_tirith_receipt_error_file=""
+_TIRITH_RECEIPT_REGISTER_ERROR=""
 if [[ $- == *i* ]]; then
   _tirith_receipt_capture_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_capture_file=""
-  if [[ -n "$_tirith_receipt_capture_file" ]] \
+  _tirith_receipt_error_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_error_file=""
+  if [[ -n "$_tirith_receipt_capture_file" && -n "$_tirith_receipt_error_file" ]] \
      && builtin command "$_TIRITH_BIN" __execution-receipt capability \
           >"$_tirith_receipt_capture_file" 2>/dev/null \
      && _tirith_read_single_capture_line "$_tirith_receipt_capture_file" \
@@ -303,7 +306,7 @@ if [[ $- == *i* ]]; then
     : > "$_tirith_receipt_capture_file"
     if builtin command "$_TIRITH_BIN" __execution-receipt register \
          --family bash --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-         >"$_tirith_receipt_capture_file" 2>/dev/null \
+         >"$_tirith_receipt_capture_file" 2>"$_tirith_receipt_error_file" \
        && _tirith_read_single_capture_line "$_tirith_receipt_capture_file"; then
       _TIRITH_RECEIPT_INSTANCE="$_TIRITH_CAPTURE_LINE"
     fi
@@ -311,12 +314,18 @@ if [[ $- == *i* ]]; then
       _TIRITH_RECEIPT_PROTOCOL=3
     else
       _TIRITH_RECEIPT_INSTANCE=""
+      # Keep the first line of the rejection so the one-shot degrade warning
+      # can say WHY instead of silently downgrading (issue #221).
+      IFS= read -r _TIRITH_RECEIPT_REGISTER_ERROR \
+        < "$_tirith_receipt_error_file" 2>/dev/null || :
     fi
   fi
   [[ -n "$_tirith_receipt_capture_file" ]] \
     && _tirith_remove_capture_file "$_tirith_receipt_capture_file" >/dev/null 2>&1
+  [[ -n "$_tirith_receipt_error_file" ]] \
+    && _tirith_remove_capture_file "$_tirith_receipt_error_file" >/dev/null 2>&1
 fi
-unset _tirith_receipt_capture_file _TIRITH_CAPTURE_LINE
+unset _tirith_receipt_capture_file _tirith_receipt_error_file _TIRITH_CAPTURE_LINE
 
 # M8 ch2 — surface "this shell is on the remote side of an SSH session" to
 # `tirith prompt-status` (planned for M8 ch6) and any other downstream
@@ -1582,6 +1591,8 @@ _tirith_preexec() {
         if [[ -z "${_TIRITH_RECEIPT_DEGRADE_WARNED:-}" ]]; then
           _TIRITH_RECEIPT_DEGRADE_WARNED=1
           _tirith_output "tirith: execution receipts unavailable; legacy checks remain active but session execution evidence is degraded"
+          [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+            && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
         fi
       fi
     else
@@ -1944,6 +1955,8 @@ if [[ $- == *i* ]] && [[ $_TIRITH_RECEIPT_PROTOCOL -ne 3 ]]; then
   if [[ -z "${_TIRITH_RECEIPT_DEGRADE_WARNED:-}" ]]; then
     _TIRITH_RECEIPT_DEGRADE_WARNED=1
     _tirith_output "tirith: execution receipts unavailable; legacy checks remain active but session execution evidence is degraded"
+    [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+      && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
   fi
 fi
 

--- a/crates/tirith/assets/shell/lib/fish-hook.fish
+++ b/crates/tirith/assets/shell/lib/fish-hook.fish
@@ -218,6 +218,15 @@ function _tirith_v3_remove_capture_files
     command "$_TIRITH_RM_BIN" -f -- $argv
 end
 
+function _tirith_v3_cleanup_registration_files
+    for file in $argv
+        if test -n "$file"
+            _tirith_v3_remove_capture_files "$file" >/dev/null 2>&1
+        end
+    end
+    return 0
+end
+
 # Protocol-v3 registration. The Rust side binds the receipt capability to its
 # immediate parent pid, so tirith must run as a direct child of this shell.
 # Register with a plain redirected foreground command rather than a command
@@ -242,7 +251,9 @@ if status is-interactive
             set -g _TIRITH_RECEIPT_INSTANCE ""
             read -g _TIRITH_RECEIPT_REGISTER_ERROR <"$register_err"
         end
-        _tirith_v3_remove_capture_files "$register_out" "$register_err" >/dev/null 2>&1
+        _tirith_v3_cleanup_registration_files "$register_out" "$register_err"
+    else
+        _tirith_v3_cleanup_registration_files "$register_out" "$register_err"
     end
 end
 

--- a/crates/tirith/assets/shell/lib/fish-hook.fish
+++ b/crates/tirith/assets/shell/lib/fish-hook.fish
@@ -77,21 +77,13 @@ for helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
     end
 end
 
+# Receipt protocol state. Registration itself happens further down, after the
+# capture-file helpers are defined.
 set -g _TIRITH_RECEIPT_PROTOCOL 0
 set -g _TIRITH_RECEIPT_INSTANCE ""
+set -g _TIRITH_RECEIPT_REGISTER_ERROR ""
 set -g _TIRITH_RECEIPT_SHELL_PID "$fish_pid"
 set -g _TIRITH_RECEIPT_FAMILY fish
-if status is-interactive
-    and test $_TIRITH_V3_HELPERS_READY -eq 1
-    and test (command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null) = "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3"
-    set -g _TIRITH_RECEIPT_INSTANCE (command "$_TIRITH_BIN" __execution-receipt register \
-        --family fish --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" 2>/dev/null)
-    if string match -rq '^[0-9a-f]{64}$' -- "$_TIRITH_RECEIPT_INSTANCE"
-        set -g _TIRITH_RECEIPT_PROTOCOL 3
-    else
-        set -g _TIRITH_RECEIPT_INSTANCE ""
-    end
-end
 
 # M8 ch2 — surface "this shell is on the remote side of an SSH session" to
 # `tirith prompt-status` (planned for M8 ch6) and any other downstream
@@ -224,6 +216,34 @@ function _tirith_v3_remove_capture_files
         return 1
     end
     command "$_TIRITH_RM_BIN" -f -- $argv
+end
+
+# Protocol-v3 registration. The Rust side binds the receipt capability to its
+# immediate parent pid, so tirith must run as a direct child of this shell.
+# Register with a plain redirected foreground command rather than a command
+# substitution, matching the bash and zsh hooks, and keep the failure reason
+# for the status warning below instead of discarding it.
+if status is-interactive
+    and test $_TIRITH_V3_HELPERS_READY -eq 1
+    and test (command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null) = "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3"
+    set -l register_out (_tirith_v3_new_capture_file)
+    set -l out_status $status
+    set -l register_err (_tirith_v3_new_capture_file)
+    set -l err_status $status
+    if test $out_status -eq 0; and test $err_status -eq 0
+        and test -n "$register_out"; and test -n "$register_err"
+        command "$_TIRITH_BIN" __execution-receipt register \
+            --family fish --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+            >"$register_out" 2>"$register_err"
+        read -g _TIRITH_RECEIPT_INSTANCE <"$register_out"
+        if string match -rq '^[0-9a-f]{64}$' -- "$_TIRITH_RECEIPT_INSTANCE"
+            set -g _TIRITH_RECEIPT_PROTOCOL 3
+        else
+            set -g _TIRITH_RECEIPT_INSTANCE ""
+            read -g _TIRITH_RECEIPT_REGISTER_ERROR <"$register_err"
+        end
+        _tirith_v3_remove_capture_files "$register_out" "$register_err" >/dev/null 2>&1
+    end
 end
 
 function _tirith_receipt_exit --on-event fish_exit
@@ -718,6 +738,9 @@ if status is-interactive
     else
         set -g TIRITH_STATUS degraded
         _tirith_output "tirith: execution receipts unavailable; shell protection is running in legacy mode"
+        if test -n "$_TIRITH_RECEIPT_REGISTER_ERROR"
+            _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
+        end
     end
 end
 

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -67,22 +67,13 @@ unset _tirith_helper
 # One receipt protocol instance per sourced hook. It is deliberately
 # non-exported; only individual Tirith subprocesses receive it. Older binaries
 # fail the capability probe and keep the legacy check flow with an honest
-# degraded status instead of misparsing the hidden flag.
+# degraded status instead of misparsing the hidden flag. Registration itself
+# happens further down, after the capture-file helpers are defined.
 _TIRITH_RECEIPT_PROTOCOL=0
 _TIRITH_RECEIPT_INSTANCE=""
+_TIRITH_RECEIPT_REGISTER_ERROR=""
 _TIRITH_RECEIPT_SHELL_PID="$$"
 _TIRITH_RECEIPT_FAMILY="zsh"
-if [[ -o interactive ]] \
-   && [[ $_TIRITH_V3_HELPERS_READY -eq 1 ]] \
-   && [[ "$(command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null)" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
-  _TIRITH_RECEIPT_INSTANCE="$(command "$_TIRITH_BIN" __execution-receipt register \
-    --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" 2>/dev/null)"
-  if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
-    _TIRITH_RECEIPT_PROTOCOL=3
-  else
-    _TIRITH_RECEIPT_INSTANCE=""
-  fi
-fi
 
 # M9 ch4 — record a shell-start environment snapshot for `tirith env diff`.
 # We exec a hidden tirith subcommand that reads ITS OWN inherited environment
@@ -204,6 +195,38 @@ _tirith_v3_remove_capture_files() {
   [[ "$_TIRITH_RM_BIN" == /* && "$#" -gt 0 ]] || return 1
   command "$_TIRITH_RM_BIN" -f -- "$@"
 }
+
+# Protocol-v3 registration. The Rust side binds the receipt capability to its
+# immediate parent pid, so tirith MUST run as a direct child of this shell.
+# A command substitution breaks that whenever zsh's exec optimization is
+# suppressed (e.g. a prompt framework installed a WINCH trap earlier in the
+# rc): the substitution then runs through an intermediate forked subshell and
+# registration is rejected. Capture stdout/stderr through temp files from a
+# plain foreground command instead, and keep the failure reason for the
+# status warning below instead of discarding it.
+if [[ -o interactive ]] \
+   && [[ $_TIRITH_V3_HELPERS_READY -eq 1 ]] \
+   && [[ "$(command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null)" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
+  _tirith_register_out="$(_tirith_v3_new_capture_file)" || _tirith_register_out=""
+  _tirith_register_err="$(_tirith_v3_new_capture_file)" || _tirith_register_err=""
+  if [[ -n "$_tirith_register_out" && -n "$_tirith_register_err" ]]; then
+    command "$_TIRITH_BIN" __execution-receipt register \
+      --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+      >"$_tirith_register_out" 2>"$_tirith_register_err"
+    _TIRITH_RECEIPT_INSTANCE="$(<"$_tirith_register_out")"
+    _TIRITH_RECEIPT_INSTANCE="${_TIRITH_RECEIPT_INSTANCE%%$'\n'*}"
+    if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
+      _TIRITH_RECEIPT_PROTOCOL=3
+    else
+      _TIRITH_RECEIPT_INSTANCE=""
+      _TIRITH_RECEIPT_REGISTER_ERROR="$(<"$_tirith_register_err")"
+      _TIRITH_RECEIPT_REGISTER_ERROR="${_TIRITH_RECEIPT_REGISTER_ERROR%%$'\n'*}"
+    fi
+    _tirith_v3_remove_capture_files "$_tirith_register_out" "$_tirith_register_err" \
+      >/dev/null 2>&1
+  fi
+  unset _tirith_register_out _tirith_register_err
+fi
 
 
 _tirith_parse_approval() {
@@ -631,6 +654,8 @@ if [[ -o interactive ]]; then
   else
     TIRITH_STATUS="degraded"
     _tirith_output "tirith: execution receipts unavailable; shell protection is running in legacy mode"
+    [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+      && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
   fi
 fi
 

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -196,6 +196,15 @@ _tirith_v3_remove_capture_files() {
   command "$_TIRITH_RM_BIN" -f -- "$@"
 }
 
+_tirith_v3_cleanup_registration_files() {
+  local file
+  for file in "$@"; do
+    [[ -n "$file" ]] || continue
+    _tirith_v3_remove_capture_files "$file" >/dev/null 2>&1 || :
+  done
+  return 0
+}
+
 # Protocol-v3 registration. The Rust side binds the receipt capability to its
 # immediate parent pid, so tirith MUST run as a direct child of this shell.
 # A command substitution breaks that whenever zsh's exec optimization is
@@ -210,9 +219,15 @@ if [[ -o interactive ]] \
   _tirith_register_out="$(_tirith_v3_new_capture_file)" || _tirith_register_out=""
   _tirith_register_err="$(_tirith_v3_new_capture_file)" || _tirith_register_err=""
   if [[ -n "$_tirith_register_out" && -n "$_tirith_register_err" ]]; then
-    command "$_TIRITH_BIN" __execution-receipt register \
-      --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-      >"$_tirith_register_out" 2>"$_tirith_register_err"
+    # Keep a rejected registration inside an explicit condition so a user's
+    # ERR_EXIT setting cannot abort hook initialization before we record the
+    # rejection and fall back honestly. The files already exist, so force the
+    # redirects through a user's NOCLOBBER setting.
+    if command "$_TIRITH_BIN" __execution-receipt register \
+         --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+         >|"$_tirith_register_out" 2>|"$_tirith_register_err"; then
+      :
+    fi
     _TIRITH_RECEIPT_INSTANCE="$(<"$_tirith_register_out")"
     _TIRITH_RECEIPT_INSTANCE="${_TIRITH_RECEIPT_INSTANCE%%$'\n'*}"
     if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
@@ -222,8 +237,9 @@ if [[ -o interactive ]] \
       _TIRITH_RECEIPT_REGISTER_ERROR="$(<"$_tirith_register_err")"
       _TIRITH_RECEIPT_REGISTER_ERROR="${_TIRITH_RECEIPT_REGISTER_ERROR%%$'\n'*}"
     fi
-    _tirith_v3_remove_capture_files "$_tirith_register_out" "$_tirith_register_err" \
-      >/dev/null 2>&1
+    _tirith_v3_cleanup_registration_files "$_tirith_register_out" "$_tirith_register_err"
+  else
+    _tirith_v3_cleanup_registration_files "$_tirith_register_out" "$_tirith_register_err"
   fi
   unset _tirith_register_out _tirith_register_err
 fi

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -3477,7 +3477,8 @@ export PATH
 capture="$(_tirith_v3_new_capture_file)" || exit 61
 command "$_TIRITH_WC_BIN" -c <"$capture" >/dev/null || exit 62
 command "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN" -c ':' || exit 63
-_tirith_v3_remove_capture_files "$capture" || exit 64
+_tirith_v3_cleanup_registration_files "" "$capture" || exit 64
+[[ ! -e "$capture" ]] || exit 66
 command "$_TIRITH_BIN" __execution-receipt capability >/dev/null || exit 65
 print -r -- "$_TIRITH_MKTEMP_BIN|$_TIRITH_RM_BIN|$_TIRITH_WC_BIN|$_TIRITH_ENV_BIN|$_TIRITH_SH_BIN"
 "#,
@@ -3513,7 +3514,8 @@ set -gx PATH '{}'
 set capture (_tirith_v3_new_capture_file); or exit 71
 command "$_TIRITH_WC_BIN" -c <"$capture" >/dev/null; or exit 72
 command "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN" -c ':'; or exit 73
-_tirith_v3_remove_capture_files "$capture"; or exit 74
+_tirith_v3_cleanup_registration_files "" "$capture"; or exit 74
+not test -e "$capture"; or exit 77
 command "$_TIRITH_BIN" __execution-receipt capability >/dev/null; or exit 75
 command "$_TIRITH_BASH_TIMEOUT_BIN" -c ':'; or exit 76
 builtin printf '%s|%s|%s|%s|%s|%s\n' "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN" "$_TIRITH_BASH_TIMEOUT_BIN"
@@ -3582,7 +3584,8 @@ builtin printf '%s|%s|%s|%s|%s|%s\n' "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_
             source.contains("command \"$_TIRITH_ENV_BIN\"")
                 && source.contains("\"$_TIRITH_SH_BIN\" -c")
                 && source.contains("_tirith_v3_new_capture_file")
-                && source.contains("_tirith_v3_remove_capture_files"),
+                && source.contains("_tirith_v3_remove_capture_files")
+                && source.contains("_tirith_v3_cleanup_registration_files"),
             "v3 transport must route through pinned helpers: {}",
             hook.display()
         );

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -625,6 +625,41 @@ fn bash_noninteractive_source_installs_no_debug_trap() {
 // (forcing enter here would pass vacuously — a swallowed allowed and a swallowed
 // blocked command are indistinguishable).
 
+/// Receipt registration redirects into files returned by `mktemp`, so they
+/// must explicitly override a user's `noclobber` option. Otherwise an
+/// interactive shell silently loses protocol-v3 evidence before any command is
+/// checked.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn bash_noclobber_keeps_protocol_v3_registration() {
+    let mut env = IsolatedEnv::new();
+    let bash = match modern_bash() {
+        Some(bash) => bash,
+        None => {
+            eprintln!("skipping: no modern bash (>= 5) found");
+            return;
+        }
+    };
+    env.set("TIRITH_BASH_MODE", "preexec");
+
+    let mut sess = PtySession::spawn(&env, &bash, &["--norc", "--noprofile", "-i"]);
+    sess.send_line("export PS1='TIRITH_PTY> '; set -o noclobber");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    let hook = embedded_hook("bash-hook.bash");
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line("printf 'TIRITH_NOCLOBBER_PROTOCOL<%s>\\n' \"$_TIRITH_RECEIPT_PROTOCOL\"");
+    let output = sess.expect("TIRITH_NOCLOBBER_PROTOCOL<3>");
+    sess.close();
+
+    assert!(
+        output.contains("TIRITH_NOCLOBBER_PROTOCOL<3>"),
+        "bash noclobber must not disable receipt registration, got:\n{output}"
+    );
+}
+
 /// Contract (f): a hook that can't deliver in enter mode must degrade VISIBLY,
 /// never silently — the safety floor. `TIRITH_BASH_MODE=enter` forces enter
 /// (overriding the gate's preexec pick here); the pending-not-consumed safety
@@ -1281,6 +1316,75 @@ fn zsh_rc_file_registration_survives_suppressed_exec_optimization() {
     sess.send_line("print -r -- \"TIRITH_RC_PROTOCOL=$_TIRITH_RECEIPT_PROTOCOL\"");
     sess.expect("TIRITH_RC_PROTOCOL=3");
     sess.close();
+}
+
+/// A pre-created private capture file is intentional. `NOCLOBBER` must not
+/// reject the registration redirects and silently force a legacy session.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn zsh_noclobber_keeps_protocol_v3_registration() {
+    let env = IsolatedEnv::new();
+    let zsh = match zsh_bin() {
+        Some(zsh) => zsh,
+        None => {
+            eprintln!("skipping: zsh not installed");
+            return;
+        }
+    };
+    let hook = embedded_hook("zsh-hook.zsh");
+    let mut sess = PtySession::spawn(&env, &zsh, &["-f", "-i"]);
+    sess.send_line("PROMPT='TIRITH_PTY> '; RPROMPT=''; setopt NOCLOBBER");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line("print -r -- \"TIRITH_NOCLOBBER_PROTOCOL<$_TIRITH_RECEIPT_PROTOCOL>\"");
+    let output = sess.expect("TIRITH_NOCLOBBER_PROTOCOL<3>");
+    sess.close();
+
+    assert!(
+        output.contains("TIRITH_NOCLOBBER_PROTOCOL<3>"),
+        "zsh noclobber must not disable receipt registration, got:\n{output}"
+    );
+}
+
+/// A registration rejection is an expected fail-closed downgrade, not a
+/// reason to terminate a user's shell when their rc enables `ERR_EXIT`.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn zsh_err_exit_survives_registration_rejection() {
+    let env = IsolatedEnv::new();
+    let zsh = match zsh_bin() {
+        Some(zsh) => zsh,
+        None => {
+            eprintln!("skipping: zsh not installed");
+            return;
+        }
+    };
+    let hook = embedded_hook("zsh-hook.zsh");
+    let mut sess = PtySession::spawn(&env, &zsh, &["-f", "-i"]);
+    sess.send_line("PROMPT='TIRITH_PTY> '; RPROMPT=''");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+
+    // Re-source with the same session identity so protocol registration is
+    // rejected as a duplicate. The hook guard is intentionally cleared to
+    // exercise registration itself.
+    sess.send_line(&format!(
+        "unset _TIRITH_ZSH_LOADED; setopt ERR_EXIT; source '{}'; print -r -- TIRITH_ERR_EXIT_SURVIVED",
+        hook.display()
+    ));
+    let output = sess.expect_within("TIRITH_ERR_EXIT_SURVIVED", Duration::from_secs(15));
+    sess.close();
+
+    assert!(
+        output.contains("TIRITH_ERR_EXIT_SURVIVED"),
+        "zsh ERR_EXIT must not terminate the shell on registration rejection, got:\n{output}"
+    );
 }
 
 /// ZLE must deliver allow/warn commands exactly once, block dangerous input,

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -1236,6 +1236,53 @@ fn zsh_session(env: &mut IsolatedEnv) -> Option<PtySession> {
     Some(sess)
 }
 
+/// Issue #221: protocol-v3 registration must succeed when the hook is sourced
+/// from an rc file whose earlier content suppressed zsh's command-substitution
+/// exec optimization (a prompt framework's WINCH trap is the common trigger).
+/// With a `$(...)` registration the register call then runs behind an
+/// intermediate forked subshell, the parent-pid binding is rejected, and the
+/// shell silently degrades to legacy mode. The capture-file registration runs
+/// tirith as a direct child of the main shell in both conditions. The WINCH
+/// trap below is load-bearing: without it, a bare rc is exec-optimized and the
+/// old registration path passes too.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn zsh_rc_file_registration_survives_suppressed_exec_optimization() {
+    let mut env = IsolatedEnv::new();
+    let zsh = match zsh_bin() {
+        Some(zsh) => zsh,
+        None => {
+            eprintln!("skipping: zsh not installed");
+            return;
+        }
+    };
+    let hook = embedded_hook("zsh-hook.zsh");
+    let zdotdir = env.workdir.join("zdot");
+    std::fs::create_dir_all(&zdotdir).expect("create ZDOTDIR");
+    std::fs::write(
+        zdotdir.join(".zshrc"),
+        format!(
+            "TRAPWINCH() {{ :; }}\nPROMPT='TIRITH_PTY> '; RPROMPT=''\nsource '{}'\n",
+            hook.display()
+        ),
+    )
+    .expect("write .zshrc");
+    env.set("ZDOTDIR", &zdotdir.display().to_string());
+    // `-d` skips global rc files; ZDOTDIR/.zshrc still loads.
+    let mut sess = PtySession::spawn(&env, &zsh, &["-d", "-i"]);
+    sess.expect("TIRITH_PTY> ");
+    sess.wait_idle(QUIET, SETTLE_MAX);
+    let startup = sess.output().to_string();
+    assert!(
+        !startup.contains("legacy mode"),
+        "rc-file hook init must not degrade to legacy mode, got:\n{startup}"
+    );
+    sess.clear_buffer();
+    sess.send_line("print -r -- \"TIRITH_RC_PROTOCOL=$_TIRITH_RECEIPT_PROTOCOL\"");
+    sess.expect("TIRITH_RC_PROTOCOL=3");
+    sess.close();
+}
+
 /// ZLE must deliver allow/warn commands exactly once, block dangerous input,
 /// and record delivered lines as durable (but honestly shell-unresolved)
 /// protocol-v3 evidence.

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -1273,7 +1273,7 @@ _tirith_preexec_receipt_check() {
     _TIRITH_RECEIPT_FAMILY="$_TIRITH_RECEIPT_FAMILY" \
     builtin command "$_TIRITH_BIN" check --approval-check --execution-receipt bash-preexec \
     --non-interactive --interactive --shell posix "${render_args[@]}" -- "$scan_target" \
-    >"$stdout_file"
+    >|"$stdout_file"
   rc=$?
 
   local parse_rc token
@@ -1770,7 +1770,7 @@ _TIRITH_DEBUG_CAPTURE_FILE=""
 _TIRITH_DEBUG_OWNERSHIP_FILE=""
 _TIRITH_DEBUG_TRAP_OWNERSHIP_OK=0
 _TIRITH_PREEXEC_ENFORCE_PENDING=0
-_TIRITH_PREEXEC_BOOTSTRAP_COMMAND='if [[ "${_TIRITH_DEBUG_TRAP_CAPTURE_READY:-0}" == "0" ]]; then builtin trap -p DEBUG >"$_TIRITH_DEBUG_CAPTURE_FILE" 2>/dev/null; _tirith_finalize_debug_trap_capture; fi; if [[ "${_TIRITH_DEBUG_TRAP_INSTALLED:-0}" == "1" ]]; then builtin trap -p DEBUG >"$_TIRITH_DEBUG_OWNERSHIP_FILE" 2>/dev/null; _tirith_verify_debug_trap_ownership; fi; _tirith_restore_prompt_status'
+_TIRITH_PREEXEC_BOOTSTRAP_COMMAND='if [[ "${_TIRITH_DEBUG_TRAP_CAPTURE_READY:-0}" == "0" ]]; then builtin trap -p DEBUG >|"$_TIRITH_DEBUG_CAPTURE_FILE" 2>/dev/null; _tirith_finalize_debug_trap_capture; fi; if [[ "${_TIRITH_DEBUG_TRAP_INSTALLED:-0}" == "1" ]]; then builtin trap -p DEBUG >|"$_TIRITH_DEBUG_OWNERSHIP_FILE" 2>/dev/null; _tirith_verify_debug_trap_ownership; fi; _tirith_restore_prompt_status'
 
 
 if [[ -n "${TIRITH_BASH_MODE:-}" ]]; then
@@ -2096,7 +2096,7 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         _TIRITH_RECEIPT_SHELL_PID="$_TIRITH_RECEIPT_SHELL_PID" \
         _TIRITH_RECEIPT_FAMILY="$_TIRITH_RECEIPT_FAMILY" \
         builtin command "$_TIRITH_BIN" check --approval-check --non-interactive --interactive --shell posix \
-        "${receipt_args[@]}" -- "$READLINE_LINE" >"$stdout_file" 2>"$errfile"
+        "${receipt_args[@]}" -- "$READLINE_LINE" >|"$stdout_file" 2>|"$errfile"
       rc=$?
       _TIRITH_BASH_INTERNAL="$_tirith_prev_internal"
       local output
@@ -2339,7 +2339,7 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         }
         local _tirith_prev_internal="${_TIRITH_BASH_INTERNAL:-0}"
         _TIRITH_BASH_INTERNAL=1
-        printf '%s' "$pasted" | builtin command "$_TIRITH_BIN" paste --shell posix --interactive >"$tmpfile" 2>&1
+        printf '%s' "$pasted" | builtin command "$_TIRITH_BIN" paste --shell posix --interactive >|"$tmpfile" 2>&1
         local rc=$?
         _TIRITH_BASH_INTERNAL="$_tirith_prev_internal"
         local output=$(<"$tmpfile")

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -300,13 +300,13 @@ if [[ $- == *i* ]]; then
   _tirith_receipt_error_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_error_file=""
   if [[ -n "$_tirith_receipt_capture_file" && -n "$_tirith_receipt_error_file" ]] \
      && builtin command "$_TIRITH_BIN" __execution-receipt capability \
-          >"$_tirith_receipt_capture_file" 2>/dev/null \
+          >|"$_tirith_receipt_capture_file" 2>/dev/null \
      && _tirith_read_single_capture_line "$_tirith_receipt_capture_file" \
      && [[ "$_TIRITH_CAPTURE_LINE" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
-    : > "$_tirith_receipt_capture_file"
+    : >| "$_tirith_receipt_capture_file"
     if builtin command "$_TIRITH_BIN" __execution-receipt register \
          --family bash --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-         >"$_tirith_receipt_capture_file" 2>"$_tirith_receipt_error_file" \
+         >|"$_tirith_receipt_capture_file" 2>|"$_tirith_receipt_error_file" \
        && _tirith_read_single_capture_line "$_tirith_receipt_capture_file"; then
       _TIRITH_RECEIPT_INSTANCE="$_TIRITH_CAPTURE_LINE"
     fi

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -293,9 +293,12 @@ _tirith_receipt_parent_context_is_valid() {
 }
 
 _tirith_receipt_capture_file=""
+_tirith_receipt_error_file=""
+_TIRITH_RECEIPT_REGISTER_ERROR=""
 if [[ $- == *i* ]]; then
   _tirith_receipt_capture_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_capture_file=""
-  if [[ -n "$_tirith_receipt_capture_file" ]] \
+  _tirith_receipt_error_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_error_file=""
+  if [[ -n "$_tirith_receipt_capture_file" && -n "$_tirith_receipt_error_file" ]] \
      && builtin command "$_TIRITH_BIN" __execution-receipt capability \
           >"$_tirith_receipt_capture_file" 2>/dev/null \
      && _tirith_read_single_capture_line "$_tirith_receipt_capture_file" \
@@ -303,7 +306,7 @@ if [[ $- == *i* ]]; then
     : > "$_tirith_receipt_capture_file"
     if builtin command "$_TIRITH_BIN" __execution-receipt register \
          --family bash --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-         >"$_tirith_receipt_capture_file" 2>/dev/null \
+         >"$_tirith_receipt_capture_file" 2>"$_tirith_receipt_error_file" \
        && _tirith_read_single_capture_line "$_tirith_receipt_capture_file"; then
       _TIRITH_RECEIPT_INSTANCE="$_TIRITH_CAPTURE_LINE"
     fi
@@ -311,12 +314,18 @@ if [[ $- == *i* ]]; then
       _TIRITH_RECEIPT_PROTOCOL=3
     else
       _TIRITH_RECEIPT_INSTANCE=""
+      # Keep the first line of the rejection so the one-shot degrade warning
+      # can say WHY instead of silently downgrading (issue #221).
+      IFS= read -r _TIRITH_RECEIPT_REGISTER_ERROR \
+        < "$_tirith_receipt_error_file" 2>/dev/null || :
     fi
   fi
   [[ -n "$_tirith_receipt_capture_file" ]] \
     && _tirith_remove_capture_file "$_tirith_receipt_capture_file" >/dev/null 2>&1
+  [[ -n "$_tirith_receipt_error_file" ]] \
+    && _tirith_remove_capture_file "$_tirith_receipt_error_file" >/dev/null 2>&1
 fi
-unset _tirith_receipt_capture_file _TIRITH_CAPTURE_LINE
+unset _tirith_receipt_capture_file _tirith_receipt_error_file _TIRITH_CAPTURE_LINE
 
 # M8 ch2 — surface "this shell is on the remote side of an SSH session" to
 # `tirith prompt-status` (planned for M8 ch6) and any other downstream
@@ -1582,6 +1591,8 @@ _tirith_preexec() {
         if [[ -z "${_TIRITH_RECEIPT_DEGRADE_WARNED:-}" ]]; then
           _TIRITH_RECEIPT_DEGRADE_WARNED=1
           _tirith_output "tirith: execution receipts unavailable; legacy checks remain active but session execution evidence is degraded"
+          [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+            && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
         fi
       fi
     else
@@ -1944,6 +1955,8 @@ if [[ $- == *i* ]] && [[ $_TIRITH_RECEIPT_PROTOCOL -ne 3 ]]; then
   if [[ -z "${_TIRITH_RECEIPT_DEGRADE_WARNED:-}" ]]; then
     _TIRITH_RECEIPT_DEGRADE_WARNED=1
     _tirith_output "tirith: execution receipts unavailable; legacy checks remain active but session execution evidence is degraded"
+    [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+      && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
   fi
 fi
 

--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -218,6 +218,15 @@ function _tirith_v3_remove_capture_files
     command "$_TIRITH_RM_BIN" -f -- $argv
 end
 
+function _tirith_v3_cleanup_registration_files
+    for file in $argv
+        if test -n "$file"
+            _tirith_v3_remove_capture_files "$file" >/dev/null 2>&1
+        end
+    end
+    return 0
+end
+
 # Protocol-v3 registration. The Rust side binds the receipt capability to its
 # immediate parent pid, so tirith must run as a direct child of this shell.
 # Register with a plain redirected foreground command rather than a command
@@ -242,7 +251,9 @@ if status is-interactive
             set -g _TIRITH_RECEIPT_INSTANCE ""
             read -g _TIRITH_RECEIPT_REGISTER_ERROR <"$register_err"
         end
-        _tirith_v3_remove_capture_files "$register_out" "$register_err" >/dev/null 2>&1
+        _tirith_v3_cleanup_registration_files "$register_out" "$register_err"
+    else
+        _tirith_v3_cleanup_registration_files "$register_out" "$register_err"
     end
 end
 

--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -77,21 +77,13 @@ for helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
     end
 end
 
+# Receipt protocol state. Registration itself happens further down, after the
+# capture-file helpers are defined.
 set -g _TIRITH_RECEIPT_PROTOCOL 0
 set -g _TIRITH_RECEIPT_INSTANCE ""
+set -g _TIRITH_RECEIPT_REGISTER_ERROR ""
 set -g _TIRITH_RECEIPT_SHELL_PID "$fish_pid"
 set -g _TIRITH_RECEIPT_FAMILY fish
-if status is-interactive
-    and test $_TIRITH_V3_HELPERS_READY -eq 1
-    and test (command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null) = "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3"
-    set -g _TIRITH_RECEIPT_INSTANCE (command "$_TIRITH_BIN" __execution-receipt register \
-        --family fish --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" 2>/dev/null)
-    if string match -rq '^[0-9a-f]{64}$' -- "$_TIRITH_RECEIPT_INSTANCE"
-        set -g _TIRITH_RECEIPT_PROTOCOL 3
-    else
-        set -g _TIRITH_RECEIPT_INSTANCE ""
-    end
-end
 
 # M8 ch2 — surface "this shell is on the remote side of an SSH session" to
 # `tirith prompt-status` (planned for M8 ch6) and any other downstream
@@ -224,6 +216,34 @@ function _tirith_v3_remove_capture_files
         return 1
     end
     command "$_TIRITH_RM_BIN" -f -- $argv
+end
+
+# Protocol-v3 registration. The Rust side binds the receipt capability to its
+# immediate parent pid, so tirith must run as a direct child of this shell.
+# Register with a plain redirected foreground command rather than a command
+# substitution, matching the bash and zsh hooks, and keep the failure reason
+# for the status warning below instead of discarding it.
+if status is-interactive
+    and test $_TIRITH_V3_HELPERS_READY -eq 1
+    and test (command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null) = "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3"
+    set -l register_out (_tirith_v3_new_capture_file)
+    set -l out_status $status
+    set -l register_err (_tirith_v3_new_capture_file)
+    set -l err_status $status
+    if test $out_status -eq 0; and test $err_status -eq 0
+        and test -n "$register_out"; and test -n "$register_err"
+        command "$_TIRITH_BIN" __execution-receipt register \
+            --family fish --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+            >"$register_out" 2>"$register_err"
+        read -g _TIRITH_RECEIPT_INSTANCE <"$register_out"
+        if string match -rq '^[0-9a-f]{64}$' -- "$_TIRITH_RECEIPT_INSTANCE"
+            set -g _TIRITH_RECEIPT_PROTOCOL 3
+        else
+            set -g _TIRITH_RECEIPT_INSTANCE ""
+            read -g _TIRITH_RECEIPT_REGISTER_ERROR <"$register_err"
+        end
+        _tirith_v3_remove_capture_files "$register_out" "$register_err" >/dev/null 2>&1
+    end
 end
 
 function _tirith_receipt_exit --on-event fish_exit
@@ -718,6 +738,9 @@ if status is-interactive
     else
         set -g TIRITH_STATUS degraded
         _tirith_output "tirith: execution receipts unavailable; shell protection is running in legacy mode"
+        if test -n "$_TIRITH_RECEIPT_REGISTER_ERROR"
+            _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
+        end
     end
 end
 

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -67,22 +67,13 @@ unset _tirith_helper
 # One receipt protocol instance per sourced hook. It is deliberately
 # non-exported; only individual Tirith subprocesses receive it. Older binaries
 # fail the capability probe and keep the legacy check flow with an honest
-# degraded status instead of misparsing the hidden flag.
+# degraded status instead of misparsing the hidden flag. Registration itself
+# happens further down, after the capture-file helpers are defined.
 _TIRITH_RECEIPT_PROTOCOL=0
 _TIRITH_RECEIPT_INSTANCE=""
+_TIRITH_RECEIPT_REGISTER_ERROR=""
 _TIRITH_RECEIPT_SHELL_PID="$$"
 _TIRITH_RECEIPT_FAMILY="zsh"
-if [[ -o interactive ]] \
-   && [[ $_TIRITH_V3_HELPERS_READY -eq 1 ]] \
-   && [[ "$(command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null)" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
-  _TIRITH_RECEIPT_INSTANCE="$(command "$_TIRITH_BIN" __execution-receipt register \
-    --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" 2>/dev/null)"
-  if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
-    _TIRITH_RECEIPT_PROTOCOL=3
-  else
-    _TIRITH_RECEIPT_INSTANCE=""
-  fi
-fi
 
 # M9 ch4 — record a shell-start environment snapshot for `tirith env diff`.
 # We exec a hidden tirith subcommand that reads ITS OWN inherited environment
@@ -204,6 +195,38 @@ _tirith_v3_remove_capture_files() {
   [[ "$_TIRITH_RM_BIN" == /* && "$#" -gt 0 ]] || return 1
   command "$_TIRITH_RM_BIN" -f -- "$@"
 }
+
+# Protocol-v3 registration. The Rust side binds the receipt capability to its
+# immediate parent pid, so tirith MUST run as a direct child of this shell.
+# A command substitution breaks that whenever zsh's exec optimization is
+# suppressed (e.g. a prompt framework installed a WINCH trap earlier in the
+# rc): the substitution then runs through an intermediate forked subshell and
+# registration is rejected. Capture stdout/stderr through temp files from a
+# plain foreground command instead, and keep the failure reason for the
+# status warning below instead of discarding it.
+if [[ -o interactive ]] \
+   && [[ $_TIRITH_V3_HELPERS_READY -eq 1 ]] \
+   && [[ "$(command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null)" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
+  _tirith_register_out="$(_tirith_v3_new_capture_file)" || _tirith_register_out=""
+  _tirith_register_err="$(_tirith_v3_new_capture_file)" || _tirith_register_err=""
+  if [[ -n "$_tirith_register_out" && -n "$_tirith_register_err" ]]; then
+    command "$_TIRITH_BIN" __execution-receipt register \
+      --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+      >"$_tirith_register_out" 2>"$_tirith_register_err"
+    _TIRITH_RECEIPT_INSTANCE="$(<"$_tirith_register_out")"
+    _TIRITH_RECEIPT_INSTANCE="${_TIRITH_RECEIPT_INSTANCE%%$'\n'*}"
+    if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
+      _TIRITH_RECEIPT_PROTOCOL=3
+    else
+      _TIRITH_RECEIPT_INSTANCE=""
+      _TIRITH_RECEIPT_REGISTER_ERROR="$(<"$_tirith_register_err")"
+      _TIRITH_RECEIPT_REGISTER_ERROR="${_TIRITH_RECEIPT_REGISTER_ERROR%%$'\n'*}"
+    fi
+    _tirith_v3_remove_capture_files "$_tirith_register_out" "$_tirith_register_err" \
+      >/dev/null 2>&1
+  fi
+  unset _tirith_register_out _tirith_register_err
+fi
 
 
 _tirith_parse_approval() {
@@ -631,6 +654,8 @@ if [[ -o interactive ]]; then
   else
     TIRITH_STATUS="degraded"
     _tirith_output "tirith: execution receipts unavailable; shell protection is running in legacy mode"
+    [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+      && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
   fi
 fi
 

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -196,6 +196,15 @@ _tirith_v3_remove_capture_files() {
   command "$_TIRITH_RM_BIN" -f -- "$@"
 }
 
+_tirith_v3_cleanup_registration_files() {
+  local file
+  for file in "$@"; do
+    [[ -n "$file" ]] || continue
+    _tirith_v3_remove_capture_files "$file" >/dev/null 2>&1 || :
+  done
+  return 0
+}
+
 # Protocol-v3 registration. The Rust side binds the receipt capability to its
 # immediate parent pid, so tirith MUST run as a direct child of this shell.
 # A command substitution breaks that whenever zsh's exec optimization is
@@ -210,9 +219,15 @@ if [[ -o interactive ]] \
   _tirith_register_out="$(_tirith_v3_new_capture_file)" || _tirith_register_out=""
   _tirith_register_err="$(_tirith_v3_new_capture_file)" || _tirith_register_err=""
   if [[ -n "$_tirith_register_out" && -n "$_tirith_register_err" ]]; then
-    command "$_TIRITH_BIN" __execution-receipt register \
-      --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-      >"$_tirith_register_out" 2>"$_tirith_register_err"
+    # Keep a rejected registration inside an explicit condition so a user's
+    # ERR_EXIT setting cannot abort hook initialization before we record the
+    # rejection and fall back honestly. The files already exist, so force the
+    # redirects through a user's NOCLOBBER setting.
+    if command "$_TIRITH_BIN" __execution-receipt register \
+         --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+         >|"$_tirith_register_out" 2>|"$_tirith_register_err"; then
+      :
+    fi
     _TIRITH_RECEIPT_INSTANCE="$(<"$_tirith_register_out")"
     _TIRITH_RECEIPT_INSTANCE="${_TIRITH_RECEIPT_INSTANCE%%$'\n'*}"
     if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
@@ -222,8 +237,9 @@ if [[ -o interactive ]] \
       _TIRITH_RECEIPT_REGISTER_ERROR="$(<"$_tirith_register_err")"
       _TIRITH_RECEIPT_REGISTER_ERROR="${_TIRITH_RECEIPT_REGISTER_ERROR%%$'\n'*}"
     fi
-    _tirith_v3_remove_capture_files "$_tirith_register_out" "$_tirith_register_err" \
-      >/dev/null 2>&1
+    _tirith_v3_cleanup_registration_files "$_tirith_register_out" "$_tirith_register_err"
+  else
+    _tirith_v3_cleanup_registration_files "$_tirith_register_out" "$_tirith_register_err"
   fi
   unset _tirith_register_out _tirith_register_err
 fi


### PR DESCRIPTION
The zsh and fish hooks registered the protocol-v3 receipt instance
through a command substitution. Whenever zsh's exec optimization is
suppressed while the rc file is sourced (a prompt framework's WINCH
trap is the common trigger), the substitution runs behind an
intermediate forked subshell, the Rust side's parent-pid binding
rejects the registration, and the shell silently drops to legacy mode.

Register with a plain foreground command capturing stdout/stderr into
temp files instead, the way the bash hook already does, so tirith is a
direct child of the main shell in every condition. Also stop discarding
the register stderr in all three hooks: the first line of the rejection
is kept in _TIRITH_RECEIPT_REGISTER_ERROR and printed with the
legacy-mode warning, so a downgrade is diagnosable.

The new conformance test sources the hook from a .zshrc that installs a
WINCH trap first; without the trap a bare rc is exec-optimized and the
old registration path passes too.

Fixes #221 (finding 1).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell hook receipt registration reliability across Bash, Fish, and Zsh.
  * Added clearer error reporting when registration fails or returns an invalid instance.
  * Ensured temporary registration capture files are securely cleaned up.
  * Preserved protocol v3 operation in Zsh startup scenarios involving `WINCH` traps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Fish and Zsh receipt registration to run Tirith as a direct child of the interactive shell and preserves registration errors for degraded-mode diagnostics.

- Captures registration output and errors in temporary files rather than command substitutions.
- Cleans up complete and partial capture-file allocations.
- Overrides Bash and Zsh noclobber behavior for pre-created private capture files.
- Adds conformance coverage for Zsh startup traps, noclobber, ERR_EXIT, and helper cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith/assets/shell/lib/zsh-hook.zsh | Registration now executes as a foreground direct child, forces redirects through NOCLOBBER, captures rejection diagnostics, and cleans partial allocations. |
| crates/tirith/assets/shell/lib/fish-hook.fish | Registration now uses redirected foreground execution with cleanup covering both successful and one-sided capture-file allocations. |
| crates/tirith/assets/shell/lib/bash-hook.bash | Registration captures stderr for diagnostics and consistently overrides noclobber when writing hook-created capture files. |
| crates/tirith/tests/shell_conformance.rs | Adds focused coverage for direct-parent Zsh registration, NOCLOBBER compatibility, and ERR_EXIT-safe rejection handling. |
| crates/tirith/tests/cli_integration.rs | Extends helper integration checks to verify registration cleanup removes allocated capture files. |

<sub>Reviews (4): Last reviewed commit: ["fix(bash): honor noclobber across privat..."](https://github.com/sheeki03/tirith/commit/c555d078b34b12819d0a243659b8234fcca385a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58726091)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Installation and self-management](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/installation-and-self-management.md)
- Knowledge Base — [Interactive safety workflows](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/interactive-safety-workflows.md)
- Knowledge Base — [Execution provenance and trust](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/execution-provenance-and-trust.md)
</details>


<!-- /greptile_comment -->