### PR TITLE
fix(ux): correct misleading advisories and surface hidden policy state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,18 @@ allowlist_rules:
       - "get.docker.com"
 ```
 
+`allowlist` and `allowlist_rules` patterns match **only URLs** extracted from
+the input that appear in a finding's evidence. They never match raw command
+text, and a finding with no URL evidence can never be suppressed by an
+allowlist, so a command-shaped pattern like `launchctl list` is inert. Patterns
+use the same grammar as `tirith trust`: a pattern containing `://`, `/`, `?`,
+or `#` is an exact match on the normalized URL (anchored, query and fragment
+significant); a bare dotted host such as `get.docker.com` matches that domain
+and its subdomains; `*.example.com` is an explicit wildcard; a bare token
+without a dot is a substring match against the URL text. Inspect what a policy
+resolves to with `tirith policy effective`, and check a specific command with
+`tirith policy test '<command>'`.
+
 ### Managing trust from the CLI
 
 `tirith trust` manages trusted patterns without hand-editing policy YAML. Trust

--- a/crates/tirith-core/src/output.rs
+++ b/crates/tirith-core/src/output.rs
@@ -472,7 +472,11 @@ fn write_human_color_into(
         if is_warn_only_block {
             writeln!(
                 w,
-                "  Safer: use an enter-capable shell (bash 5+/zsh/fish) to actually block this, or prefix with TIRITH=0 to suppress."
+                "  Safer: use zsh or fish to actually block this, or prefix with TIRITH=0 to suppress."
+            )?;
+            writeln!(
+                w,
+                "  Bash can block too: export TIRITH_BASH_PREEXEC_ENFORCE=1 before the tirith init line (remove any TIRITH_BASH_MODE=enter override)."
             )?;
         } else {
             writeln!(
@@ -890,7 +894,11 @@ fn write_human_no_color_into(
         if is_warn_only_block {
             writeln!(
                 w,
-                "  Safer: use an enter-capable shell (bash 5+/zsh/fish) to actually block this, or prefix with TIRITH=0 to suppress."
+                "  Safer: use zsh or fish to actually block this, or prefix with TIRITH=0 to suppress."
+            )?;
+            writeln!(
+                w,
+                "  Bash can block too: export TIRITH_BASH_PREEXEC_ENFORCE=1 before the tirith init line (remove any TIRITH_BASH_MODE=enter override)."
             )?;
         } else {
             writeln!(

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -1273,7 +1273,7 @@ _tirith_preexec_receipt_check() {
     _TIRITH_RECEIPT_FAMILY="$_TIRITH_RECEIPT_FAMILY" \
     builtin command "$_TIRITH_BIN" check --approval-check --execution-receipt bash-preexec \
     --non-interactive --interactive --shell posix "${render_args[@]}" -- "$scan_target" \
-    >"$stdout_file"
+    >|"$stdout_file"
   rc=$?
 
   local parse_rc token
@@ -1770,7 +1770,7 @@ _TIRITH_DEBUG_CAPTURE_FILE=""
 _TIRITH_DEBUG_OWNERSHIP_FILE=""
 _TIRITH_DEBUG_TRAP_OWNERSHIP_OK=0
 _TIRITH_PREEXEC_ENFORCE_PENDING=0
-_TIRITH_PREEXEC_BOOTSTRAP_COMMAND='if [[ "${_TIRITH_DEBUG_TRAP_CAPTURE_READY:-0}" == "0" ]]; then builtin trap -p DEBUG >"$_TIRITH_DEBUG_CAPTURE_FILE" 2>/dev/null; _tirith_finalize_debug_trap_capture; fi; if [[ "${_TIRITH_DEBUG_TRAP_INSTALLED:-0}" == "1" ]]; then builtin trap -p DEBUG >"$_TIRITH_DEBUG_OWNERSHIP_FILE" 2>/dev/null; _tirith_verify_debug_trap_ownership; fi; _tirith_restore_prompt_status'
+_TIRITH_PREEXEC_BOOTSTRAP_COMMAND='if [[ "${_TIRITH_DEBUG_TRAP_CAPTURE_READY:-0}" == "0" ]]; then builtin trap -p DEBUG >|"$_TIRITH_DEBUG_CAPTURE_FILE" 2>/dev/null; _tirith_finalize_debug_trap_capture; fi; if [[ "${_TIRITH_DEBUG_TRAP_INSTALLED:-0}" == "1" ]]; then builtin trap -p DEBUG >|"$_TIRITH_DEBUG_OWNERSHIP_FILE" 2>/dev/null; _tirith_verify_debug_trap_ownership; fi; _tirith_restore_prompt_status'
 
 
 if [[ -n "${TIRITH_BASH_MODE:-}" ]]; then
@@ -2096,7 +2096,7 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         _TIRITH_RECEIPT_SHELL_PID="$_TIRITH_RECEIPT_SHELL_PID" \
         _TIRITH_RECEIPT_FAMILY="$_TIRITH_RECEIPT_FAMILY" \
         builtin command "$_TIRITH_BIN" check --approval-check --non-interactive --interactive --shell posix \
-        "${receipt_args[@]}" -- "$READLINE_LINE" >"$stdout_file" 2>"$errfile"
+        "${receipt_args[@]}" -- "$READLINE_LINE" >|"$stdout_file" 2>|"$errfile"
       rc=$?
       _TIRITH_BASH_INTERNAL="$_tirith_prev_internal"
       local output
@@ -2339,7 +2339,7 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         }
         local _tirith_prev_internal="${_TIRITH_BASH_INTERNAL:-0}"
         _TIRITH_BASH_INTERNAL=1
-        printf '%s' "$pasted" | builtin command "$_TIRITH_BIN" paste --shell posix --interactive >"$tmpfile" 2>&1
+        printf '%s' "$pasted" | builtin command "$_TIRITH_BIN" paste --shell posix --interactive >|"$tmpfile" 2>&1
         local rc=$?
         _TIRITH_BASH_INTERNAL="$_tirith_prev_internal"
         local output=$(<"$tmpfile")

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -300,13 +300,13 @@ if [[ $- == *i* ]]; then
   _tirith_receipt_error_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_error_file=""
   if [[ -n "$_tirith_receipt_capture_file" && -n "$_tirith_receipt_error_file" ]] \
      && builtin command "$_TIRITH_BIN" __execution-receipt capability \
-          >"$_tirith_receipt_capture_file" 2>/dev/null \
+          >|"$_tirith_receipt_capture_file" 2>/dev/null \
      && _tirith_read_single_capture_line "$_tirith_receipt_capture_file" \
      && [[ "$_TIRITH_CAPTURE_LINE" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
-    : > "$_tirith_receipt_capture_file"
+    : >| "$_tirith_receipt_capture_file"
     if builtin command "$_TIRITH_BIN" __execution-receipt register \
          --family bash --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-         >"$_tirith_receipt_capture_file" 2>"$_tirith_receipt_error_file" \
+         >|"$_tirith_receipt_capture_file" 2>|"$_tirith_receipt_error_file" \
        && _tirith_read_single_capture_line "$_tirith_receipt_capture_file"; then
       _TIRITH_RECEIPT_INSTANCE="$_TIRITH_CAPTURE_LINE"
     fi

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -293,9 +293,12 @@ _tirith_receipt_parent_context_is_valid() {
 }
 
 _tirith_receipt_capture_file=""
+_tirith_receipt_error_file=""
+_TIRITH_RECEIPT_REGISTER_ERROR=""
 if [[ $- == *i* ]]; then
   _tirith_receipt_capture_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_capture_file=""
-  if [[ -n "$_tirith_receipt_capture_file" ]] \
+  _tirith_receipt_error_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_error_file=""
+  if [[ -n "$_tirith_receipt_capture_file" && -n "$_tirith_receipt_error_file" ]] \
      && builtin command "$_TIRITH_BIN" __execution-receipt capability \
           >"$_tirith_receipt_capture_file" 2>/dev/null \
      && _tirith_read_single_capture_line "$_tirith_receipt_capture_file" \
@@ -303,7 +306,7 @@ if [[ $- == *i* ]]; then
     : > "$_tirith_receipt_capture_file"
     if builtin command "$_TIRITH_BIN" __execution-receipt register \
          --family bash --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-         >"$_tirith_receipt_capture_file" 2>/dev/null \
+         >"$_tirith_receipt_capture_file" 2>"$_tirith_receipt_error_file" \
        && _tirith_read_single_capture_line "$_tirith_receipt_capture_file"; then
       _TIRITH_RECEIPT_INSTANCE="$_TIRITH_CAPTURE_LINE"
     fi
@@ -311,12 +314,18 @@ if [[ $- == *i* ]]; then
       _TIRITH_RECEIPT_PROTOCOL=3
     else
       _TIRITH_RECEIPT_INSTANCE=""
+      # Keep the first line of the rejection so the one-shot degrade warning
+      # can say WHY instead of silently downgrading (issue #221).
+      IFS= read -r _TIRITH_RECEIPT_REGISTER_ERROR \
+        < "$_tirith_receipt_error_file" 2>/dev/null || :
     fi
   fi
   [[ -n "$_tirith_receipt_capture_file" ]] \
     && _tirith_remove_capture_file "$_tirith_receipt_capture_file" >/dev/null 2>&1
+  [[ -n "$_tirith_receipt_error_file" ]] \
+    && _tirith_remove_capture_file "$_tirith_receipt_error_file" >/dev/null 2>&1
 fi
-unset _tirith_receipt_capture_file _TIRITH_CAPTURE_LINE
+unset _tirith_receipt_capture_file _tirith_receipt_error_file _TIRITH_CAPTURE_LINE
 
 # M8 ch2 — surface "this shell is on the remote side of an SSH session" to
 # `tirith prompt-status` (planned for M8 ch6) and any other downstream
@@ -1582,6 +1591,8 @@ _tirith_preexec() {
         if [[ -z "${_TIRITH_RECEIPT_DEGRADE_WARNED:-}" ]]; then
           _TIRITH_RECEIPT_DEGRADE_WARNED=1
           _tirith_output "tirith: execution receipts unavailable; legacy checks remain active but session execution evidence is degraded"
+          [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+            && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
         fi
       fi
     else
@@ -1944,6 +1955,8 @@ if [[ $- == *i* ]] && [[ $_TIRITH_RECEIPT_PROTOCOL -ne 3 ]]; then
   if [[ -z "${_TIRITH_RECEIPT_DEGRADE_WARNED:-}" ]]; then
     _TIRITH_RECEIPT_DEGRADE_WARNED=1
     _tirith_output "tirith: execution receipts unavailable; legacy checks remain active but session execution evidence is degraded"
+    [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+      && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
   fi
 fi
 

--- a/crates/tirith/assets/shell/lib/fish-hook.fish
+++ b/crates/tirith/assets/shell/lib/fish-hook.fish
@@ -218,6 +218,15 @@ function _tirith_v3_remove_capture_files
     command "$_TIRITH_RM_BIN" -f -- $argv
 end
 
+function _tirith_v3_cleanup_registration_files
+    for file in $argv
+        if test -n "$file"
+            _tirith_v3_remove_capture_files "$file" >/dev/null 2>&1
+        end
+    end
+    return 0
+end
+
 # Protocol-v3 registration. The Rust side binds the receipt capability to its
 # immediate parent pid, so tirith must run as a direct child of this shell.
 # Register with a plain redirected foreground command rather than a command
@@ -242,7 +251,9 @@ if status is-interactive
             set -g _TIRITH_RECEIPT_INSTANCE ""
             read -g _TIRITH_RECEIPT_REGISTER_ERROR <"$register_err"
         end
-        _tirith_v3_remove_capture_files "$register_out" "$register_err" >/dev/null 2>&1
+        _tirith_v3_cleanup_registration_files "$register_out" "$register_err"
+    else
+        _tirith_v3_cleanup_registration_files "$register_out" "$register_err"
     end
 end
 

--- a/crates/tirith/assets/shell/lib/fish-hook.fish
+++ b/crates/tirith/assets/shell/lib/fish-hook.fish
@@ -77,21 +77,13 @@ for helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
     end
 end
 
+# Receipt protocol state. Registration itself happens further down, after the
+# capture-file helpers are defined.
 set -g _TIRITH_RECEIPT_PROTOCOL 0
 set -g _TIRITH_RECEIPT_INSTANCE ""
+set -g _TIRITH_RECEIPT_REGISTER_ERROR ""
 set -g _TIRITH_RECEIPT_SHELL_PID "$fish_pid"
 set -g _TIRITH_RECEIPT_FAMILY fish
-if status is-interactive
-    and test $_TIRITH_V3_HELPERS_READY -eq 1
-    and test (command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null) = "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3"
-    set -g _TIRITH_RECEIPT_INSTANCE (command "$_TIRITH_BIN" __execution-receipt register \
-        --family fish --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" 2>/dev/null)
-    if string match -rq '^[0-9a-f]{64}$' -- "$_TIRITH_RECEIPT_INSTANCE"
-        set -g _TIRITH_RECEIPT_PROTOCOL 3
-    else
-        set -g _TIRITH_RECEIPT_INSTANCE ""
-    end
-end
 
 # M8 ch2 — surface "this shell is on the remote side of an SSH session" to
 # `tirith prompt-status` (planned for M8 ch6) and any other downstream
@@ -224,6 +216,34 @@ function _tirith_v3_remove_capture_files
         return 1
     end
     command "$_TIRITH_RM_BIN" -f -- $argv
+end
+
+# Protocol-v3 registration. The Rust side binds the receipt capability to its
+# immediate parent pid, so tirith must run as a direct child of this shell.
+# Register with a plain redirected foreground command rather than a command
+# substitution, matching the bash and zsh hooks, and keep the failure reason
+# for the status warning below instead of discarding it.
+if status is-interactive
+    and test $_TIRITH_V3_HELPERS_READY -eq 1
+    and test (command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null) = "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3"
+    set -l register_out (_tirith_v3_new_capture_file)
+    set -l out_status $status
+    set -l register_err (_tirith_v3_new_capture_file)
+    set -l err_status $status
+    if test $out_status -eq 0; and test $err_status -eq 0
+        and test -n "$register_out"; and test -n "$register_err"
+        command "$_TIRITH_BIN" __execution-receipt register \
+            --family fish --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+            >"$register_out" 2>"$register_err"
+        read -g _TIRITH_RECEIPT_INSTANCE <"$register_out"
+        if string match -rq '^[0-9a-f]{64}$' -- "$_TIRITH_RECEIPT_INSTANCE"
+            set -g _TIRITH_RECEIPT_PROTOCOL 3
+        else
+            set -g _TIRITH_RECEIPT_INSTANCE ""
+            read -g _TIRITH_RECEIPT_REGISTER_ERROR <"$register_err"
+        end
+        _tirith_v3_remove_capture_files "$register_out" "$register_err" >/dev/null 2>&1
+    end
 end
 
 function _tirith_receipt_exit --on-event fish_exit
@@ -718,6 +738,9 @@ if status is-interactive
     else
         set -g TIRITH_STATUS degraded
         _tirith_output "tirith: execution receipts unavailable; shell protection is running in legacy mode"
+        if test -n "$_TIRITH_RECEIPT_REGISTER_ERROR"
+            _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
+        end
     end
 end
 

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -67,22 +67,13 @@ unset _tirith_helper
 # One receipt protocol instance per sourced hook. It is deliberately
 # non-exported; only individual Tirith subprocesses receive it. Older binaries
 # fail the capability probe and keep the legacy check flow with an honest
-# degraded status instead of misparsing the hidden flag.
+# degraded status instead of misparsing the hidden flag. Registration itself
+# happens further down, after the capture-file helpers are defined.
 _TIRITH_RECEIPT_PROTOCOL=0
 _TIRITH_RECEIPT_INSTANCE=""
+_TIRITH_RECEIPT_REGISTER_ERROR=""
 _TIRITH_RECEIPT_SHELL_PID="$$"
 _TIRITH_RECEIPT_FAMILY="zsh"
-if [[ -o interactive ]] \
-   && [[ $_TIRITH_V3_HELPERS_READY -eq 1 ]] \
-   && [[ "$(command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null)" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
-  _TIRITH_RECEIPT_INSTANCE="$(command "$_TIRITH_BIN" __execution-receipt register \
-    --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" 2>/dev/null)"
-  if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
-    _TIRITH_RECEIPT_PROTOCOL=3
-  else
-    _TIRITH_RECEIPT_INSTANCE=""
-  fi
-fi
 
 # M9 ch4 — record a shell-start environment snapshot for `tirith env diff`.
 # We exec a hidden tirith subcommand that reads ITS OWN inherited environment
@@ -204,6 +195,38 @@ _tirith_v3_remove_capture_files() {
   [[ "$_TIRITH_RM_BIN" == /* && "$#" -gt 0 ]] || return 1
   command "$_TIRITH_RM_BIN" -f -- "$@"
 }
+
+# Protocol-v3 registration. The Rust side binds the receipt capability to its
+# immediate parent pid, so tirith MUST run as a direct child of this shell.
+# A command substitution breaks that whenever zsh's exec optimization is
+# suppressed (e.g. a prompt framework installed a WINCH trap earlier in the
+# rc): the substitution then runs through an intermediate forked subshell and
+# registration is rejected. Capture stdout/stderr through temp files from a
+# plain foreground command instead, and keep the failure reason for the
+# status warning below instead of discarding it.
+if [[ -o interactive ]] \
+   && [[ $_TIRITH_V3_HELPERS_READY -eq 1 ]] \
+   && [[ "$(command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null)" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
+  _tirith_register_out="$(_tirith_v3_new_capture_file)" || _tirith_register_out=""
+  _tirith_register_err="$(_tirith_v3_new_capture_file)" || _tirith_register_err=""
+  if [[ -n "$_tirith_register_out" && -n "$_tirith_register_err" ]]; then
+    command "$_TIRITH_BIN" __execution-receipt register \
+      --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+      >"$_tirith_register_out" 2>"$_tirith_register_err"
+    _TIRITH_RECEIPT_INSTANCE="$(<"$_tirith_register_out")"
+    _TIRITH_RECEIPT_INSTANCE="${_TIRITH_RECEIPT_INSTANCE%%$'\n'*}"
+    if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
+      _TIRITH_RECEIPT_PROTOCOL=3
+    else
+      _TIRITH_RECEIPT_INSTANCE=""
+      _TIRITH_RECEIPT_REGISTER_ERROR="$(<"$_tirith_register_err")"
+      _TIRITH_RECEIPT_REGISTER_ERROR="${_TIRITH_RECEIPT_REGISTER_ERROR%%$'\n'*}"
+    fi
+    _tirith_v3_remove_capture_files "$_tirith_register_out" "$_tirith_register_err" \
+      >/dev/null 2>&1
+  fi
+  unset _tirith_register_out _tirith_register_err
+fi
 
 
 _tirith_parse_approval() {
@@ -631,6 +654,8 @@ if [[ -o interactive ]]; then
   else
     TIRITH_STATUS="degraded"
     _tirith_output "tirith: execution receipts unavailable; shell protection is running in legacy mode"
+    [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+      && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
   fi
 fi
 

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -196,6 +196,15 @@ _tirith_v3_remove_capture_files() {
   command "$_TIRITH_RM_BIN" -f -- "$@"
 }
 
+_tirith_v3_cleanup_registration_files() {
+  local file
+  for file in "$@"; do
+    [[ -n "$file" ]] || continue
+    _tirith_v3_remove_capture_files "$file" >/dev/null 2>&1 || :
+  done
+  return 0
+}
+
 # Protocol-v3 registration. The Rust side binds the receipt capability to its
 # immediate parent pid, so tirith MUST run as a direct child of this shell.
 # A command substitution breaks that whenever zsh's exec optimization is
@@ -210,9 +219,15 @@ if [[ -o interactive ]] \
   _tirith_register_out="$(_tirith_v3_new_capture_file)" || _tirith_register_out=""
   _tirith_register_err="$(_tirith_v3_new_capture_file)" || _tirith_register_err=""
   if [[ -n "$_tirith_register_out" && -n "$_tirith_register_err" ]]; then
-    command "$_TIRITH_BIN" __execution-receipt register \
-      --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-      >"$_tirith_register_out" 2>"$_tirith_register_err"
+    # Keep a rejected registration inside an explicit condition so a user's
+    # ERR_EXIT setting cannot abort hook initialization before we record the
+    # rejection and fall back honestly. The files already exist, so force the
+    # redirects through a user's NOCLOBBER setting.
+    if command "$_TIRITH_BIN" __execution-receipt register \
+         --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+         >|"$_tirith_register_out" 2>|"$_tirith_register_err"; then
+      :
+    fi
     _TIRITH_RECEIPT_INSTANCE="$(<"$_tirith_register_out")"
     _TIRITH_RECEIPT_INSTANCE="${_TIRITH_RECEIPT_INSTANCE%%$'\n'*}"
     if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
@@ -222,8 +237,9 @@ if [[ -o interactive ]] \
       _TIRITH_RECEIPT_REGISTER_ERROR="$(<"$_tirith_register_err")"
       _TIRITH_RECEIPT_REGISTER_ERROR="${_TIRITH_RECEIPT_REGISTER_ERROR%%$'\n'*}"
     fi
-    _tirith_v3_remove_capture_files "$_tirith_register_out" "$_tirith_register_err" \
-      >/dev/null 2>&1
+    _tirith_v3_cleanup_registration_files "$_tirith_register_out" "$_tirith_register_err"
+  else
+    _tirith_v3_cleanup_registration_files "$_tirith_register_out" "$_tirith_register_err"
   fi
   unset _tirith_register_out _tirith_register_err
 fi

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -2666,12 +2666,23 @@ fn print_human(info: &DoctorInfo) {
                 .as_deref()
                 .map(env_is_truthy)
                 .unwrap_or(false);
+            let live_enforcement_degraded = enforce_armed
+                && matches!(
+                    info.bash_effective_protection.as_deref(),
+                    Some(protection) if !protection.eq_ignore_ascii_case("blocks")
+                );
             if forced_enter || !enforce_armed {
                 println!("  to block on bash:     export TIRITH_BASH_PREEXEC_ENFORCE=1 before the");
                 println!(
                     "                        'eval \"$(tirith init --shell bash)\"' line, then"
                 );
                 println!("                        start a new shell.");
+            } else if live_enforcement_degraded {
+                println!("  to restore blocking:  TIRITH_BASH_PREEXEC_ENFORCE is set, but this");
+                println!(
+                    "                        shell is not blocking. Resolve any hook warning,"
+                );
+                println!("                        then start a new shell.");
             }
             if forced_enter {
                 println!("                        Also remove 'export TIRITH_BASH_MODE=enter': it");

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -805,6 +805,27 @@ fn env_is_truthy(s: &str) -> bool {
     )
 }
 
+/// Whether the Bash section should explain how to enable blocking preexec.
+/// Enter mode is available only with a fresh positive self-test. An explicit
+/// or effective preexec mode still needs the guidance even when that cached
+/// Enter verdict is positive.
+fn bash_blocking_remediation_needed(
+    requested_mode: Option<&str>,
+    effective_mode: Option<&str>,
+    enter_capability: Option<&str>,
+    enter_capability_fresh: Option<bool>,
+) -> bool {
+    let preexec_selected = requested_mode
+        .into_iter()
+        .chain(effective_mode)
+        .any(|mode| mode.eq_ignore_ascii_case("preexec"));
+    let enter_is_proven = matches!(
+        (enter_capability, enter_capability_fresh),
+        (Some("works"), Some(true))
+    );
+    preexec_selected || !enter_is_proven
+}
+
 /// True when a persisted bash safe-mode flag is overridden by
 /// `TIRITH_BASH_MODE=enter` (so the hook re-attempts enter mode despite the
 /// recorded failure). Case-sensitive — mirrors the hook's `== "enter"` test.
@@ -2628,11 +2649,13 @@ fn print_human(info: &DoctorInfo) {
         // Enter cannot block here: print the working bash blocking path
         // (issue #224). Preexec enforcement arms only for shells that START
         // in preexec mode, so a forced TIRITH_BASH_MODE=enter suppresses it.
-        let enter_blocked = matches!(
+        let blocking_remediation_needed = bash_blocking_remediation_needed(
+            info.bash_requested_mode.as_deref(),
+            info.bash_effective_mode.as_deref(),
             info.bash_enter_capability.as_deref(),
-            Some(verdict) if verdict != "works"
+            info.bash_enter_capability_fresh,
         );
-        if enter_blocked {
+        if blocking_remediation_needed {
             let forced_enter = info
                 .bash_requested_mode
                 .as_deref()
@@ -3107,6 +3130,28 @@ mod tests {
 
     fn count_named(tools: &[DetectedTool], name: &str) -> usize {
         tools.iter().filter(|t| t.name == name).count()
+    }
+
+    #[test]
+    fn bash_blocking_guidance_requires_a_fresh_working_enter_mode() {
+        assert!(!bash_blocking_remediation_needed(
+            None,
+            Some("enter"),
+            Some("works"),
+            Some(true),
+        ));
+        for (requested, effective, capability, fresh) in [
+            (None, Some("preexec"), Some("works"), Some(true)),
+            (Some("preexec"), None, Some("works"), Some(true)),
+            (None, None, Some("works"), Some(false)),
+            (None, None, Some("broken"), Some(true)),
+            (None, None, None, None),
+        ] {
+            assert!(
+                bash_blocking_remediation_needed(requested, effective, capability, fresh,),
+                "missing, stale, broken, or preexec state must retain blocking guidance"
+            );
+        }
     }
 
     // M13 #132 F2: the shared `check_shell_profile` diagnostic must use the

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -2571,7 +2571,13 @@ fn print_human(info: &DoctorInfo) {
         };
         println!("  requested mode:       {requested_mode}");
         println!("  requested enforce:    {requested_enforce}");
-        println!("  require-enter:        {require_enter}");
+        if require_enter == "on" {
+            // Displayed honestly until a hook actually consumes the variable:
+            // nothing enforces require-enter semantics yet.
+            println!("  require-enter:        on (reserved; not enforced by this version)");
+        } else {
+            println!("  require-enter:        {require_enter}");
+        }
 
         match (
             info.bash_effective_mode.as_deref(),
@@ -2617,6 +2623,37 @@ fn print_human(info: &DoctorInfo) {
             }
             None => {
                 println!("  enter capability:     not tested — run tirith doctor --simulate-enter");
+            }
+        }
+        // Enter cannot block here: print the working bash blocking path
+        // (issue #224). Preexec enforcement arms only for shells that START
+        // in preexec mode, so a forced TIRITH_BASH_MODE=enter suppresses it.
+        let enter_blocked = matches!(
+            info.bash_enter_capability.as_deref(),
+            Some(verdict) if verdict != "works"
+        );
+        if enter_blocked {
+            let forced_enter = info
+                .bash_requested_mode
+                .as_deref()
+                .map(|mode| mode.eq_ignore_ascii_case("enter"))
+                .unwrap_or(false);
+            let enforce_armed = info
+                .bash_requested_enforce
+                .as_deref()
+                .map(env_is_truthy)
+                .unwrap_or(false);
+            if forced_enter || !enforce_armed {
+                println!("  to block on bash:     export TIRITH_BASH_PREEXEC_ENFORCE=1 before the");
+                println!(
+                    "                        'eval \"$(tirith init --shell bash)\"' line, then"
+                );
+                println!("                        start a new shell.");
+            }
+            if forced_enter {
+                println!("                        Also remove 'export TIRITH_BASH_MODE=enter': it");
+                println!("                        forces the broken enter mode, and preexec");
+                println!("                        enforcement never arms in a forced-enter shell.");
             }
         }
         if safe_mode_overridden_by_env(info.bash_safe_mode, info.bash_requested_mode.as_deref()) {

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -1975,14 +1975,13 @@ pub fn read_stdin_capped(max: u64) -> std::io::Result<Vec<u8>> {
 /// only for a REPO-scoped policy (the only untrusted scope) that actually had weakening
 /// fields dropped, and only when this session hasn't been warned yet (marker absent).
 /// Pure so the matrix is unit-testable without `state_dir()` I/O or process globals.
-fn should_warn_neutralized(
-    scope: tirith_core::policy::PolicyScope,
-    neutralized_fields: &[&str],
-    marker_exists: bool,
-) -> bool {
-    scope == tirith_core::policy::PolicyScope::Repo
-        && !neutralized_fields.is_empty()
-        && !marker_exists
+fn should_warn_neutralized(neutralized_fields: &[&str], marker_exists: bool) -> bool {
+    // Keyed on the drop set, NOT on `scope == Repo`: when a trusted user/org
+    // baseline exists, the merged policy keeps the baseline's scope while the
+    // repo overlay's dropped fields are still recorded, and the operator still
+    // deserves the notice. Only repo sanitization populates
+    // `neutralized_fields`, so this cannot fire for a purely trusted policy.
+    !neutralized_fields.is_empty() && !marker_exists
 }
 
 fn invalid_injection_seed_message(
@@ -2038,9 +2037,8 @@ pub fn warn_bad_injection_seeds(policy: &tirith_core::policy::Policy) {
 /// through `note()`/`--quiet`. `tirith policy effective` always lists the full drop
 /// set regardless of this throttle.
 pub fn warn_repo_policy_neutralized(policy: &tirith_core::policy::Policy) {
-    if policy.scope != tirith_core::policy::PolicyScope::Repo
-        || policy.neutralized_fields.is_empty()
-    {
+    // Scope is deliberately not consulted here; see `should_warn_neutralized`.
+    if policy.neutralized_fields.is_empty() {
         return;
     }
     // Throttle by SESSION id (so it re-warns in every new shell) + policy path —
@@ -2057,7 +2055,7 @@ pub fn warn_repo_policy_neutralized(policy: &tirith_core::policy::Policy) {
         format!("{:016x}", h.finish())
     };
     let marker = dir.join(format!("{session}-{path_key}"));
-    if !should_warn_neutralized(policy.scope, &policy.neutralized_fields, marker.exists()) {
+    if !should_warn_neutralized(&policy.neutralized_fields, marker.exists()) {
         return;
     }
     eprintln!(
@@ -2079,7 +2077,6 @@ mod tests {
     };
     use std::fs;
     use std::path::PathBuf;
-    use tirith_core::policy::PolicyScope;
 
     #[test]
     fn invalid_custom_seed_message_is_indexed_and_never_accepts_raw_pattern() {
@@ -2343,28 +2340,15 @@ mod tests {
     }
 
     #[test]
-    fn should_warn_neutralized_only_fires_for_repo_with_drops_and_no_marker() {
-        // Repo scope + something neutralized + no session marker → warn.
-        assert!(should_warn_neutralized(
-            PolicyScope::Repo,
-            &["allowlist"],
-            false
-        ));
+    fn should_warn_neutralized_fires_on_drops_regardless_of_merged_scope() {
+        // Something neutralized + no session marker → warn. The merged policy
+        // may carry the trusted baseline's User/Org scope while the repo
+        // overlay's drops are recorded, so scope is deliberately not consulted.
+        assert!(should_warn_neutralized(&["allowlist"], false));
         // Already warned this session (marker present) → silent.
-        assert!(!should_warn_neutralized(
-            PolicyScope::Repo,
-            &["allowlist"],
-            true
-        ));
-        // A non-repo (trusted) scope is never sanitized, so never warned — even with
-        // a (would-be) drop set and no marker.
-        assert!(!should_warn_neutralized(
-            PolicyScope::Org,
-            &["allowlist"],
-            false
-        ));
-        // Repo scope but nothing was neutralized → nothing to report.
-        assert!(!should_warn_neutralized(PolicyScope::Repo, &[], false));
+        assert!(!should_warn_neutralized(&["allowlist"], true));
+        // Nothing was neutralized → nothing to report.
+        assert!(!should_warn_neutralized(&[], false));
     }
 
     #[test]

--- a/crates/tirith/src/cli/receipt.rs
+++ b/crates/tirith/src/cli/receipt.rs
@@ -1,5 +1,15 @@
 use tirith_core::receipt::Receipt;
 
+fn print_no_receipts_hint() {
+    eprintln!("tirith: no download receipts found");
+    if let Some(dir) = tirith_core::policy::data_dir() {
+        eprintln!(
+            "  `tirith run` records download receipts under {}; shell execution receipts are a separate store",
+            dir.join("receipts").display()
+        );
+    }
+}
+
 pub fn last(json: bool) -> i32 {
     match Receipt::list() {
         Ok(receipts) => {
@@ -19,7 +29,7 @@ pub fn last(json: bool) -> i32 {
                 }
                 0
             } else {
-                eprintln!("tirith: no receipts found");
+                print_no_receipts_hint();
                 1
             }
         }
@@ -41,7 +51,7 @@ pub fn list(json: bool) -> i32 {
                 }
                 println!();
             } else if receipts.is_empty() {
-                eprintln!("tirith: no receipts found");
+                print_no_receipts_hint();
             } else {
                 for r in &receipts {
                     eprintln!(

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -733,8 +733,11 @@ Examples:
         json: bool,
     },
 
-    /// Manage execution receipts
+    /// Manage download receipts recorded by `tirith run`
     #[command(after_help = "\
+Shows receipts for downloads performed via `tirith run` (URL, redirects,
+SHA-256). Shell execution receipts are a separate store with no CLI viewer.
+
 Examples:
   tirith receipt last
   tirith receipt list

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -463,6 +463,10 @@ fn doctor_shows_effective_state_when_hook_loaded() {
         stdout.contains("effective protection: blocks"),
         "effective protection missing, got:\n{stdout}"
     );
+    assert!(
+        !stdout.contains("to restore blocking:"),
+        "a live blocking hook must not print degradation recovery guidance, got:\n{stdout}"
+    );
 }
 
 #[test]
@@ -482,6 +486,10 @@ fn doctor_distinguishes_requested_from_effective_on_degrade() {
     assert!(
         stdout.contains("effective protection: warn-only"),
         "effective protection should report the live degraded value, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("to restore blocking:"),
+        "a requested-but-degraded blocking hook must explain how to recover, got:\n{stdout}"
     );
 }
 

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -486,6 +486,19 @@ fn doctor_distinguishes_requested_from_effective_on_degrade() {
 }
 
 #[test]
+fn doctor_explains_blocking_when_preexec_has_no_enforcement() {
+    let stdout = doctor_stdout(&[
+        ("TIRITH_BASH_MODE", "preexec"),
+        ("TIRITH_BASH_EFFECTIVE_MODE", "preexec"),
+        ("TIRITH_BASH_EFFECTIVE_PROTECTION", "warn-only"),
+    ]);
+    assert!(
+        stdout.contains("to block on bash:     export TIRITH_BASH_PREEXEC_ENFORCE=1"),
+        "an explicit warn-only preexec session must retain its blocking remedy, got:\n{stdout}"
+    );
+}
+
+#[test]
 fn doctor_reports_not_loaded_when_exports_absent() {
     // User set a bash knob but the hook exported no effective state (e.g. the
     // shell was non-interactive, so the hook no-op'd).

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -3477,7 +3477,8 @@ export PATH
 capture="$(_tirith_v3_new_capture_file)" || exit 61
 command "$_TIRITH_WC_BIN" -c <"$capture" >/dev/null || exit 62
 command "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN" -c ':' || exit 63
-_tirith_v3_remove_capture_files "$capture" || exit 64
+_tirith_v3_cleanup_registration_files "" "$capture" || exit 64
+[[ ! -e "$capture" ]] || exit 66
 command "$_TIRITH_BIN" __execution-receipt capability >/dev/null || exit 65
 print -r -- "$_TIRITH_MKTEMP_BIN|$_TIRITH_RM_BIN|$_TIRITH_WC_BIN|$_TIRITH_ENV_BIN|$_TIRITH_SH_BIN"
 "#,
@@ -3513,7 +3514,8 @@ set -gx PATH '{}'
 set capture (_tirith_v3_new_capture_file); or exit 71
 command "$_TIRITH_WC_BIN" -c <"$capture" >/dev/null; or exit 72
 command "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN" -c ':'; or exit 73
-_tirith_v3_remove_capture_files "$capture"; or exit 74
+_tirith_v3_cleanup_registration_files "" "$capture"; or exit 74
+not test -e "$capture"; or exit 77
 command "$_TIRITH_BIN" __execution-receipt capability >/dev/null; or exit 75
 command "$_TIRITH_BASH_TIMEOUT_BIN" -c ':'; or exit 76
 builtin printf '%s|%s|%s|%s|%s|%s\n' "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN" "$_TIRITH_BASH_TIMEOUT_BIN"
@@ -3582,7 +3584,8 @@ builtin printf '%s|%s|%s|%s|%s|%s\n' "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_
             source.contains("command \"$_TIRITH_ENV_BIN\"")
                 && source.contains("\"$_TIRITH_SH_BIN\" -c")
                 && source.contains("_tirith_v3_new_capture_file")
-                && source.contains("_tirith_v3_remove_capture_files"),
+                && source.contains("_tirith_v3_remove_capture_files")
+                && source.contains("_tirith_v3_cleanup_registration_files"),
             "v3 transport must route through pinned helpers: {}",
             hook.display()
         );

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -625,6 +625,41 @@ fn bash_noninteractive_source_installs_no_debug_trap() {
 // (forcing enter here would pass vacuously — a swallowed allowed and a swallowed
 // blocked command are indistinguishable).
 
+/// Receipt registration redirects into files returned by `mktemp`, so they
+/// must explicitly override a user's `noclobber` option. Otherwise an
+/// interactive shell silently loses protocol-v3 evidence before any command is
+/// checked.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn bash_noclobber_keeps_protocol_v3_registration() {
+    let mut env = IsolatedEnv::new();
+    let bash = match modern_bash() {
+        Some(bash) => bash,
+        None => {
+            eprintln!("skipping: no modern bash (>= 5) found");
+            return;
+        }
+    };
+    env.set("TIRITH_BASH_MODE", "preexec");
+
+    let mut sess = PtySession::spawn(&env, &bash, &["--norc", "--noprofile", "-i"]);
+    sess.send_line("export PS1='TIRITH_PTY> '; set -o noclobber");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    let hook = embedded_hook("bash-hook.bash");
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line("printf 'TIRITH_NOCLOBBER_PROTOCOL<%s>\\n' \"$_TIRITH_RECEIPT_PROTOCOL\"");
+    let output = sess.expect("TIRITH_NOCLOBBER_PROTOCOL<3>");
+    sess.close();
+
+    assert!(
+        output.contains("TIRITH_NOCLOBBER_PROTOCOL<3>"),
+        "bash noclobber must not disable receipt registration, got:\n{output}"
+    );
+}
+
 /// Contract (f): a hook that can't deliver in enter mode must degrade VISIBLY,
 /// never silently — the safety floor. `TIRITH_BASH_MODE=enter` forces enter
 /// (overriding the gate's preexec pick here); the pending-not-consumed safety
@@ -1281,6 +1316,75 @@ fn zsh_rc_file_registration_survives_suppressed_exec_optimization() {
     sess.send_line("print -r -- \"TIRITH_RC_PROTOCOL=$_TIRITH_RECEIPT_PROTOCOL\"");
     sess.expect("TIRITH_RC_PROTOCOL=3");
     sess.close();
+}
+
+/// A pre-created private capture file is intentional. `NOCLOBBER` must not
+/// reject the registration redirects and silently force a legacy session.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn zsh_noclobber_keeps_protocol_v3_registration() {
+    let env = IsolatedEnv::new();
+    let zsh = match zsh_bin() {
+        Some(zsh) => zsh,
+        None => {
+            eprintln!("skipping: zsh not installed");
+            return;
+        }
+    };
+    let hook = embedded_hook("zsh-hook.zsh");
+    let mut sess = PtySession::spawn(&env, &zsh, &["-f", "-i"]);
+    sess.send_line("PROMPT='TIRITH_PTY> '; RPROMPT=''; setopt NOCLOBBER");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line("print -r -- \"TIRITH_NOCLOBBER_PROTOCOL<$_TIRITH_RECEIPT_PROTOCOL>\"");
+    let output = sess.expect("TIRITH_NOCLOBBER_PROTOCOL<3>");
+    sess.close();
+
+    assert!(
+        output.contains("TIRITH_NOCLOBBER_PROTOCOL<3>"),
+        "zsh noclobber must not disable receipt registration, got:\n{output}"
+    );
+}
+
+/// A registration rejection is an expected fail-closed downgrade, not a
+/// reason to terminate a user's shell when their rc enables `ERR_EXIT`.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn zsh_err_exit_survives_registration_rejection() {
+    let env = IsolatedEnv::new();
+    let zsh = match zsh_bin() {
+        Some(zsh) => zsh,
+        None => {
+            eprintln!("skipping: zsh not installed");
+            return;
+        }
+    };
+    let hook = embedded_hook("zsh-hook.zsh");
+    let mut sess = PtySession::spawn(&env, &zsh, &["-f", "-i"]);
+    sess.send_line("PROMPT='TIRITH_PTY> '; RPROMPT=''");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+
+    // Re-source with the same session identity so protocol registration is
+    // rejected as a duplicate. The hook guard is intentionally cleared to
+    // exercise registration itself.
+    sess.send_line(&format!(
+        "unset _TIRITH_ZSH_LOADED; setopt ERR_EXIT; source '{}'; print -r -- TIRITH_ERR_EXIT_SURVIVED",
+        hook.display()
+    ));
+    let output = sess.expect_within("TIRITH_ERR_EXIT_SURVIVED", Duration::from_secs(15));
+    sess.close();
+
+    assert!(
+        output.contains("TIRITH_ERR_EXIT_SURVIVED"),
+        "zsh ERR_EXIT must not terminate the shell on registration rejection, got:\n{output}"
+    );
 }
 
 /// ZLE must deliver allow/warn commands exactly once, block dangerous input,

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -1236,6 +1236,53 @@ fn zsh_session(env: &mut IsolatedEnv) -> Option<PtySession> {
     Some(sess)
 }
 
+/// Issue #221: protocol-v3 registration must succeed when the hook is sourced
+/// from an rc file whose earlier content suppressed zsh's command-substitution
+/// exec optimization (a prompt framework's WINCH trap is the common trigger).
+/// With a `$(...)` registration the register call then runs behind an
+/// intermediate forked subshell, the parent-pid binding is rejected, and the
+/// shell silently degrades to legacy mode. The capture-file registration runs
+/// tirith as a direct child of the main shell in both conditions. The WINCH
+/// trap below is load-bearing: without it, a bare rc is exec-optimized and the
+/// old registration path passes too.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn zsh_rc_file_registration_survives_suppressed_exec_optimization() {
+    let mut env = IsolatedEnv::new();
+    let zsh = match zsh_bin() {
+        Some(zsh) => zsh,
+        None => {
+            eprintln!("skipping: zsh not installed");
+            return;
+        }
+    };
+    let hook = embedded_hook("zsh-hook.zsh");
+    let zdotdir = env.workdir.join("zdot");
+    std::fs::create_dir_all(&zdotdir).expect("create ZDOTDIR");
+    std::fs::write(
+        zdotdir.join(".zshrc"),
+        format!(
+            "TRAPWINCH() {{ :; }}\nPROMPT='TIRITH_PTY> '; RPROMPT=''\nsource '{}'\n",
+            hook.display()
+        ),
+    )
+    .expect("write .zshrc");
+    env.set("ZDOTDIR", &zdotdir.display().to_string());
+    // `-d` skips global rc files; ZDOTDIR/.zshrc still loads.
+    let mut sess = PtySession::spawn(&env, &zsh, &["-d", "-i"]);
+    sess.expect("TIRITH_PTY> ");
+    sess.wait_idle(QUIET, SETTLE_MAX);
+    let startup = sess.output().to_string();
+    assert!(
+        !startup.contains("legacy mode"),
+        "rc-file hook init must not degrade to legacy mode, got:\n{startup}"
+    );
+    sess.clear_buffer();
+    sess.send_line("print -r -- \"TIRITH_RC_PROTOCOL=$_TIRITH_RECEIPT_PROTOCOL\"");
+    sess.expect("TIRITH_RC_PROTOCOL=3");
+    sess.close();
+}
+
 /// ZLE must deliver allow/warn commands exactly once, block dangerous input,
 /// and record delivered lines as durable (but honestly shell-unresolved)
 /// protocol-v3 evidence.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -26,7 +26,7 @@ what an experimental command must satisfy to move to stable.
 | `score` | Stable | Risk-score a URL (`--explain` shows the deterministic factor breakdown). |
 | `diff` | Stable | Compare a URL against known-good patterns. |
 | `why` | Stable | Explain the last triggered rule. |
-| `receipt` | Stable | Manage execution receipts. |
+| `receipt` | Stable | Manage download receipts recorded by `tirith run`. |
 | `init` | Stable | Initialize shell hooks. |
 | `scan` | Experimental | File/directory scanning for hidden content and config poisoning. Integration-critical (CI, MCP). |
 | `doctor` | Experimental | Installation and configuration diagnostics. Integration-critical. |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -315,7 +315,7 @@ If you have your own `DEBUG` trap installed before sourcing the tirith hook, the
 ```
   requested mode:       preexec          ← from TIRITH_BASH_MODE env var
   requested enforce:    off              ← from TIRITH_BASH_PREEXEC_ENFORCE
-  require-enter:        off              ← from TIRITH_BASH_REQUIRE_ENTER
+  require-enter:        off              ← from TIRITH_BASH_REQUIRE_ENTER (reserved; not enforced yet)
   bash mode:            preexec          ← live, exported by the hook
   effective protection: warn-only        ← live, exported by the hook
   safe mode:            off              ← persistent enter-mode-failure flag

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -1273,7 +1273,7 @@ _tirith_preexec_receipt_check() {
     _TIRITH_RECEIPT_FAMILY="$_TIRITH_RECEIPT_FAMILY" \
     builtin command "$_TIRITH_BIN" check --approval-check --execution-receipt bash-preexec \
     --non-interactive --interactive --shell posix "${render_args[@]}" -- "$scan_target" \
-    >"$stdout_file"
+    >|"$stdout_file"
   rc=$?
 
   local parse_rc token
@@ -1770,7 +1770,7 @@ _TIRITH_DEBUG_CAPTURE_FILE=""
 _TIRITH_DEBUG_OWNERSHIP_FILE=""
 _TIRITH_DEBUG_TRAP_OWNERSHIP_OK=0
 _TIRITH_PREEXEC_ENFORCE_PENDING=0
-_TIRITH_PREEXEC_BOOTSTRAP_COMMAND='if [[ "${_TIRITH_DEBUG_TRAP_CAPTURE_READY:-0}" == "0" ]]; then builtin trap -p DEBUG >"$_TIRITH_DEBUG_CAPTURE_FILE" 2>/dev/null; _tirith_finalize_debug_trap_capture; fi; if [[ "${_TIRITH_DEBUG_TRAP_INSTALLED:-0}" == "1" ]]; then builtin trap -p DEBUG >"$_TIRITH_DEBUG_OWNERSHIP_FILE" 2>/dev/null; _tirith_verify_debug_trap_ownership; fi; _tirith_restore_prompt_status'
+_TIRITH_PREEXEC_BOOTSTRAP_COMMAND='if [[ "${_TIRITH_DEBUG_TRAP_CAPTURE_READY:-0}" == "0" ]]; then builtin trap -p DEBUG >|"$_TIRITH_DEBUG_CAPTURE_FILE" 2>/dev/null; _tirith_finalize_debug_trap_capture; fi; if [[ "${_TIRITH_DEBUG_TRAP_INSTALLED:-0}" == "1" ]]; then builtin trap -p DEBUG >|"$_TIRITH_DEBUG_OWNERSHIP_FILE" 2>/dev/null; _tirith_verify_debug_trap_ownership; fi; _tirith_restore_prompt_status'
 
 
 if [[ -n "${TIRITH_BASH_MODE:-}" ]]; then
@@ -2096,7 +2096,7 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         _TIRITH_RECEIPT_SHELL_PID="$_TIRITH_RECEIPT_SHELL_PID" \
         _TIRITH_RECEIPT_FAMILY="$_TIRITH_RECEIPT_FAMILY" \
         builtin command "$_TIRITH_BIN" check --approval-check --non-interactive --interactive --shell posix \
-        "${receipt_args[@]}" -- "$READLINE_LINE" >"$stdout_file" 2>"$errfile"
+        "${receipt_args[@]}" -- "$READLINE_LINE" >|"$stdout_file" 2>|"$errfile"
       rc=$?
       _TIRITH_BASH_INTERNAL="$_tirith_prev_internal"
       local output
@@ -2339,7 +2339,7 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         }
         local _tirith_prev_internal="${_TIRITH_BASH_INTERNAL:-0}"
         _TIRITH_BASH_INTERNAL=1
-        printf '%s' "$pasted" | builtin command "$_TIRITH_BIN" paste --shell posix --interactive >"$tmpfile" 2>&1
+        printf '%s' "$pasted" | builtin command "$_TIRITH_BIN" paste --shell posix --interactive >|"$tmpfile" 2>&1
         local rc=$?
         _TIRITH_BASH_INTERNAL="$_tirith_prev_internal"
         local output=$(<"$tmpfile")

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -300,13 +300,13 @@ if [[ $- == *i* ]]; then
   _tirith_receipt_error_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_error_file=""
   if [[ -n "$_tirith_receipt_capture_file" && -n "$_tirith_receipt_error_file" ]] \
      && builtin command "$_TIRITH_BIN" __execution-receipt capability \
-          >"$_tirith_receipt_capture_file" 2>/dev/null \
+          >|"$_tirith_receipt_capture_file" 2>/dev/null \
      && _tirith_read_single_capture_line "$_tirith_receipt_capture_file" \
      && [[ "$_TIRITH_CAPTURE_LINE" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
-    : > "$_tirith_receipt_capture_file"
+    : >| "$_tirith_receipt_capture_file"
     if builtin command "$_TIRITH_BIN" __execution-receipt register \
          --family bash --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-         >"$_tirith_receipt_capture_file" 2>"$_tirith_receipt_error_file" \
+         >|"$_tirith_receipt_capture_file" 2>|"$_tirith_receipt_error_file" \
        && _tirith_read_single_capture_line "$_tirith_receipt_capture_file"; then
       _TIRITH_RECEIPT_INSTANCE="$_TIRITH_CAPTURE_LINE"
     fi

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -293,9 +293,12 @@ _tirith_receipt_parent_context_is_valid() {
 }
 
 _tirith_receipt_capture_file=""
+_tirith_receipt_error_file=""
+_TIRITH_RECEIPT_REGISTER_ERROR=""
 if [[ $- == *i* ]]; then
   _tirith_receipt_capture_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_capture_file=""
-  if [[ -n "$_tirith_receipt_capture_file" ]] \
+  _tirith_receipt_error_file="$(_tirith_new_capture_file 2>/dev/null)" || _tirith_receipt_error_file=""
+  if [[ -n "$_tirith_receipt_capture_file" && -n "$_tirith_receipt_error_file" ]] \
      && builtin command "$_TIRITH_BIN" __execution-receipt capability \
           >"$_tirith_receipt_capture_file" 2>/dev/null \
      && _tirith_read_single_capture_line "$_tirith_receipt_capture_file" \
@@ -303,7 +306,7 @@ if [[ $- == *i* ]]; then
     : > "$_tirith_receipt_capture_file"
     if builtin command "$_TIRITH_BIN" __execution-receipt register \
          --family bash --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-         >"$_tirith_receipt_capture_file" 2>/dev/null \
+         >"$_tirith_receipt_capture_file" 2>"$_tirith_receipt_error_file" \
        && _tirith_read_single_capture_line "$_tirith_receipt_capture_file"; then
       _TIRITH_RECEIPT_INSTANCE="$_TIRITH_CAPTURE_LINE"
     fi
@@ -311,12 +314,18 @@ if [[ $- == *i* ]]; then
       _TIRITH_RECEIPT_PROTOCOL=3
     else
       _TIRITH_RECEIPT_INSTANCE=""
+      # Keep the first line of the rejection so the one-shot degrade warning
+      # can say WHY instead of silently downgrading (issue #221).
+      IFS= read -r _TIRITH_RECEIPT_REGISTER_ERROR \
+        < "$_tirith_receipt_error_file" 2>/dev/null || :
     fi
   fi
   [[ -n "$_tirith_receipt_capture_file" ]] \
     && _tirith_remove_capture_file "$_tirith_receipt_capture_file" >/dev/null 2>&1
+  [[ -n "$_tirith_receipt_error_file" ]] \
+    && _tirith_remove_capture_file "$_tirith_receipt_error_file" >/dev/null 2>&1
 fi
-unset _tirith_receipt_capture_file _TIRITH_CAPTURE_LINE
+unset _tirith_receipt_capture_file _tirith_receipt_error_file _TIRITH_CAPTURE_LINE
 
 # M8 ch2 — surface "this shell is on the remote side of an SSH session" to
 # `tirith prompt-status` (planned for M8 ch6) and any other downstream
@@ -1582,6 +1591,8 @@ _tirith_preexec() {
         if [[ -z "${_TIRITH_RECEIPT_DEGRADE_WARNED:-}" ]]; then
           _TIRITH_RECEIPT_DEGRADE_WARNED=1
           _tirith_output "tirith: execution receipts unavailable; legacy checks remain active but session execution evidence is degraded"
+          [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+            && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
         fi
       fi
     else
@@ -1944,6 +1955,8 @@ if [[ $- == *i* ]] && [[ $_TIRITH_RECEIPT_PROTOCOL -ne 3 ]]; then
   if [[ -z "${_TIRITH_RECEIPT_DEGRADE_WARNED:-}" ]]; then
     _TIRITH_RECEIPT_DEGRADE_WARNED=1
     _tirith_output "tirith: execution receipts unavailable; legacy checks remain active but session execution evidence is degraded"
+    [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+      && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
   fi
 fi
 

--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -218,6 +218,15 @@ function _tirith_v3_remove_capture_files
     command "$_TIRITH_RM_BIN" -f -- $argv
 end
 
+function _tirith_v3_cleanup_registration_files
+    for file in $argv
+        if test -n "$file"
+            _tirith_v3_remove_capture_files "$file" >/dev/null 2>&1
+        end
+    end
+    return 0
+end
+
 # Protocol-v3 registration. The Rust side binds the receipt capability to its
 # immediate parent pid, so tirith must run as a direct child of this shell.
 # Register with a plain redirected foreground command rather than a command
@@ -242,7 +251,9 @@ if status is-interactive
             set -g _TIRITH_RECEIPT_INSTANCE ""
             read -g _TIRITH_RECEIPT_REGISTER_ERROR <"$register_err"
         end
-        _tirith_v3_remove_capture_files "$register_out" "$register_err" >/dev/null 2>&1
+        _tirith_v3_cleanup_registration_files "$register_out" "$register_err"
+    else
+        _tirith_v3_cleanup_registration_files "$register_out" "$register_err"
     end
 end
 

--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -77,21 +77,13 @@ for helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
     end
 end
 
+# Receipt protocol state. Registration itself happens further down, after the
+# capture-file helpers are defined.
 set -g _TIRITH_RECEIPT_PROTOCOL 0
 set -g _TIRITH_RECEIPT_INSTANCE ""
+set -g _TIRITH_RECEIPT_REGISTER_ERROR ""
 set -g _TIRITH_RECEIPT_SHELL_PID "$fish_pid"
 set -g _TIRITH_RECEIPT_FAMILY fish
-if status is-interactive
-    and test $_TIRITH_V3_HELPERS_READY -eq 1
-    and test (command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null) = "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3"
-    set -g _TIRITH_RECEIPT_INSTANCE (command "$_TIRITH_BIN" __execution-receipt register \
-        --family fish --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" 2>/dev/null)
-    if string match -rq '^[0-9a-f]{64}$' -- "$_TIRITH_RECEIPT_INSTANCE"
-        set -g _TIRITH_RECEIPT_PROTOCOL 3
-    else
-        set -g _TIRITH_RECEIPT_INSTANCE ""
-    end
-end
 
 # M8 ch2 — surface "this shell is on the remote side of an SSH session" to
 # `tirith prompt-status` (planned for M8 ch6) and any other downstream
@@ -224,6 +216,34 @@ function _tirith_v3_remove_capture_files
         return 1
     end
     command "$_TIRITH_RM_BIN" -f -- $argv
+end
+
+# Protocol-v3 registration. The Rust side binds the receipt capability to its
+# immediate parent pid, so tirith must run as a direct child of this shell.
+# Register with a plain redirected foreground command rather than a command
+# substitution, matching the bash and zsh hooks, and keep the failure reason
+# for the status warning below instead of discarding it.
+if status is-interactive
+    and test $_TIRITH_V3_HELPERS_READY -eq 1
+    and test (command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null) = "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3"
+    set -l register_out (_tirith_v3_new_capture_file)
+    set -l out_status $status
+    set -l register_err (_tirith_v3_new_capture_file)
+    set -l err_status $status
+    if test $out_status -eq 0; and test $err_status -eq 0
+        and test -n "$register_out"; and test -n "$register_err"
+        command "$_TIRITH_BIN" __execution-receipt register \
+            --family fish --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+            >"$register_out" 2>"$register_err"
+        read -g _TIRITH_RECEIPT_INSTANCE <"$register_out"
+        if string match -rq '^[0-9a-f]{64}$' -- "$_TIRITH_RECEIPT_INSTANCE"
+            set -g _TIRITH_RECEIPT_PROTOCOL 3
+        else
+            set -g _TIRITH_RECEIPT_INSTANCE ""
+            read -g _TIRITH_RECEIPT_REGISTER_ERROR <"$register_err"
+        end
+        _tirith_v3_remove_capture_files "$register_out" "$register_err" >/dev/null 2>&1
+    end
 end
 
 function _tirith_receipt_exit --on-event fish_exit
@@ -718,6 +738,9 @@ if status is-interactive
     else
         set -g TIRITH_STATUS degraded
         _tirith_output "tirith: execution receipts unavailable; shell protection is running in legacy mode"
+        if test -n "$_TIRITH_RECEIPT_REGISTER_ERROR"
+            _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
+        end
     end
 end
 

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -67,22 +67,13 @@ unset _tirith_helper
 # One receipt protocol instance per sourced hook. It is deliberately
 # non-exported; only individual Tirith subprocesses receive it. Older binaries
 # fail the capability probe and keep the legacy check flow with an honest
-# degraded status instead of misparsing the hidden flag.
+# degraded status instead of misparsing the hidden flag. Registration itself
+# happens further down, after the capture-file helpers are defined.
 _TIRITH_RECEIPT_PROTOCOL=0
 _TIRITH_RECEIPT_INSTANCE=""
+_TIRITH_RECEIPT_REGISTER_ERROR=""
 _TIRITH_RECEIPT_SHELL_PID="$$"
 _TIRITH_RECEIPT_FAMILY="zsh"
-if [[ -o interactive ]] \
-   && [[ $_TIRITH_V3_HELPERS_READY -eq 1 ]] \
-   && [[ "$(command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null)" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
-  _TIRITH_RECEIPT_INSTANCE="$(command "$_TIRITH_BIN" __execution-receipt register \
-    --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" 2>/dev/null)"
-  if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
-    _TIRITH_RECEIPT_PROTOCOL=3
-  else
-    _TIRITH_RECEIPT_INSTANCE=""
-  fi
-fi
 
 # M9 ch4 — record a shell-start environment snapshot for `tirith env diff`.
 # We exec a hidden tirith subcommand that reads ITS OWN inherited environment
@@ -204,6 +195,38 @@ _tirith_v3_remove_capture_files() {
   [[ "$_TIRITH_RM_BIN" == /* && "$#" -gt 0 ]] || return 1
   command "$_TIRITH_RM_BIN" -f -- "$@"
 }
+
+# Protocol-v3 registration. The Rust side binds the receipt capability to its
+# immediate parent pid, so tirith MUST run as a direct child of this shell.
+# A command substitution breaks that whenever zsh's exec optimization is
+# suppressed (e.g. a prompt framework installed a WINCH trap earlier in the
+# rc): the substitution then runs through an intermediate forked subshell and
+# registration is rejected. Capture stdout/stderr through temp files from a
+# plain foreground command instead, and keep the failure reason for the
+# status warning below instead of discarding it.
+if [[ -o interactive ]] \
+   && [[ $_TIRITH_V3_HELPERS_READY -eq 1 ]] \
+   && [[ "$(command "$_TIRITH_BIN" __execution-receipt capability 2>/dev/null)" == "TIRITH_EXECUTION_RECEIPT_PROTOCOL=3" ]]; then
+  _tirith_register_out="$(_tirith_v3_new_capture_file)" || _tirith_register_out=""
+  _tirith_register_err="$(_tirith_v3_new_capture_file)" || _tirith_register_err=""
+  if [[ -n "$_tirith_register_out" && -n "$_tirith_register_err" ]]; then
+    command "$_TIRITH_BIN" __execution-receipt register \
+      --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+      >"$_tirith_register_out" 2>"$_tirith_register_err"
+    _TIRITH_RECEIPT_INSTANCE="$(<"$_tirith_register_out")"
+    _TIRITH_RECEIPT_INSTANCE="${_TIRITH_RECEIPT_INSTANCE%%$'\n'*}"
+    if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
+      _TIRITH_RECEIPT_PROTOCOL=3
+    else
+      _TIRITH_RECEIPT_INSTANCE=""
+      _TIRITH_RECEIPT_REGISTER_ERROR="$(<"$_tirith_register_err")"
+      _TIRITH_RECEIPT_REGISTER_ERROR="${_TIRITH_RECEIPT_REGISTER_ERROR%%$'\n'*}"
+    fi
+    _tirith_v3_remove_capture_files "$_tirith_register_out" "$_tirith_register_err" \
+      >/dev/null 2>&1
+  fi
+  unset _tirith_register_out _tirith_register_err
+fi
 
 
 _tirith_parse_approval() {
@@ -631,6 +654,8 @@ if [[ -o interactive ]]; then
   else
     TIRITH_STATUS="degraded"
     _tirith_output "tirith: execution receipts unavailable; shell protection is running in legacy mode"
+    [[ -n "${_TIRITH_RECEIPT_REGISTER_ERROR:-}" ]] \
+      && _tirith_output "$_TIRITH_RECEIPT_REGISTER_ERROR"
   fi
 fi
 

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -196,6 +196,15 @@ _tirith_v3_remove_capture_files() {
   command "$_TIRITH_RM_BIN" -f -- "$@"
 }
 
+_tirith_v3_cleanup_registration_files() {
+  local file
+  for file in "$@"; do
+    [[ -n "$file" ]] || continue
+    _tirith_v3_remove_capture_files "$file" >/dev/null 2>&1 || :
+  done
+  return 0
+}
+
 # Protocol-v3 registration. The Rust side binds the receipt capability to its
 # immediate parent pid, so tirith MUST run as a direct child of this shell.
 # A command substitution breaks that whenever zsh's exec optimization is
@@ -210,9 +219,15 @@ if [[ -o interactive ]] \
   _tirith_register_out="$(_tirith_v3_new_capture_file)" || _tirith_register_out=""
   _tirith_register_err="$(_tirith_v3_new_capture_file)" || _tirith_register_err=""
   if [[ -n "$_tirith_register_out" && -n "$_tirith_register_err" ]]; then
-    command "$_TIRITH_BIN" __execution-receipt register \
-      --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
-      >"$_tirith_register_out" 2>"$_tirith_register_err"
+    # Keep a rejected registration inside an explicit condition so a user's
+    # ERR_EXIT setting cannot abort hook initialization before we record the
+    # rejection and fall back honestly. The files already exist, so force the
+    # redirects through a user's NOCLOBBER setting.
+    if command "$_TIRITH_BIN" __execution-receipt register \
+         --family zsh --shell-pid "$_TIRITH_RECEIPT_SHELL_PID" \
+         >|"$_tirith_register_out" 2>|"$_tirith_register_err"; then
+      :
+    fi
     _TIRITH_RECEIPT_INSTANCE="$(<"$_tirith_register_out")"
     _TIRITH_RECEIPT_INSTANCE="${_TIRITH_RECEIPT_INSTANCE%%$'\n'*}"
     if [[ ${#_TIRITH_RECEIPT_INSTANCE} -eq 64 && "$_TIRITH_RECEIPT_INSTANCE" != *[^0-9a-f]* ]]; then
@@ -222,8 +237,9 @@ if [[ -o interactive ]] \
       _TIRITH_RECEIPT_REGISTER_ERROR="$(<"$_tirith_register_err")"
       _TIRITH_RECEIPT_REGISTER_ERROR="${_TIRITH_RECEIPT_REGISTER_ERROR%%$'\n'*}"
     fi
-    _tirith_v3_remove_capture_files "$_tirith_register_out" "$_tirith_register_err" \
-      >/dev/null 2>&1
+    _tirith_v3_cleanup_registration_files "$_tirith_register_out" "$_tirith_register_err"
+  else
+    _tirith_v3_cleanup_registration_files "$_tirith_register_out" "$_tirith_register_err"
   fi
   unset _tirith_register_out _tirith_register_err
 fi


### PR DESCRIPTION
Issue-triage quick wins from #221, #223, #224:

- The warn-only block advisory recommended 'an enter-capable shell
  (bash 5+/zsh/fish)'; the self-test proves stock bash 5.x cannot run
  enter mode, so bash 5 users were told to switch to bash 5. Recommend
  zsh/fish, plus the working bash path (preexec enforce).
- tirith doctor now prints the concrete blocking remedy when the enter
  capability verdict is not 'works': export TIRITH_BASH_PREEXEC_ENFORCE=1
  before the init line, and drop a forced TIRITH_BASH_MODE=enter, which
  suppresses preexec enforcement entirely.
- 'tirith receipt' fronts download receipts from 'tirith run', but its
  help said 'Manage execution receipts', which sent #221's reporter to
  the wrong store. Help, empty-store message, and compatibility doc now
  say what the command actually manages.
- warn_repo_policy_neutralized was keyed on scope == Repo, but since the
  baseline+overlay merge the merged policy keeps the trusted baseline's
  scope, so operators with a user policy never saw the notice. Key on
  the recorded drop set instead.
- README now documents allowlist pattern grammar and the URL-evidence-
  only matching rule (#223 ask 3).
- TIRITH_BASH_REQUIRE_ENTER is displayed by doctor but consumed nowhere;
  doctor and docs now mark it reserved instead of implying enforcement.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified allowlist matching for URL evidence, including exact, domain, wildcard, normalization, query, and fragment behavior.
  - Documented how to inspect effective policy and test commands.
  - Updated receipt documentation to distinguish download receipts from shell execution receipts.
  - Clarified that `TIRITH_BASH_REQUIRE_ENTER=1` is reserved and not currently enforced.

- **Improvements**
  - Improved Bash enforcement guidance in warnings and diagnostics.
  - Enhanced receipt commands with clearer empty-state guidance and receipt details.
  - Improved neutralized-policy warnings to reflect recorded session state consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects operator guidance around Bash protection and receipt storage while making neutralized repository-policy state visible after policy merging.
- Adds blocking remediation for missing, stale, preexec, and live-degraded Bash states.
- Clarifies download-receipt help and empty-store messaging.
- Keys neutralized-policy warnings on recorded dropped fields instead of merged scope.
- Documents allowlist URL matching and the reserved require-enter setting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith/src/cli/doctor.rs | The revised predicate and degradation branch address both previously reported guidance gaps for realistic live Bash states. |
| crates/tirith/tests/bash_hook_exports.rs | Integration coverage verifies guidance appears for degraded and unenforced preexec sessions but not for actively blocking sessions. |
| crates/tirith/src/cli/mod.rs | Neutralized-policy notices now follow the recorded drop set so merged trusted scope does not conceal repository sanitization. |
| crates/tirith/src/cli/receipt.rs | Empty-state output now accurately identifies download receipts and distinguishes the separate shell execution-receipt store. |
| crates/tirith-core/src/output.rs | Warn-only advisories now provide viable shell choices and concrete Bash preexec-enforcement setup. |

<sub>Reviews (4): Last reviewed commit: ["fix(doctor): explain degraded bash enfor..."](https://github.com/sheeki03/tirith/commit/688d0601ff7f0e291834706923e21fd2a1a55212) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58726102)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Installation and self-management](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/installation-and-self-management.md)
- Knowledge Base — [CLI and user workflows](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/cli-and-workflows.md)
- Knowledge Base — [Interactive safety workflows](https://app.greptile.com/my-company-org-6010/-/custom-context/knowledge-base/sheeki03/tirith/-/docs/interactive-safety-workflows.md)
</details>


<!-- /greptile_comment -->