### PR TITLE
feat(bash): deliver and block in enter mode via readline macro dispatch

### DIFF
--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -2115,6 +2115,32 @@ _tirith_unsafe_to_eval() {
 }
 
 
+_tirith_queue_enter_delivery() {
+  local cmd="$1" receipt_token="$2"
+  _TIRITH_PENDING_EVAL="$cmd"
+  _TIRITH_PENDING_COMMAND="$cmd"
+  # Commit marker: publish only after both command copies are complete.
+  if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
+    _TIRITH_PENDING_RECEIPT="$receipt_token"
+  fi
+
+  # The accept sub-sequence is processed only after this bind-x callback
+  # returns. If any keymap cannot be armed, roll the delivery back while the
+  # command can still be put visibly into Readline for a safe retry.
+  if ! _tirith_enter_arm_accept; then
+    unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_COMMAND _TIRITH_PENDING_RECEIPT
+    _tirith_receipt_discard bash-enter "$receipt_token" || true
+    READLINE_LINE="$cmd"
+    READLINE_POINT=${#cmd}
+    _tirith_degrade_to_preexec "could not arm guarded accept-line" || true
+    return 1
+  fi
+
+  history -s -- "$cmd"
+  return 0
+}
+
+
 _tirith_startup_health_check() {
   # Test-only override: bypass startup gate to reach runtime failure paths in PTY tests.
   [[ "${_TIRITH_TEST_SKIP_HEALTH:-}" == "1" ]] && return 0
@@ -2416,30 +2442,12 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
       # one quoted argument to the builtin preserves multiline/heredoc/compound
       # syntax without a source file, process-substitution race, or disk copy.
       if _tirith_unsafe_to_eval "$cmd"; then
-        history -s -- "$cmd"
-        _TIRITH_PENDING_EVAL="$cmd"
-        _TIRITH_PENDING_COMMAND="$cmd"
-        # Commit marker: publish only after both command copies are complete.
-        if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
-          _TIRITH_PENDING_RECEIPT="$receipt_token"
-        fi
-        # Arm the guarded accept-line so the now-emptied buffer is accepted and
-        # the prompt hook delivers the stashed command.
-        _tirith_enter_arm_accept
-        return 0
+        _tirith_queue_enter_delivery "$cmd" "$receipt_token"
+        return $?
       fi
 
-      history -s -- "$cmd"
-      _TIRITH_PENDING_EVAL="$cmd"
-      _TIRITH_PENDING_COMMAND="$cmd"
-      # Commit marker: publish only after both command copies are complete.
-      if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
-        _TIRITH_PENDING_RECEIPT="$receipt_token"
-      fi
-      # Arm the guarded accept-line so the now-emptied buffer is accepted and
-      # the prompt hook delivers the stashed command.
-      _tirith_enter_arm_accept
-      return 0
+      _tirith_queue_enter_delivery "$cmd" "$receipt_token"
+      return $?
     }
 
     # Bracketed paste interception

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -1630,6 +1630,14 @@ _tirith_bind_x_record_is_ctrl_o() {
   [[ "$key" == '"\C-o"' ]]
 }
 
+_tirith_bind_output_has_ctrl_o() {
+  local output="$1" line
+  while IFS= read -r line; do
+    _tirith_bind_x_record_is_ctrl_o "$line" && return 0
+  done <<< "$output"
+  return 1
+}
+
 _tirith_bind_x_has_exact_binding() {
   local output="$1"
   local key="$2"
@@ -1707,7 +1715,7 @@ _tirith_restore_ctrl_o_bindings() {
         builtin bind -m "$map" "$binding" 2>/dev/null || restore_rc=1
         ;;
       *)
-        builtin bind -m "$map" -r '"\C-o"' 2>/dev/null || true
+        builtin bind -m "$map" -r '\C-o' 2>/dev/null || restore_rc=1
         ;;
     esac
   done
@@ -1729,11 +1737,11 @@ _tirith_degrade_to_preexec() {
       builtin bind -m "$_tirith_keymap" '"\C-j": accept-line' 2>/dev/null || true
       # Unbind the macro-dispatch helper sequences (checker + guarded accept)
       # so no stale binding survives the degrade in any switchable keymap.
-      builtin bind -m "$_tirith_keymap" -r '"\C-x\C-t7"' 2>/dev/null || true
-      builtin bind -m "$_tirith_keymap" -r '"\C-x\C-r7"' 2>/dev/null || true
+      builtin bind -m "$_tirith_keymap" -r "$_TIRITH_ENTER_CHECK_KEYS" 2>/dev/null || true
+      builtin bind -m "$_tirith_keymap" -r "$_TIRITH_ENTER_ACCEPT_KEYS" 2>/dev/null || true
       # Restore bracketed paste to the Readline default if available.
       builtin bind -m "$_tirith_keymap" '"\e[200~": bracketed-paste-begin' \
-        2>/dev/null || builtin bind -m "$_tirith_keymap" -r '"\e[200~"' 2>/dev/null || true
+        2>/dev/null || builtin bind -m "$_tirith_keymap" -r '\e[200~' 2>/dev/null || true
     done
     _tirith_restore_ctrl_o_bindings || true
     _TIRITH_BINDS_INSTALLED=0
@@ -1811,7 +1819,16 @@ _tirith_prompt_hook() {
   # accept-line until this runs, so disarming here closes the window in which
   # an injected accept sequence could accept a line the checker never approved.
   if declare -F _tirith_enter_disarm_accept >/dev/null 2>&1; then
-    _tirith_enter_disarm_accept
+    if ! _tirith_enter_disarm_accept; then
+      local failed_pending_receipt="${_TIRITH_PENDING_RECEIPT:-}"
+      unset _TIRITH_PENDING_EVAL
+      unset _TIRITH_PENDING_RECEIPT _TIRITH_PENDING_COMMAND
+      if [[ -n "$failed_pending_receipt" ]]; then
+        _tirith_receipt_discard bash-enter "$failed_pending_receipt" || true
+      fi
+      _tirith_degrade_to_preexec "could not disarm guarded accept-line" || true
+      return
+    fi
   fi
   local pending_eval="${_TIRITH_PENDING_EVAL:-}"
   local pending_receipt="${_TIRITH_PENDING_RECEIPT:-}"
@@ -2164,7 +2181,7 @@ _tirith_startup_health_check() {
   # Test-only override for CI (avoids needing PTY)
   [[ "${_TIRITH_TEST_FAIL_HEALTH:-}" == "1" ]] && return 1
   # The checker must be installed as a bind -x function.
-  local map xbinds sbinds
+  local map xbinds sbinds pbinds
   # Both \C-m and \C-j must map to the checker+accept Enter macro in every
   # primary keymap. A later `set -o vi` must not expose an unguarded accept-line.
   local macro="$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS"
@@ -2176,9 +2193,13 @@ _tirith_startup_health_check() {
       "$xbinds" "$_TIRITH_ENTER_CHECK_KEYS" "_tirith_enter" || return 1
     _tirith_bind_x_has_exact_binding \
       "$xbinds" "$_TIRITH_ENTER_ACCEPT_KEYS" "_tirith_enter_accept_noop" || return 1
+    _tirith_bind_output_has_ctrl_o "$xbinds" && return 1
     sbinds="$(builtin bind -m "$map" -s 2>/dev/null)" || return 1
     [[ "$sbinds" == *"$cm_needle"* ]] || return 1
     [[ "$sbinds" == *"$cj_needle"* ]] || return 1
+    _tirith_bind_output_has_ctrl_o "$sbinds" && return 1
+    pbinds="$(builtin bind -m "$map" -p 2>/dev/null)" || return 1
+    _tirith_bind_output_has_ctrl_o "$pbinds" && return 1
   done
   # Verify prompt hook is still attached
   _tirith_is_prompt_hook_attached || return 1
@@ -2578,7 +2599,8 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         builtin bind -m "$_tirith_keymap" -x '"\e[200~": _tirith_paste' \
           || _tirith_bind_install_ok=0
         # operate-and-get-next accepts the current line without the checker.
-        builtin bind -m "$_tirith_keymap" -r '"\C-o"' 2>/dev/null || true
+        builtin bind -m "$_tirith_keymap" -r '\C-o' 2>/dev/null \
+          || _tirith_bind_install_ok=0
       done
       _tirith_enter_disarm_accept || _tirith_bind_install_ok=0
       _TIRITH_BINDS_INSTALLED=1

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -502,13 +502,16 @@ _tirith_persist_safe_mode() {
   fi
 }
 
-# --- Enter-mode capability cache (issue #111) -------------------------------
+# --- Enter-mode capability cache (issues #111, #224) ------------------------
 #
-# `bind -x` on Enter runs the bound function but, in many environments, does
-# NOT then accept the line — bash never returns to its command loop, the
-# pending command is never delivered, and it is silently eaten. Whether this
-# happens is a property of the running bash/readline build, not the version
-# number, so it cannot be decided by a version gate.
+# A bare `bind -x` on Enter runs the bound function but does NOT then accept the
+# line on stock bash, so the pending command was never delivered and was
+# silently eaten (#111). Enter mode now binds Enter to a MACRO that runs the
+# checker and then a guarded accept-line (see the install block below), which
+# delivers and blocks on every stock bash tested (5.2, 5.3). The self-test is
+# retained as a fail-closed gate: if the macro mechanism ever fails to deliver
+# or block on some exotic build, the probe records that and the hook falls back
+# to preexec rather than risk eating a command.
 #
 # `tirith setup` / `tirith doctor` run a PTY self-test that PROVES whether
 # enter-mode delivery works, and write the verdict to a cache file. This hook
@@ -1619,6 +1622,12 @@ _tirith_degrade_to_preexec() {
   if [[ "${_TIRITH_BINDS_INSTALLED:-0}" == "1" ]]; then
     bind '"\C-m": accept-line' 2>/dev/null || true
     bind '"\C-j": accept-line' 2>/dev/null || true
+    # Unbind the macro-dispatch helper sequences (checker + guarded accept) so
+    # no stale binding survives the degrade.
+    bind -r '"\C-x\C-t7"' 2>/dev/null || true
+    bind -r '"\C-x\C-r7"' 2>/dev/null || true
+    # Restore operate-and-get-next, unbound in enter mode.
+    bind '"\C-o": operate-and-get-next' 2>/dev/null || true
     # Restore bracketed paste to readline default if available, otherwise unbind
     bind '"\e[200~": bracketed-paste-begin' 2>/dev/null || bind -r '"\e[200~"' 2>/dev/null || true
     _TIRITH_BINDS_INSTALLED=0
@@ -1692,6 +1701,12 @@ _tirith_degrade_to_preexec() {
 
 
 _tirith_prompt_hook() {
+  # Re-disarm the guarded accept-line every prompt. Arming leaves it bound to
+  # accept-line until this runs, so disarming here closes the window in which
+  # an injected accept sequence could accept a line the checker never approved.
+  if declare -F _tirith_enter_disarm_accept >/dev/null 2>&1; then
+    _tirith_enter_disarm_accept
+  fi
   local pending_eval="${_TIRITH_PENDING_EVAL:-}"
   local pending_receipt="${_TIRITH_PENDING_RECEIPT:-}"
   local pending_command="${_TIRITH_PENDING_COMMAND:-}"
@@ -1745,8 +1760,18 @@ _tirith_is_prompt_hook_attached() {
 _tirith_ensure_prompt_hook() {
   _tirith_is_prompt_hook_attached && return 0
 
-  local pc_decl
+  local pc_decl pc_attrs
   pc_decl="$(declare -p PROMPT_COMMAND 2>/dev/null)" || pc_decl=""
+  pc_attrs="${pc_decl#declare }"
+  pc_attrs="${pc_attrs%% *}"
+  # Never attempt the assignment when PROMPT_COMMAND is readonly (or otherwise
+  # unwrappable): assigning to a readonly variable is a FATAL error that aborts
+  # this whole function before it can report failure, so the caller would never
+  # see a return value and never degrade. Refuse cleanly instead, and let the
+  # caller degrade (the preexec-guard install refuses the same attributes).
+  if [[ -n "$pc_decl" ]]; then
+    _tirith_prompt_command_attrs_safe "$pc_attrs" || return 1
+  fi
 
   if [[ "$pc_decl" == "declare -a"* ]]; then
     PROMPT_COMMAND=(_tirith_prompt_hook "${PROMPT_COMMAND[@]}") 2>/dev/null || return 1
@@ -1755,7 +1780,8 @@ _tirith_ensure_prompt_hook() {
   else
     PROMPT_COMMAND="_tirith_prompt_hook" 2>/dev/null || return 1
   fi
-  return 0
+  # Confirm the reattachment actually took effect.
+  _tirith_is_prompt_hook_attached
 }
 
 
@@ -2005,11 +2031,20 @@ _tirith_startup_health_check() {
   [[ "${_TIRITH_TEST_SKIP_HEALTH:-}" == "1" ]] && return 0
   # Test-only override for CI (avoids needing PTY)
   [[ "${_TIRITH_TEST_FAIL_HEALTH:-}" == "1" ]] && return 1
-  # Verify both \C-m and \C-j are bound to _tirith_enter
-  local binds
-  binds="$(bind -X 2>/dev/null)" || return 1
-  [[ "$binds" =~ \\C-m.*_tirith_enter ]] || return 1
-  [[ "$binds" =~ \\C-j.*_tirith_enter ]] || return 1
+  # The checker must be installed as a bind -x function.
+  local xbinds
+  xbinds="$(bind -X 2>/dev/null)" || return 1
+  [[ "$xbinds" == *_tirith_enter* ]] || return 1
+  # Both \C-m and \C-j must map to the checker+accept Enter macro. Build the
+  # exact `bind -s` line as a literal and match it quoted so the backslashes in
+  # the key sequences are compared literally, not treated as glob escapes.
+  local sbinds
+  sbinds="$(bind -s 2>/dev/null)" || return 1
+  local macro="$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS"
+  local cm_needle="\"\\C-m\": \"$macro\""
+  local cj_needle="\"\\C-j\": \"$macro\""
+  [[ "$sbinds" == *"$cm_needle"* ]] || return 1
+  [[ "$sbinds" == *"$cj_needle"* ]] || return 1
   # Verify prompt hook is still attached
   _tirith_is_prompt_hook_attached || return 1
   return 0
@@ -2054,10 +2089,11 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         return  # READLINE_LINE stays intact
       fi
 
-      # Empty input: just return (shows new prompt)
+      # Empty input: accept the empty line so a fresh prompt is shown.
       if [[ -z "$READLINE_LINE" ]]; then
         READLINE_LINE=""
         READLINE_POINT=0
+        _tirith_enter_arm_accept
         return
       fi
 
@@ -2295,6 +2331,9 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
           _TIRITH_PENDING_RECEIPT="$receipt_token"
         fi
+        # Arm the guarded accept-line so the now-emptied buffer is accepted and
+        # the prompt hook delivers the stashed command.
+        _tirith_enter_arm_accept
         return 0
       fi
 
@@ -2305,6 +2344,9 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
       if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
         _TIRITH_PENDING_RECEIPT="$receipt_token"
       fi
+      # Arm the guarded accept-line so the now-emptied buffer is accepted and
+      # the prompt hook delivers the stashed command.
+      _tirith_enter_arm_accept
       return 0
     }
 
@@ -2368,15 +2410,40 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
       READLINE_POINT=$((READLINE_POINT + ${#pasted}))
     }
 
-    # Install key bindings
-    bind -x '"\C-m": _tirith_enter' || true
-    bind -x '"\C-j": _tirith_enter' || true
+    # Macro-dispatch delivery (issues #111, #224). A bare `bind -x` on Enter
+    # runs the checker but does NOT then accept the line on stock bash, so the
+    # stashed command was silently eaten and the hook degraded to preexec. Bind
+    # Enter to a MACRO that runs the checker and then a GUARDED accept-line: the
+    # accept sub-sequence is a no-op until `_tirith_enter` arms it, so a line is
+    # only accepted once the checker has decided to deliver it (the prompt hook
+    # then evaluates the stashed command, exactly as before). A raw injection of
+    # the accept bytes hits the disarmed no-op, and every prompt re-disarms it,
+    # so possession of the accept sequence alone can never accept a line.
+    _TIRITH_ENTER_CHECK_KEYS='\C-x\C-t7'
+    _TIRITH_ENTER_ACCEPT_KEYS='\C-x\C-r7'
+    _tirith_enter_accept_noop() { :; }
+    _tirith_enter_arm_accept() {
+      bind "\"$_TIRITH_ENTER_ACCEPT_KEYS\": accept-line" 2>/dev/null
+    }
+    _tirith_enter_disarm_accept() {
+      bind -x "\"$_TIRITH_ENTER_ACCEPT_KEYS\": _tirith_enter_accept_noop" 2>/dev/null
+    }
+
+    # Install key bindings: checker (bind -x), disarmed accept, Enter macros.
+    bind -x "\"$_TIRITH_ENTER_CHECK_KEYS\": _tirith_enter" || true
+    _tirith_enter_disarm_accept
+    bind "\"\C-m\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" || true
+    bind "\"\C-j\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" || true
     bind -x '"\e[200~": _tirith_paste' || true
+    # Close accept-line-equivalent bypasses: operate-and-get-next (\C-o) accepts
+    # the current line WITHOUT running the checker. Remove it in enter mode; the
+    # degrade path restores it.
+    bind -r '"\C-o"' 2>/dev/null || true
     _TIRITH_BINDS_INSTALLED=1
 
-    # Startup health gate: verify bind-x took effect for BOTH keys
+    # Startup health gate: verify the checker and the Enter macro took effect.
     if ! _tirith_startup_health_check; then
-      _tirith_degrade_to_preexec "startup health check failed (bind-x or PROMPT_COMMAND)"
+      _tirith_degrade_to_preexec "startup health check failed (enter macro or PROMPT_COMMAND)"
     fi
   fi
 

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -1630,6 +1630,23 @@ _tirith_bind_x_record_is_ctrl_o() {
   [[ "$key" == '"\C-o"' ]]
 }
 
+_tirith_bind_x_has_exact_binding() {
+  local output="$1"
+  local key="$2"
+  local command="$3"
+  local line
+  # Bash 5.2 prints inputrc-style `"key": "command"` records, while 5.3
+  # omits the colon. Match complete records in either reusable format so a
+  # substring or a similarly named callback cannot satisfy the health gate.
+  while IFS= read -r line; do
+    if [[ "$line" == "\"${key}\" \"${command}\"" \
+       || "$line" == "\"${key}\": \"${command}\"" ]]; then
+      return 0
+    fi
+  done <<< "$output"
+  return 1
+}
+
 _tirith_capture_ctrl_o_bindings() {
   local map output line index
   # Bash versions that cannot enumerate bind-x entries cannot safely preserve
@@ -2153,12 +2170,12 @@ _tirith_startup_health_check() {
   local macro="$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS"
   local cm_needle="\"\\C-m\": \"$macro\""
   local cj_needle="\"\\C-j\": \"$macro\""
-  local check_needle="\"$_TIRITH_ENTER_CHECK_KEYS\" \"_tirith_enter\""
-  local accept_needle="\"$_TIRITH_ENTER_ACCEPT_KEYS\" \"_tirith_enter_accept_noop\""
   for map in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
     xbinds="$(builtin bind -m "$map" -X 2>/dev/null)" || return 1
-    [[ "$xbinds" == *"$check_needle"* ]] || return 1
-    [[ "$xbinds" == *"$accept_needle"* ]] || return 1
+    _tirith_bind_x_has_exact_binding \
+      "$xbinds" "$_TIRITH_ENTER_CHECK_KEYS" "_tirith_enter" || return 1
+    _tirith_bind_x_has_exact_binding \
+      "$xbinds" "$_TIRITH_ENTER_ACCEPT_KEYS" "_tirith_enter_accept_noop" || return 1
     sbinds="$(builtin bind -m "$map" -s 2>/dev/null)" || return 1
     [[ "$sbinds" == *"$cm_needle"* ]] || return 1
     [[ "$sbinds" == *"$cj_needle"* ]] || return 1

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -79,7 +79,8 @@ for _tirith_inherited_state in \
   _tirith_last_key _tirith_last_rc _tirith_last_cmd \
   _TIRITH_PREV_DEBUG_TRAP \
   _TIRITH_DEGRADE_WARNED _TIRITH_OFF_WARNED _TIRITH_PREEXEC_WARNED _TIRITH_RECEIPT_DEGRADE_WARNED \
-  _TIRITH_BINDS_INSTALLED _TIRITH_PREEXEC_PROMPT_STATUS
+  _TIRITH_BINDS_INSTALLED _TIRITH_PREEXEC_PROMPT_STATUS \
+  _TIRITH_PROTECTED_KEYMAPS _TIRITH_SAVED_CTRL_O_KINDS _TIRITH_SAVED_CTRL_O_BINDINGS
 do
   unset "$_tirith_inherited_state"
 done
@@ -1613,6 +1614,83 @@ _tirith_preexec() {
 }
 
 
+# Enter mode has to cover every primary Readline keymap a session can switch
+# to after the hook is loaded. Preserve Ctrl-O separately for each map because
+# it is an accept-line equivalent that must be disabled only while enter mode
+# owns command delivery.
+_TIRITH_PROTECTED_KEYMAPS=(emacs-standard vi-insert vi-command)
+_TIRITH_SAVED_CTRL_O_KINDS=()
+_TIRITH_SAVED_CTRL_O_BINDINGS=()
+
+_tirith_capture_ctrl_o_bindings() {
+  local map output line index
+  # Bash versions that cannot enumerate bind-x entries cannot safely preserve
+  # an existing shell-command binding. They already fail the enter-mode health
+  # gate, so refuse before changing any bindings and use preexec instead.
+  builtin bind -X >/dev/null 2>&1 || return 1
+  _TIRITH_SAVED_CTRL_O_KINDS=()
+  _TIRITH_SAVED_CTRL_O_BINDINGS=()
+
+  for ((index = 0; index < ${#_TIRITH_PROTECTED_KEYMAPS[@]}; index++)); do
+    map="${_TIRITH_PROTECTED_KEYMAPS[index]}"
+    _TIRITH_SAVED_CTRL_O_KINDS[index]="unbound"
+    _TIRITH_SAVED_CTRL_O_BINDINGS[index]=""
+
+    output="$(builtin bind -m "$map" -X 2>/dev/null)" || return 1
+    while IFS= read -r line; do
+      if [[ "${line%% *}" == '"\C-o"' ]]; then
+        _TIRITH_SAVED_CTRL_O_KINDS[index]="bind-x"
+        _TIRITH_SAVED_CTRL_O_BINDINGS[index]="$line"
+        break
+      fi
+    done <<< "$output"
+    [[ "${_TIRITH_SAVED_CTRL_O_KINDS[index]}" == "bind-x" ]] && continue
+
+    output="$(builtin bind -m "$map" -s 2>/dev/null)" || return 1
+    while IFS= read -r line; do
+      if [[ "${line%%:*}" == '"\C-o"' ]]; then
+        _TIRITH_SAVED_CTRL_O_KINDS[index]="binding"
+        _TIRITH_SAVED_CTRL_O_BINDINGS[index]="$line"
+        break
+      fi
+    done <<< "$output"
+    [[ "${_TIRITH_SAVED_CTRL_O_KINDS[index]}" == "binding" ]] && continue
+
+    output="$(builtin bind -m "$map" -p 2>/dev/null)" || return 1
+    while IFS= read -r line; do
+      if [[ "${line%%:*}" == '"\C-o"' ]]; then
+        _TIRITH_SAVED_CTRL_O_KINDS[index]="binding"
+        _TIRITH_SAVED_CTRL_O_BINDINGS[index]="$line"
+        break
+      fi
+    done <<< "$output"
+  done
+  return 0
+}
+
+_tirith_restore_ctrl_o_bindings() {
+  local map kind binding index restore_rc=0
+  for ((index = 0; index < ${#_TIRITH_PROTECTED_KEYMAPS[@]}; index++)); do
+    map="${_TIRITH_PROTECTED_KEYMAPS[index]}"
+    kind="${_TIRITH_SAVED_CTRL_O_KINDS[index]:-unbound}"
+    binding="${_TIRITH_SAVED_CTRL_O_BINDINGS[index]:-}"
+    case "$kind" in
+      bind-x)
+        builtin bind -m "$map" -x "$binding" 2>/dev/null || restore_rc=1
+        ;;
+      binding)
+        builtin bind -m "$map" "$binding" 2>/dev/null || restore_rc=1
+        ;;
+      *)
+        builtin bind -m "$map" -r '"\C-o"' 2>/dev/null || true
+        ;;
+    esac
+  done
+  unset _TIRITH_SAVED_CTRL_O_KINDS _TIRITH_SAVED_CTRL_O_BINDINGS
+  return "$restore_rc"
+}
+
+
 _tirith_degrade_to_preexec() {
   local reason="${1:-unknown}"
 
@@ -1620,16 +1698,19 @@ _tirith_degrade_to_preexec() {
   # Custom bindings from .inputrc/.bashrc return on next shell (safe mode persisted,
   # so tirith won't install bind-x on restart).
   if [[ "${_TIRITH_BINDS_INSTALLED:-0}" == "1" ]]; then
-    bind '"\C-m": accept-line' 2>/dev/null || true
-    bind '"\C-j": accept-line' 2>/dev/null || true
-    # Unbind the macro-dispatch helper sequences (checker + guarded accept) so
-    # no stale binding survives the degrade.
-    bind -r '"\C-x\C-t7"' 2>/dev/null || true
-    bind -r '"\C-x\C-r7"' 2>/dev/null || true
-    # Restore operate-and-get-next, unbound in enter mode.
-    bind '"\C-o": operate-and-get-next' 2>/dev/null || true
-    # Restore bracketed paste to readline default if available, otherwise unbind
-    bind '"\e[200~": bracketed-paste-begin' 2>/dev/null || bind -r '"\e[200~"' 2>/dev/null || true
+    local _tirith_keymap
+    for _tirith_keymap in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+      builtin bind -m "$_tirith_keymap" '"\C-m": accept-line' 2>/dev/null || true
+      builtin bind -m "$_tirith_keymap" '"\C-j": accept-line' 2>/dev/null || true
+      # Unbind the macro-dispatch helper sequences (checker + guarded accept)
+      # so no stale binding survives the degrade in any switchable keymap.
+      builtin bind -m "$_tirith_keymap" -r '"\C-x\C-t7"' 2>/dev/null || true
+      builtin bind -m "$_tirith_keymap" -r '"\C-x\C-r7"' 2>/dev/null || true
+      # Restore bracketed paste to the Readline default if available.
+      builtin bind -m "$_tirith_keymap" '"\e[200~": bracketed-paste-begin' \
+        2>/dev/null || builtin bind -m "$_tirith_keymap" -r '"\e[200~"' 2>/dev/null || true
+    done
+    _tirith_restore_ctrl_o_bindings || true
     _TIRITH_BINDS_INSTALLED=0
   fi
 
@@ -2032,19 +2113,22 @@ _tirith_startup_health_check() {
   # Test-only override for CI (avoids needing PTY)
   [[ "${_TIRITH_TEST_FAIL_HEALTH:-}" == "1" ]] && return 1
   # The checker must be installed as a bind -x function.
-  local xbinds
-  xbinds="$(bind -X 2>/dev/null)" || return 1
-  [[ "$xbinds" == *_tirith_enter* ]] || return 1
-  # Both \C-m and \C-j must map to the checker+accept Enter macro. Build the
-  # exact `bind -s` line as a literal and match it quoted so the backslashes in
-  # the key sequences are compared literally, not treated as glob escapes.
-  local sbinds
-  sbinds="$(bind -s 2>/dev/null)" || return 1
+  local map xbinds sbinds
+  # Both \C-m and \C-j must map to the checker+accept Enter macro in every
+  # primary keymap. A later `set -o vi` must not expose an unguarded accept-line.
   local macro="$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS"
   local cm_needle="\"\\C-m\": \"$macro\""
   local cj_needle="\"\\C-j\": \"$macro\""
-  [[ "$sbinds" == *"$cm_needle"* ]] || return 1
-  [[ "$sbinds" == *"$cj_needle"* ]] || return 1
+  local check_needle="\"$_TIRITH_ENTER_CHECK_KEYS\" \"_tirith_enter\""
+  local accept_needle="\"$_TIRITH_ENTER_ACCEPT_KEYS\" \"_tirith_enter_accept_noop\""
+  for map in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+    xbinds="$(builtin bind -m "$map" -X 2>/dev/null)" || return 1
+    [[ "$xbinds" == *"$check_needle"* ]] || return 1
+    [[ "$xbinds" == *"$accept_needle"* ]] || return 1
+    sbinds="$(builtin bind -m "$map" -s 2>/dev/null)" || return 1
+    [[ "$sbinds" == *"$cm_needle"* ]] || return 1
+    [[ "$sbinds" == *"$cj_needle"* ]] || return 1
+  done
   # Verify prompt hook is still attached
   _tirith_is_prompt_hook_attached || return 1
   return 0
@@ -2423,27 +2507,52 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
     _TIRITH_ENTER_ACCEPT_KEYS='\C-x\C-r7'
     _tirith_enter_accept_noop() { :; }
     _tirith_enter_arm_accept() {
-      bind "\"$_TIRITH_ENTER_ACCEPT_KEYS\": accept-line" 2>/dev/null
+      local _tirith_keymap _tirith_bind_rc=0
+      for _tirith_keymap in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+        builtin bind -m "$_tirith_keymap" \
+          "\"$_TIRITH_ENTER_ACCEPT_KEYS\": accept-line" 2>/dev/null \
+          || _tirith_bind_rc=1
+      done
+      return "$_tirith_bind_rc"
     }
     _tirith_enter_disarm_accept() {
-      bind -x "\"$_TIRITH_ENTER_ACCEPT_KEYS\": _tirith_enter_accept_noop" 2>/dev/null
+      local _tirith_keymap _tirith_bind_rc=0
+      for _tirith_keymap in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+        builtin bind -m "$_tirith_keymap" -x \
+          "\"$_TIRITH_ENTER_ACCEPT_KEYS\": _tirith_enter_accept_noop" 2>/dev/null \
+          || _tirith_bind_rc=1
+      done
+      return "$_tirith_bind_rc"
     }
 
-    # Install key bindings: checker (bind -x), disarmed accept, Enter macros.
-    bind -x "\"$_TIRITH_ENTER_CHECK_KEYS\": _tirith_enter" || true
-    _tirith_enter_disarm_accept
-    bind "\"\C-m\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" || true
-    bind "\"\C-j\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" || true
-    bind -x '"\e[200~": _tirith_paste' || true
-    # Close accept-line-equivalent bypasses: operate-and-get-next (\C-o) accepts
-    # the current line WITHOUT running the checker. Remove it in enter mode; the
-    # degrade path restores it.
-    bind -r '"\C-o"' 2>/dev/null || true
-    _TIRITH_BINDS_INSTALLED=1
+    if ! _tirith_capture_ctrl_o_bindings; then
+      _tirith_degrade_to_preexec "could not preserve existing Ctrl-O bindings"
+    else
+      # Install checker, guarded accept, Enter macros, paste interception, and
+      # Ctrl-O closure in every keymap a live session can switch to.
+      _tirith_bind_install_ok=1
+      for _tirith_keymap in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+        builtin bind -m "$_tirith_keymap" -x \
+          "\"$_TIRITH_ENTER_CHECK_KEYS\": _tirith_enter" || _tirith_bind_install_ok=0
+        builtin bind -m "$_tirith_keymap" \
+          "\"\C-m\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" \
+          || _tirith_bind_install_ok=0
+        builtin bind -m "$_tirith_keymap" \
+          "\"\C-j\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" \
+          || _tirith_bind_install_ok=0
+        builtin bind -m "$_tirith_keymap" -x '"\e[200~": _tirith_paste' \
+          || _tirith_bind_install_ok=0
+        # operate-and-get-next accepts the current line without the checker.
+        builtin bind -m "$_tirith_keymap" -r '"\C-o"' 2>/dev/null || true
+      done
+      _tirith_enter_disarm_accept || _tirith_bind_install_ok=0
+      _TIRITH_BINDS_INSTALLED=1
 
-    # Startup health gate: verify the checker and the Enter macro took effect.
-    if ! _tirith_startup_health_check; then
-      _tirith_degrade_to_preexec "startup health check failed (enter macro or PROMPT_COMMAND)"
+      # Startup health gate: verify every protected keymap took effect.
+      if [[ "$_tirith_bind_install_ok" != "1" ]] || ! _tirith_startup_health_check; then
+        _tirith_degrade_to_preexec "startup health check failed (enter macro or PROMPT_COMMAND)"
+      fi
+      unset _tirith_keymap _tirith_bind_install_ok
     fi
   fi
 

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -2228,7 +2228,9 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
       if [[ -z "$READLINE_LINE" ]]; then
         READLINE_LINE=""
         READLINE_POINT=0
-        _tirith_enter_arm_accept
+        if ! _tirith_enter_arm_accept; then
+          _tirith_degrade_to_preexec "could not arm guarded accept-line" || true
+        fi
         return
       fi
 

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -1622,6 +1622,14 @@ _TIRITH_PROTECTED_KEYMAPS=(emacs-standard vi-insert vi-command)
 _TIRITH_SAVED_CTRL_O_KINDS=()
 _TIRITH_SAVED_CTRL_O_BINDINGS=()
 
+_tirith_bind_x_record_is_ctrl_o() {
+  local key="${1%%[[:space:]]*}"
+  # Bash releases have emitted both `"\C-o" command` and
+  # `"\C-o": command` forms from `bind -X`.
+  key="${key%:}"
+  [[ "$key" == '"\C-o"' ]]
+}
+
 _tirith_capture_ctrl_o_bindings() {
   local map output line index
   # Bash versions that cannot enumerate bind-x entries cannot safely preserve
@@ -1638,7 +1646,7 @@ _tirith_capture_ctrl_o_bindings() {
 
     output="$(builtin bind -m "$map" -X 2>/dev/null)" || return 1
     while IFS= read -r line; do
-      if [[ "${line%% *}" == '"\C-o"' ]]; then
+      if _tirith_bind_x_record_is_ctrl_o "$line"; then
         _TIRITH_SAVED_CTRL_O_KINDS[index]="bind-x"
         _TIRITH_SAVED_CTRL_O_BINDINGS[index]="$line"
         break

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -23,6 +23,10 @@ fn bash_under_test() -> std::path::PathBuf {
     pty_support::modern_bash().unwrap_or_else(|| std::path::PathBuf::from("bash"))
 }
 
+fn enter_mode_supported() -> bool {
+    pty_support::modern_bash().is_some()
+}
+
 fn hook_path() -> String {
     format!(
         "{}/assets/shell/lib/bash-hook.bash",
@@ -147,6 +151,9 @@ fn source_hook_and_dump_exports(capability: Option<&str>, extra_env: &[(&str, &s
 
 #[test]
 fn hook_exports_enter_when_capability_cache_proves_it() {
+    if !enter_mode_supported() {
+        return;
+    }
     // #111: enter mode is the default only with a proven `works` capability.
     // `_TIRITH_TEST_SKIP_HEALTH=1` skips the startup health gate (in a non-PTY
     // `bash -i -c` `bind -x` may not register, degrading enter->preexec); this
@@ -327,6 +334,9 @@ fn failed_builtin_bootstrap_clears_stale_exports_without_calling_shadowed_export
 
 #[test]
 fn hook_exports_status_blocks_in_enter_mode() {
+    if !enter_mode_supported() {
+        return;
+    }
     // A proven-`works` cache resolves to enter mode (blocks), so the prompt-facing
     // `TIRITH_STATUS` must read `blocks`.
     let out = source_hook_and_dump_exports(Some("works"), &[("_TIRITH_TEST_SKIP_HEALTH", "1")]);
@@ -359,6 +369,9 @@ fn hook_exports_status_off_before_plain_preexec_bootstrap() {
 /// child.
 #[test]
 fn status_is_not_exported_to_child_processes() {
+    if !enter_mode_supported() {
+        return;
+    }
     let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
     let hook = hook_path();
     // Use explicit enter mode with the health gate skipped so the parent has a
@@ -404,6 +417,9 @@ fn status_is_not_exported_to_child_processes() {
 /// A runtime enter->preexec auto-degrade must flip `TIRITH_STATUS` to `degraded`.
 #[test]
 fn degrade_to_preexec_exports_status_degraded() {
+    if !enter_mode_supported() {
+        return;
+    }
     let out = source_hook_run_and_dump(
         &[("_TIRITH_TEST_SKIP_HEALTH", "1")],
         "_tirith_degrade_to_preexec degrade-test",
@@ -474,6 +490,40 @@ printf 'LINE=[%s]\nPOINT=[%s]\nEVAL=[%s]\nCOMMAND=[%s]\nRECEIPT=[%s]\nDISCARDED=
             "missing {expected:?} from arm-failure rollback output:\n{stdout}"
         );
     }
+}
+
+#[test]
+fn bind_x_health_matcher_accepts_bash_52_and_53_records() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let script = format!(
+        r#"source '{}'
+key='\C-x\C-t7'
+command='_tirith_enter'
+_tirith_bind_x_has_exact_binding '"\C-x\C-t7": "_tirith_enter"' "$key" "$command" || exit 70
+_tirith_bind_x_has_exact_binding '"\C-x\C-t7" "_tirith_enter"' "$key" "$command" || exit 71
+if _tirith_bind_x_has_exact_binding '"\C-x\C-t7": "_tirith_enter_suffix"' "$key" "$command"; then
+  exit 72
+fi
+if _tirith_bind_x_has_exact_binding '"\C-x\C-r7": "_tirith_enter"' "$key" "$command"; then
+  exit 73
+fi
+"#,
+        hook_path()
+    );
+    let out = Command::new(bash_under_test())
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env_clear()
+        .env("HOME", std::env::var("HOME").unwrap_or_default())
+        .env("PATH", path_with_tirith_under_test())
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .output()
+        .expect("exercise bind-x health matcher");
+    assert!(
+        out.status.success(),
+        "bind-x health matcher failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
 }
 
 // Doctor is driven off env vars; seed them directly and assert the output
@@ -650,6 +700,9 @@ fn source_hook_run_and_dump(extra_env: &[(&str, &str)], body: &str) -> String {
 /// `enter`/`blocks` values.
 #[test]
 fn degrade_to_preexec_reexports_effective_state() {
+    if !enter_mode_supported() {
+        return;
+    }
     // `_TIRITH_TEST_SKIP_HEALTH=1` keeps the hook in enter mode (else it would
     // auto-degrade at the startup gate, so the explicit degrade below wouldn't
     // be the transition under test).

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -544,6 +544,65 @@ printf 'DEGRADED=[%s]\nLINE=[%s]\nPOINT=[%s]\n' \
 }
 
 #[test]
+fn failed_accept_disarm_drops_pending_delivery_before_degrading() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let token = "b".repeat(64);
+    let script = format!(
+        r#"source '{}'
+_TIRITH_RECEIPT_PROTOCOL=3
+_tirith_enter_disarm_accept() {{ return 1; }}
+_tirith_receipt_discard() {{
+  [[ "$1:$2" == "bash-enter:{}" ]] || return 9
+  TIRITH_TEST_DISCARDED=yes
+}}
+_tirith_degrade_to_preexec() {{
+  TIRITH_TEST_DEGRADED="$1"
+  return 0
+}}
+_TIRITH_PENDING_EVAL='TIRITH_TEST_EVAL_RAN=yes'
+_TIRITH_PENDING_COMMAND='printf approved'
+_TIRITH_PENDING_RECEIPT='{}'
+_tirith_prompt_hook
+printf 'EVAL_RAN=[%s]\nEVAL=[%s]\nCOMMAND=[%s]\nRECEIPT=[%s]\nDISCARDED=[%s]\nDEGRADED=[%s]\n' \
+  "${{TIRITH_TEST_EVAL_RAN:-}}" "${{_TIRITH_PENDING_EVAL+x}}" \
+  "${{_TIRITH_PENDING_COMMAND+x}}" "${{_TIRITH_PENDING_RECEIPT+x}}" \
+  "${{TIRITH_TEST_DISCARDED:-}}" "${{TIRITH_TEST_DEGRADED:-}}"
+"#,
+        hook_path(),
+        token,
+        token
+    );
+    let out = Command::new(bash_under_test())
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env_clear()
+        .env("HOME", std::env::var("HOME").unwrap_or_default())
+        .env("PATH", path_with_tirith_under_test())
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .output()
+        .expect("exercise failed guarded-accept disarming");
+    assert!(
+        out.status.success(),
+        "accept-disarm failure failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for expected in [
+        "EVAL_RAN=[]",
+        "EVAL=[]",
+        "COMMAND=[]",
+        "RECEIPT=[]",
+        "DISCARDED=[yes]",
+        "DEGRADED=[could not disarm guarded accept-line]",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "missing {expected:?} from accept-disarm failure output:\n{stdout}"
+        );
+    }
+}
+
+#[test]
 fn bind_x_health_matcher_accepts_bash_52_and_53_records() {
     let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
     let script = format!(

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -414,6 +414,68 @@ fn degrade_to_preexec_exports_status_degraded() {
     );
 }
 
+#[test]
+fn failed_enter_accept_arm_rolls_back_pending_delivery() {
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let token = "a".repeat(64);
+    let script = format!(
+        r#"source '{}'
+_TIRITH_RECEIPT_PROTOCOL=3
+_tirith_enter_arm_accept() {{ return 1; }}
+_tirith_receipt_discard() {{
+  [[ "$1:$2" == "bash-enter:{}" ]] || return 9
+  TIRITH_TEST_DISCARDED=yes
+}}
+_tirith_degrade_to_preexec() {{
+  TIRITH_TEST_DEGRADED="$1"
+  return 0
+}}
+READLINE_LINE=""
+READLINE_POINT=0
+if _tirith_queue_enter_delivery 'printf approved' '{}'; then
+  exit 70
+fi
+printf 'LINE=[%s]\nPOINT=[%s]\nEVAL=[%s]\nCOMMAND=[%s]\nRECEIPT=[%s]\nDISCARDED=[%s]\nDEGRADED=[%s]\n' \
+  "$READLINE_LINE" "$READLINE_POINT" \
+  "${{_TIRITH_PENDING_EVAL+x}}" "${{_TIRITH_PENDING_COMMAND+x}}" \
+  "${{_TIRITH_PENDING_RECEIPT+x}}" "${{TIRITH_TEST_DISCARDED:-}}" \
+  "${{TIRITH_TEST_DEGRADED:-}}"
+"#,
+        hook_path(),
+        token,
+        token
+    );
+    let out = Command::new(bash_under_test())
+        .args(["--norc", "--noprofile", "-c", &script])
+        .env_clear()
+        .env("HOME", std::env::var("HOME").unwrap_or_default())
+        .env("PATH", path_with_tirith_under_test())
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .output()
+        .expect("exercise failed guarded-accept arming");
+    assert!(
+        out.status.success(),
+        "arm-failure rollback failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for expected in [
+        "LINE=[printf approved]",
+        "POINT=[15]",
+        "EVAL=[]",
+        "COMMAND=[]",
+        "RECEIPT=[]",
+        "DISCARDED=[yes]",
+        "DEGRADED=[could not arm guarded accept-line]",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "missing {expected:?} from arm-failure rollback output:\n{stdout}"
+        );
+    }
+}
+
 // Doctor is driven off env vars; seed them directly and assert the output
 // splits "requested" (user knobs) from "effective" (live hook-exported state).
 

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -493,6 +493,57 @@ printf 'LINE=[%s]\nPOINT=[%s]\nEVAL=[%s]\nCOMMAND=[%s]\nRECEIPT=[%s]\nDISCARDED=
 }
 
 #[test]
+fn failed_empty_enter_accept_arm_degrades_visibly() {
+    if !enter_mode_supported() {
+        return;
+    }
+    let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+    let script = format!(
+        r#"_TIRITH_TEST_SKIP_HEALTH=1
+TIRITH_BASH_MODE=enter
+source '{}' 2>/dev/null
+_tirith_ensure_prompt_hook() {{ return 0; }}
+_tirith_enter_arm_accept() {{ return 1; }}
+_tirith_degrade_to_preexec() {{
+  TIRITH_TEST_DEGRADED="$1"
+  return 0
+}}
+READLINE_LINE=""
+READLINE_POINT=0
+_tirith_enter
+printf 'DEGRADED=[%s]\nLINE=[%s]\nPOINT=[%s]\n' \
+  "${{TIRITH_TEST_DEGRADED:-}}" "$READLINE_LINE" "$READLINE_POINT"
+"#,
+        hook_path()
+    );
+    let out = Command::new(bash_under_test())
+        .args(["--norc", "--noprofile", "-i", "-c", &script])
+        .env_clear()
+        .env("HOME", std::env::var("HOME").unwrap_or_default())
+        .env("PATH", path_with_tirith_under_test())
+        .env("XDG_STATE_HOME", tmpdir.path())
+        .output()
+        .expect("exercise failed empty-line guarded-accept arming");
+    assert!(
+        out.status.success(),
+        "empty-line arm failure failed: stderr={} stdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for expected in [
+        "DEGRADED=[could not arm guarded accept-line]",
+        "LINE=[]",
+        "POINT=[0]",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "missing {expected:?} from empty-line arm failure output:\n{stdout}"
+        );
+    }
+}
+
+#[test]
 fn bind_x_health_matcher_accepts_bash_52_and_53_records() {
     let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
     let script = format!(

--- a/crates/tirith/tests/bash_hook_exports.rs
+++ b/crates/tirith/tests/bash_hook_exports.rs
@@ -16,6 +16,13 @@
 
 use std::process::Command;
 
+#[path = "pty_support/mod.rs"]
+mod pty_support;
+
+fn bash_under_test() -> std::path::PathBuf {
+    pty_support::modern_bash().unwrap_or_else(|| std::path::PathBuf::from("bash"))
+}
+
 fn hook_path() -> String {
     format!(
         "{}/assets/shell/lib/bash-hook.bash",
@@ -60,7 +67,7 @@ fn split_test_env(extra_env: &[(&str, &str)]) -> (String, Vec<(String, String)>)
 /// `Command::new("bash")` reports.
 fn seed_capability_cache(state_dir: &std::path::Path, verdict: &str) {
     let (bash_version, bash_path) = {
-        let out = Command::new("bash")
+        let out = Command::new(bash_under_test())
             .args(["-c", "printf '%s\\n%s' \"$BASH_VERSION\" \"$BASH\""])
             .output()
             .expect("query bash identity");
@@ -120,7 +127,7 @@ fn source_hook_and_dump_exports(capability: Option<&str>, extra_env: &[(&str, &s
     );
 
     // Minimal env so user shell config can't influence results.
-    let mut cmd = Command::new("bash");
+    let mut cmd = Command::new(bash_under_test());
     cmd.args(["--norc", "--noprofile", "-i", "-c", &script])
         .env_clear()
         .env("HOME", std::env::var("HOME").unwrap_or_default())
@@ -242,7 +249,7 @@ fn hook_does_not_export_in_noninteractive_shell() {
            \"${{TIRITH_STATUS:-unset}}\""
     );
 
-    let out = Command::new("bash")
+    let out = Command::new(bash_under_test())
         .args(["--norc", "--noprofile", "-c", &script])
         .env_clear()
         .env("HOME", std::env::var("HOME").unwrap_or_default())
@@ -268,7 +275,7 @@ fn hook_does_not_export_in_noninteractive_shell() {
 
 #[test]
 fn failed_builtin_bootstrap_clears_stale_exports_without_calling_shadowed_export() {
-    let version = Command::new("bash")
+    let version = Command::new(bash_under_test())
         .args([
             "--norc",
             "--noprofile",
@@ -296,7 +303,7 @@ fn failed_builtin_bootstrap_clears_stale_exports_without_calling_shadowed_export
          readonly POSIXLY_CORRECT; source "$TIRITH_TEST_HOOK" 2>/dev/null;
          /bin/sh -c 'printf "CHILD_MODE=%s\nCHILD_PROT=%s\n" \
            "$TIRITH_BASH_EFFECTIVE_MODE" "$TIRITH_BASH_EFFECTIVE_PROTECTION"'"#;
-    let output = Command::new("bash")
+    let output = Command::new(bash_under_test())
         .args(["--norc", "--noprofile", "-c", script])
         .env_clear()
         .env("TIRITH_TEST_HOOK", &hook)
@@ -363,7 +370,7 @@ fn status_is_not_exported_to_child_processes() {
          printf 'PARENT=%s\\n' \"${{TIRITH_STATUS:-unset}}\"; \
          bash --norc --noprofile -c 'printf \"CHILD=[%s]\\n\" \"${{TIRITH_STATUS:-}}\"'"
     );
-    let out = Command::new("bash")
+    let out = Command::new(bash_under_test())
         .args(["--norc", "--noprofile", "-i", "-c", &script])
         .env_clear()
         .env("HOME", std::env::var("HOME").unwrap_or_default())
@@ -423,7 +430,7 @@ fn doctor_stdout(env: &[(&str, &str)]) -> String {
         .collect();
     let bash_script = format!("{}\n'{bin}' doctor", export_lines.join("\n"));
 
-    let out = Command::new("bash")
+    let out = Command::new(bash_under_test())
         .args(["--norc", "--noprofile", "-c", &bash_script])
         .env_clear()
         .env("HOME", std::env::var("HOME").unwrap_or_default())
@@ -558,7 +565,7 @@ fn source_hook_run_and_dump(extra_env: &[(&str, &str)], body: &str) -> String {
            \"${{TIRITH_STATUS:-}}\""
     );
 
-    let mut cmd = Command::new("bash");
+    let mut cmd = Command::new(bash_under_test());
     cmd.args(["--norc", "--noprofile", "-i", "-c", &script])
         .env_clear()
         .env("HOME", std::env::var("HOME").unwrap_or_default())

--- a/crates/tirith/tests/bash_preexec_enforce.rs
+++ b/crates/tirith/tests/bash_preexec_enforce.rs
@@ -1607,10 +1607,11 @@ echo post_scan_target
 // on enter mode the hook binds `\C-m` then health-checks via `bind -X`, and
 // macOS bash 3.2 does NOT honour `bind -x` here, so the gate degrades to preexec.
 //
-// These tests verify the cache *reader*, not bind-x viability, so the
-// `EFFMODE=<enter>` ones pass `_TIRITH_TEST_SKIP_HEALTH=1` (the test-only gate
-// bypass) to stay green on bash 3.2; real delivery is the PTY harness's job.
-// Preexec-fallback tests (`broken`/`absent`/`stale`) need no override.
+// These tests verify the cache *reader*, not bind-x delivery, so the
+// `EFFMODE=<enter>` ones pass `_TIRITH_TEST_SKIP_HEALTH=1` to bypass the
+// non-PTY health probe. Enter-mode installation still needs Bash 5's `bind -X`
+// enumeration, so those assertions skip Apple Bash 3.2 just like the PTY
+// suite. Preexec-fallback tests (`broken`/`absent`/`stale`) need no override.
 //
 // They also pin the reader against the bash history configs that historically
 // perturbed the hook (HISTCONTROL/HISTIGNORE/HISTTIMEFORMAT/pre-set IFS/extdebug)
@@ -1654,6 +1655,14 @@ fn spawned_bash_major() -> u32 {
         .next()
         .and_then(|major| major.parse().ok())
         .unwrap_or(0)
+}
+
+fn spawned_bash_supports_enter_tests() -> bool {
+    if spawned_bash_major() < 5 {
+        eprintln!("skipping: enter-mode capability assertions require bash >= 5");
+        return false;
+    }
+    true
 }
 
 fn spawned_bash_identity() -> (String, String) {
@@ -1771,8 +1780,11 @@ fn run_hook_with_capability(verdict: Option<&str>, env_vars: &[(&str, &str)]) ->
 
 #[test]
 fn capability_works_cache_selects_enter_mode() {
+    if !spawned_bash_supports_enter_tests() {
+        return;
+    }
     // A fresh `works` verdict selects enter mode. `SKIP_HEALTH` bypasses the
-    // health gate so this holds on any bash (incl. bash 3.2).
+    // non-PTY health gate; installation viability is covered separately.
     let (stdout, _stderr) = run_hook_with_capability(Some("works"), &[SKIP_HEALTH]);
     assert!(
         stdout.contains("EFFMODE=<enter>"),
@@ -1800,6 +1812,9 @@ fn capability_absent_cache_falls_back_to_preexec() {
 
 #[test]
 fn capability_cache_read_survives_hostile_histcontrol() {
+    if !spawned_bash_supports_enter_tests() {
+        return;
+    }
     // HISTCONTROL=ignorespace gates preexec enforcement but must not affect the
     // capability-cache read: a `works` verdict still selects enter.
     let (stdout, _stderr) = run_hook_with_capability(
@@ -1814,6 +1829,9 @@ fn capability_cache_read_survives_hostile_histcontrol() {
 
 #[test]
 fn capability_cache_read_survives_histignore() {
+    if !spawned_bash_supports_enter_tests() {
+        return;
+    }
     let (stdout, _stderr) =
         run_hook_with_capability(Some("works"), &[("HISTIGNORE", "ls:cd:pwd"), SKIP_HEALTH]);
     assert!(
@@ -1824,6 +1842,9 @@ fn capability_cache_read_survives_histignore() {
 
 #[test]
 fn capability_cache_read_survives_histtimeformat_and_preset_ifs() {
+    if !spawned_bash_supports_enter_tests() {
+        return;
+    }
     // The reader sets `IFS` locally per-read, so a pre-set `IFS`/`HISTTIMEFORMAT`
     // must not break its `IFS='='` loop / `wc`.
     let (stdout, _stderr) = run_hook_with_capability(
@@ -1838,6 +1859,9 @@ fn capability_cache_read_survives_histtimeformat_and_preset_ifs() {
 
 #[test]
 fn capability_cache_decision_independent_of_preset_extdebug() {
+    if !spawned_bash_supports_enter_tests() {
+        return;
+    }
     // A user-enabled `extdebug` must not change the decision (passed via BASHOPTS,
     // which bash applies at startup).
     let (stdout, _stderr) =
@@ -1850,6 +1874,9 @@ fn capability_cache_decision_independent_of_preset_extdebug() {
 
 #[test]
 fn capability_cache_read_survives_set_plus_o_history() {
+    if !spawned_bash_supports_enter_tests() {
+        return;
+    }
     // `set +o history` before sourcing must not change the decision — the reader
     // does not touch history. `TempDir` (not `.keep()`) cleans up on return.
     let state = tempfile::tempdir().unwrap();

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -4377,7 +4377,7 @@ send -- "PROMPT_COMMAND=':'; readonly PROMPT_COMMAND\r"
 expect "PROMPT> "
 send -- "echo PTY_RUNTIME_CHECK\r"
 expect {
-  -re {protection downgraded} {}
+  -re {protection downgraded|interception is off|enter mode failed} {}
   timeout { exit 2 }
 }
 send -- "\r"

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -1046,10 +1046,26 @@ fn bash_enter_degradation_restores_custom_ctrl_o_bindings() {
     sess.send_line(&format!("source '{}'", hook.display()));
     sess.expect("TIRITH_PTY> ");
     sess.clear_buffer();
+    sess.send_line("printf 'TIRITH_CTRL_O_MODE<%s>\\n' \"$TIRITH_BASH_EFFECTIVE_MODE\"");
+    let mode_output = sess.expect_any(
+        &["TIRITH_CTRL_O_MODE<enter>", "TIRITH_CTRL_O_MODE<preexec>"],
+        Duration::from_secs(10),
+    );
+    assert!(
+        mode_output.contains("TIRITH_CTRL_O_MODE<enter>"),
+        "enter mode must remove every captured Ctrl-O bypass before its health gate, got:\n{mode_output}"
+    );
+    sess.clear_buffer();
     sess.send_line(
         r#"if _tirith_bind_x_record_is_ctrl_o '"\C-o" "printf modern"' && _tirith_bind_x_record_is_ctrl_o '"\C-o": "printf legacy"'; then printf 'TIRITH_CTRL_O_RECORDS_%s\n' OK; else printf 'TIRITH_CTRL_O_RECORDS_%s\n' BAD; fi"#,
     );
     sess.expect("TIRITH_CTRL_O_RECORDS_OK");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line(
+        r#"bind -m emacs-standard '"\C-o": operate-and-get-next'; if _tirith_startup_health_check; then printf 'TIRITH_CTRL_O_HEALTH_%s\n' BAD; else printf 'TIRITH_CTRL_O_HEALTH_%s\n' OK; fi"#,
+    );
+    sess.expect("TIRITH_CTRL_O_HEALTH_OK");
     sess.expect("TIRITH_PTY> ");
     sess.clear_buffer();
     sess.send_line("_tirith_degrade_to_preexec ctrl-o-test");

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -1038,7 +1038,7 @@ fn bash_enter_degradation_restores_custom_ctrl_o_bindings() {
     sess.expect("TIRITH_PTY> ");
     sess.clear_buffer();
     sess.send_line(
-        r#"bind -m emacs-standard '"\C-o": "EMACS-C-O"'; bind -m vi-insert '"\C-o": "VI-INSERT-C-O"'; bind -m vi-command '"\C-o": "VI-COMMAND-C-O"'"#,
+        r#"bind -m emacs-standard -x '"\C-o":printf EMACS-C-O'; bind -m vi-insert '"\C-o": "VI-INSERT-C-O"'; bind -m vi-command '"\C-o": "VI-COMMAND-C-O"'"#,
     );
     sess.expect("TIRITH_PTY> ");
     sess.clear_buffer();
@@ -1046,10 +1046,16 @@ fn bash_enter_degradation_restores_custom_ctrl_o_bindings() {
     sess.send_line(&format!("source '{}'", hook.display()));
     sess.expect("TIRITH_PTY> ");
     sess.clear_buffer();
+    sess.send_line(
+        r#"if _tirith_bind_x_record_is_ctrl_o '"\C-o" "printf modern"' && _tirith_bind_x_record_is_ctrl_o '"\C-o": "printf legacy"'; then printf 'TIRITH_CTRL_O_RECORDS_%s\n' OK; else printf 'TIRITH_CTRL_O_RECORDS_%s\n' BAD; fi"#,
+    );
+    sess.expect("TIRITH_CTRL_O_RECORDS_OK");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
     sess.send_line("_tirith_degrade_to_preexec ctrl-o-test");
     sess.expect("TIRITH_PTY> ");
     sess.clear_buffer();
-    sess.send_line("bind -m emacs-standard -s; bind -m vi-insert -s; bind -m vi-command -s");
+    sess.send_line("bind -m emacs-standard -X; bind -m vi-insert -s; bind -m vi-command -s");
     let output = sess.expect("VI-COMMAND-C-O");
     sess.close();
 

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -13,13 +13,14 @@
 //! SKIPS cleanly when its shell is missing or too old, so `cargo test` stays
 //! green (put a modern bash first on `PATH` to exercise the bash tests).
 //!
-//! Issue #111: bash ENTER mode can't deliver in a standard PTY (`bind -x` runs
-//! the function without accepting the line, so `PROMPT_COMMAND` never fires).
-//! A self-test (`cli::bash_capability`) proves the capability and the hook uses
-//! enter only where proven, else falls back to preexec. This bare PTY is a
-//! broken-delivery environment, so preexec is the capability-correct behaviour;
-//! the tests assert the gated SYSTEM contract (allowed runs once, blocked does
-//! not) through whichever mode the gate selected, with an anti-vacuous guard.
+//! Issues #111, #224: a bare `bind -x` on Enter runs the function without
+//! accepting the line, so the stashed command was never delivered. Enter mode
+//! now binds Enter to a MACRO that runs the checker and then a guarded
+//! accept-line, which delivers and blocks on stock bash (5.2, 5.3). A self-test
+//! (`cli::bash_capability`) still proves the capability per build and the hook
+//! falls back to preexec if it ever fails. These tests assert the gated SYSTEM
+//! contract (allowed runs once, blocked does not) through whichever mode the
+//! gate selected, with an anti-vacuous guard.
 
 #![cfg(unix)]
 
@@ -660,10 +661,11 @@ fn bash_noclobber_keeps_protocol_v3_registration() {
     );
 }
 
-/// Contract (f): a hook that can't deliver in enter mode must degrade VISIBLY,
-/// never silently — the safety floor. `TIRITH_BASH_MODE=enter` forces enter
-/// (overriding the gate's preexec pick here); the pending-not-consumed safety
-/// net must then fire loudly and persist the safe-mode flag.
+/// Contract (f): a hook that can't set up enter mode must degrade VISIBLY,
+/// never silently — the safety floor. `TIRITH_BASH_MODE=enter` forces enter,
+/// and `_TIRITH_TEST_FAIL_HEALTH=1` (a shell-local, since the hook clears any
+/// EXPORTED test override) forces the startup health gate to fail, so the
+/// degrade-to-preexec path must fire loudly and persist the safe-mode flag.
 #[test]
 fn bash_enter_degradation_is_visible_not_silent() {
     let mut env = IsolatedEnv::new();
@@ -680,28 +682,21 @@ fn bash_enter_degradation_is_visible_not_silent() {
     sess.send_line("export PS1='TIRITH_PTY> '");
     sess.expect("TIRITH_PTY> ");
     sess.clear_buffer();
-    let hook = embedded_hook("bash-hook.bash");
-    sess.send_line(&format!("source '{}'", hook.display()));
+    // Shell-local (not exported): the hook keeps a session-local test override
+    // but strips an inherited/exported one, so this must be set in-shell.
+    sess.send_line("_TIRITH_TEST_FAIL_HEALTH=1");
     sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    let hook = embedded_hook("bash-hook.bash");
+    // The degrade banner is printed while the hook is sourced.
+    sess.send_line(&format!("source '{}'", hook.display()));
+    let out = sess.expect_within("enter mode failed", Duration::from_secs(15));
     sess.wait_idle(QUIET, SETTLE_MAX);
-    sess.clear_buffer();
-
-    // First Enter: `_tirith_enter` captures a pending command but the line is
-    // never accepted in this PTY (#111). It's a WARNED command (shortened URL)
-    // so `tirith check` prints a visible warning — `expect`ing it is race-free
-    // proof the first `_tirith_enter` ran and set `_TIRITH_PENDING_EVAL`.
-    sess.send_line("echo https://bit.ly/enterprobe");
-    sess.expect("bit.ly/enterprobe");
-    sess.clear_buffer();
-    // Second Enter: the hook sees the un-consumed pending command and must
-    // announce a degrade to preexec; `expect` polls patiently for the banner.
-    sess.send_line("echo trigger_degrade");
-    let out = sess.expect_within("protection downgraded", Duration::from_secs(15));
     sess.close();
 
     assert!(
-        out.contains("protection downgraded to warn-only") || out.contains("enter mode failed"),
-        "enter mode losing delivery must print a visible degrade message, got:\n{out}"
+        out.contains("enter mode failed") || out.contains("protection downgraded to warn-only"),
+        "a failed enter-mode setup must print a visible degrade message, got:\n{out}"
     );
     // A visible degrade must also be a *persisted* one, so the next shell
     // starts safe.
@@ -818,11 +813,11 @@ fn bash_enter_blocked_command_does_not_execute() {
     );
 }
 
-/// The capability cache steers the hook's default mode, observable through
-/// behaviour: a `broken`/stale verdict → preexec (delivers → marker written); a
-/// `works` verdict for the running bash → enter (broken in this PTY → swallowed
-/// → marker absent). So a written marker proves preexec, an absent one enter —
-/// demonstrating why the gate exists.
+/// The capability cache steers the hook's default mode, observable through the
+/// exported `TIRITH_BASH_EFFECTIVE_MODE`: a `broken`/stale verdict → preexec, a
+/// `works` verdict for the running bash → enter. (Since the macro-dispatch fix,
+/// both modes deliver a command, so delivery alone no longer distinguishes
+/// them; the exported effective mode does.)
 #[test]
 fn bash_capability_cache_steers_default_mode() {
     let bash = match modern_bash() {
@@ -841,16 +836,13 @@ fn bash_capability_cache_steers_default_mode() {
     };
     let hook = embedded_hook("bash-hook.bash");
 
-    // Returns whether the marker was written (true ⇒ preexec delivered, false ⇒
-    // enter swallowed) for a seeded verdict. `seed_bash` is the cache's bash
-    // path: the real spawn path makes the verdict apply, a bogus one reads stale.
-    // No terminal output, so `wait_for_marker` polls the file (a `false` waits
-    // out `MARKER_MAX` to be sure the marker never appears).
-    let marker_written =
-        |verdict: &str, seed_bash_ver: &str, seed_bash: &Path, tag: &str| -> bool {
+    // Returns the exported effective mode ("enter" or "preexec") the hook
+    // selected for a seeded verdict. `seed_bash` is the cache's bash path: the
+    // real spawn path makes the verdict apply, a bogus one reads stale.
+    let effective_mode =
+        |verdict: &str, seed_bash_ver: &str, seed_bash: &Path, _tag: &str| -> String {
             let env = IsolatedEnv::new();
             env.seed_bash_enter_capability(verdict, seed_bash_ver, seed_bash);
-            let marker = env.workdir.join(format!("steer_{tag}.txt"));
             let mut sess = PtySession::spawn(&env, &bash, &["--norc", "--noprofile", "-i"]);
             sess.send_line("export PS1='TIRITH_PTY> '");
             sess.expect("TIRITH_PTY> ");
@@ -859,42 +851,121 @@ fn bash_capability_cache_steers_default_mode() {
             sess.expect("TIRITH_PTY> ");
             sess.wait_idle(QUIET, SETTLE_MAX);
             sess.clear_buffer();
-            sess.send_line(&format!("printf 'STEERED\\n' >> '{}'", marker.display()));
-            let body = wait_for_marker(&marker, "STEERED", MARKER_MAX);
+            // The `%s` stays literal in the command echo, so waiting for the
+            // substituted value never matches the echoed command line.
+            sess.send_line("printf 'TIRITHMODE<%s>\\n' \"$TIRITH_BASH_EFFECTIVE_MODE\"");
+            let out = sess.expect_any(
+                &["TIRITHMODE<enter>", "TIRITHMODE<preexec>"],
+                Duration::from_secs(10),
+            );
             sess.close();
-            count_occurrences(&body, "STEERED") == 1
+            if out.contains("TIRITHMODE<enter>") {
+                "enter".to_string()
+            } else if out.contains("TIRITHMODE<preexec>") {
+                "preexec".to_string()
+            } else {
+                format!("unknown: {out}")
+            }
         };
 
-    // `broken` ⇒ preexec ⇒ delivered ⇒ marker written.
-    assert!(
-        marker_written("broken", &bash_ver, &bash, "broken"),
-        "a `broken` capability verdict must keep the hook in preexec (command must run)"
+    // `broken` ⇒ preexec.
+    assert_eq!(
+        effective_mode("broken", &bash_ver, &bash, "broken"),
+        "preexec",
+        "a `broken` capability verdict must keep the hook in preexec"
     );
 
-    // `works` for a different bash version is stale ⇒ preexec ⇒ marker written.
-    assert!(
-        marker_written("works", "1.0.0-not-this-bash", &bash, "stale_version"),
-        "a capability verdict for a different bash version must be ignored as stale \
-         (hook must stay in preexec and run the command)"
+    // `works` for a different bash version is stale ⇒ preexec.
+    assert_eq!(
+        effective_mode("works", "1.0.0-not-this-bash", &bash, "stale_version"),
+        "preexec",
+        "a capability verdict for a different bash version must be ignored as stale"
     );
 
-    // `works` for a different bash path is stale ⇒ preexec ⇒ marker written.
-    assert!(
-        marker_written(
+    // `works` for a different bash path is stale ⇒ preexec.
+    assert_eq!(
+        effective_mode(
             "works",
             &bash_ver,
             Path::new("/nonexistent/other/bash"),
             "stale_path"
         ),
-        "a capability verdict for a different bash path must be ignored as stale \
-         (hook must stay in preexec and run the command)"
+        "preexec",
+        "a capability verdict for a different bash path must be ignored as stale"
     );
 
-    // `works` for this exact bash ⇒ enter ⇒ swallowed in this PTY ⇒ no marker.
+    // `works` for this exact bash ⇒ enter.
+    assert_eq!(
+        effective_mode("works", &bash_ver, &bash, "works"),
+        "enter",
+        "a `works` capability verdict must make the hook select enter mode"
+    );
+}
+
+/// The macro-dispatch enter mechanism (issues #111, #224): forcing enter mode
+/// must DELIVER an allowed command exactly once and BLOCK a dangerous one,
+/// with no preexec enforcement and no capability cache. This is the direct
+/// proof that the fix makes bash enter mode functional on the running bash.
+#[test]
+fn bash_enter_mode_delivers_and_blocks() {
+    let mut env = IsolatedEnv::new();
+    let bash = match modern_bash() {
+        Some(b) => b,
+        None => {
+            eprintln!("skipping: no modern bash (>= 5) found");
+            return;
+        }
+    };
+    // Force enter (bypasses the capability gate) and skip preexec enforcement,
+    // so a blocked command is stopped ONLY if enter mode itself blocks.
+    env.set("TIRITH_BASH_MODE", "enter");
+    let allowed = env.workdir.join("enter_allowed.txt");
+    let blocked = env.workdir.join("enter_blocked.txt");
+
+    let mut sess = PtySession::spawn(&env, &bash, &["--norc", "--noprofile", "-i"]);
+    sess.send_line("export PS1='TIRITH_PTY> '");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    let hook = embedded_hook("bash-hook.bash");
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.wait_idle(QUIET, SETTLE_MAX);
+    sess.clear_buffer();
+
+    // Confirm the hook is actually in enter mode, not a degrade to preexec.
+    // The `%s` stays literal in the command echo, so waiting for a substituted
+    // value never matches the echoed command line.
+    sess.send_line("printf 'TIRITHMODE<%s>\\n' \"$TIRITH_BASH_EFFECTIVE_MODE\"");
+    let mode_out = sess.expect_any(
+        &["TIRITHMODE<enter>", "TIRITHMODE<preexec>"],
+        Duration::from_secs(10),
+    );
     assert!(
-        !marker_written("works", &bash_ver, &bash, "works"),
-        "a `works` capability verdict must make the hook select enter mode \
-         (which, in this PTY, swallows the command — marker must be absent)"
+        mode_out.contains("TIRITHMODE<enter>"),
+        "forced enter mode must not degrade at startup, got:\n{mode_out}"
+    );
+    sess.clear_buffer();
+
+    // Allowed, side-effect-only command must be delivered exactly once.
+    sess.send_line(&format!("printf 'RAN\\n' >> '{}'", allowed.display()));
+    let allowed_body = wait_for_marker(&allowed, "RAN", MARKER_MAX);
+    assert_eq!(
+        count_occurrences(&allowed_body, "RAN"),
+        1,
+        "enter mode must deliver an allowed command exactly once, got: {allowed_body:?}"
+    );
+
+    // Blocked pipe-to-interpreter: the `&&`-guarded marker write runs only if
+    // the pipeline executed. Enter mode must block it.
+    sess.send_line(&format!(
+        "printf 'true' | bash && touch '{}'",
+        blocked.display()
+    ));
+    sess.wait_idle(QUIET, SETTLE_MAX);
+    sess.close();
+    assert!(
+        !blocked.exists(),
+        "enter mode must block a pipe-to-interpreter command"
     );
 }
 

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -969,6 +969,98 @@ fn bash_enter_mode_delivers_and_blocks() {
     );
 }
 
+/// Switching Readline from emacs to vi after hook installation must not expose
+/// an unguarded Enter key in either vi insertion or command mode.
+#[test]
+fn bash_enter_mode_protects_vi_keymaps_after_runtime_switch() {
+    let mut env = IsolatedEnv::new();
+    let bash = match modern_bash() {
+        Some(bash) => bash,
+        None => {
+            eprintln!("skipping: no modern bash (>= 5) found");
+            return;
+        }
+    };
+    env.set("TIRITH_BASH_MODE", "enter");
+    let allowed = env.workdir.join("vi_insert_allowed.txt");
+    let blocked = env.workdir.join("vi_command_blocked.txt");
+
+    let mut sess = PtySession::spawn(&env, &bash, &["--norc", "--noprofile", "-i"]);
+    sess.send_line("export PS1='TIRITH_PTY> '");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    let hook = embedded_hook("bash-hook.bash");
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+
+    sess.send_line("set -o vi");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line(&format!("printf 'RAN\\n' >> '{}'", allowed.display()));
+    let allowed_body = wait_for_marker(&allowed, "RAN", MARKER_MAX);
+    assert_eq!(
+        count_occurrences(&allowed_body, "RAN"),
+        1,
+        "vi-insert Enter must deliver an allowed command exactly once"
+    );
+
+    // Type in vi insertion mode, then press Escape followed by Enter so the
+    // accept action is dispatched from the separate vi-command keymap.
+    let dangerous = format!("printf 'true' | bash && touch '{}'", blocked.display());
+    sess.send_raw(dangerous.as_bytes());
+    sess.send_raw(b"\x1b\r");
+    sess.wait_idle(QUIET, SETTLE_MAX);
+    sess.close();
+    assert!(
+        !blocked.exists(),
+        "vi-command Enter must still pass through Tirith's guarded dispatcher"
+    );
+}
+
+/// Enter-mode degradation is a session-local transition. It must restore the
+/// exact Ctrl-O bindings the user had in each protected keymap, rather than a
+/// hard-coded default.
+#[test]
+fn bash_enter_degradation_restores_custom_ctrl_o_bindings() {
+    let mut env = IsolatedEnv::new();
+    let bash = match modern_bash() {
+        Some(bash) => bash,
+        None => {
+            eprintln!("skipping: no modern bash (>= 5) found");
+            return;
+        }
+    };
+    env.set("TIRITH_BASH_MODE", "enter");
+
+    let mut sess = PtySession::spawn(&env, &bash, &["--norc", "--noprofile", "-i"]);
+    sess.send_line("export PS1='TIRITH_PTY> '");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line(
+        r#"bind -m emacs-standard '"\C-o": "EMACS-C-O"'; bind -m vi-insert '"\C-o": "VI-INSERT-C-O"'; bind -m vi-command '"\C-o": "VI-COMMAND-C-O"'"#,
+    );
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    let hook = embedded_hook("bash-hook.bash");
+    sess.send_line(&format!("source '{}'", hook.display()));
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line("_tirith_degrade_to_preexec ctrl-o-test");
+    sess.expect("TIRITH_PTY> ");
+    sess.clear_buffer();
+    sess.send_line("bind -m emacs-standard -s; bind -m vi-insert -s; bind -m vi-command -s");
+    let output = sess.expect("VI-COMMAND-C-O");
+    sess.close();
+
+    for expected in ["EMACS-C-O", "VI-INSERT-C-O", "VI-COMMAND-C-O"] {
+        assert!(
+            output.contains(expected),
+            "degradation did not restore {expected}; got:\n{output}"
+        );
+    }
+}
+
 // === fish ===
 // The fish hook binds Enter to `_tirith_check_command`, ending with
 // `commandline -f execute` (fish's supported line-accept). Delivery is reliable;

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -2115,6 +2115,32 @@ _tirith_unsafe_to_eval() {
 }
 
 
+_tirith_queue_enter_delivery() {
+  local cmd="$1" receipt_token="$2"
+  _TIRITH_PENDING_EVAL="$cmd"
+  _TIRITH_PENDING_COMMAND="$cmd"
+  # Commit marker: publish only after both command copies are complete.
+  if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
+    _TIRITH_PENDING_RECEIPT="$receipt_token"
+  fi
+
+  # The accept sub-sequence is processed only after this bind-x callback
+  # returns. If any keymap cannot be armed, roll the delivery back while the
+  # command can still be put visibly into Readline for a safe retry.
+  if ! _tirith_enter_arm_accept; then
+    unset _TIRITH_PENDING_EVAL _TIRITH_PENDING_COMMAND _TIRITH_PENDING_RECEIPT
+    _tirith_receipt_discard bash-enter "$receipt_token" || true
+    READLINE_LINE="$cmd"
+    READLINE_POINT=${#cmd}
+    _tirith_degrade_to_preexec "could not arm guarded accept-line" || true
+    return 1
+  fi
+
+  history -s -- "$cmd"
+  return 0
+}
+
+
 _tirith_startup_health_check() {
   # Test-only override: bypass startup gate to reach runtime failure paths in PTY tests.
   [[ "${_TIRITH_TEST_SKIP_HEALTH:-}" == "1" ]] && return 0
@@ -2416,30 +2442,12 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
       # one quoted argument to the builtin preserves multiline/heredoc/compound
       # syntax without a source file, process-substitution race, or disk copy.
       if _tirith_unsafe_to_eval "$cmd"; then
-        history -s -- "$cmd"
-        _TIRITH_PENDING_EVAL="$cmd"
-        _TIRITH_PENDING_COMMAND="$cmd"
-        # Commit marker: publish only after both command copies are complete.
-        if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
-          _TIRITH_PENDING_RECEIPT="$receipt_token"
-        fi
-        # Arm the guarded accept-line so the now-emptied buffer is accepted and
-        # the prompt hook delivers the stashed command.
-        _tirith_enter_arm_accept
-        return 0
+        _tirith_queue_enter_delivery "$cmd" "$receipt_token"
+        return $?
       fi
 
-      history -s -- "$cmd"
-      _TIRITH_PENDING_EVAL="$cmd"
-      _TIRITH_PENDING_COMMAND="$cmd"
-      # Commit marker: publish only after both command copies are complete.
-      if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
-        _TIRITH_PENDING_RECEIPT="$receipt_token"
-      fi
-      # Arm the guarded accept-line so the now-emptied buffer is accepted and
-      # the prompt hook delivers the stashed command.
-      _tirith_enter_arm_accept
-      return 0
+      _tirith_queue_enter_delivery "$cmd" "$receipt_token"
+      return $?
     }
 
     # Bracketed paste interception

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -1630,6 +1630,14 @@ _tirith_bind_x_record_is_ctrl_o() {
   [[ "$key" == '"\C-o"' ]]
 }
 
+_tirith_bind_output_has_ctrl_o() {
+  local output="$1" line
+  while IFS= read -r line; do
+    _tirith_bind_x_record_is_ctrl_o "$line" && return 0
+  done <<< "$output"
+  return 1
+}
+
 _tirith_bind_x_has_exact_binding() {
   local output="$1"
   local key="$2"
@@ -1707,7 +1715,7 @@ _tirith_restore_ctrl_o_bindings() {
         builtin bind -m "$map" "$binding" 2>/dev/null || restore_rc=1
         ;;
       *)
-        builtin bind -m "$map" -r '"\C-o"' 2>/dev/null || true
+        builtin bind -m "$map" -r '\C-o' 2>/dev/null || restore_rc=1
         ;;
     esac
   done
@@ -1729,11 +1737,11 @@ _tirith_degrade_to_preexec() {
       builtin bind -m "$_tirith_keymap" '"\C-j": accept-line' 2>/dev/null || true
       # Unbind the macro-dispatch helper sequences (checker + guarded accept)
       # so no stale binding survives the degrade in any switchable keymap.
-      builtin bind -m "$_tirith_keymap" -r '"\C-x\C-t7"' 2>/dev/null || true
-      builtin bind -m "$_tirith_keymap" -r '"\C-x\C-r7"' 2>/dev/null || true
+      builtin bind -m "$_tirith_keymap" -r "$_TIRITH_ENTER_CHECK_KEYS" 2>/dev/null || true
+      builtin bind -m "$_tirith_keymap" -r "$_TIRITH_ENTER_ACCEPT_KEYS" 2>/dev/null || true
       # Restore bracketed paste to the Readline default if available.
       builtin bind -m "$_tirith_keymap" '"\e[200~": bracketed-paste-begin' \
-        2>/dev/null || builtin bind -m "$_tirith_keymap" -r '"\e[200~"' 2>/dev/null || true
+        2>/dev/null || builtin bind -m "$_tirith_keymap" -r '\e[200~' 2>/dev/null || true
     done
     _tirith_restore_ctrl_o_bindings || true
     _TIRITH_BINDS_INSTALLED=0
@@ -1811,7 +1819,16 @@ _tirith_prompt_hook() {
   # accept-line until this runs, so disarming here closes the window in which
   # an injected accept sequence could accept a line the checker never approved.
   if declare -F _tirith_enter_disarm_accept >/dev/null 2>&1; then
-    _tirith_enter_disarm_accept
+    if ! _tirith_enter_disarm_accept; then
+      local failed_pending_receipt="${_TIRITH_PENDING_RECEIPT:-}"
+      unset _TIRITH_PENDING_EVAL
+      unset _TIRITH_PENDING_RECEIPT _TIRITH_PENDING_COMMAND
+      if [[ -n "$failed_pending_receipt" ]]; then
+        _tirith_receipt_discard bash-enter "$failed_pending_receipt" || true
+      fi
+      _tirith_degrade_to_preexec "could not disarm guarded accept-line" || true
+      return
+    fi
   fi
   local pending_eval="${_TIRITH_PENDING_EVAL:-}"
   local pending_receipt="${_TIRITH_PENDING_RECEIPT:-}"
@@ -2164,7 +2181,7 @@ _tirith_startup_health_check() {
   # Test-only override for CI (avoids needing PTY)
   [[ "${_TIRITH_TEST_FAIL_HEALTH:-}" == "1" ]] && return 1
   # The checker must be installed as a bind -x function.
-  local map xbinds sbinds
+  local map xbinds sbinds pbinds
   # Both \C-m and \C-j must map to the checker+accept Enter macro in every
   # primary keymap. A later `set -o vi` must not expose an unguarded accept-line.
   local macro="$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS"
@@ -2176,9 +2193,13 @@ _tirith_startup_health_check() {
       "$xbinds" "$_TIRITH_ENTER_CHECK_KEYS" "_tirith_enter" || return 1
     _tirith_bind_x_has_exact_binding \
       "$xbinds" "$_TIRITH_ENTER_ACCEPT_KEYS" "_tirith_enter_accept_noop" || return 1
+    _tirith_bind_output_has_ctrl_o "$xbinds" && return 1
     sbinds="$(builtin bind -m "$map" -s 2>/dev/null)" || return 1
     [[ "$sbinds" == *"$cm_needle"* ]] || return 1
     [[ "$sbinds" == *"$cj_needle"* ]] || return 1
+    _tirith_bind_output_has_ctrl_o "$sbinds" && return 1
+    pbinds="$(builtin bind -m "$map" -p 2>/dev/null)" || return 1
+    _tirith_bind_output_has_ctrl_o "$pbinds" && return 1
   done
   # Verify prompt hook is still attached
   _tirith_is_prompt_hook_attached || return 1
@@ -2578,7 +2599,8 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         builtin bind -m "$_tirith_keymap" -x '"\e[200~": _tirith_paste' \
           || _tirith_bind_install_ok=0
         # operate-and-get-next accepts the current line without the checker.
-        builtin bind -m "$_tirith_keymap" -r '"\C-o"' 2>/dev/null || true
+        builtin bind -m "$_tirith_keymap" -r '\C-o' 2>/dev/null \
+          || _tirith_bind_install_ok=0
       done
       _tirith_enter_disarm_accept || _tirith_bind_install_ok=0
       _TIRITH_BINDS_INSTALLED=1

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -502,13 +502,16 @@ _tirith_persist_safe_mode() {
   fi
 }
 
-# --- Enter-mode capability cache (issue #111) -------------------------------
+# --- Enter-mode capability cache (issues #111, #224) ------------------------
 #
-# `bind -x` on Enter runs the bound function but, in many environments, does
-# NOT then accept the line — bash never returns to its command loop, the
-# pending command is never delivered, and it is silently eaten. Whether this
-# happens is a property of the running bash/readline build, not the version
-# number, so it cannot be decided by a version gate.
+# A bare `bind -x` on Enter runs the bound function but does NOT then accept the
+# line on stock bash, so the pending command was never delivered and was
+# silently eaten (#111). Enter mode now binds Enter to a MACRO that runs the
+# checker and then a guarded accept-line (see the install block below), which
+# delivers and blocks on every stock bash tested (5.2, 5.3). The self-test is
+# retained as a fail-closed gate: if the macro mechanism ever fails to deliver
+# or block on some exotic build, the probe records that and the hook falls back
+# to preexec rather than risk eating a command.
 #
 # `tirith setup` / `tirith doctor` run a PTY self-test that PROVES whether
 # enter-mode delivery works, and write the verdict to a cache file. This hook
@@ -1619,6 +1622,12 @@ _tirith_degrade_to_preexec() {
   if [[ "${_TIRITH_BINDS_INSTALLED:-0}" == "1" ]]; then
     bind '"\C-m": accept-line' 2>/dev/null || true
     bind '"\C-j": accept-line' 2>/dev/null || true
+    # Unbind the macro-dispatch helper sequences (checker + guarded accept) so
+    # no stale binding survives the degrade.
+    bind -r '"\C-x\C-t7"' 2>/dev/null || true
+    bind -r '"\C-x\C-r7"' 2>/dev/null || true
+    # Restore operate-and-get-next, unbound in enter mode.
+    bind '"\C-o": operate-and-get-next' 2>/dev/null || true
     # Restore bracketed paste to readline default if available, otherwise unbind
     bind '"\e[200~": bracketed-paste-begin' 2>/dev/null || bind -r '"\e[200~"' 2>/dev/null || true
     _TIRITH_BINDS_INSTALLED=0
@@ -1692,6 +1701,12 @@ _tirith_degrade_to_preexec() {
 
 
 _tirith_prompt_hook() {
+  # Re-disarm the guarded accept-line every prompt. Arming leaves it bound to
+  # accept-line until this runs, so disarming here closes the window in which
+  # an injected accept sequence could accept a line the checker never approved.
+  if declare -F _tirith_enter_disarm_accept >/dev/null 2>&1; then
+    _tirith_enter_disarm_accept
+  fi
   local pending_eval="${_TIRITH_PENDING_EVAL:-}"
   local pending_receipt="${_TIRITH_PENDING_RECEIPT:-}"
   local pending_command="${_TIRITH_PENDING_COMMAND:-}"
@@ -1745,8 +1760,18 @@ _tirith_is_prompt_hook_attached() {
 _tirith_ensure_prompt_hook() {
   _tirith_is_prompt_hook_attached && return 0
 
-  local pc_decl
+  local pc_decl pc_attrs
   pc_decl="$(declare -p PROMPT_COMMAND 2>/dev/null)" || pc_decl=""
+  pc_attrs="${pc_decl#declare }"
+  pc_attrs="${pc_attrs%% *}"
+  # Never attempt the assignment when PROMPT_COMMAND is readonly (or otherwise
+  # unwrappable): assigning to a readonly variable is a FATAL error that aborts
+  # this whole function before it can report failure, so the caller would never
+  # see a return value and never degrade. Refuse cleanly instead, and let the
+  # caller degrade (the preexec-guard install refuses the same attributes).
+  if [[ -n "$pc_decl" ]]; then
+    _tirith_prompt_command_attrs_safe "$pc_attrs" || return 1
+  fi
 
   if [[ "$pc_decl" == "declare -a"* ]]; then
     PROMPT_COMMAND=(_tirith_prompt_hook "${PROMPT_COMMAND[@]}") 2>/dev/null || return 1
@@ -1755,7 +1780,8 @@ _tirith_ensure_prompt_hook() {
   else
     PROMPT_COMMAND="_tirith_prompt_hook" 2>/dev/null || return 1
   fi
-  return 0
+  # Confirm the reattachment actually took effect.
+  _tirith_is_prompt_hook_attached
 }
 
 
@@ -2005,11 +2031,20 @@ _tirith_startup_health_check() {
   [[ "${_TIRITH_TEST_SKIP_HEALTH:-}" == "1" ]] && return 0
   # Test-only override for CI (avoids needing PTY)
   [[ "${_TIRITH_TEST_FAIL_HEALTH:-}" == "1" ]] && return 1
-  # Verify both \C-m and \C-j are bound to _tirith_enter
-  local binds
-  binds="$(bind -X 2>/dev/null)" || return 1
-  [[ "$binds" =~ \\C-m.*_tirith_enter ]] || return 1
-  [[ "$binds" =~ \\C-j.*_tirith_enter ]] || return 1
+  # The checker must be installed as a bind -x function.
+  local xbinds
+  xbinds="$(bind -X 2>/dev/null)" || return 1
+  [[ "$xbinds" == *_tirith_enter* ]] || return 1
+  # Both \C-m and \C-j must map to the checker+accept Enter macro. Build the
+  # exact `bind -s` line as a literal and match it quoted so the backslashes in
+  # the key sequences are compared literally, not treated as glob escapes.
+  local sbinds
+  sbinds="$(bind -s 2>/dev/null)" || return 1
+  local macro="$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS"
+  local cm_needle="\"\\C-m\": \"$macro\""
+  local cj_needle="\"\\C-j\": \"$macro\""
+  [[ "$sbinds" == *"$cm_needle"* ]] || return 1
+  [[ "$sbinds" == *"$cj_needle"* ]] || return 1
   # Verify prompt hook is still attached
   _tirith_is_prompt_hook_attached || return 1
   return 0
@@ -2054,10 +2089,11 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         return  # READLINE_LINE stays intact
       fi
 
-      # Empty input: just return (shows new prompt)
+      # Empty input: accept the empty line so a fresh prompt is shown.
       if [[ -z "$READLINE_LINE" ]]; then
         READLINE_LINE=""
         READLINE_POINT=0
+        _tirith_enter_arm_accept
         return
       fi
 
@@ -2295,6 +2331,9 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
         if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
           _TIRITH_PENDING_RECEIPT="$receipt_token"
         fi
+        # Arm the guarded accept-line so the now-emptied buffer is accepted and
+        # the prompt hook delivers the stashed command.
+        _tirith_enter_arm_accept
         return 0
       fi
 
@@ -2305,6 +2344,9 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
       if [[ $_TIRITH_RECEIPT_PROTOCOL -eq 3 ]]; then
         _TIRITH_PENDING_RECEIPT="$receipt_token"
       fi
+      # Arm the guarded accept-line so the now-emptied buffer is accepted and
+      # the prompt hook delivers the stashed command.
+      _tirith_enter_arm_accept
       return 0
     }
 
@@ -2368,15 +2410,40 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
       READLINE_POINT=$((READLINE_POINT + ${#pasted}))
     }
 
-    # Install key bindings
-    bind -x '"\C-m": _tirith_enter' || true
-    bind -x '"\C-j": _tirith_enter' || true
+    # Macro-dispatch delivery (issues #111, #224). A bare `bind -x` on Enter
+    # runs the checker but does NOT then accept the line on stock bash, so the
+    # stashed command was silently eaten and the hook degraded to preexec. Bind
+    # Enter to a MACRO that runs the checker and then a GUARDED accept-line: the
+    # accept sub-sequence is a no-op until `_tirith_enter` arms it, so a line is
+    # only accepted once the checker has decided to deliver it (the prompt hook
+    # then evaluates the stashed command, exactly as before). A raw injection of
+    # the accept bytes hits the disarmed no-op, and every prompt re-disarms it,
+    # so possession of the accept sequence alone can never accept a line.
+    _TIRITH_ENTER_CHECK_KEYS='\C-x\C-t7'
+    _TIRITH_ENTER_ACCEPT_KEYS='\C-x\C-r7'
+    _tirith_enter_accept_noop() { :; }
+    _tirith_enter_arm_accept() {
+      bind "\"$_TIRITH_ENTER_ACCEPT_KEYS\": accept-line" 2>/dev/null
+    }
+    _tirith_enter_disarm_accept() {
+      bind -x "\"$_TIRITH_ENTER_ACCEPT_KEYS\": _tirith_enter_accept_noop" 2>/dev/null
+    }
+
+    # Install key bindings: checker (bind -x), disarmed accept, Enter macros.
+    bind -x "\"$_TIRITH_ENTER_CHECK_KEYS\": _tirith_enter" || true
+    _tirith_enter_disarm_accept
+    bind "\"\C-m\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" || true
+    bind "\"\C-j\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" || true
     bind -x '"\e[200~": _tirith_paste' || true
+    # Close accept-line-equivalent bypasses: operate-and-get-next (\C-o) accepts
+    # the current line WITHOUT running the checker. Remove it in enter mode; the
+    # degrade path restores it.
+    bind -r '"\C-o"' 2>/dev/null || true
     _TIRITH_BINDS_INSTALLED=1
 
-    # Startup health gate: verify bind-x took effect for BOTH keys
+    # Startup health gate: verify the checker and the Enter macro took effect.
     if ! _tirith_startup_health_check; then
-      _tirith_degrade_to_preexec "startup health check failed (bind-x or PROMPT_COMMAND)"
+      _tirith_degrade_to_preexec "startup health check failed (enter macro or PROMPT_COMMAND)"
     fi
   fi
 

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -1630,6 +1630,23 @@ _tirith_bind_x_record_is_ctrl_o() {
   [[ "$key" == '"\C-o"' ]]
 }
 
+_tirith_bind_x_has_exact_binding() {
+  local output="$1"
+  local key="$2"
+  local command="$3"
+  local line
+  # Bash 5.2 prints inputrc-style `"key": "command"` records, while 5.3
+  # omits the colon. Match complete records in either reusable format so a
+  # substring or a similarly named callback cannot satisfy the health gate.
+  while IFS= read -r line; do
+    if [[ "$line" == "\"${key}\" \"${command}\"" \
+       || "$line" == "\"${key}\": \"${command}\"" ]]; then
+      return 0
+    fi
+  done <<< "$output"
+  return 1
+}
+
 _tirith_capture_ctrl_o_bindings() {
   local map output line index
   # Bash versions that cannot enumerate bind-x entries cannot safely preserve
@@ -2153,12 +2170,12 @@ _tirith_startup_health_check() {
   local macro="$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS"
   local cm_needle="\"\\C-m\": \"$macro\""
   local cj_needle="\"\\C-j\": \"$macro\""
-  local check_needle="\"$_TIRITH_ENTER_CHECK_KEYS\" \"_tirith_enter\""
-  local accept_needle="\"$_TIRITH_ENTER_ACCEPT_KEYS\" \"_tirith_enter_accept_noop\""
   for map in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
     xbinds="$(builtin bind -m "$map" -X 2>/dev/null)" || return 1
-    [[ "$xbinds" == *"$check_needle"* ]] || return 1
-    [[ "$xbinds" == *"$accept_needle"* ]] || return 1
+    _tirith_bind_x_has_exact_binding \
+      "$xbinds" "$_TIRITH_ENTER_CHECK_KEYS" "_tirith_enter" || return 1
+    _tirith_bind_x_has_exact_binding \
+      "$xbinds" "$_TIRITH_ENTER_ACCEPT_KEYS" "_tirith_enter_accept_noop" || return 1
     sbinds="$(builtin bind -m "$map" -s 2>/dev/null)" || return 1
     [[ "$sbinds" == *"$cm_needle"* ]] || return 1
     [[ "$sbinds" == *"$cj_needle"* ]] || return 1

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -79,7 +79,8 @@ for _tirith_inherited_state in \
   _tirith_last_key _tirith_last_rc _tirith_last_cmd \
   _TIRITH_PREV_DEBUG_TRAP \
   _TIRITH_DEGRADE_WARNED _TIRITH_OFF_WARNED _TIRITH_PREEXEC_WARNED _TIRITH_RECEIPT_DEGRADE_WARNED \
-  _TIRITH_BINDS_INSTALLED _TIRITH_PREEXEC_PROMPT_STATUS
+  _TIRITH_BINDS_INSTALLED _TIRITH_PREEXEC_PROMPT_STATUS \
+  _TIRITH_PROTECTED_KEYMAPS _TIRITH_SAVED_CTRL_O_KINDS _TIRITH_SAVED_CTRL_O_BINDINGS
 do
   unset "$_tirith_inherited_state"
 done
@@ -1613,6 +1614,83 @@ _tirith_preexec() {
 }
 
 
+# Enter mode has to cover every primary Readline keymap a session can switch
+# to after the hook is loaded. Preserve Ctrl-O separately for each map because
+# it is an accept-line equivalent that must be disabled only while enter mode
+# owns command delivery.
+_TIRITH_PROTECTED_KEYMAPS=(emacs-standard vi-insert vi-command)
+_TIRITH_SAVED_CTRL_O_KINDS=()
+_TIRITH_SAVED_CTRL_O_BINDINGS=()
+
+_tirith_capture_ctrl_o_bindings() {
+  local map output line index
+  # Bash versions that cannot enumerate bind-x entries cannot safely preserve
+  # an existing shell-command binding. They already fail the enter-mode health
+  # gate, so refuse before changing any bindings and use preexec instead.
+  builtin bind -X >/dev/null 2>&1 || return 1
+  _TIRITH_SAVED_CTRL_O_KINDS=()
+  _TIRITH_SAVED_CTRL_O_BINDINGS=()
+
+  for ((index = 0; index < ${#_TIRITH_PROTECTED_KEYMAPS[@]}; index++)); do
+    map="${_TIRITH_PROTECTED_KEYMAPS[index]}"
+    _TIRITH_SAVED_CTRL_O_KINDS[index]="unbound"
+    _TIRITH_SAVED_CTRL_O_BINDINGS[index]=""
+
+    output="$(builtin bind -m "$map" -X 2>/dev/null)" || return 1
+    while IFS= read -r line; do
+      if [[ "${line%% *}" == '"\C-o"' ]]; then
+        _TIRITH_SAVED_CTRL_O_KINDS[index]="bind-x"
+        _TIRITH_SAVED_CTRL_O_BINDINGS[index]="$line"
+        break
+      fi
+    done <<< "$output"
+    [[ "${_TIRITH_SAVED_CTRL_O_KINDS[index]}" == "bind-x" ]] && continue
+
+    output="$(builtin bind -m "$map" -s 2>/dev/null)" || return 1
+    while IFS= read -r line; do
+      if [[ "${line%%:*}" == '"\C-o"' ]]; then
+        _TIRITH_SAVED_CTRL_O_KINDS[index]="binding"
+        _TIRITH_SAVED_CTRL_O_BINDINGS[index]="$line"
+        break
+      fi
+    done <<< "$output"
+    [[ "${_TIRITH_SAVED_CTRL_O_KINDS[index]}" == "binding" ]] && continue
+
+    output="$(builtin bind -m "$map" -p 2>/dev/null)" || return 1
+    while IFS= read -r line; do
+      if [[ "${line%%:*}" == '"\C-o"' ]]; then
+        _TIRITH_SAVED_CTRL_O_KINDS[index]="binding"
+        _TIRITH_SAVED_CTRL_O_BINDINGS[index]="$line"
+        break
+      fi
+    done <<< "$output"
+  done
+  return 0
+}
+
+_tirith_restore_ctrl_o_bindings() {
+  local map kind binding index restore_rc=0
+  for ((index = 0; index < ${#_TIRITH_PROTECTED_KEYMAPS[@]}; index++)); do
+    map="${_TIRITH_PROTECTED_KEYMAPS[index]}"
+    kind="${_TIRITH_SAVED_CTRL_O_KINDS[index]:-unbound}"
+    binding="${_TIRITH_SAVED_CTRL_O_BINDINGS[index]:-}"
+    case "$kind" in
+      bind-x)
+        builtin bind -m "$map" -x "$binding" 2>/dev/null || restore_rc=1
+        ;;
+      binding)
+        builtin bind -m "$map" "$binding" 2>/dev/null || restore_rc=1
+        ;;
+      *)
+        builtin bind -m "$map" -r '"\C-o"' 2>/dev/null || true
+        ;;
+    esac
+  done
+  unset _TIRITH_SAVED_CTRL_O_KINDS _TIRITH_SAVED_CTRL_O_BINDINGS
+  return "$restore_rc"
+}
+
+
 _tirith_degrade_to_preexec() {
   local reason="${1:-unknown}"
 
@@ -1620,16 +1698,19 @@ _tirith_degrade_to_preexec() {
   # Custom bindings from .inputrc/.bashrc return on next shell (safe mode persisted,
   # so tirith won't install bind-x on restart).
   if [[ "${_TIRITH_BINDS_INSTALLED:-0}" == "1" ]]; then
-    bind '"\C-m": accept-line' 2>/dev/null || true
-    bind '"\C-j": accept-line' 2>/dev/null || true
-    # Unbind the macro-dispatch helper sequences (checker + guarded accept) so
-    # no stale binding survives the degrade.
-    bind -r '"\C-x\C-t7"' 2>/dev/null || true
-    bind -r '"\C-x\C-r7"' 2>/dev/null || true
-    # Restore operate-and-get-next, unbound in enter mode.
-    bind '"\C-o": operate-and-get-next' 2>/dev/null || true
-    # Restore bracketed paste to readline default if available, otherwise unbind
-    bind '"\e[200~": bracketed-paste-begin' 2>/dev/null || bind -r '"\e[200~"' 2>/dev/null || true
+    local _tirith_keymap
+    for _tirith_keymap in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+      builtin bind -m "$_tirith_keymap" '"\C-m": accept-line' 2>/dev/null || true
+      builtin bind -m "$_tirith_keymap" '"\C-j": accept-line' 2>/dev/null || true
+      # Unbind the macro-dispatch helper sequences (checker + guarded accept)
+      # so no stale binding survives the degrade in any switchable keymap.
+      builtin bind -m "$_tirith_keymap" -r '"\C-x\C-t7"' 2>/dev/null || true
+      builtin bind -m "$_tirith_keymap" -r '"\C-x\C-r7"' 2>/dev/null || true
+      # Restore bracketed paste to the Readline default if available.
+      builtin bind -m "$_tirith_keymap" '"\e[200~": bracketed-paste-begin' \
+        2>/dev/null || builtin bind -m "$_tirith_keymap" -r '"\e[200~"' 2>/dev/null || true
+    done
+    _tirith_restore_ctrl_o_bindings || true
     _TIRITH_BINDS_INSTALLED=0
   fi
 
@@ -2032,19 +2113,22 @@ _tirith_startup_health_check() {
   # Test-only override for CI (avoids needing PTY)
   [[ "${_TIRITH_TEST_FAIL_HEALTH:-}" == "1" ]] && return 1
   # The checker must be installed as a bind -x function.
-  local xbinds
-  xbinds="$(bind -X 2>/dev/null)" || return 1
-  [[ "$xbinds" == *_tirith_enter* ]] || return 1
-  # Both \C-m and \C-j must map to the checker+accept Enter macro. Build the
-  # exact `bind -s` line as a literal and match it quoted so the backslashes in
-  # the key sequences are compared literally, not treated as glob escapes.
-  local sbinds
-  sbinds="$(bind -s 2>/dev/null)" || return 1
+  local map xbinds sbinds
+  # Both \C-m and \C-j must map to the checker+accept Enter macro in every
+  # primary keymap. A later `set -o vi` must not expose an unguarded accept-line.
   local macro="$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS"
   local cm_needle="\"\\C-m\": \"$macro\""
   local cj_needle="\"\\C-j\": \"$macro\""
-  [[ "$sbinds" == *"$cm_needle"* ]] || return 1
-  [[ "$sbinds" == *"$cj_needle"* ]] || return 1
+  local check_needle="\"$_TIRITH_ENTER_CHECK_KEYS\" \"_tirith_enter\""
+  local accept_needle="\"$_TIRITH_ENTER_ACCEPT_KEYS\" \"_tirith_enter_accept_noop\""
+  for map in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+    xbinds="$(builtin bind -m "$map" -X 2>/dev/null)" || return 1
+    [[ "$xbinds" == *"$check_needle"* ]] || return 1
+    [[ "$xbinds" == *"$accept_needle"* ]] || return 1
+    sbinds="$(builtin bind -m "$map" -s 2>/dev/null)" || return 1
+    [[ "$sbinds" == *"$cm_needle"* ]] || return 1
+    [[ "$sbinds" == *"$cj_needle"* ]] || return 1
+  done
   # Verify prompt hook is still attached
   _tirith_is_prompt_hook_attached || return 1
   return 0
@@ -2423,27 +2507,52 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
     _TIRITH_ENTER_ACCEPT_KEYS='\C-x\C-r7'
     _tirith_enter_accept_noop() { :; }
     _tirith_enter_arm_accept() {
-      bind "\"$_TIRITH_ENTER_ACCEPT_KEYS\": accept-line" 2>/dev/null
+      local _tirith_keymap _tirith_bind_rc=0
+      for _tirith_keymap in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+        builtin bind -m "$_tirith_keymap" \
+          "\"$_TIRITH_ENTER_ACCEPT_KEYS\": accept-line" 2>/dev/null \
+          || _tirith_bind_rc=1
+      done
+      return "$_tirith_bind_rc"
     }
     _tirith_enter_disarm_accept() {
-      bind -x "\"$_TIRITH_ENTER_ACCEPT_KEYS\": _tirith_enter_accept_noop" 2>/dev/null
+      local _tirith_keymap _tirith_bind_rc=0
+      for _tirith_keymap in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+        builtin bind -m "$_tirith_keymap" -x \
+          "\"$_TIRITH_ENTER_ACCEPT_KEYS\": _tirith_enter_accept_noop" 2>/dev/null \
+          || _tirith_bind_rc=1
+      done
+      return "$_tirith_bind_rc"
     }
 
-    # Install key bindings: checker (bind -x), disarmed accept, Enter macros.
-    bind -x "\"$_TIRITH_ENTER_CHECK_KEYS\": _tirith_enter" || true
-    _tirith_enter_disarm_accept
-    bind "\"\C-m\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" || true
-    bind "\"\C-j\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" || true
-    bind -x '"\e[200~": _tirith_paste' || true
-    # Close accept-line-equivalent bypasses: operate-and-get-next (\C-o) accepts
-    # the current line WITHOUT running the checker. Remove it in enter mode; the
-    # degrade path restores it.
-    bind -r '"\C-o"' 2>/dev/null || true
-    _TIRITH_BINDS_INSTALLED=1
+    if ! _tirith_capture_ctrl_o_bindings; then
+      _tirith_degrade_to_preexec "could not preserve existing Ctrl-O bindings"
+    else
+      # Install checker, guarded accept, Enter macros, paste interception, and
+      # Ctrl-O closure in every keymap a live session can switch to.
+      _tirith_bind_install_ok=1
+      for _tirith_keymap in "${_TIRITH_PROTECTED_KEYMAPS[@]}"; do
+        builtin bind -m "$_tirith_keymap" -x \
+          "\"$_TIRITH_ENTER_CHECK_KEYS\": _tirith_enter" || _tirith_bind_install_ok=0
+        builtin bind -m "$_tirith_keymap" \
+          "\"\C-m\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" \
+          || _tirith_bind_install_ok=0
+        builtin bind -m "$_tirith_keymap" \
+          "\"\C-j\": \"$_TIRITH_ENTER_CHECK_KEYS$_TIRITH_ENTER_ACCEPT_KEYS\"" \
+          || _tirith_bind_install_ok=0
+        builtin bind -m "$_tirith_keymap" -x '"\e[200~": _tirith_paste' \
+          || _tirith_bind_install_ok=0
+        # operate-and-get-next accepts the current line without the checker.
+        builtin bind -m "$_tirith_keymap" -r '"\C-o"' 2>/dev/null || true
+      done
+      _tirith_enter_disarm_accept || _tirith_bind_install_ok=0
+      _TIRITH_BINDS_INSTALLED=1
 
-    # Startup health gate: verify the checker and the Enter macro took effect.
-    if ! _tirith_startup_health_check; then
-      _tirith_degrade_to_preexec "startup health check failed (enter macro or PROMPT_COMMAND)"
+      # Startup health gate: verify every protected keymap took effect.
+      if [[ "$_tirith_bind_install_ok" != "1" ]] || ! _tirith_startup_health_check; then
+        _tirith_degrade_to_preexec "startup health check failed (enter macro or PROMPT_COMMAND)"
+      fi
+      unset _tirith_keymap _tirith_bind_install_ok
     fi
   fi
 

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -2228,7 +2228,9 @@ if [[ "$_TIRITH_BASH_MODE" == "enter" ]] && [[ $- == *i* ]]; then
       if [[ -z "$READLINE_LINE" ]]; then
         READLINE_LINE=""
         READLINE_POINT=0
-        _tirith_enter_arm_accept
+        if ! _tirith_enter_arm_accept; then
+          _tirith_degrade_to_preexec "could not arm guarded accept-line" || true
+        fi
         return
       fi
 

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -1622,6 +1622,14 @@ _TIRITH_PROTECTED_KEYMAPS=(emacs-standard vi-insert vi-command)
 _TIRITH_SAVED_CTRL_O_KINDS=()
 _TIRITH_SAVED_CTRL_O_BINDINGS=()
 
+_tirith_bind_x_record_is_ctrl_o() {
+  local key="${1%%[[:space:]]*}"
+  # Bash releases have emitted both `"\C-o" command` and
+  # `"\C-o": command` forms from `bind -X`.
+  key="${key%:}"
+  [[ "$key" == '"\C-o"' ]]
+}
+
 _tirith_capture_ctrl_o_bindings() {
   local map output line index
   # Bash versions that cannot enumerate bind-x entries cannot safely preserve
@@ -1638,7 +1646,7 @@ _tirith_capture_ctrl_o_bindings() {
 
     output="$(builtin bind -m "$map" -X 2>/dev/null)" || return 1
     while IFS= read -r line; do
-      if [[ "${line%% *}" == '"\C-o"' ]]; then
+      if _tirith_bind_x_record_is_ctrl_o "$line"; then
         _TIRITH_SAVED_CTRL_O_KINDS[index]="bind-x"
         _TIRITH_SAVED_CTRL_O_BINDINGS[index]="$line"
         break


### PR DESCRIPTION
A bare `bind -x` on Enter runs the bound function but does not then
accept the line on stock bash, so enter mode never delivered a command
and every bash user degraded to warn-only preexec (issues #111, #224).
The self-test correctly reported this, so v0.4.0 was safe but could not
block on bash.

Bind Enter to a readline MACRO that runs the checker (bind -x) and then
a GUARDED accept-line. The accept sub-sequence is a no-op until the
checker arms it, so a line is accepted only once the checker has decided
to deliver it; the prompt hook then evaluates the stashed command
exactly as before, so the whole protocol-v3 receipt lifecycle is
unchanged. A raw injection of the accept bytes hits the disarmed no-op,
and the prompt hook re-disarms every prompt, so possession of the accept
sequence alone can never accept a line. operate-and-get-next (\C-o), an
accept-line-equivalent bypass, is unbound in enter mode.

Verified over a real PTY with the real binary on GNU bash 5.2.0 and
5.3.15: allowed commands deliver exactly once, a pipe-to-interpreter is
blocked, incomplete input keeps editing, a continuation line delivers,
and injected accept bytes are rejected. The in-tree self-test now
returns `works` and enables enter-mode blocking for bash by default.

Also fixes a latent bug this change exposed: `_tirith_ensure_prompt_hook`
attempted a PROMPT_COMMAND assignment even when it was readonly, which is
a fatal error that aborts the function before it can signal failure, so
the runtime self-heal never degraded. It now refuses the unsafe
attributes first (matching the preexec-guard install) and degrades
cleanly.

Closes #224.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Enter-mode protection across Bash editing modes, including vi mode.
  - Preserved and restored custom key bindings during protection, fallback, and recovery.
  - Improved startup validation and safe fallback when protection cannot be enabled.
  - Enhanced prompt safety and command delivery, including empty commands and rejected input.
  - Prevented stale capture data from affecting subsequent commands.
- **Tests**
  - Expanded coverage for keymaps, rollback, fallback behavior, and Bash version compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces Bash’s bare Enter `bind -x` interception with guarded Readline macro dispatch so approved commands are delivered while blocked commands remain blocked.
- Protects Enter and Ctrl-O across emacs and vi keymaps.
- Preserves and restores existing per-keymap Ctrl-O bindings during degradation.
- Fails closed when guarded accept-line arming, disarming, installation, or prompt-hook attachment fails.
- Expands export, integration, enforcement, and PTY conformance coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shell/lib/bash-hook.bash | Implements guarded Enter macro dispatch, per-keymap Ctrl-O preservation, fail-closed health checks, and safe degradation. |
| crates/tirith/assets/shell/lib/bash-hook.bash | Updates the embedded Bash hook to match the root runtime hook. |
| crates/tirith/tests/shell_conformance.rs | Adds PTY coverage for guarded delivery, protected keymaps, Ctrl-O restoration, and degradation behavior. |
| crates/tirith/tests/bash_hook_exports.rs | Adds focused coverage for guarded accept-line failure handling and pending-state cleanup. |
| crates/tirith/tests/bash_preexec_enforce.rs | Updates Bash preexec enforcement coverage for the revised hook lifecycle. |
| crates/tirith/tests/cli_integration.rs | Updates integration expectations for successful Bash Enter-mode capability detection. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant R as Readline
    participant T as Tirith checker
    participant P as Prompt hook
    U->>R: Press Enter
    R->>T: Dispatch guarded checker
    alt Command approved
        T->>R: Arm guarded accept-line
        R->>P: Accept line and display prompt
        P->>R: Disarm guarded accept-line
        P->>P: Consume receipt and evaluate command
    else Command blocked
        T->>R: Leave accept-line disarmed
        R-->>U: Command is not delivered
    else Guard operation fails
        T->>T: Clear pending delivery and discard receipt
        T-->>U: Degrade visibly to preexec mode
    end
```

<sub>Reviews (8): Last reviewed commit: ["fix(bash): fail closed on readline bypas..."](https://github.com/sheeki03/tirith/commit/1cf15b858c91d48649be282f78a99bd2a73d2986) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58726116)</sub>

<!-- /greptile_comment -->