### PR TITLE
fix(threatdb): refresh reviewed source snapshots

### DIFF
--- a/.github/scripts/fetch-threatdb-sources.sh
+++ b/.github/scripts/fetch-threatdb-sources.sh
@@ -15,8 +15,8 @@ FINAL_DIR="$OUTPUT_ROOT/tirith-threatdb-sources"
 
 # Reviewed immutable upstream revisions. The workflow mirrors these values and
 # every clone is verified against them before it becomes compiler-visible.
-OSSF_MP_REF=${THREATDB_OSSF_MP_REF:-1ea2762d5fb415aef003a244d5aa83c5fc48cc6e}
-DD_MP_REF=${THREATDB_DD_MP_REF:-ef4a781d476cd6eb89c8517ff9adbb54a5cfa8cc}
+OSSF_MP_REF=${THREATDB_OSSF_MP_REF:-54642f7ee96e780b046660519b028fefb635375a}
+DD_MP_REF=${THREATDB_DD_MP_REF:-2d09839012cedc387ce438debeb77884ac2a242c}
 TYPOSQUAT_REF=${THREATDB_TYPOSQUAT_REF:-fd0bde98d200efe5c282a07edc4c68fba13252c6}
 COMPILER_BIN=${THREATDB_COMPILER_BIN:-./target/release/tirith-threatdb-compile}
 WEB3_ANCHOR_FILE=${THREATDB_WEB3_ANCHOR_FILE:-$REPO_ROOT/crates/tirith/assets/data/web3_package_anchors.csv}
@@ -28,9 +28,9 @@ CURL_CONNECT_TIMEOUT_SECONDS=15
 CURL_MAX_TIME_SECONDS=120
 FEODO_MAX_BYTES=$((16 * 1024 * 1024))
 CISA_KEV_MAX_BYTES=$((64 * 1024 * 1024))
-# The reviewed immutable OpenSSF revision above materializes to 235,293 files
-# and 441,674,789 bytes (verified by the 2026-08-24 main build). Keep bounded
-# headroom for filesystem accounting while still rejecting an unexpected tree.
+# Keep bounded headroom above the reviewed OpenSSF snapshot while still
+# rejecting an unexpectedly large tree. Candidate pin changes exercise these
+# limits before review and publication.
 OSSF_MAX_FILES=250000
 OSSF_MAX_BYTES=$((512 * 1024 * 1024))
 DATADOG_MANIFEST_MAX_BYTES=$((64 * 1024 * 1024))
@@ -68,7 +68,11 @@ mkdir -p -- "$STAGED_SOURCES"
 # input. No source tree can become visible without its exact revisions/hashes.
 PINS_FILE="$STAGED_SOURCES/source-provenance.json"
 
-FETCH_TIMEOUT_SECONDS=${THREATDB_FETCH_TIMEOUT_SECONDS:-180}
+# The reviewed OpenSSF tree contains roughly 200k sparse-materialized advisory
+# files. Keep each network/materialization step bounded, but allow enough time
+# for that tree on a standard Linux runner; the 600s transaction deadline below
+# remains the stricter end-to-end ceiling.
+FETCH_TIMEOUT_SECONDS=${THREATDB_FETCH_TIMEOUT_SECONDS:-300}
 case "$FETCH_TIMEOUT_SECONDS" in
   ''|*[!0-9]*|0*)
     echo "::error::THREATDB_FETCH_TIMEOUT_SECONDS must be a positive integer" >&2
@@ -179,14 +183,13 @@ content_sha256() {
   shift
   (
     cd -- "$root"
-    find "$@" -type f -print0 \
-      | LC_ALL=C sort -z \
-      | while IFS= read -r -d '' file; do
-          printf '%s\0' "$file"
-          sha256sum "$file" | cut -d' ' -f1 | tr -d '\n'
-          printf '\0'
-        done
-  ) | sha256sum | cut -d' ' -f1
+    # Hash every regular file in bytewise path order without spawning two
+    # processes per file. OpenSSF now contains hundreds of thousands of
+    # records, so the former `sha256sum | cut` loop spent minutes creating
+    # nearly half a million subprocesses. `lstat` retains `find -type f`
+    # semantics: symlinks are not followed or included.
+    run_bounded python3 "$SCRIPT_DIR/hash-threatdb-tree.py" "$@"
+  )
 }
 
 run_fetch git clone --depth 1 --filter=blob:none --sparse --no-checkout \

--- a/.github/scripts/hash-threatdb-tree.py
+++ b/.github/scripts/hash-threatdb-tree.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Hash a reviewed source tree using Tirith's provenance stream format."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import sys
+from typing import Iterator
+
+
+def regular_files(path: bytes) -> Iterator[bytes]:
+    metadata = os.lstat(path)
+    if stat.S_ISREG(metadata.st_mode):
+        yield path
+        return
+    if not stat.S_ISDIR(metadata.st_mode):
+        return
+
+    for directory, directories, filenames in os.walk(path, followlinks=False):
+        directories[:] = [
+            name
+            for name in directories
+            if stat.S_ISDIR(os.lstat(os.path.join(directory, name)).st_mode)
+        ]
+        for filename in filenames:
+            candidate = os.path.join(directory, filename)
+            if stat.S_ISREG(os.lstat(candidate).st_mode):
+                yield candidate
+
+
+def hash_file(path: bytes) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(arguments: list[str]) -> int:
+    if not arguments:
+        print("usage: hash-threatdb-tree.py PATH [PATH ...]", file=sys.stderr)
+        return 2
+
+    paths = sorted(
+        path
+        for source in arguments
+        for path in regular_files(os.fsencode(source))
+    )
+    tree_digest = hashlib.sha256()
+    for path in paths:
+        tree_digest.update(path)
+        tree_digest.update(b"\0")
+        tree_digest.update(hash_file(path).encode("ascii"))
+        tree_digest.update(b"\0")
+    print(tree_digest.hexdigest())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/test-fetch-threatdb-sources.sh
+++ b/.github/scripts/test-fetch-threatdb-sources.sh
@@ -16,11 +16,11 @@ FAKE_BIN="$TEST_ROOT/bin"
 OUTPUT_ROOT="$TEST_ROOT/output"
 mkdir -p -- "$FAKE_BIN" "$OUTPUT_ROOT"
 
-# The immutable OpenSSF revision currently contains 235,293 files totaling
-# 441,674,789 bytes. Guard the calibrated defaults so the reviewed snapshot
-# cannot silently become unbuildable again while both resource limits remain.
+# Guard the calibrated defaults so a reviewed OpenSSF snapshot cannot silently
+# become unbuildable again while both resource limits remain bounded.
 grep -Fq 'OSSF_MAX_FILES=250000' "$FETCH_SCRIPT"
 grep -Fq 'OSSF_MAX_BYTES=$((512 * 1024 * 1024))' "$FETCH_SCRIPT"
+grep -Fq 'FETCH_TIMEOUT_SECONDS=${THREATDB_FETCH_TIMEOUT_SECONDS:-300}' "$FETCH_SCRIPT"
 
 cat > "$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
@@ -28,8 +28,8 @@ set -euo pipefail
 # `git -C <dir> rev-parse HEAD` records the resolved source revision.
 if [[ "$*" == *rev-parse* ]]; then
   case "$2" in
-    *ossf-mp) echo "1ea2762d5fb415aef003a244d5aa83c5fc48cc6e" ;;
-    *dd-mp) echo "ef4a781d476cd6eb89c8517ff9adbb54a5cfa8cc" ;;
+    *ossf-mp) echo "54642f7ee96e780b046660519b028fefb635375a" ;;
+    *dd-mp) echo "2d09839012cedc387ce438debeb77884ac2a242c" ;;
     *typosquats) echo "fd0bde98d200efe5c282a07edc4c68fba13252c6" ;;
     *) exit 64 ;;
   esac
@@ -59,6 +59,7 @@ case "$*" in
       printf '{"id":"MAL-2099-%04d","affected":[{"package":{"ecosystem":"npm","name":"bad-%d"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"}]}]}]}\n' \
         "$index" "$index" > "$destination/osv/MAL-2099-$(printf '%04d' "$index").json"
     done
+    ln -s MAL-2099-0001.json "$destination/osv/linked-record.json"
     ;;
   *DataDog/malicious-software-packages-dataset*)
     mkdir -p -- "$destination/samples/npm" "$destination/samples/pypi"
@@ -116,7 +117,7 @@ retrieved_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 # Two representative entries so the fetch script's per-package validator rules
 # (media type per ecosystem/status, resolution consistency) actually execute.
 cat > "$output" <<JSON
-{"schema_version":2,"ossf_commit":"1ea2762d5fb415aef003a244d5aa83c5fc48cc6e","retrieved_at":"$retrieved_at","packages":[
+{"schema_version":2,"ossf_commit":"54642f7ee96e780b046660519b028fefb635375a","retrieved_at":"$retrieved_at","packages":[
 {"ecosystem":"npm","name":"fake-live","source_url":"https://registry.npmjs.org/fake-live","media_type":"application/vnd.npm.install-v1+json","http_status":200,"resolution":"registry_versions","response_sha256":"1111111111111111111111111111111111111111111111111111111111111111","response_bytes":64,"versions":["1.0.0","1.0.1"]},
 {"ecosystem":"npm","name":"fake-gone","source_url":"https://registry.npmjs.org/fake-gone","media_type":"application/json","http_status":404,"resolution":"package_not_found","response_sha256":"2222222222222222222222222222222222222222222222222222222222222222","response_bytes":21,"versions":[]}
 ]}
@@ -205,13 +206,25 @@ esac
 "$@" &
 child=$!
 (
-  sleep "$duration"
+  sleeper=
+  cleanup_watchdog() {
+    if [ -n "$sleeper" ]; then
+      kill "$sleeper" 2>/dev/null || true
+      sleeper=
+    fi
+  }
+  trap 'cleanup_watchdog; exit 0' TERM INT
+  trap cleanup_watchdog EXIT
+  sleep "$duration" &
+  sleeper=$!
+  wait "$sleeper" || exit 0
+  sleeper=
   kill -TERM "$child" 2>/dev/null || exit 0
   # Give the fake worker's TERM trap time to record graceful termination even
   # on loaded macOS runners before exercising the hard-kill fallback.
   sleep 1
   kill -KILL "$child" 2>/dev/null || true
-) &
+) </dev/null >/dev/null 2>&1 &
 watchdog=$!
 wait "$child"
 status=$?
@@ -600,7 +613,7 @@ test -s "$published/typosquats/typosquats.csv"
 
 # The resolved upstream revisions must be recorded on the success path only.
 test -s "$published/source-provenance.json"
-grep -Eq '"commit"[[:space:]]*:[[:space:]]*"1ea2762d5fb415aef003a244d5aa83c5fc48cc6e"' \
+grep -Eq '"commit"[[:space:]]*:[[:space:]]*"54642f7ee96e780b046660519b028fefb635375a"' \
   "$published/source-provenance.json"
 grep -Eq '"compiler_version"[[:space:]]*:[[:space:]]*"0.3.3"' \
   "$published/source-provenance.json"
@@ -622,6 +635,28 @@ grep -Eq '"content_sha256"[[:space:]]*:[[:space:]]*"[0-9a-f]{64}"' \
   "$published/source-provenance.json"
 grep -Eq '"retrieved_at"[[:space:]]*:[[:space:]]*"[0-9]{4}-[0-9]{2}-[0-9]{2}T' \
   "$published/source-provenance.json"
+
+# The single-process tree hasher must remain byte-for-byte compatible with the
+# original path-NUL/file-digest-NUL stream format consumed by published source
+# provenance. The fixture is intentionally small enough for the legacy oracle.
+expected_ossf_digest=$(
+  cd -- "$published/ossf-mp"
+  find osv -type f -print0 \
+    | LC_ALL=C sort -z \
+    | while IFS= read -r -d '' file; do
+        printf '%s\0' "$file"
+        sha256sum "$file" | cut -d' ' -f1 | tr -d '\n'
+        printf '\0'
+      done \
+    | sha256sum \
+    | cut -d' ' -f1
+)
+actual_ossf_digest=$(jq -r '.ossf_malicious_packages.content_sha256' \
+  "$published/source-provenance.json")
+if [ "$actual_ossf_digest" != "$expected_ossf_digest" ]; then
+  echo "single-process content digest is not provenance-compatible: expected $expected_ossf_digest, got $actual_ossf_digest" >&2
+  exit 1
+fi
 
 # Provenance retention follows the union of retained/protected database
 # generations. Generation 20 survives through its protected v1 DB; generation

--- a/.github/workflows/threatdb.yml
+++ b/.github/workflows/threatdb.yml
@@ -23,8 +23,8 @@ env:
   THREATDB_LEGACY_RELEASE_TAG: threatdb-latest
   # Reviewed immutable source revisions consumed and verified by the atomic
   # fetch transaction. Updating any pin is a source-review event.
-  THREATDB_OSSF_MP_REF: 1ea2762d5fb415aef003a244d5aa83c5fc48cc6e
-  THREATDB_DD_MP_REF: ef4a781d476cd6eb89c8517ff9adbb54a5cfa8cc
+  THREATDB_OSSF_MP_REF: 54642f7ee96e780b046660519b028fefb635375a
+  THREATDB_DD_MP_REF: 2d09839012cedc387ce438debeb77884ac2a242c
   THREATDB_TYPOSQUAT_REF: fd0bde98d200efe5c282a07edc4c68fba13252c6
 
 jobs:


### PR DESCRIPTION
## Summary

- advance the immutable OpenSSF and DataDog source pins to reviewed 2026-08-31 revisions
- raise the bounded per-source materialization ceiling from 180s to 300s while retaining the 600s transaction deadline
- replace the per-file subprocess hashing loop with one deadline-bounded helper that preserves the published provenance digest byte-for-byte
- extend the fetch regression to lock the timeout, digest format, symlink behavior, and refreshed revisions

Depends on #228.

## Source review

- OpenSSF: `1ea2762d5fb415aef003a244d5aa83c5fc48cc6e` → `54642f7ee96e780b046660519b028fefb635375a` ([compare](https://github.com/ossf/malicious-packages/compare/1ea2762d5fb415aef003a244d5aa83c5fc48cc6e...54642f7ee96e780b046660519b028fefb635375a))
  - 2,419 files changed: 1,982 added, 426 modified, 11 renamed
  - active snapshot has 236,392 JSON records and no provisional `MAL-0000-*` records
  - `LICENSE` and `README.md` are unchanged; non-`osv/` changes are upstream tooling/config not consumed by the compiler
- DataDog: `ef4a781d476cd6eb89c8517ff9adbb54a5cfa8cc` → `2d09839012cedc387ce438debeb77884ac2a242c` ([compare](https://github.com/DataDog/malicious-software-packages-dataset/compare/ef4a781d476cd6eb89c8517ff9adbb54a5cfa8cc...2d09839012cedc387ce438debeb77884ac2a242c))
  - compiler-visible manifests add 314 packages and remove one obsolete npm entry
- ecosyste.ms typosquat remains pinned at upstream HEAD `fd0bde98d200efe5c282a07edc4c68fba13252c6`

A provisional OpenSSF ingestion commit was deliberately rejected during validation because its temporary records lacked assigned IDs; the selected pin is the subsequent immutable `Assign IDs` boundary.

## Validation

- `bash .github/scripts/test-fetch-threatdb-sources.sh`
- `cargo test --locked -p tirith --bin tirith-threatdb-compile source_provenance_binds_exact_snapshot_revision_digest_and_bytes`
- real Linux fetch of all sources under production timeout/size caps
- real compiler run against the fetched snapshot, signed with a disposable test key
  - 236,884 OpenSSF claims accepted; 0 corrupt records; 0 unsupported shapes; 0 snapshot failures
  - 49,452 DataDog packages accepted
  - candidate database: 240,994 v1 package keys, 127 network IPv4 IOCs, 137 typosquats, 1,687 CISA KEV CVEs
- final helper digest on the 448 MB live OpenSSF tree exactly matched `source-provenance.json`

Compared with the latest published provenance, this adds 1,972 accepted OpenSSF claims, 314 DataDog packages, and 2 CISA KEV entries without increasing rejected or failed snapshot counts.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved Threat Database source fetching reliability with a longer timeout for slow connections.
  - Enhanced source validation to ensure files, links, and provenance data are processed consistently.
- **Updates**
  - Refreshed the bundled OpenSSF and DataDog threat intelligence source revisions.
- **Tests**
  - Expanded automated checks for timeout handling, source revisions, symlinks, and provenance verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refreshes the reviewed OpenSSF and DataDog ThreatDB source revisions and increases the bounded materialization timeout. It also replaces per-file hashing subprocesses with a single deadline-bounded Python helper and expands regression coverage for provenance compatibility and symlink behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the available review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/scripts/fetch-threatdb-sources.sh | Updates immutable source pins and timeout defaults while delegating provenance hashing to the new bounded helper. |
| .github/scripts/hash-threatdb-tree.py | Implements bytewise-ordered regular-file hashing compatible with the existing path-NUL/digest-NUL provenance stream. |
| .github/scripts/test-fetch-threatdb-sources.sh | Refreshes pinned revision fixtures and verifies timeout defaults, digest compatibility, and symlink exclusion. |
| .github/workflows/threatdb.yml | Keeps workflow-level OpenSSF and DataDog revisions synchronized with the fetch script. |

<sub>Reviews (8): Last reviewed commit: ["fix(threatdb): refresh reviewed source s..."](https://github.com/sheeki03/tirith/commit/29bf927aeaa16d464e4c5b0195c6ce4e06ac75ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58767876)</sub>

<!-- /greptile_comment -->