### PR TITLE
fix(threatdb): automate reviewed source pin proposals

### DIFF
--- a/.github/scripts/fetch-threatdb-sources.sh
+++ b/.github/scripts/fetch-threatdb-sources.sh
@@ -9,15 +9,45 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../.." && pwd -P)
+SOURCE_PINS_FILE=${THREATDB_SOURCE_PINS_FILE:-$REPO_ROOT/.github/threatdb-source-pins.json}
+
+if ! IFS=$'\t' read -r \
+  MANIFEST_OSSF_REF MANIFEST_OSSF_COMMIT_TIMESTAMP MANIFEST_OSSF_SELECTED_AT \
+  MANIFEST_DD_REF MANIFEST_DD_COMMIT_TIMESTAMP MANIFEST_DD_SELECTED_AT \
+  MANIFEST_TYPOSQUAT_REF MANIFEST_TYPOSQUAT_COMMIT_TIMESTAMP MANIFEST_TYPOSQUAT_SELECTED_AT \
+  < <(python3 "$SCRIPT_DIR/threatdb_source_pins.py" resolve "$SOURCE_PINS_FILE")
+then
+  echo "::error::cannot resolve the canonical ThreatDB source-pin manifest" >&2
+  exit 1
+fi
 
 OUTPUT_ROOT=${THREATDB_FETCH_OUTPUT_DIR:-/tmp}
 FINAL_DIR="$OUTPUT_ROOT/tirith-threatdb-sources"
 
-# Reviewed immutable upstream revisions. The workflow mirrors these values and
-# every clone is verified against them before it becomes compiler-visible.
-OSSF_MP_REF=${THREATDB_OSSF_MP_REF:-54642f7ee96e780b046660519b028fefb635375a}
-DD_MP_REF=${THREATDB_DD_MP_REF:-2d09839012cedc387ce438debeb77884ac2a242c}
-TYPOSQUAT_REF=${THREATDB_TYPOSQUAT_REF:-fd0bde98d200efe5c282a07edc4c68fba13252c6}
+# Reviewed immutable upstream revisions have one canonical manifest. Explicit
+# overrides remain available for pre-review shadow builds, but production uses
+# the manifest and verifies every checkout before it becomes compiler-visible.
+OSSF_MP_REF=${THREATDB_OSSF_MP_REF:-$MANIFEST_OSSF_REF}
+DD_MP_REF=${THREATDB_DD_MP_REF:-$MANIFEST_DD_REF}
+TYPOSQUAT_REF=${THREATDB_TYPOSQUAT_REF:-$MANIFEST_TYPOSQUAT_REF}
+OSSF_PIN_SELECTED_AT=${THREATDB_OSSF_PIN_SELECTED_AT:-}
+DD_PIN_SELECTED_AT=${THREATDB_DD_PIN_SELECTED_AT:-}
+TYPOSQUAT_PIN_SELECTED_AT=${THREATDB_TYPOSQUAT_PIN_SELECTED_AT:-}
+if [ "$OSSF_MP_REF" = "$MANIFEST_OSSF_REF" ]; then
+  OSSF_PIN_SELECTED_AT=$MANIFEST_OSSF_SELECTED_AT
+fi
+if [ "$DD_MP_REF" = "$MANIFEST_DD_REF" ]; then
+  DD_PIN_SELECTED_AT=$MANIFEST_DD_SELECTED_AT
+fi
+if [ "$TYPOSQUAT_REF" = "$MANIFEST_TYPOSQUAT_REF" ]; then
+  TYPOSQUAT_PIN_SELECTED_AT=$MANIFEST_TYPOSQUAT_SELECTED_AT
+fi
+if [ -z "$OSSF_PIN_SELECTED_AT" ] ||
+   [ -z "$DD_PIN_SELECTED_AT" ] ||
+   [ -z "$TYPOSQUAT_PIN_SELECTED_AT" ]; then
+  echo "::error::source-ref overrides require matching THREATDB_*_PIN_SELECTED_AT provenance" >&2
+  exit 1
+fi
 COMPILER_BIN=${THREATDB_COMPILER_BIN:-./target/release/tirith-threatdb-compile}
 WEB3_ANCHOR_FILE=${THREATDB_WEB3_ANCHOR_FILE:-$REPO_ROOT/crates/tirith/assets/data/web3_package_anchors.csv}
 
@@ -145,6 +175,22 @@ run_fetch() {
   local timeout_seconds
   timeout_seconds=$(remaining_timeout_seconds) || return 1
   "$TIMEOUT_BIN" --signal=TERM --kill-after=10s "${timeout_seconds}s" "$@" &
+}
+
+git_commit_timestamp() {
+  local checkout=$1
+  local timestamp
+  timestamp=$(run_bounded git -C "$checkout" show -s --format=%cI HEAD)
+  python3 -c '
+import datetime
+import sys
+
+value = sys.argv[1]
+parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+if parsed.tzinfo is None:
+    raise SystemExit("git commit timestamp is not timezone-aware")
+print(parsed.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+' "$timestamp"
 }
 
 run_source_git_step() {
@@ -292,6 +338,25 @@ if [ "$OSSF_MP_SHA" != "$OSSF_MP_REF" ] ||
   exit 1
 fi
 
+OSSF_COMMIT_TIMESTAMP=$(git_commit_timestamp "$STAGED_SOURCES/ossf-mp")
+DD_COMMIT_TIMESTAMP=$(git_commit_timestamp "$STAGED_SOURCES/dd-mp")
+TYPOSQUAT_COMMIT_TIMESTAMP=$(git_commit_timestamp "$STAGED_SOURCES/typosquats")
+if [ "$OSSF_MP_REF" = "$MANIFEST_OSSF_REF" ] &&
+   [ "$OSSF_COMMIT_TIMESTAMP" != "$MANIFEST_OSSF_COMMIT_TIMESTAMP" ]; then
+  echo "::error::OpenSSF commit timestamp disagrees with the canonical pin manifest" >&2
+  exit 1
+fi
+if [ "$DD_MP_REF" = "$MANIFEST_DD_REF" ] &&
+   [ "$DD_COMMIT_TIMESTAMP" != "$MANIFEST_DD_COMMIT_TIMESTAMP" ]; then
+  echo "::error::DataDog commit timestamp disagrees with the canonical pin manifest" >&2
+  exit 1
+fi
+if [ "$TYPOSQUAT_REF" = "$MANIFEST_TYPOSQUAT_REF" ] &&
+   [ "$TYPOSQUAT_COMMIT_TIMESTAMP" != "$MANIFEST_TYPOSQUAT_COMMIT_TIMESTAMP" ]; then
+  echo "::error::typosquat commit timestamp disagrees with the canonical pin manifest" >&2
+  exit 1
+fi
+
 for required in \
   "$STAGED_SOURCES/ossf-mp/LICENSE" \
   "$STAGED_SOURCES/dd-mp/LICENSE" \
@@ -423,11 +488,17 @@ jq -cS -n \
   --arg retrieved_at "$RETRIEVED_AT" \
   --arg compiler_version "$COMPILER_VERSION" \
   --arg ossf_ref "$OSSF_MP_REF" --arg ossf_commit "$OSSF_MP_SHA" \
+  --arg ossf_commit_timestamp "$OSSF_COMMIT_TIMESTAMP" \
+  --arg ossf_pin_selected_at "$OSSF_PIN_SELECTED_AT" \
   --arg ossf_content_sha "$OSSF_CONTENT_SHA" \
   --argjson ossf_files "$OSSF_FILE_COUNT" --argjson ossf_bytes "$OSSF_FILE_BYTES" \
   --arg dd_ref "$DD_MP_REF" --arg dd_commit "$DD_MP_SHA" --argjson dd_bytes "$DD_FILE_BYTES" \
+  --arg dd_commit_timestamp "$DD_COMMIT_TIMESTAMP" \
+  --arg dd_pin_selected_at "$DD_PIN_SELECTED_AT" \
   --arg dd_content_sha "$DD_CONTENT_SHA" \
   --arg typo_ref "$TYPOSQUAT_REF" --arg typo_commit "$TYPOSQUAT_SHA" \
+  --arg typo_commit_timestamp "$TYPOSQUAT_COMMIT_TIMESTAMP" \
+  --arg typo_pin_selected_at "$TYPOSQUAT_PIN_SELECTED_AT" \
   --arg typo_content_sha "$TYPOSQUAT_CONTENT_SHA" \
   --argjson typo_rows "$TYPOSQUAT_COUNT" --argjson typo_bytes "$TYPOSQUAT_BYTES" \
   --arg registry_retrieved_at "$REGISTRY_SNAPSHOT_RETRIEVED_AT" \
@@ -441,22 +512,22 @@ jq -cS -n \
     schema_version: 2,
     retrieved_at: $retrieved_at,
     compiler_version: $compiler_version,
-    ossf_malicious_packages: {
+    ossf_malicious_packages: ({
       source_url: "https://github.com/ossf/malicious-packages.git",
       ref: $ossf_ref, commit: $ossf_commit, spdx: "CC-BY-4.0",
       files: $ossf_files, bytes: $ossf_bytes, content_sha256: $ossf_content_sha
-    },
-    datadog_malicious_software_packages: {
+    } + {commit_timestamp: $ossf_commit_timestamp, pin_selected_at: $ossf_pin_selected_at}),
+    datadog_malicious_software_packages: ({
       source_url: "https://github.com/DataDog/malicious-software-packages-dataset.git",
       ref: $dd_ref, commit: $dd_commit, spdx: "Apache-2.0",
       files: 2, bytes: $dd_bytes, content_sha256: $dd_content_sha
-    },
-    ecosystems_typosquatting_dataset: {
+    } + {commit_timestamp: $dd_commit_timestamp, pin_selected_at: $dd_pin_selected_at}),
+    ecosystems_typosquatting_dataset: ({
       source_url: "https://github.com/ecosyste-ms/typosquatting-dataset.git",
       ref: $typo_ref, commit: $typo_commit, spdx: "CC0-1.0",
       files: 1, rows: $typo_rows, bytes: $typo_bytes,
       content_sha256: $typo_content_sha
-    },
+    } + {commit_timestamp: $typo_commit_timestamp, pin_selected_at: $typo_pin_selected_at}),
     registry_version_snapshot: {
       ossf_commit: $ossf_commit, retrieved_at: $registry_retrieved_at,
       source_urls: ["https://registry.npmjs.org/", "https://pypi.org/pypi/"],

--- a/.github/scripts/test-fetch-threatdb-sources.sh
+++ b/.github/scripts/test-fetch-threatdb-sources.sh
@@ -25,6 +25,16 @@ grep -Fq 'FETCH_TIMEOUT_SECONDS=${THREATDB_FETCH_TIMEOUT_SECONDS:-300}' "$FETCH_
 cat > "$FAKE_BIN/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+# `git -C <dir> show ...` records the source commit timestamp in provenance.
+if [[ "$*" == *" show "* ]] && [[ "$*" == *"--format=%cI"* ]]; then
+  case "$2" in
+    *ossf-mp) echo "2026-08-31T18:32:57+00:00" ;;
+    *dd-mp) echo "2026-08-31T04:05:01+00:00" ;;
+    *typosquats) echo "2025-12-17T11:33:09+00:00" ;;
+    *) exit 64 ;;
+  esac
+  exit 0
+fi
 # `git -C <dir> rev-parse HEAD` records the resolved source revision.
 if [[ "$*" == *rev-parse* ]]; then
   case "$2" in
@@ -634,6 +644,10 @@ grep -Eq '"spdx"[[:space:]]*:[[:space:]]*"LicenseRef-Package-Name-Facts"' \
 grep -Eq '"content_sha256"[[:space:]]*:[[:space:]]*"[0-9a-f]{64}"' \
   "$published/source-provenance.json"
 grep -Eq '"retrieved_at"[[:space:]]*:[[:space:]]*"[0-9]{4}-[0-9]{2}-[0-9]{2}T' \
+  "$published/source-provenance.json"
+grep -Eq '"commit_timestamp"[[:space:]]*:[[:space:]]*"2026-08-31T18:32:57Z"' \
+  "$published/source-provenance.json"
+grep -Eq '"pin_selected_at"[[:space:]]*:[[:space:]]*"2026-08-31T19:22:30Z"' \
   "$published/source-provenance.json"
 
 # The single-process tree hasher must remain byte-for-byte compatible with the

--- a/.github/scripts/test_threatdb_source_pins.py
+++ b/.github/scripts/test_threatdb_source_pins.py
@@ -42,6 +42,9 @@ class ThreatDbSourcePinsTests(unittest.TestCase):
         self.typosquat = self.manifest["sources"]["ecosystems_typosquatting_dataset"][
             "commit"
         ]
+        self.typosquat_timestamp = self.manifest["sources"][
+            "ecosystems_typosquatting_dataset"
+        ]["commit_timestamp"]
         self.new_ossf = "a" * 40
         self.transient_ossf = "b" * 40
         self.new_datadog = "c" * 40
@@ -61,7 +64,7 @@ class ThreatDbSourcePinsTests(unittest.TestCase):
                 "ecosyste-ms/typosquatting-dataset": [
                     commit(
                         self.typosquat,
-                        "2025-12-17T11:33:09Z",
+                        self.typosquat_timestamp,
                         "Add tools and API information",
                     )
                 ],

--- a/.github/scripts/test_threatdb_source_pins.py
+++ b/.github/scripts/test_threatdb_source_pins.py
@@ -139,6 +139,29 @@ class ThreatDbSourcePinsTests(unittest.TestCase):
             )
             self.assertFalse(changed_again)
 
+    def test_ossf_assign_ids_discovery_paginates_past_transient_commits(self) -> None:
+        transient_page = [
+            commit(
+                f"{index + 1:040x}",
+                "2026-09-01T01:10:00Z",
+                "Ingest OSV - Cloud Storage",
+            )
+            for index in range(PINS.COMMITS_PER_PAGE)
+        ]
+        self.fixture["commits"]["ossf/malicious-packages"] = {
+            "1": transient_page,
+            "2": [commit(self.new_ossf, "2026-09-01T01:08:00Z", "Assign IDs")],
+        }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            client = self.fixture_client(Path(temporary))
+            candidate = PINS.discover_candidate(
+                self.manifest["sources"]["ossf_malicious_packages"], client
+            )
+
+        self.assertEqual(candidate["commit"], self.new_ossf)
+        self.assertEqual(candidate["subject"], "Assign IDs")
+
     def test_manifest_rejects_unreviewed_repository_and_bad_metadata(self) -> None:
         wrong_repository = copy.deepcopy(self.manifest)
         wrong_repository["sources"]["ossf_malicious_packages"]["repository"] = (

--- a/.github/scripts/test_threatdb_source_pins.py
+++ b/.github/scripts/test_threatdb_source_pins.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Deterministic tests for the ThreatDB source-pin watcher."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MANIFEST = SCRIPT_DIR.parent / "threatdb-source-pins.json"
+SPEC = importlib.util.spec_from_file_location(
+    "threatdb_source_pins", SCRIPT_DIR / "threatdb_source_pins.py"
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("cannot load threatdb_source_pins.py")
+PINS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PINS)
+
+
+def commit(sha: str, timestamp: str, subject: str) -> dict[str, object]:
+    return {
+        "sha": sha,
+        "commit": {
+            "committer": {"date": timestamp},
+            "message": subject,
+        },
+    }
+
+
+class ThreatDbSourcePinsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = PINS.load_manifest(MANIFEST)
+        self.old_ossf = self.manifest["sources"]["ossf_malicious_packages"]["commit"]
+        self.old_datadog = self.manifest["sources"][
+            "datadog_malicious_software_packages"
+        ]["commit"]
+        self.typosquat = self.manifest["sources"]["ecosystems_typosquatting_dataset"][
+            "commit"
+        ]
+        self.new_ossf = "a" * 40
+        self.transient_ossf = "b" * 40
+        self.new_datadog = "c" * 40
+        self.fixture = {
+            "commits": {
+                "ossf/malicious-packages": [
+                    commit(
+                        self.transient_ossf,
+                        "2026-09-01T01:10:00Z",
+                        "Ingest OSV - Cloud Storage",
+                    ),
+                    commit(self.new_ossf, "2026-09-01T01:08:00Z", "Assign IDs"),
+                ],
+                "DataDog/malicious-software-packages-dataset": [
+                    commit(self.new_datadog, "2026-09-01T00:30:00Z", "Sync manifests")
+                ],
+                "ecosyste-ms/typosquatting-dataset": [
+                    commit(
+                        self.typosquat,
+                        "2025-12-17T11:33:09Z",
+                        "Add tools and API information",
+                    )
+                ],
+            },
+            "comparisons": {
+                (f"ossf/malicious-packages:{self.old_ossf}...{self.new_ossf}"): {
+                    "status": "ahead",
+                    "ahead_by": 4,
+                    "total_commits": 4,
+                    "files": [
+                        {"status": "added", "filename": "osv/malicious/npm/a.json"},
+                        {"status": "modified", "filename": "config/config.toml"},
+                    ],
+                },
+                (
+                    "DataDog/malicious-software-packages-dataset:"
+                    f"{self.old_datadog}...{self.new_datadog}"
+                ): {
+                    "status": "ahead",
+                    "ahead_by": 2,
+                    "total_commits": 2,
+                    "files": [
+                        {"status": "modified", "filename": "samples/npm/manifest.json"}
+                    ],
+                },
+            },
+        }
+
+    def fixture_client(self, directory: Path):
+        fixture_path = directory / "api.json"
+        fixture_path.write_text(json.dumps(self.fixture), encoding="utf-8")
+        return PINS.FixtureClient(fixture_path)
+
+    def test_manifest_resolves_exact_required_sources(self) -> None:
+        self.assertEqual(set(self.manifest["sources"]), set(PINS.SOURCE_ORDER))
+        for source_name in PINS.SOURCE_ORDER:
+            source = self.manifest["sources"][source_name]
+            self.assertRegex(source["commit"], r"^[0-9a-f]{40}$")
+
+    def test_update_skips_transient_ossf_ingestion_and_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            client = self.fixture_client(Path(temporary))
+            changed, changes = PINS.update_pins(
+                self.manifest, client, "2026-09-01T02:00:00Z"
+            )
+            self.assertTrue(changed)
+            self.assertEqual(
+                self.manifest["sources"]["ossf_malicious_packages"]["commit"],
+                self.new_ossf,
+            )
+            self.assertNotEqual(
+                self.manifest["sources"]["ossf_malicious_packages"]["commit"],
+                self.transient_ossf,
+            )
+            self.assertEqual(
+                self.manifest["sources"]["datadog_malicious_software_packages"][
+                    "commit"
+                ],
+                self.new_datadog,
+            )
+            self.assertEqual(
+                [item["source"] for item in changes if item["changed"]],
+                [
+                    "ossf_malicious_packages",
+                    "datadog_malicious_software_packages",
+                ],
+            )
+            report = PINS.render_report("2026-09-01T02:00:00Z", changes)
+            self.assertIn("osv", report)
+            self.assertIn("samples", report)
+            self.assertIn("Do not auto-merge", report)
+
+            changed_again, _ = PINS.update_pins(
+                self.manifest, client, "2026-09-01T02:05:00Z"
+            )
+            self.assertFalse(changed_again)
+
+    def test_manifest_rejects_unreviewed_repository_and_bad_metadata(self) -> None:
+        wrong_repository = copy.deepcopy(self.manifest)
+        wrong_repository["sources"]["ossf_malicious_packages"]["repository"] = (
+            "attacker/malicious-packages"
+        )
+        with self.assertRaises(PINS.PinError):
+            PINS.validate_manifest(wrong_repository)
+
+        bad_commit = copy.deepcopy(self.manifest)
+        bad_commit["sources"]["ossf_malicious_packages"]["commit"] = "A" * 40
+        with self.assertRaises(PINS.PinError):
+            PINS.validate_manifest(bad_commit)
+
+        selected_too_early = copy.deepcopy(self.manifest)
+        selected_too_early["sources"]["ossf_malicious_packages"]["selected_at"] = (
+            "2020-01-01T00:00:00Z"
+        )
+        with self.assertRaises(PINS.PinError):
+            PINS.validate_manifest(selected_too_early)
+
+    def test_comparison_must_be_strictly_ahead(self) -> None:
+        with self.assertRaises(PINS.PinError):
+            PINS.summarize_comparison(
+                "ossf/malicious-packages",
+                self.old_ossf,
+                self.new_ossf,
+                {"status": "diverged", "ahead_by": 1, "total_commits": 1, "files": []},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/threatdb_source_pins.py
+++ b/.github/scripts/threatdb_source_pins.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Validate, resolve, and propose immutable ThreatDB source pins."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import tempfile
+from typing import Any, Protocol
+import urllib.error
+import urllib.request
+
+
+SOURCE_ORDER = (
+    "ossf_malicious_packages",
+    "datadog_malicious_software_packages",
+    "ecosystems_typosquatting_dataset",
+)
+EXPECTED_REPOSITORIES = {
+    "ossf_malicious_packages": "ossf/malicious-packages",
+    "datadog_malicious_software_packages": (
+        "DataDog/malicious-software-packages-dataset"
+    ),
+    "ecosystems_typosquatting_dataset": "ecosyste-ms/typosquatting-dataset",
+}
+ALLOWED_POLICIES = {"default_branch_head", "latest_assign_ids"}
+HEX_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+UTC_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+class PinError(RuntimeError):
+    """A fail-closed pin manifest or discovery error."""
+
+
+class JsonClient(Protocol):
+    def commits(self, repository: str) -> Any: ...
+
+    def compare(self, repository: str, base: str, head: str) -> Any: ...
+
+
+def parse_timestamp(value: Any, label: str) -> datetime:
+    if not isinstance(value, str) or not UTC_TIMESTAMP.fullmatch(value):
+        raise PinError(
+            f"{label} must be an RFC3339 UTC timestamp with second precision"
+        )
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError as error:
+        raise PinError(f"{label} is not a valid UTC timestamp") from error
+
+
+def format_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def validate_manifest(document: Any) -> dict[str, Any]:
+    if not isinstance(document, dict) or set(document) != {"schema_version", "sources"}:
+        raise PinError("pin manifest must contain only schema_version and sources")
+    if document["schema_version"] != 1:
+        raise PinError("unsupported pin manifest schema_version")
+    sources = document["sources"]
+    if not isinstance(sources, dict) or set(sources) != set(SOURCE_ORDER):
+        raise PinError("pin manifest does not contain the exact required sources")
+
+    expected_fields = {
+        "candidate_policy",
+        "commit",
+        "commit_timestamp",
+        "max_lag_hours",
+        "repository",
+        "selected_at",
+    }
+    for source_name in SOURCE_ORDER:
+        source = sources[source_name]
+        if not isinstance(source, dict) or set(source) != expected_fields:
+            raise PinError(f"{source_name} has unexpected or missing fields")
+        if source["repository"] != EXPECTED_REPOSITORIES[source_name]:
+            raise PinError(f"{source_name} repository is not the reviewed upstream")
+        if source["candidate_policy"] not in ALLOWED_POLICIES:
+            raise PinError(f"{source_name} has an unsupported candidate policy")
+        if (
+            source_name == "ossf_malicious_packages"
+            and source["candidate_policy"] != "latest_assign_ids"
+        ):
+            raise PinError("OpenSSF must select a completed Assign IDs boundary")
+        if (
+            source_name != "ossf_malicious_packages"
+            and source["candidate_policy"] != "default_branch_head"
+        ):
+            raise PinError(f"{source_name} must track the default-branch head")
+        if not isinstance(source["commit"], str) or not HEX_COMMIT.fullmatch(
+            source["commit"]
+        ):
+            raise PinError(f"{source_name} commit must be lowercase 40-hex")
+        commit_time = parse_timestamp(
+            source["commit_timestamp"], f"{source_name} commit_timestamp"
+        )
+        selected_time = parse_timestamp(
+            source["selected_at"], f"{source_name} selected_at"
+        )
+        if commit_time > selected_time:
+            raise PinError(f"{source_name} was selected before its commit existed")
+        max_lag = source["max_lag_hours"]
+        if isinstance(max_lag, bool) or not isinstance(max_lag, int):
+            raise PinError(f"{source_name} max_lag_hours must be an integer")
+        if not 1 <= max_lag <= 8760:
+            raise PinError(f"{source_name} max_lag_hours is outside the safe range")
+    return document
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise PinError(f"cannot read pin manifest {path}: {error}") from error
+    return validate_manifest(document)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False
+    ) as staged:
+        staged.write(content)
+        staged.flush()
+        os.fsync(staged.fileno())
+        staged_path = Path(staged.name)
+    os.replace(staged_path, path)
+
+
+def write_json(path: Path, document: Any) -> None:
+    atomic_write(path, json.dumps(document, indent=2, sort_keys=True) + "\n")
+
+
+class GitHubClient:
+    def __init__(self, token: str | None) -> None:
+        self.token = token
+
+    def _get(self, endpoint: str) -> Any:
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "tirith-threatdb-pin-watcher/1",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(
+            f"https://api.github.com{endpoint}", headers=headers
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                if response.status != 200:
+                    raise PinError(
+                        f"GitHub API returned HTTP {response.status} for {endpoint}"
+                    )
+                return json.load(response)
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+            raise PinError(
+                f"GitHub API request failed for {endpoint}: {error}"
+            ) from error
+
+    def commits(self, repository: str) -> Any:
+        return self._get(f"/repos/{repository}/commits?per_page=100")
+
+    def compare(self, repository: str, base: str, head: str) -> Any:
+        return self._get(f"/repos/{repository}/compare/{base}...{head}")
+
+
+class FixtureClient:
+    def __init__(self, path: Path) -> None:
+        try:
+            self.document = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise PinError(f"cannot read API fixture {path}: {error}") from error
+
+    def commits(self, repository: str) -> Any:
+        try:
+            return self.document["commits"][repository]
+        except (KeyError, TypeError) as error:
+            raise PinError(f"API fixture has no commits for {repository}") from error
+
+    def compare(self, repository: str, base: str, head: str) -> Any:
+        key = f"{repository}:{base}...{head}"
+        try:
+            return self.document["comparisons"][key]
+        except (KeyError, TypeError) as error:
+            raise PinError(f"API fixture has no comparison for {key}") from error
+
+
+def normalized_commit(entry: Any, repository: str) -> dict[str, str]:
+    try:
+        sha = entry["sha"]
+        commit = entry["commit"]
+        timestamp = commit["committer"]["date"]
+        subject = commit["message"].splitlines()[0]
+    except (KeyError, IndexError, TypeError, AttributeError) as error:
+        raise PinError(f"{repository} returned malformed commit metadata") from error
+    if not isinstance(sha, str) or not HEX_COMMIT.fullmatch(sha):
+        raise PinError(f"{repository} returned a non-immutable commit id")
+    parsed = parse_timestamp(timestamp, f"{repository} candidate timestamp")
+    if not isinstance(subject, str) or not subject.strip():
+        raise PinError(f"{repository} returned an empty commit subject")
+    return {
+        "commit": sha,
+        "commit_timestamp": format_timestamp(parsed),
+        "subject": subject.strip(),
+    }
+
+
+def discover_candidate(source: dict[str, Any], client: JsonClient) -> dict[str, str]:
+    repository = source["repository"]
+    entries = client.commits(repository)
+    if not isinstance(entries, list) or not entries:
+        raise PinError(f"{repository} returned no default-branch commits")
+    candidates = [normalized_commit(entry, repository) for entry in entries]
+    if source["candidate_policy"] == "default_branch_head":
+        return candidates[0]
+    for candidate in candidates:
+        if candidate["subject"] == "Assign IDs":
+            return candidate
+    raise PinError(f"{repository} returned no completed Assign IDs boundary")
+
+
+def summarize_comparison(
+    repository: str, base: str, head: str, document: Any
+) -> dict[str, Any]:
+    if not isinstance(document, dict) or document.get("status") != "ahead":
+        raise PinError(
+            f"{repository} candidate is not strictly ahead of the pinned commit"
+        )
+    ahead_by = document.get("ahead_by")
+    total_commits = document.get("total_commits")
+    files = document.get("files")
+    if (
+        isinstance(ahead_by, bool)
+        or not isinstance(ahead_by, int)
+        or ahead_by < 1
+        or isinstance(total_commits, bool)
+        or not isinstance(total_commits, int)
+        or total_commits < 1
+        or not isinstance(files, list)
+    ):
+        raise PinError(f"{repository} returned malformed comparison metadata")
+    statuses: Counter[str] = Counter()
+    prefixes: Counter[str] = Counter()
+    for file in files:
+        if not isinstance(file, dict):
+            raise PinError(f"{repository} returned a malformed changed file")
+        status = file.get("status")
+        filename = file.get("filename")
+        if not isinstance(status, str) or not isinstance(filename, str) or not filename:
+            raise PinError(f"{repository} returned incomplete changed-file metadata")
+        statuses[status] += 1
+        prefixes[filename.split("/", 1)[0]] += 1
+    return {
+        "ahead_by": ahead_by,
+        "compare_url": f"https://github.com/{repository}/compare/{base}...{head}",
+        "files_returned": len(files),
+        "files_truncated": len(files) >= 300,
+        "path_prefixes": dict(sorted(prefixes.items())),
+        "status_counts": dict(sorted(statuses.items())),
+        "total_commits": total_commits,
+    }
+
+
+def update_pins(
+    manifest: dict[str, Any], client: JsonClient, selected_at: str
+) -> tuple[bool, list[dict[str, Any]]]:
+    selected_time = parse_timestamp(selected_at, "selection time")
+    changes: list[dict[str, Any]] = []
+    changed = False
+    for source_name in SOURCE_ORDER:
+        source = manifest["sources"][source_name]
+        candidate = discover_candidate(source, client)
+        candidate_time = parse_timestamp(
+            candidate["commit_timestamp"], f"{source_name} candidate timestamp"
+        )
+        if candidate_time > selected_time:
+            raise PinError(f"{source_name} candidate is newer than the selection time")
+        pinned_time = parse_timestamp(
+            source["commit_timestamp"], f"{source_name} pinned timestamp"
+        )
+        lag_hours = max(0.0, (candidate_time - pinned_time).total_seconds() / 3600)
+        item: dict[str, Any] = {
+            "candidate": candidate,
+            "changed": candidate["commit"] != source["commit"],
+            "lag_hours": lag_hours,
+            "max_lag_hours": source["max_lag_hours"],
+            "old_commit": source["commit"],
+            "old_commit_timestamp": source["commit_timestamp"],
+            "policy": source["candidate_policy"],
+            "repository": source["repository"],
+            "source": source_name,
+            "stale": lag_hours > source["max_lag_hours"],
+        }
+        if item["changed"]:
+            comparison = client.compare(
+                source["repository"], source["commit"], candidate["commit"]
+            )
+            item["comparison"] = summarize_comparison(
+                source["repository"],
+                source["commit"],
+                candidate["commit"],
+                comparison,
+            )
+            source["commit"] = candidate["commit"]
+            source["commit_timestamp"] = candidate["commit_timestamp"]
+            source["selected_at"] = selected_at
+            changed = True
+        elif candidate["commit_timestamp"] != source["commit_timestamp"]:
+            raise PinError(
+                f"{source_name} pinned commit timestamp disagrees with GitHub"
+            )
+        changes.append(item)
+    validate_manifest(manifest)
+    return changed, changes
+
+
+def markdown_code(value: str) -> str:
+    return value.replace("`", "'").replace("\r", " ").replace("\n", " ")
+
+
+def render_report(selected_at: str, changes: list[dict[str, Any]]) -> str:
+    lines = [
+        "## ThreatDB source-pin refresh",
+        "",
+        f"Generated at `{selected_at}` by the read-only source watcher.",
+        "The watcher has no ThreatDB signing key, release permission, or auto-merge step.",
+        "",
+        "| Source | State | Pinned | Candidate | Lag | Policy |",
+        "|---|---:|---|---|---:|---|",
+    ]
+    for item in changes:
+        state = (
+            "stale" if item["stale"] else ("update" if item["changed"] else "current")
+        )
+        candidate = item["candidate"]
+        lines.append(
+            "| {source} | {state} | `{old}` | `{new}` | {lag:.1f}h / {limit}h | `{policy}` |".format(
+                source=item["source"],
+                state=state,
+                old=item["old_commit"][:12],
+                new=candidate["commit"][:12],
+                lag=item["lag_hours"],
+                limit=item["max_lag_hours"],
+                policy=item["policy"],
+            )
+        )
+    lines.extend(["", "### Review evidence", ""])
+    for item in changes:
+        candidate = item["candidate"]
+        lines.extend(
+            [
+                f"#### `{item['source']}`",
+                "",
+                f"- repository: `{item['repository']}`",
+                f"- candidate: `{candidate['commit']}` at `{candidate['commit_timestamp']}`",
+                f"- subject: `{markdown_code(candidate['subject'])}`",
+            ]
+        )
+        comparison = item.get("comparison")
+        if comparison:
+            lines.extend(
+                [
+                    f"- compare: {comparison['compare_url']}",
+                    f"- commits: {comparison['ahead_by']} ahead ({comparison['total_commits']} in comparison)",
+                    f"- file statuses returned: `{json.dumps(comparison['status_counts'], sort_keys=True)}`",
+                    f"- changed path prefixes: `{json.dumps(comparison['path_prefixes'], sort_keys=True)}`",
+                    f"- GitHub file list truncated: `{str(comparison['files_truncated']).lower()}`",
+                ]
+            )
+        else:
+            lines.append("- no change")
+        lines.append("")
+    lines.extend(
+        [
+            "### Required review",
+            "",
+            "Do not auto-merge this PR. Review the upstream comparisons and require the normal Tirith CI checks. The watcher already ran the fail-closed fixture suite and a real source fetch against these exact immutable revisions before publishing this branch.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def command_validate(arguments: argparse.Namespace) -> int:
+    load_manifest(arguments.manifest)
+    return 0
+
+
+def command_resolve(arguments: argparse.Namespace) -> int:
+    manifest = load_manifest(arguments.manifest)
+    fields: list[str] = []
+    for source_name in SOURCE_ORDER:
+        source = manifest["sources"][source_name]
+        fields.extend(
+            [source["commit"], source["commit_timestamp"], source["selected_at"]]
+        )
+    print("\t".join(fields))
+    return 0
+
+
+def command_update(arguments: argparse.Namespace) -> int:
+    manifest = load_manifest(arguments.manifest)
+    selected_at = arguments.now or format_timestamp(datetime.now(timezone.utc))
+    client: JsonClient
+    if arguments.api_fixture:
+        client = FixtureClient(arguments.api_fixture)
+    else:
+        client = GitHubClient(os.environ.get("GITHUB_TOKEN"))
+    changed, changes = update_pins(manifest, client, selected_at)
+    if changed:
+        write_json(arguments.manifest, manifest)
+    report = render_report(selected_at, changes)
+    atomic_write(arguments.report, report)
+    result = {
+        "changed": changed,
+        "changed_sources": [item["source"] for item in changes if item["changed"]],
+        "selected_at": selected_at,
+        "stale_sources": [item["source"] for item in changes if item["stale"]],
+    }
+    write_json(arguments.result, result)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("manifest", type=Path)
+    validate.set_defaults(handler=command_validate)
+
+    resolve = subparsers.add_parser("resolve")
+    resolve.add_argument("manifest", type=Path)
+    resolve.set_defaults(handler=command_resolve)
+
+    update = subparsers.add_parser("update")
+    update.add_argument("manifest", type=Path)
+    update.add_argument("--api-fixture", type=Path)
+    update.add_argument("--now")
+    update.add_argument("--report", type=Path, required=True)
+    update.add_argument("--result", type=Path, required=True)
+    update.set_defaults(handler=command_update)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    arguments = parser.parse_args()
+    try:
+        return arguments.handler(arguments)
+    except PinError as error:
+        parser.error(str(error))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/threatdb_source_pins.py
+++ b/.github/scripts/threatdb_source_pins.py
@@ -31,6 +31,8 @@ EXPECTED_REPOSITORIES = {
 ALLOWED_POLICIES = {"default_branch_head", "latest_assign_ids"}
 HEX_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 UTC_TIMESTAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+COMMITS_PER_PAGE = 100
+MAX_COMMIT_PAGES = 10
 
 
 class PinError(RuntimeError):
@@ -38,7 +40,7 @@ class PinError(RuntimeError):
 
 
 class JsonClient(Protocol):
-    def commits(self, repository: str) -> Any: ...
+    def commits(self, repository: str, page: int = 1) -> Any: ...
 
     def compare(self, repository: str, base: str, head: str) -> Any: ...
 
@@ -166,8 +168,10 @@ class GitHubClient:
                 f"GitHub API request failed for {endpoint}: {error}"
             ) from error
 
-    def commits(self, repository: str) -> Any:
-        return self._get(f"/repos/{repository}/commits?per_page=100")
+    def commits(self, repository: str, page: int = 1) -> Any:
+        return self._get(
+            f"/repos/{repository}/commits?per_page={COMMITS_PER_PAGE}&page={page}"
+        )
 
     def compare(self, repository: str, base: str, head: str) -> Any:
         return self._get(f"/repos/{repository}/compare/{base}...{head}")
@@ -180,11 +184,14 @@ class FixtureClient:
         except (OSError, json.JSONDecodeError) as error:
             raise PinError(f"cannot read API fixture {path}: {error}") from error
 
-    def commits(self, repository: str) -> Any:
+    def commits(self, repository: str, page: int = 1) -> Any:
         try:
-            return self.document["commits"][repository]
+            fixture = self.document["commits"][repository]
         except (KeyError, TypeError) as error:
             raise PinError(f"API fixture has no commits for {repository}") from error
+        if isinstance(fixture, dict):
+            return fixture.get(str(page), [])
+        return fixture if page == 1 else []
 
     def compare(self, repository: str, base: str, head: str) -> Any:
         key = f"{repository}:{base}...{head}"
@@ -216,15 +223,24 @@ def normalized_commit(entry: Any, repository: str) -> dict[str, str]:
 
 def discover_candidate(source: dict[str, Any], client: JsonClient) -> dict[str, str]:
     repository = source["repository"]
-    entries = client.commits(repository)
-    if not isinstance(entries, list) or not entries:
-        raise PinError(f"{repository} returned no default-branch commits")
-    candidates = [normalized_commit(entry, repository) for entry in entries]
     if source["candidate_policy"] == "default_branch_head":
-        return candidates[0]
-    for candidate in candidates:
-        if candidate["subject"] == "Assign IDs":
-            return candidate
+        entries = client.commits(repository, 1)
+        if not isinstance(entries, list) or not entries:
+            raise PinError(f"{repository} returned no default-branch commits")
+        return normalized_commit(entries[0], repository)
+
+    for page in range(1, MAX_COMMIT_PAGES + 1):
+        entries = client.commits(repository, page)
+        if not isinstance(entries, list):
+            raise PinError(f"{repository} returned malformed commit page {page}")
+        if not entries:
+            break
+        for entry in entries:
+            candidate = normalized_commit(entry, repository)
+            if candidate["subject"] == "Assign IDs":
+                return candidate
+        if len(entries) < COMMITS_PER_PAGE:
+            break
     raise PinError(f"{repository} returned no completed Assign IDs boundary")
 
 

--- a/.github/threatdb-source-pins.json
+++ b/.github/threatdb-source-pins.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "sources": {
+    "datadog_malicious_software_packages": {
+      "candidate_policy": "default_branch_head",
+      "commit": "2d09839012cedc387ce438debeb77884ac2a242c",
+      "commit_timestamp": "2026-08-31T04:05:01Z",
+      "max_lag_hours": 168,
+      "repository": "DataDog/malicious-software-packages-dataset",
+      "selected_at": "2026-08-31T19:22:30Z"
+    },
+    "ecosystems_typosquatting_dataset": {
+      "candidate_policy": "default_branch_head",
+      "commit": "fd0bde98d200efe5c282a07edc4c68fba13252c6",
+      "commit_timestamp": "2025-12-17T11:33:09Z",
+      "max_lag_hours": 720,
+      "repository": "ecosyste-ms/typosquatting-dataset",
+      "selected_at": "2026-08-31T19:22:30Z"
+    },
+    "ossf_malicious_packages": {
+      "candidate_policy": "latest_assign_ids",
+      "commit": "54642f7ee96e780b046660519b028fefb635375a",
+      "commit_timestamp": "2026-08-31T18:32:57Z",
+      "max_lag_hours": 48,
+      "repository": "ossf/malicious-packages",
+      "selected_at": "2026-08-31T19:22:30Z"
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
           .github/scripts/fetch-threatdb-sources.sh
           .github/scripts/test-fetch-threatdb-sources.sh
           .github/scripts/test-threatdb-manifest-transition.sh
+      - name: Validate ThreatDB source-pin manifest and watcher
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/threatdb_source_pins.py validate \
+            .github/threatdb-source-pins.json
+          python3 .github/scripts/test_threatdb_source_pins.py
       - name: Validate fail-closed ThreatDB fetch orchestration
         run: bash .github/scripts/test-fetch-threatdb-sources.sh
       - name: Validate ThreatDB manifest transition fixtures

--- a/.github/workflows/threatdb-source-pins.yml
+++ b/.github/workflows/threatdb-source-pins.yml
@@ -1,0 +1,160 @@
+name: ThreatDB source pin watcher
+
+on:
+  schedule:
+    - cron: "37 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: threatdb-source-pin-watcher
+  cancel-in-progress: false
+
+# Discovery uses this read-only token. Publishing the reviewed candidate branch
+# requires the separately scoped THREATDB_PIN_PR_TOKEN and happens only after a
+# real fetch and compile. This workflow has no signing key or release permission.
+permissions:
+  contents: read
+
+jobs:
+  propose:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Discover completed upstream revisions
+        id: pins
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          report="$RUNNER_TEMP/threatdb-source-pin-report.md"
+          result="$RUNNER_TEMP/threatdb-source-pin-result.json"
+          python3 .github/scripts/threatdb_source_pins.py update \
+            .github/threatdb-source-pins.json \
+            --report "$report" \
+            --result "$result"
+          changed=$(jq -er '.changed | if . then "true" else "false" end' "$result")
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "report=$report" >> "$GITHUB_OUTPUT"
+          cat "$report" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate deterministic pin and fetch contracts
+        if: steps.pins.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/threatdb_source_pins.py validate \
+            .github/threatdb-source-pins.json
+          python3 .github/scripts/test_threatdb_source_pins.py
+          bash .github/scripts/test-fetch-threatdb-sources.sh
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        if: steps.pins.outputs.changed == 'true'
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        if: steps.pins.outputs.changed == 'true'
+
+      - name: Build the unprivileged validation compiler
+        if: steps.pins.outputs.changed == 'true'
+        run: cargo build --locked --release -p tirith --bin tirith-threatdb-compile
+
+      - name: Fetch and compile the exact candidate snapshots
+        if: steps.pins.outputs.changed == 'true'
+        env:
+          # Public, deterministic test seed. Production signing material is not
+          # available to this workflow.
+          TIRITH_WATCHER_SIGNING_KEY: KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio=
+        run: |
+          set -euo pipefail
+          fetch_root="$RUNNER_TEMP/threatdb-pin-validation"
+          THREATDB_FETCH_OUTPUT_DIR="$fetch_root" \
+            bash .github/scripts/fetch-threatdb-sources.sh
+          sources="$fetch_root/tirith-threatdb-sources"
+          ./target/release/tirith-threatdb-compile \
+            --ossf "$sources/ossf-mp" \
+            --registry-snapshots "$sources/registry-versions.json" \
+            --source-provenance "$sources/source-provenance.json" \
+            --compiler-metadata "$RUNNER_TEMP/compiler-metadata.json" \
+            --datadog "$sources/dd-mp" \
+            --feodo "$sources/feodo.txt" \
+            --cisa-kev "$sources/cisa-kev.json" \
+            --typosquats "$sources/typosquats/typosquats.csv" \
+            --sequence 1 \
+            --sign-key-env TIRITH_WATCHER_SIGNING_KEY \
+            --output "$RUNNER_TEMP/tirith-threatdb-candidate.dat"
+
+      - name: Require the dedicated PR token
+        if: steps.pins.outputs.changed == 'true'
+        env:
+          PIN_PR_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN }}
+        run: |
+          if [ -z "$PIN_PR_TOKEN" ]; then
+            echo "::error::THREATDB_PIN_PR_TOKEN is required (contents + pull requests for this repository only)"
+            exit 1
+          fi
+
+      - name: Publish the automation-owned candidate branch
+        if: steps.pins.outputs.changed == 'true'
+        id: branch
+        env:
+          PIN_PR_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch="automation/threatdb-source-pins"
+          git config user.name "tirith-threatdb-pin-watcher[bot]"
+          git config user.email "tirith-threatdb-pin-watcher[bot]@users.noreply.github.com"
+          git fetch --quiet origin "+refs/heads/$branch:refs/remotes/origin/$branch" || true
+          expected=$(git rev-parse --verify "refs/remotes/origin/$branch" 2>/dev/null || true)
+          git switch -c "$branch"
+          git add .github/threatdb-source-pins.json
+          git commit -m "chore(threatdb): refresh source pins"
+
+          askpass="$RUNNER_TEMP/tirith-pin-git-askpass.sh"
+          cat > "$askpass" <<'SCRIPT'
+          #!/bin/sh
+          case "$1" in
+            *Username*) printf '%s\n' x-access-token ;;
+            *Password*) printf '%s\n' "$PIN_PR_TOKEN" ;;
+            *) exit 1 ;;
+          esac
+          SCRIPT
+          chmod 700 "$askpass"
+          lease="--force-with-lease=refs/heads/$branch:$expected"
+          GIT_ASKPASS="$askpass" GIT_TERMINAL_PROMPT=0 \
+            git push "$lease" "https://github.com/$GITHUB_REPOSITORY.git" \
+            "HEAD:refs/heads/$branch"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open or refresh the review PR
+        if: steps.pins.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN }}
+          REPORT: ${{ steps.pins.outputs.report }}
+          SOURCE_BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          set -euo pipefail
+          head="$GITHUB_REPOSITORY_OWNER:$SOURCE_BRANCH"
+          number=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --head "$head" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$number" ]; then
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$SOURCE_BRANCH" \
+              --title "chore(threatdb): refresh source pins" \
+              --body-file "$REPORT"
+          else
+            gh pr edit "$number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "chore(threatdb): refresh source pins" \
+              --body-file "$REPORT"
+          fi

--- a/.github/workflows/threatdb.yml
+++ b/.github/workflows/threatdb.yml
@@ -21,11 +21,6 @@ env:
   # is published through this replacement tag.
   THREATDB_RELEASE_TAG: threatdb-current
   THREATDB_LEGACY_RELEASE_TAG: threatdb-latest
-  # Reviewed immutable source revisions consumed and verified by the atomic
-  # fetch transaction. Updating any pin is a source-review event.
-  THREATDB_OSSF_MP_REF: 54642f7ee96e780b046660519b028fefb635375a
-  THREATDB_DD_MP_REF: 2d09839012cedc387ce438debeb77884ac2a242c
-  THREATDB_TYPOSQUAT_REF: fd0bde98d200efe5c282a07edc4c68fba13252c6
 
 jobs:
   build-threatdb:

--- a/crates/tirith/src/bin/tirith_threatdb_compile.rs
+++ b/crates/tirith/src/bin/tirith_threatdb_compile.rs
@@ -732,6 +732,10 @@ struct GitSourceProvenance {
     source_url: String,
     r#ref: String,
     commit: String,
+    #[serde(default)]
+    commit_timestamp: Option<String>,
+    #[serde(default)]
+    pin_selected_at: Option<String>,
     spdx: String,
     files: usize,
     bytes: usize,
@@ -744,6 +748,10 @@ struct RowSourceProvenance {
     source_url: String,
     r#ref: String,
     commit: String,
+    #[serde(default)]
+    commit_timestamp: Option<String>,
+    #[serde(default)]
+    pin_selected_at: Option<String>,
     spdx: String,
     files: usize,
     rows: usize,
@@ -853,6 +861,38 @@ fn validate_utc_timestamp(value: &str, label: &str) -> FeedResult<()> {
     Ok(())
 }
 
+fn validate_pin_timestamps(
+    commit_timestamp: Option<&str>,
+    pin_selected_at: Option<&str>,
+    label: &str,
+) -> FeedResult<()> {
+    let (Some(commit_timestamp), Some(pin_selected_at)) = (commit_timestamp, pin_selected_at)
+    else {
+        if commit_timestamp.is_none() && pin_selected_at.is_none() {
+            // Historical provenance predates source-pin freshness metadata.
+            return Ok(());
+        }
+        return Err(format!(
+            "{label} commit_timestamp and pin_selected_at must appear together"
+        ));
+    };
+    validate_utc_timestamp(
+        commit_timestamp,
+        &format!("{label} source commit timestamp"),
+    )?;
+    validate_utc_timestamp(pin_selected_at, &format!("{label} pin selection time"))?;
+    let committed =
+        chrono::DateTime::parse_from_rfc3339(commit_timestamp).expect("timestamp validated above");
+    let selected =
+        chrono::DateTime::parse_from_rfc3339(pin_selected_at).expect("timestamp validated above");
+    if committed > selected {
+        return Err(format!(
+            "{label} pin was selected before its commit existed"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_git_source(
     source: &GitSourceProvenance,
     expected_url: &str,
@@ -867,6 +907,11 @@ fn validate_git_source(
     if source.r#ref != source.commit || source.files == 0 || source.bytes == 0 {
         return Err(format!("{label} revision/count metadata is inconsistent"));
     }
+    validate_pin_timestamps(
+        source.commit_timestamp.as_deref(),
+        source.pin_selected_at.as_deref(),
+        label,
+    )?;
     validate_lower_hex(
         &source.content_sha256,
         32,
@@ -990,7 +1035,12 @@ fn verify_expected_summary(
     Ok(())
 }
 
-fn verify_git_checkout(root: &Path, expected_commit: &str, label: &str) -> FeedResult<()> {
+fn verify_git_checkout(
+    root: &Path,
+    expected_commit: &str,
+    expected_timestamp: Option<&str>,
+    label: &str,
+) -> FeedResult<()> {
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(root)
@@ -1007,6 +1057,32 @@ fn verify_git_checkout(root: &Path, expected_commit: &str, label: &str) -> FeedR
         return Err(format!(
             "{label} Git HEAD {head} does not match pinned {expected_commit}"
         ));
+    }
+    if let Some(expected_timestamp) = expected_timestamp {
+        validate_utc_timestamp(
+            expected_timestamp,
+            &format!("{label} source commit timestamp"),
+        )?;
+        let timestamp = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["show", "-s", "--format=%cI", "HEAD"])
+            .output()
+            .map_err(|error| format!("cannot inspect {label} Git commit time: {error}"))?;
+        if !timestamp.status.success() {
+            return Err(format!("cannot resolve {label} Git commit time"));
+        }
+        let timestamp = std::str::from_utf8(&timestamp.stdout)
+            .map_err(|_| format!("{label} Git commit time is not UTF-8"))?
+            .trim();
+        let timestamp = chrono::DateTime::parse_from_rfc3339(timestamp)
+            .map_err(|error| format!("{label} Git commit time is not RFC3339: {error}"))?
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        if timestamp != expected_timestamp {
+            return Err(format!(
+                "{label} Git commit time {timestamp} does not match provenance {expected_timestamp}"
+            ));
+        }
     }
     let status = std::process::Command::new("git")
         .arg("-C")
@@ -1123,11 +1199,16 @@ fn verify_source_inputs(
     verify_git_checkout(
         inputs.ossf,
         &document.ossf_malicious_packages.commit,
+        document.ossf_malicious_packages.commit_timestamp.as_deref(),
         "OpenSSF",
     )?;
     verify_git_checkout(
         inputs.datadog,
         &document.datadog_malicious_software_packages.commit,
+        document
+            .datadog_malicious_software_packages
+            .commit_timestamp
+            .as_deref(),
         "Datadog",
     )?;
     verify_git_checkout(
@@ -1136,6 +1217,10 @@ fn verify_source_inputs(
             .parent()
             .ok_or_else(|| "typosquat CSV has no source root".to_string())?,
         &document.ecosystems_typosquatting_dataset.commit,
+        document
+            .ecosystems_typosquatting_dataset
+            .commit_timestamp
+            .as_deref(),
         "typosquat",
     )?;
     verify_source_contents(document, inputs)
@@ -1206,6 +1291,11 @@ impl SourceTransactionBinding {
         if typosquats.r#ref != typosquats.commit {
             return Err("typosquat ref/commit metadata disagrees".to_string());
         }
+        validate_pin_timestamps(
+            typosquats.commit_timestamp.as_deref(),
+            typosquats.pin_selected_at.as_deref(),
+            "typosquat",
+        )?;
         validate_lower_hex(&typosquats.content_sha256, 32, "typosquat content SHA-256")?;
         for (source, expected_url, expected_spdx, label) in [
             (
@@ -7118,6 +7208,8 @@ mod tests {
                 "source_url": "https://github.com/ossf/malicious-packages.git",
                 "ref": "1ea2762d5fb415aef003a244d5aa83c5fc48cc6e",
                 "commit": "1ea2762d5fb415aef003a244d5aa83c5fc48cc6e",
+                "commit_timestamp": "2026-08-08T00:00:00Z",
+                "pin_selected_at": "2026-08-08T00:00:01Z",
                 "spdx": "CC-BY-4.0", "files": 1, "bytes": 1,
                 "content_sha256": "11".repeat(32)
             },
@@ -7125,6 +7217,8 @@ mod tests {
                 "source_url": "https://github.com/DataDog/malicious-software-packages-dataset.git",
                 "ref": "ef4a781d476cd6eb89c8517ff9adbb54a5cfa8cc",
                 "commit": "ef4a781d476cd6eb89c8517ff9adbb54a5cfa8cc",
+                "commit_timestamp": "2026-08-07T00:00:00Z",
+                "pin_selected_at": "2026-08-08T00:00:01Z",
                 "spdx": "Apache-2.0", "files": 2, "bytes": 2,
                 "content_sha256": "22".repeat(32)
             },
@@ -7132,6 +7226,8 @@ mod tests {
                 "source_url": "https://github.com/ecosyste-ms/typosquatting-dataset.git",
                 "ref": "fd0bde98d200efe5c282a07edc4c68fba13252c6",
                 "commit": "fd0bde98d200efe5c282a07edc4c68fba13252c6",
+                "commit_timestamp": "2025-12-17T11:33:09Z",
+                "pin_selected_at": "2026-08-08T00:00:01Z",
                 "spdx": "CC0-1.0", "files": 1, "rows": 100, "bytes": 3,
                 "content_sha256": "33".repeat(32)
             },
@@ -7176,6 +7272,29 @@ mod tests {
                 .unwrap_err()
                 .contains("do not match source provenance")
         );
+    }
+
+    #[test]
+    fn source_pin_freshness_timestamps_are_paired_and_chronological() {
+        assert!(validate_pin_timestamps(None, None, "fixture").is_ok());
+        assert!(validate_pin_timestamps(
+            Some("2026-08-31T18:32:57Z"),
+            Some("2026-08-31T20:01:37Z"),
+            "fixture"
+        )
+        .is_ok());
+        assert!(
+            validate_pin_timestamps(Some("2026-08-31T18:32:57Z"), None, "fixture")
+                .unwrap_err()
+                .contains("must appear together")
+        );
+        assert!(validate_pin_timestamps(
+            Some("2026-09-01T00:00:01Z"),
+            Some("2026-09-01T00:00:00Z"),
+            "fixture"
+        )
+        .unwrap_err()
+        .contains("before its commit existed"));
     }
 
     #[test]
@@ -7335,10 +7454,29 @@ mod tests {
             .output()
             .unwrap();
         let commit = std::str::from_utf8(&output.stdout).unwrap().trim();
-        verify_git_checkout(directory.path(), commit, "fixture").unwrap();
-        assert!(verify_git_checkout(directory.path(), &"77".repeat(20), "fixture").is_err());
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(directory.path())
+            .args(["show", "-s", "--format=%cI", "HEAD"])
+            .output()
+            .unwrap();
+        let timestamp = chrono::DateTime::parse_from_rfc3339(
+            std::str::from_utf8(&output.stdout).unwrap().trim(),
+        )
+        .unwrap()
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        verify_git_checkout(directory.path(), commit, Some(&timestamp), "fixture").unwrap();
+        assert!(verify_git_checkout(
+            directory.path(),
+            commit,
+            Some("2020-01-01T00:00:00Z"),
+            "fixture"
+        )
+        .unwrap_err()
+        .contains("does not match provenance"));
+        assert!(verify_git_checkout(directory.path(), &"77".repeat(20), None, "fixture").is_err());
         std::fs::write(directory.path().join("input.txt"), b"dirty\n").unwrap();
-        assert!(verify_git_checkout(directory.path(), commit, "fixture").is_err());
+        assert!(verify_git_checkout(directory.path(), commit, None, "fixture").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make `.github/threatdb-source-pins.json` the canonical immutable source-pin manifest
- add a daily, proposal-only watcher that selects completed OpenSSF `Assign IDs` boundaries, validates every candidate with the fail-closed fetch fixtures plus a real full fetch/compile, and then opens or refreshes a review PR
- bind source commit and pin-selection timestamps into provenance and have the compiler independently verify the checked-out commit timestamps
- remove duplicated production pins from the release workflow

## Security boundaries

- discovery uses the workflow read-only token
- publishing happens only after validation and requires the separately scoped `THREATDB_PIN_PR_TOKEN`
- the watcher has no ThreatDB signing key, release permission, auto-merge step, or direct release mutation
- candidate comparisons must be strictly ahead of the reviewed pin; malformed, divergent, or unrecognized upstream state fails closed

After merge, configure `THREATDB_PIN_PR_TOKEN` with repository-scoped Contents and Pull requests write access so the watcher can maintain its fixed automation branch.

## Validation

- `python3 .github/scripts/test_threatdb_source_pins.py`
- `python3 -m ruff check` and `ruff format --check` for the watcher
- `bash .github/scripts/test-fetch-threatdb-sources.sh`
- `cargo test --locked -p tirith --bin tirith-threatdb-compile` (89 tests)
- `cargo clippy --locked -p tirith --bin tirith-threatdb-compile -- -D warnings`
- full Linux fetch and compile of the exact reviewed snapshots: 236,884 OpenSSF claims, 49,452 DataDog packages, 240,994 v1 keys, zero corrupt records, zero unsupported shapes, and zero registry snapshot failures



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated monitoring for updated threat intelligence sources.
  - Generates review-ready updates with immutable source revisions and timestamp provenance.
  - Supports scheduled and manual source refreshes with controlled publication workflows.

- **Bug Fixes**
  - Prevents unverified, mismatched, stale, or improperly timestamped source data from being accepted.
  - Improves validation of fetched source snapshots and provenance consistency.

- **Tests**
  - Expanded coverage for source updates, validation failures, timestamps, idempotency, and report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the immutable source-pin manifest canonical and adds a daily proposal-only workflow that discovers, validates, and publishes reviewed pin updates.
- Adds paginated OpenSSF `Assign IDs` boundary discovery and default-branch discovery for other sources.
- Validates candidate ancestry, timestamps, fetch fixtures, and a full fetch/compile before publishing an automation-owned branch.
- Extends source provenance and compiler verification with commit and pin-selection timestamps.
- Removes duplicated source pins from the release workflow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current pagination implementation and regression test address the previously reported single-page discovery failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/scripts/threatdb_source_pins.py | Implements fail-closed manifest validation, paginated source discovery, ancestry comparison, pin updates, and review-report generation. |
| .github/workflows/threatdb-source-pins.yml | Adds the scheduled proposal workflow with validation before privileged branch publication. |
| .github/scripts/fetch-threatdb-sources.sh | Resolves canonical source pins and records verified commit and selection timestamps in provenance. |
| crates/tirith/src/bin/tirith_threatdb_compile.rs | Validates optional timestamp provenance and checks it against source Git commits. |
| .github/scripts/test_threatdb_source_pins.py | Covers manifest constraints, strict ancestry, idempotent updates, and page-two OpenSSF discovery. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  S[Daily or manual watcher] --> D[Discover upstream candidates]
  D --> M[Update canonical pin manifest]
  M --> V[Run manifest and fixture validation]
  V --> F[Fetch immutable snapshots]
  F --> C[Compile candidate ThreatDB]
  C --> T[Require dedicated PR token]
  T --> B[Push automation branch]
  B --> P[Open or refresh review PR]
```

<sub>Reviews (8): Last reviewed commit: ["test(threatdb): derive unchanged fixture..."](https://github.com/sheeki03/tirith/commit/8b37a8be82b281c25cb32bb399f6314f433c6b54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58784362)</sub>

<!-- /greptile_comment -->