### PR TITLE
fix(register): resolve symlinked launch path before O_NOFOLLOW open

### DIFF
--- a/crates/tirith-core/src/execution_state/shell_receipt.rs
+++ b/crates/tirith-core/src/execution_state/shell_receipt.rs
@@ -648,8 +648,19 @@ fn shell_process_identity(
 fn current_tirith_executable_identity() -> Result<TirithExecutableIdentity, String> {
     use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
 
-    let path = std::env::current_exe()
+    let launch_path = std::env::current_exe()
         .map_err(|error| format!("resolve current Tirith executable: {error}"))?;
+    // `current_exe()` returns the path the process was launched through, not
+    // the fully resolved binary. That path is legitimately a symlink under
+    // common install methods (Homebrew's Cellar symlink, cargo/npm shims,
+    // PATH entries pointing at a versioned binary), so opening it directly
+    // with O_NOFOLLOW below rejects every one of those installs with ELOOP.
+    // Canonicalize first to resolve the full chain the same way the zsh hook
+    // already does with `${_TIRITH_BIN:A}`, then let O_NOFOLLOW do its real
+    // job: refusing a symlink swapped in at the resolved location between
+    // this call and the open below.
+    let path = fs::canonicalize(&launch_path)
+        .map_err(|error| format!("resolve current Tirith executable path: {error}"))?;
     let file = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK)
@@ -4195,6 +4206,49 @@ mod tests {
             let directory = receipt_directory().expect("receipt directory");
             assert_eq!(capability_artifact_count(&directory, false), 2);
             assert_eq!(capability_artifact_count(&directory, true), 2);
+        });
+    }
+
+    #[test]
+    fn register_succeeds_when_the_tirith_binary_is_invoked_through_a_symlink() {
+        // Regression test for a Homebrew-symlink registration failure
+        // (`open current Tirith executable: Too many levels of symbolic
+        // links (os error 62)`, sheeki03/tirith#221): a package manager or
+        // PATH shim commonly exposes the binary through a symlink, and
+        // `current_tirith_executable_identity` must resolve that symlink
+        // before the O_NOFOLLOW open rather than reject it outright.
+        //
+        // `std::env::current_exe()` on Linux already reports the fully
+        // resolved path regardless of how the process was invoked (it reads
+        // `/proc/self/exe`), so this does not reproduce the macOS-specific
+        // launch-path behaviour the original report hit. It does exercise
+        // the `fs::canonicalize` call this fix adds and locks in that
+        // invoking the binary through a symlink keeps working.
+        isolated_state(|temporary, session_id| {
+            let real_exe = std::env::current_exe().expect("test executable path");
+            let symlink_dir = tempfile::tempdir().expect("symlink staging dir");
+            let symlinked_exe = symlink_dir.path().join("tirith-via-symlink");
+            std::os::unix::fs::symlink(&real_exe, &symlinked_exe)
+                .expect("symlink to test executable");
+
+            let output = std::process::Command::new(&symlinked_exe)
+                .args([
+                    "--ignored",
+                    "--exact",
+                    CAPABILITY_PROCESS_HELPER,
+                    "--nocapture",
+                ])
+                .env("TIRITH_CAPABILITY_PROCESS_HELPER", "register")
+                .env("TIRITH_SESSION_ID", session_id)
+                .env("XDG_STATE_HOME", temporary.path())
+                .output()
+                .expect("run capability process helper through symlink");
+            assert!(
+                output.status.success(),
+                "registration through a symlinked executable failed: stdout={} stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
         });
     }
 


### PR DESCRIPTION
Fixes the "register fails through the Homebrew symlink" finding from #221.

`current_tirith_executable_identity()` opens `std::env::current_exe()` directly under `O_NOFOLLOW`. On macOS, `current_exe()` returns the process's launch path rather than the fully resolved binary, so any symlinked install (Homebrew's Cellar symlink, a cargo/npm shim, a PATH entry pointing at a versioned binary) makes `register` fail with `ELOOP` ("Too many levels of symbolic links"), while every other subcommand keeps working (`capability` resolves the path differently and is unaffected, per the issue).

The zsh hook already works around this on its own side with `${_TIRITH_BIN:A}`. This applies the same resolution inside the binary, so `register` is robust no matter how it gets invoked, not only when the caller happens to resolve the symlink first.

Fix: canonicalize the launch path before opening it, then keep the `O_NOFOLLOW` open on the resolved path. That preserves the actual security property (a symlink swapped in between `canonicalize()` and `open()` is still rejected) instead of rejecting every symlinked install outright.

## Scope

This addresses only the symlink/`ELOOP` finding. I haven't touched the main zsh-hook process-identity issue (`register` rejecting the rc-file fork) or the `receipt list`/`receipt last` directory mismatch that #221 also reports, since those are separate subsystems, and I'd rather send small, reviewable changes than one PR touching three code paths.

## Testing

- `cargo test -p tirith-core --lib execution_state::shell_receipt`: 33 passed, 1 ignored (the existing subprocess-helper test, same as before this change).
- Added `register_succeeds_when_the_tirith_binary_is_invoked_through_a_symlink`, which spawns the test binary through a symlink and asserts `register` still succeeds.
- `cargo clippy -p tirith-core --lib --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tirith-core`: clean.

Caveat on the test: `std::env::current_exe()` on Linux already resolves through `/proc/self/exe` regardless of how the process was launched, so this test doesn't reproduce the macOS-specific launch-path behavior from the report — I don't have a macOS box to verify against. It does exercise the new `fs::canonicalize` call and locks in that invoking the binary through a symlink keeps working. If you have a way to verify on macOS I'd appreciate it; happy to adjust if the fix needs a platform-specific tweak I'm not seeing from here.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Canonicalizes the current executable’s launch path before opening it with `O_NOFOLLOW`, allowing registration through legitimate installation symlinks while retaining final-component symlink rejection.
- Adds explanatory documentation around the executable-path resolution and security checks.
- Adds an end-to-end registration test that launches the test executable through a symlink.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The change fixes symlinked registration while retaining the existing open, metadata, ownership, permission, and file-identity checks, and the regression test runs on the repository’s macOS CI target.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/tirith-core/src/execution_state/shell_receipt.rs | Resolves symlinked launch paths before executable identity collection and adds cross-platform Unix regression coverage; no actionable defect was established. |

<sub>Reviews (1): Last reviewed commit: ["fix(register): resolve symlinked launch ..."](https://github.com/sheeki03/tirith/commit/bf2997f90e18fdceba9676d1a0477de3782ec0a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58874439)</sub>

<!-- /greptile_comment -->