### PR TITLE
fix(shell): resolve pinned hook helpers via PATH when FHS paths are absent

### DIFF
--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -125,21 +125,32 @@ fi
 # long-lived interactive shell) Tirith's parent. Capture Tirith stdout in a
 # private temporary file instead: Tirith remains a direct child, parsing happens
 # in this shell, and every caller removes the file immediately.
-_TIRITH_MKTEMP_BIN=""
-[[ -f /usr/bin/mktemp && -x /usr/bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/usr/bin/mktemp
-[[ -z "$_TIRITH_MKTEMP_BIN" && -f /bin/mktemp && -x /bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/bin/mktemp
-_TIRITH_RM_BIN=""
-[[ -f /bin/rm && -x /bin/rm ]] && _TIRITH_RM_BIN=/bin/rm
-[[ -z "$_TIRITH_RM_BIN" && -f /usr/bin/rm && -x /usr/bin/rm ]] && _TIRITH_RM_BIN=/usr/bin/rm
-_TIRITH_MKDIR_BIN=""
-[[ -f /bin/mkdir && -x /bin/mkdir ]] && _TIRITH_MKDIR_BIN=/bin/mkdir
-[[ -z "$_TIRITH_MKDIR_BIN" && -f /usr/bin/mkdir && -x /usr/bin/mkdir ]] && _TIRITH_MKDIR_BIN=/usr/bin/mkdir
-_TIRITH_WC_BIN=""
-[[ -f /usr/bin/wc && -x /usr/bin/wc ]] && _TIRITH_WC_BIN=/usr/bin/wc
-[[ -z "$_TIRITH_WC_BIN" && -f /bin/wc && -x /bin/wc ]] && _TIRITH_WC_BIN=/bin/wc
-_TIRITH_STTY_BIN=""
-[[ -f /bin/stty && -x /bin/stty ]] && _TIRITH_STTY_BIN=/bin/stty
-[[ -z "$_TIRITH_STTY_BIN" && -f /usr/bin/stty && -x /usr/bin/stty ]] && _TIRITH_STTY_BIN=/usr/bin/stty
+#
+# Every external helper below is pinned to an absolute path while the hook is
+# sourced, so a later PATH change cannot swap it. A conventional FHS location is
+# preferred; when none exists (NixOS provides only /bin/sh and /usr/bin/env),
+# fall back to the PATH in effect now — the same trust already extended to
+# _TIRITH_BIN above. `type -P` only ever names a file, never a builtin,
+# function, or alias; the absolute-path check rejects a relative PATH entry.
+# The callers below test these variables with `-n` only, so this function is
+# the sole guarantee that a non-empty value is an absolute executable.
+_tirith_resolve_helper() {
+  local name="$1" candidate
+  shift
+  for candidate in "$@"; do
+    [[ -f "$candidate" && -x "$candidate" ]] || continue
+    builtin printf '%s\n' "$candidate"
+    return 0
+  done
+  candidate="$(builtin type -P -- "$name" 2>/dev/null)" || return 1
+  [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]] || return 1
+  builtin printf '%s\n' "$candidate"
+}
+_TIRITH_MKTEMP_BIN="$(_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)" || _TIRITH_MKTEMP_BIN=""
+_TIRITH_RM_BIN="$(_tirith_resolve_helper rm /bin/rm /usr/bin/rm)" || _TIRITH_RM_BIN=""
+_TIRITH_MKDIR_BIN="$(_tirith_resolve_helper mkdir /bin/mkdir /usr/bin/mkdir)" || _TIRITH_MKDIR_BIN=""
+_TIRITH_WC_BIN="$(_tirith_resolve_helper wc /usr/bin/wc /bin/wc)" || _TIRITH_WC_BIN=""
+_TIRITH_STTY_BIN="$(_tirith_resolve_helper stty /bin/stty /usr/bin/stty)" || _TIRITH_STTY_BIN=""
 
 _tirith_new_capture_file() {
   [[ -n "$_TIRITH_MKTEMP_BIN" && -n "$_TIRITH_RM_BIN" ]] || return 1

--- a/crates/tirith/assets/shell/lib/fish-hook.fish
+++ b/crates/tirith/assets/shell/lib/fish-hook.fish
@@ -31,44 +31,35 @@ if not string match -q '/*' -- "$_TIRITH_BIN"; or not test -x "$_TIRITH_BIN"
 end
 
 # Protocol-v3 callbacks run after arbitrary commands may have changed PATH.
-# Pin every external helper they use to a fixed system location now, and only
-# advertise receipt support when the complete helper set is available.
-set -g _TIRITH_MKTEMP_BIN ""
-if test -f /usr/bin/mktemp; and test -x /usr/bin/mktemp
-    set -g _TIRITH_MKTEMP_BIN /usr/bin/mktemp
-else if test -f /bin/mktemp; and test -x /bin/mktemp
-    set -g _TIRITH_MKTEMP_BIN /bin/mktemp
+# Pin every external helper they use to an absolute path now, and only
+# advertise receipt support when the complete helper set is available. A
+# conventional FHS location is preferred; when none exists (NixOS provides only
+# /bin/sh and /usr/bin/env), fall back to the PATH in effect while the hook is
+# sourced — the same trust already extended to _TIRITH_BIN above. Either way
+# the helper is resolved once here and never re-resolved per command.
+function _tirith_resolve_helper
+    set -l name $argv[1]
+    set -l candidate
+    for candidate in $argv[2..-1]
+        if test -f "$candidate"; and test -x "$candidate"
+            builtin printf '%s\n' "$candidate"
+            return 0
+        end
+    end
+    # `command -s` searches PATH for an external command only — never a
+    # builtin or function — so the fallback can only ever name a file.
+    set candidate (command -s $name 2>/dev/null)[1]
+    if not string match -q '/*' -- "$candidate"; or not test -f "$candidate"; or not test -x "$candidate"
+        return 1
+    end
+    builtin printf '%s\n' "$candidate"
 end
-set -g _TIRITH_RM_BIN ""
-if test -f /bin/rm; and test -x /bin/rm
-    set -g _TIRITH_RM_BIN /bin/rm
-else if test -f /usr/bin/rm; and test -x /usr/bin/rm
-    set -g _TIRITH_RM_BIN /usr/bin/rm
-end
-set -g _TIRITH_WC_BIN ""
-if test -f /usr/bin/wc; and test -x /usr/bin/wc
-    set -g _TIRITH_WC_BIN /usr/bin/wc
-else if test -f /bin/wc; and test -x /bin/wc
-    set -g _TIRITH_WC_BIN /bin/wc
-end
-set -g _TIRITH_ENV_BIN ""
-if test -f /usr/bin/env; and test -x /usr/bin/env
-    set -g _TIRITH_ENV_BIN /usr/bin/env
-else if test -f /bin/env; and test -x /bin/env
-    set -g _TIRITH_ENV_BIN /bin/env
-end
-set -g _TIRITH_SH_BIN ""
-if test -f /bin/sh; and test -x /bin/sh
-    set -g _TIRITH_SH_BIN /bin/sh
-else if test -f /usr/bin/sh; and test -x /usr/bin/sh
-    set -g _TIRITH_SH_BIN /usr/bin/sh
-end
-set -g _TIRITH_BASH_TIMEOUT_BIN ""
-if test -f /bin/bash; and test -x /bin/bash
-    set -g _TIRITH_BASH_TIMEOUT_BIN /bin/bash
-else if test -f /usr/bin/bash; and test -x /usr/bin/bash
-    set -g _TIRITH_BASH_TIMEOUT_BIN /usr/bin/bash
-end
+set -g _TIRITH_MKTEMP_BIN (_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)
+set -g _TIRITH_RM_BIN (_tirith_resolve_helper rm /bin/rm /usr/bin/rm)
+set -g _TIRITH_WC_BIN (_tirith_resolve_helper wc /usr/bin/wc /bin/wc)
+set -g _TIRITH_ENV_BIN (_tirith_resolve_helper env /usr/bin/env /bin/env)
+set -g _TIRITH_SH_BIN (_tirith_resolve_helper sh /bin/sh /usr/bin/sh)
+set -g _TIRITH_BASH_TIMEOUT_BIN (_tirith_resolve_helper bash /bin/bash /usr/bin/bash)
 set -g _TIRITH_V3_HELPERS_READY 1
 for helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
         "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN"

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -34,28 +34,36 @@ if [[ -z "$_TIRITH_BIN" || ! -x "$_TIRITH_BIN" ]]; then
 fi
 
 # Protocol-v3 callbacks run after arbitrary commands may have changed PATH.
-# Pin every external helper they use to a fixed system location now, and only
-# advertise receipt support when the complete helper set is available.
-_TIRITH_MKTEMP_BIN=""
-[[ -f /usr/bin/mktemp && -x /usr/bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/usr/bin/mktemp
-[[ -z "$_TIRITH_MKTEMP_BIN" && -f /bin/mktemp && -x /bin/mktemp ]] \
-  && _TIRITH_MKTEMP_BIN=/bin/mktemp
-_TIRITH_RM_BIN=""
-[[ -f /bin/rm && -x /bin/rm ]] && _TIRITH_RM_BIN=/bin/rm
-[[ -z "$_TIRITH_RM_BIN" && -f /usr/bin/rm && -x /usr/bin/rm ]] \
-  && _TIRITH_RM_BIN=/usr/bin/rm
-_TIRITH_WC_BIN=""
-[[ -f /usr/bin/wc && -x /usr/bin/wc ]] && _TIRITH_WC_BIN=/usr/bin/wc
-[[ -z "$_TIRITH_WC_BIN" && -f /bin/wc && -x /bin/wc ]] \
-  && _TIRITH_WC_BIN=/bin/wc
-_TIRITH_ENV_BIN=""
-[[ -f /usr/bin/env && -x /usr/bin/env ]] && _TIRITH_ENV_BIN=/usr/bin/env
-[[ -z "$_TIRITH_ENV_BIN" && -f /bin/env && -x /bin/env ]] \
-  && _TIRITH_ENV_BIN=/bin/env
-_TIRITH_SH_BIN=""
-[[ -f /bin/sh && -x /bin/sh ]] && _TIRITH_SH_BIN=/bin/sh
-[[ -z "$_TIRITH_SH_BIN" && -f /usr/bin/sh && -x /usr/bin/sh ]] \
-  && _TIRITH_SH_BIN=/usr/bin/sh
+# Pin every external helper they use to an absolute path now, and only
+# advertise receipt support when the complete helper set is available. A
+# conventional FHS location is preferred; when none exists (NixOS provides only
+# /bin/sh and /usr/bin/env), fall back to the PATH in effect while the hook is
+# sourced — the same trust already extended to _TIRITH_BIN above. Either way
+# the helper is resolved once here and never re-resolved per command.
+_tirith_resolve_helper() {
+  local name="$1" candidate
+  shift
+  for candidate in "$@"; do
+    [[ -f "$candidate" && -x "$candidate" ]] || continue
+    print -r -- "$candidate"
+    return 0
+  done
+  # `commands` holds external commands only — never a builtin, function, or
+  # alias — so the fallback can only ever name a file.
+  candidate="${commands[$name]:-}"
+  [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]] || return 1
+  print -r -- "$candidate"
+}
+_TIRITH_MKTEMP_BIN="$(_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)" \
+  || _TIRITH_MKTEMP_BIN=""
+_TIRITH_RM_BIN="$(_tirith_resolve_helper rm /bin/rm /usr/bin/rm)" \
+  || _TIRITH_RM_BIN=""
+_TIRITH_WC_BIN="$(_tirith_resolve_helper wc /usr/bin/wc /bin/wc)" \
+  || _TIRITH_WC_BIN=""
+_TIRITH_ENV_BIN="$(_tirith_resolve_helper env /usr/bin/env /bin/env)" \
+  || _TIRITH_ENV_BIN=""
+_TIRITH_SH_BIN="$(_tirith_resolve_helper sh /bin/sh /usr/bin/sh)" \
+  || _TIRITH_SH_BIN=""
 _TIRITH_V3_HELPERS_READY=1
 for _tirith_helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
   "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN"; do

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -48,9 +48,11 @@ _tirith_resolve_helper() {
     print -r -- "$candidate"
     return 0
   done
-  # `commands` holds external commands only — never a builtin, function, or
-  # alias — so the fallback can only ever name a file.
-  candidate="${commands[$name]:-}"
+  # `whence -p` performs a fresh PATH search every time: it does not consult
+  # the command hash table, which can still hold an entry for a helper that
+  # was removed or replaced since it was hashed, and it never names a
+  # builtin, function, or alias — so the fallback can only ever name a file.
+  candidate="$(builtin whence -p -- "$name")"
   [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]] || return 1
   print -r -- "$candidate"
 }

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -24,15 +24,15 @@
 
 #![cfg(unix)]
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[path = "pty_support/mod.rs"]
 mod pty_support;
 
 use pty_support::{
-    bash_major_version, count_occurrences, embedded_hook, fish_bin, modern_bash, wait_for_marker,
-    wait_for_marker_count, zsh_bin, IsolatedEnv, PtySession,
+    bash_major_version, count_occurrences, embedded_hook, fish_bin, modern_bash, tirith_bin_dir,
+    wait_for_marker, wait_for_marker_count, zsh_bin, IsolatedEnv, PtySession,
 };
 
 // Shared timings: generous for a loaded CI box yet bounded so a hung shell
@@ -1633,6 +1633,186 @@ fn zsh_protocol_v3_delivery_and_ledger_conformance() {
         "only the allowed and warned zsh lines may enter shell-boundary history"
     );
     sess.close();
+}
+
+// === pinned-helper resolution (issue #239) ===
+// The bash, zsh, and fish hooks pin their external helpers (mktemp, rm, wc, …)
+// while they are sourced: a conventional FHS path when one exists, otherwise a
+// PATH-resolved absolute path. NixOS ships neither /usr/bin/mktemp nor
+// /bin/mktemp, and without the fallback every capture file failed and every
+// command was blocked. A CI host always has the FHS paths, so these tests call
+// `_tirith_resolve_helper` directly after a non-interactive source: a private
+// executable stands in for an FHS path, nonexistent paths force the fallback.
+
+/// A private executable standing in for an FHS helper location.
+fn fake_fixed_helper(env: &IsolatedEnv) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = env.workdir.join("fixed-mktemp");
+    std::fs::write(&path, "#!/bin/sh\nexit 0\n").expect("write fixed helper");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod fixed helper");
+    path
+}
+
+/// Source the hook, then report four resolutions as `KEY=value` lines: an
+/// existing fixed path behind a missing candidate, no existing fixed path,
+/// the `printf` builtin name, and a name found nowhere. bash and zsh share
+/// this script; [`fish_helper_probe_script`] is the fish spelling.
+fn posix_helper_probe_script(hook: &Path, fixed: &Path) -> String {
+    format!(
+        "source '{hook}'\n\
+         printf 'FIXED=%s\\n' \"$(_tirith_resolve_helper mktemp /nonexistent/tirith-helper-a '{fixed}')\"\n\
+         printf 'FALLBACK=%s\\n' \"$(_tirith_resolve_helper mktemp /nonexistent/tirith-helper-a /nonexistent/tirith-helper-b)\"\n\
+         printf 'BUILTIN=%s\\n' \"$(_tirith_resolve_helper printf /nonexistent/tirith-helper-a)\"\n\
+         if out=\"$(_tirith_resolve_helper tirith-no-such-helper-7c1e /nonexistent/tirith-helper-a)\"; then \
+           printf 'MISSING=resolved\\n'; else printf 'MISSING=unresolved\\n'; fi\n\
+         printf 'MISSING_OUT=%s\\n' \"$out\"\n",
+        hook = hook.display(),
+        fixed = fixed.display(),
+    )
+}
+
+fn fish_helper_probe_script(hook: &Path, fixed: &Path) -> String {
+    format!(
+        "source '{hook}'\n\
+         printf 'FIXED=%s\\n' (_tirith_resolve_helper mktemp /nonexistent/tirith-helper-a '{fixed}')\n\
+         printf 'FALLBACK=%s\\n' (_tirith_resolve_helper mktemp /nonexistent/tirith-helper-a /nonexistent/tirith-helper-b)\n\
+         printf 'BUILTIN=%s\\n' (_tirith_resolve_helper printf /nonexistent/tirith-helper-a)\n\
+         if set out (_tirith_resolve_helper tirith-no-such-helper-7c1e /nonexistent/tirith-helper-a); \
+           printf 'MISSING=resolved\\n'; else; printf 'MISSING=unresolved\\n'; end\n\
+         printf 'MISSING_OUT=%s\\n' \"$out\"\n",
+        hook = hook.display(),
+        fixed = fixed.display(),
+    )
+}
+
+/// Run `body` through `shell` non-interactively. The freshly built tirith goes
+/// first on PATH because the zsh hook refuses to load without one.
+fn run_helper_probe(
+    env: &IsolatedEnv,
+    shell: &Path,
+    shell_args: &[&str],
+    body: &str,
+) -> std::process::Output {
+    let mut cmd = std::process::Command::new(shell);
+    cmd.args(shell_args).arg(body);
+    for (k, v) in [
+        ("HOME", env.home.display().to_string()),
+        ("XDG_STATE_HOME", env.state_home.display().to_string()),
+        ("XDG_DATA_HOME", env.data_home.display().to_string()),
+        ("XDG_CONFIG_HOME", env.config_home.display().to_string()),
+        ("TIRITH_LOG", "0".to_string()),
+    ] {
+        cmd.env(k, v);
+    }
+    let parent_path = std::env::var("PATH").unwrap_or_default();
+    cmd.env(
+        "PATH",
+        format!("{}:{parent_path}", tirith_bin_dir().display()),
+    );
+    for guard in [
+        "_TIRITH_BASH_LOADED",
+        "_TIRITH_ZSH_LOADED",
+        "_TIRITH_FISH_LOADED",
+    ] {
+        cmd.env_remove(guard);
+    }
+    cmd.current_dir(&env.workdir);
+    cmd.output().expect("run helper resolution probe")
+}
+
+fn probe_field<'a>(stdout: &'a str, key: &str) -> &'a str {
+    let prefix = format!("{key}=");
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix.as_str()))
+        .unwrap_or_else(|| panic!("helper probe output lacks {key}:\n{stdout}"))
+}
+
+fn assert_helper_resolution(label: &str, fixed: &Path, out: &std::process::Output) {
+    use std::os::unix::fs::PermissionsExt;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "{label}: helper probe must exit 0\n---- stdout ----\n{stdout}\n---- stderr ----\n{stderr}"
+    );
+    assert_eq!(
+        probe_field(&stdout, "FIXED"),
+        fixed.display().to_string(),
+        "{label}: an existing fixed path must win over PATH, after skipping a missing candidate"
+    );
+    let fallback = probe_field(&stdout, "FALLBACK");
+    let executable = std::fs::metadata(fallback)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false);
+    assert!(
+        fallback.starts_with('/') && executable,
+        "{label}: with no fixed path the helper must resolve to an absolute executable via PATH, got {fallback:?}"
+    );
+    let builtin = probe_field(&stdout, "BUILTIN");
+    assert!(
+        builtin.starts_with('/'),
+        "{label}: the PATH fallback must never yield a bare builtin name, got {builtin:?}"
+    );
+    assert_eq!(
+        probe_field(&stdout, "MISSING"),
+        "unresolved",
+        "{label}: a helper found nowhere must fail"
+    );
+    assert_eq!(
+        probe_field(&stdout, "MISSING_OUT"),
+        "",
+        "{label}: a failed resolution must print nothing"
+    );
+}
+
+#[test]
+fn bash_helper_resolution_prefers_fixed_path_and_falls_back_to_path() {
+    let bash = match modern_bash() {
+        Some(bash) => bash,
+        None => {
+            eprintln!("skipping: no modern bash (>= 5) found");
+            return;
+        }
+    };
+    let env = IsolatedEnv::new();
+    let fixed = fake_fixed_helper(&env);
+    let script = posix_helper_probe_script(&embedded_hook("bash-hook.bash"), &fixed);
+    let out = run_helper_probe(&env, &bash, &["--norc", "--noprofile", "-c"], &script);
+    assert_helper_resolution("bash", &fixed, &out);
+}
+
+#[test]
+fn zsh_helper_resolution_prefers_fixed_path_and_falls_back_to_path() {
+    let zsh = match zsh_bin() {
+        Some(zsh) => zsh,
+        None => {
+            eprintln!("skipping: zsh not installed");
+            return;
+        }
+    };
+    let env = IsolatedEnv::new();
+    let fixed = fake_fixed_helper(&env);
+    let script = posix_helper_probe_script(&embedded_hook("zsh-hook.zsh"), &fixed);
+    let out = run_helper_probe(&env, &zsh, &["-f", "-c"], &script);
+    assert_helper_resolution("zsh", &fixed, &out);
+}
+
+#[test]
+fn fish_helper_resolution_prefers_fixed_path_and_falls_back_to_path() {
+    let fish = match fish_bin() {
+        Some(fish) => fish,
+        None => {
+            eprintln!("skipping: fish not installed");
+            return;
+        }
+    };
+    let env = IsolatedEnv::new();
+    let fixed = fake_fixed_helper(&env);
+    let script = fish_helper_probe_script(&embedded_hook("fish-hook.fish"), &fixed);
+    let out = run_helper_probe(&env, &fish, &["--no-config", "-c"], &script);
+    assert_helper_resolution("fish", &fixed, &out);
 }
 
 // === PowerShell / nushell follow-up stubs ===

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -1799,6 +1799,58 @@ fn zsh_helper_resolution_prefers_fixed_path_and_falls_back_to_path() {
     assert_helper_resolution("zsh", &fixed, &out);
 }
 
+/// zsh caches command lookups in its hash table, and `${commands[name]}`
+/// keeps reporting the cached path after the helper behind it is removed or
+/// replaced. Plant such an entry for a helper that really exists on PATH and
+/// check the resolver still returns the live absolute path. The entry must be
+/// planted after the PATH change, because assigning `path` empties the table.
+#[test]
+fn zsh_helper_resolution_ignores_stale_command_hash() {
+    use std::os::unix::fs::PermissionsExt;
+    let zsh = match zsh_bin() {
+        Some(zsh) => zsh,
+        None => {
+            eprintln!("skipping: zsh not installed");
+            return;
+        }
+    };
+    let env = IsolatedEnv::new();
+    let name = "tirith-stale-helper-91af";
+    let helper_dir = env.workdir.join("stale-helper-bin");
+    std::fs::create_dir_all(&helper_dir).expect("create helper dir");
+    let helper = helper_dir.join(name);
+    std::fs::write(&helper, "#!/bin/sh\nexit 0\n").expect("write helper");
+    std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod helper");
+    let stale = format!("/nonexistent/{name}");
+    let script = format!(
+        "source '{hook}'\n\
+         path=('{dir}' $path)\n\
+         hash {name}='{stale}'\n\
+         printf 'CACHED=%s\\n' \"${{commands[{name}]}}\"\n\
+         printf 'STALE=%s\\n' \"$(_tirith_resolve_helper {name} /nonexistent/tirith-helper-a)\"\n",
+        hook = embedded_hook("zsh-hook.zsh").display(),
+        dir = helper_dir.display(),
+    );
+    let out = run_helper_probe(&env, &zsh, &["-f", "-c"], &script);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "zsh: stale-hash probe must exit 0\n---- stdout ----\n{stdout}\n---- stderr ----\n{stderr}"
+    );
+    assert_eq!(
+        probe_field(&stdout, "CACHED"),
+        stale,
+        "zsh: the probe must plant a stale hash entry, otherwise it proves nothing"
+    );
+    assert_eq!(
+        probe_field(&stdout, "STALE"),
+        helper.display().to_string(),
+        "zsh: a stale hash entry must not hide a helper that is live on PATH"
+    );
+}
+
 #[test]
 fn fish_helper_resolution_prefers_fixed_path_and_falls_back_to_path() {
     let fish = match fish_bin() {

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -125,21 +125,32 @@ fi
 # long-lived interactive shell) Tirith's parent. Capture Tirith stdout in a
 # private temporary file instead: Tirith remains a direct child, parsing happens
 # in this shell, and every caller removes the file immediately.
-_TIRITH_MKTEMP_BIN=""
-[[ -f /usr/bin/mktemp && -x /usr/bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/usr/bin/mktemp
-[[ -z "$_TIRITH_MKTEMP_BIN" && -f /bin/mktemp && -x /bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/bin/mktemp
-_TIRITH_RM_BIN=""
-[[ -f /bin/rm && -x /bin/rm ]] && _TIRITH_RM_BIN=/bin/rm
-[[ -z "$_TIRITH_RM_BIN" && -f /usr/bin/rm && -x /usr/bin/rm ]] && _TIRITH_RM_BIN=/usr/bin/rm
-_TIRITH_MKDIR_BIN=""
-[[ -f /bin/mkdir && -x /bin/mkdir ]] && _TIRITH_MKDIR_BIN=/bin/mkdir
-[[ -z "$_TIRITH_MKDIR_BIN" && -f /usr/bin/mkdir && -x /usr/bin/mkdir ]] && _TIRITH_MKDIR_BIN=/usr/bin/mkdir
-_TIRITH_WC_BIN=""
-[[ -f /usr/bin/wc && -x /usr/bin/wc ]] && _TIRITH_WC_BIN=/usr/bin/wc
-[[ -z "$_TIRITH_WC_BIN" && -f /bin/wc && -x /bin/wc ]] && _TIRITH_WC_BIN=/bin/wc
-_TIRITH_STTY_BIN=""
-[[ -f /bin/stty && -x /bin/stty ]] && _TIRITH_STTY_BIN=/bin/stty
-[[ -z "$_TIRITH_STTY_BIN" && -f /usr/bin/stty && -x /usr/bin/stty ]] && _TIRITH_STTY_BIN=/usr/bin/stty
+#
+# Every external helper below is pinned to an absolute path while the hook is
+# sourced, so a later PATH change cannot swap it. A conventional FHS location is
+# preferred; when none exists (NixOS provides only /bin/sh and /usr/bin/env),
+# fall back to the PATH in effect now — the same trust already extended to
+# _TIRITH_BIN above. `type -P` only ever names a file, never a builtin,
+# function, or alias; the absolute-path check rejects a relative PATH entry.
+# The callers below test these variables with `-n` only, so this function is
+# the sole guarantee that a non-empty value is an absolute executable.
+_tirith_resolve_helper() {
+  local name="$1" candidate
+  shift
+  for candidate in "$@"; do
+    [[ -f "$candidate" && -x "$candidate" ]] || continue
+    builtin printf '%s\n' "$candidate"
+    return 0
+  done
+  candidate="$(builtin type -P -- "$name" 2>/dev/null)" || return 1
+  [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]] || return 1
+  builtin printf '%s\n' "$candidate"
+}
+_TIRITH_MKTEMP_BIN="$(_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)" || _TIRITH_MKTEMP_BIN=""
+_TIRITH_RM_BIN="$(_tirith_resolve_helper rm /bin/rm /usr/bin/rm)" || _TIRITH_RM_BIN=""
+_TIRITH_MKDIR_BIN="$(_tirith_resolve_helper mkdir /bin/mkdir /usr/bin/mkdir)" || _TIRITH_MKDIR_BIN=""
+_TIRITH_WC_BIN="$(_tirith_resolve_helper wc /usr/bin/wc /bin/wc)" || _TIRITH_WC_BIN=""
+_TIRITH_STTY_BIN="$(_tirith_resolve_helper stty /bin/stty /usr/bin/stty)" || _TIRITH_STTY_BIN=""
 
 _tirith_new_capture_file() {
   [[ -n "$_TIRITH_MKTEMP_BIN" && -n "$_TIRITH_RM_BIN" ]] || return 1

--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -31,44 +31,35 @@ if not string match -q '/*' -- "$_TIRITH_BIN"; or not test -x "$_TIRITH_BIN"
 end
 
 # Protocol-v3 callbacks run after arbitrary commands may have changed PATH.
-# Pin every external helper they use to a fixed system location now, and only
-# advertise receipt support when the complete helper set is available.
-set -g _TIRITH_MKTEMP_BIN ""
-if test -f /usr/bin/mktemp; and test -x /usr/bin/mktemp
-    set -g _TIRITH_MKTEMP_BIN /usr/bin/mktemp
-else if test -f /bin/mktemp; and test -x /bin/mktemp
-    set -g _TIRITH_MKTEMP_BIN /bin/mktemp
+# Pin every external helper they use to an absolute path now, and only
+# advertise receipt support when the complete helper set is available. A
+# conventional FHS location is preferred; when none exists (NixOS provides only
+# /bin/sh and /usr/bin/env), fall back to the PATH in effect while the hook is
+# sourced — the same trust already extended to _TIRITH_BIN above. Either way
+# the helper is resolved once here and never re-resolved per command.
+function _tirith_resolve_helper
+    set -l name $argv[1]
+    set -l candidate
+    for candidate in $argv[2..-1]
+        if test -f "$candidate"; and test -x "$candidate"
+            builtin printf '%s\n' "$candidate"
+            return 0
+        end
+    end
+    # `command -s` searches PATH for an external command only — never a
+    # builtin or function — so the fallback can only ever name a file.
+    set candidate (command -s $name 2>/dev/null)[1]
+    if not string match -q '/*' -- "$candidate"; or not test -f "$candidate"; or not test -x "$candidate"
+        return 1
+    end
+    builtin printf '%s\n' "$candidate"
 end
-set -g _TIRITH_RM_BIN ""
-if test -f /bin/rm; and test -x /bin/rm
-    set -g _TIRITH_RM_BIN /bin/rm
-else if test -f /usr/bin/rm; and test -x /usr/bin/rm
-    set -g _TIRITH_RM_BIN /usr/bin/rm
-end
-set -g _TIRITH_WC_BIN ""
-if test -f /usr/bin/wc; and test -x /usr/bin/wc
-    set -g _TIRITH_WC_BIN /usr/bin/wc
-else if test -f /bin/wc; and test -x /bin/wc
-    set -g _TIRITH_WC_BIN /bin/wc
-end
-set -g _TIRITH_ENV_BIN ""
-if test -f /usr/bin/env; and test -x /usr/bin/env
-    set -g _TIRITH_ENV_BIN /usr/bin/env
-else if test -f /bin/env; and test -x /bin/env
-    set -g _TIRITH_ENV_BIN /bin/env
-end
-set -g _TIRITH_SH_BIN ""
-if test -f /bin/sh; and test -x /bin/sh
-    set -g _TIRITH_SH_BIN /bin/sh
-else if test -f /usr/bin/sh; and test -x /usr/bin/sh
-    set -g _TIRITH_SH_BIN /usr/bin/sh
-end
-set -g _TIRITH_BASH_TIMEOUT_BIN ""
-if test -f /bin/bash; and test -x /bin/bash
-    set -g _TIRITH_BASH_TIMEOUT_BIN /bin/bash
-else if test -f /usr/bin/bash; and test -x /usr/bin/bash
-    set -g _TIRITH_BASH_TIMEOUT_BIN /usr/bin/bash
-end
+set -g _TIRITH_MKTEMP_BIN (_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)
+set -g _TIRITH_RM_BIN (_tirith_resolve_helper rm /bin/rm /usr/bin/rm)
+set -g _TIRITH_WC_BIN (_tirith_resolve_helper wc /usr/bin/wc /bin/wc)
+set -g _TIRITH_ENV_BIN (_tirith_resolve_helper env /usr/bin/env /bin/env)
+set -g _TIRITH_SH_BIN (_tirith_resolve_helper sh /bin/sh /usr/bin/sh)
+set -g _TIRITH_BASH_TIMEOUT_BIN (_tirith_resolve_helper bash /bin/bash /usr/bin/bash)
 set -g _TIRITH_V3_HELPERS_READY 1
 for helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
         "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN"

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -34,28 +34,36 @@ if [[ -z "$_TIRITH_BIN" || ! -x "$_TIRITH_BIN" ]]; then
 fi
 
 # Protocol-v3 callbacks run after arbitrary commands may have changed PATH.
-# Pin every external helper they use to a fixed system location now, and only
-# advertise receipt support when the complete helper set is available.
-_TIRITH_MKTEMP_BIN=""
-[[ -f /usr/bin/mktemp && -x /usr/bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/usr/bin/mktemp
-[[ -z "$_TIRITH_MKTEMP_BIN" && -f /bin/mktemp && -x /bin/mktemp ]] \
-  && _TIRITH_MKTEMP_BIN=/bin/mktemp
-_TIRITH_RM_BIN=""
-[[ -f /bin/rm && -x /bin/rm ]] && _TIRITH_RM_BIN=/bin/rm
-[[ -z "$_TIRITH_RM_BIN" && -f /usr/bin/rm && -x /usr/bin/rm ]] \
-  && _TIRITH_RM_BIN=/usr/bin/rm
-_TIRITH_WC_BIN=""
-[[ -f /usr/bin/wc && -x /usr/bin/wc ]] && _TIRITH_WC_BIN=/usr/bin/wc
-[[ -z "$_TIRITH_WC_BIN" && -f /bin/wc && -x /bin/wc ]] \
-  && _TIRITH_WC_BIN=/bin/wc
-_TIRITH_ENV_BIN=""
-[[ -f /usr/bin/env && -x /usr/bin/env ]] && _TIRITH_ENV_BIN=/usr/bin/env
-[[ -z "$_TIRITH_ENV_BIN" && -f /bin/env && -x /bin/env ]] \
-  && _TIRITH_ENV_BIN=/bin/env
-_TIRITH_SH_BIN=""
-[[ -f /bin/sh && -x /bin/sh ]] && _TIRITH_SH_BIN=/bin/sh
-[[ -z "$_TIRITH_SH_BIN" && -f /usr/bin/sh && -x /usr/bin/sh ]] \
-  && _TIRITH_SH_BIN=/usr/bin/sh
+# Pin every external helper they use to an absolute path now, and only
+# advertise receipt support when the complete helper set is available. A
+# conventional FHS location is preferred; when none exists (NixOS provides only
+# /bin/sh and /usr/bin/env), fall back to the PATH in effect while the hook is
+# sourced — the same trust already extended to _TIRITH_BIN above. Either way
+# the helper is resolved once here and never re-resolved per command.
+_tirith_resolve_helper() {
+  local name="$1" candidate
+  shift
+  for candidate in "$@"; do
+    [[ -f "$candidate" && -x "$candidate" ]] || continue
+    print -r -- "$candidate"
+    return 0
+  done
+  # `commands` holds external commands only — never a builtin, function, or
+  # alias — so the fallback can only ever name a file.
+  candidate="${commands[$name]:-}"
+  [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]] || return 1
+  print -r -- "$candidate"
+}
+_TIRITH_MKTEMP_BIN="$(_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)" \
+  || _TIRITH_MKTEMP_BIN=""
+_TIRITH_RM_BIN="$(_tirith_resolve_helper rm /bin/rm /usr/bin/rm)" \
+  || _TIRITH_RM_BIN=""
+_TIRITH_WC_BIN="$(_tirith_resolve_helper wc /usr/bin/wc /bin/wc)" \
+  || _TIRITH_WC_BIN=""
+_TIRITH_ENV_BIN="$(_tirith_resolve_helper env /usr/bin/env /bin/env)" \
+  || _TIRITH_ENV_BIN=""
+_TIRITH_SH_BIN="$(_tirith_resolve_helper sh /bin/sh /usr/bin/sh)" \
+  || _TIRITH_SH_BIN=""
 _TIRITH_V3_HELPERS_READY=1
 for _tirith_helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
   "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN"; do

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -48,9 +48,11 @@ _tirith_resolve_helper() {
     print -r -- "$candidate"
     return 0
   done
-  # `commands` holds external commands only — never a builtin, function, or
-  # alias — so the fallback can only ever name a file.
-  candidate="${commands[$name]:-}"
+  # `whence -p` performs a fresh PATH search every time: it does not consult
+  # the command hash table, which can still hold an entry for a helper that
+  # was removed or replaced since it was hashed, and it never names a
+  # builtin, function, or alias — so the fallback can only ever name a file.
+  candidate="$(builtin whence -p -- "$name")"
   [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]] || return 1
   print -r -- "$candidate"
 }


### PR DESCRIPTION
## Summary

Refs #239.

On NixOS the bash, zsh, and fish hooks never found `mktemp`, `rm`, `wc` (and friends) because each helper was pinned to `/usr/bin` or `/bin` only, and NixOS provides just `/bin/sh` and `/usr/bin/env`. Every private capture file therefore failed to be created: the zsh and fish hooks blocked every command (`tirith: secure preflight capture unavailable; command blocked`), and the bash hook lost receipt registration and enter mode. 0.3.3 was unaffected because it had no pinned helpers.

## Changes

- Each hook gains a small `_tirith_resolve_helper <name> <fixed-path>...`. The FHS candidates are tried first, in the same order as before; only when none exists does it fall back to the PATH in effect while the hook is sourced (zsh `whence -p`, bash `type -P`, fish `command -s`). The result must be an absolute executable, and it is pinned for the session exactly as before.
- bash uses `type -P` rather than `command -v`: `command -v printf` returns the bare builtin name, while `type -P` only ever names a file. The bash callers test these variables with `-n` alone, so the resolver is the single place that guarantees a non-empty value is an absolute executable; the `== /*` check also rejects a relative PATH entry.
- The "pin to a fixed system location" comments are updated to describe the fallback. `crates/tirith/assets/shell/lib/` is synced (`embedded_shell_hooks_match_repo_hooks` passes).
- New tests `{bash,zsh,fish}_helper_resolution_prefers_fixed_path_and_falls_back_to_path` in `shell_conformance.rs`: each sources its hook non-interactively and checks that an existing fixed path wins over PATH after a missing candidate is skipped, that a nonexistent fixed set falls back to an absolute executable from PATH, that the fallback never yields a bare builtin name, and that a name found nowhere fails with empty output. The test fails against the unpatched hooks.

## Why this does not weaken the pin

- FHS hosts (Debian, Ubuntu, macOS, ...) resolve exactly the same binaries as before; the fallback only runs when no FHS candidate exists.
- The fallback is evaluated once, when the hook is sourced, which is the same trust the hooks already place in `_TIRITH_BIN` (`zsh-hook.zsh:26`, `bash-hook.bash:104`, `fish-hook.fish:23`). Nothing is re-resolved per command.

## Verification

On NixOS (the affected host):

- The new helper-resolution test passes for bash, zsh, and fish.
- fish PTY conformance passes. bash PTY conformance and `bash_hook_exports` pass with a readline-enabled bash first on PATH (the Nix dev-shell bash is built without readline, so enter mode degrades there regardless of this change).
- The zsh PTY conformance tests cannot run on this host: NixOS's `/etc/zshenv` resets PATH under the harness's `env_clear`, so the hook cannot find `tirith` at all (also on `main`). zsh was verified with a manual PTY probe instead: with this branch `_TIRITH_RECEIPT_PROTOCOL=3`, `TIRITH_STATUS=blocks`, and a typed command is delivered; with `main` the shell prints `secure preflight capture unavailable; command blocked` and nothing runs. CI is the authority for the zsh PTY tests.
- `cargo fmt --check` clean. `cargo clippy -p tirith --all-targets -D warnings` clean apart from four pre-existing `nonminimal_bool` findings in `tirith-core` under the clippy 1.92 available here.

## Out of scope

- The fail-closed structure itself (capture failure → block) is unchanged. Whether a capture failure should fall back to `running unprotected` like the unexpected-rc path already does is a design decision; I will leave that as a proposal on #239.
- `bash-hook.bash`'s `/usr/bin/printf` in the bootstrap-failure branch: builtin identity is untrusted there, so PATH resolution is not an option.
- `scripts/install.sh` still assumes `/usr/bin/tar`, `/usr/bin/sha256sum`, `/usr/bin/mktemp`; NixOS users install via nixpkgs, so it is unrelated to this failure.
- Test-host FHS assumptions (`#!/bin/bash` in the fake tirith of `bash_preexec_enforce.rs`, `/bin/bash` in the `commands_warn_*` tests) make those suites fail on NixOS on `main` too; worth a follow-up, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62206247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/my-company-org-6010/-/pull-requests/sheeki03/tirith/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because zsh can still leave required helpers unresolved despite their availability on the current PATH.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Stale helper path** <a href="https://github.com/sheeki03/tirith/pull/241#discussion_r3971152125">▶</a>

<details><summary><h3>Summary</h3></summary>

- Adds equivalent resolvers for Bash, zsh, and Fish and synchronizes their embedded copies.
- Adds conformance probes covering fixed-path preference, external PATH fallback, builtin rejection, and missing helpers.
- The zsh implementation can incorrectly reject an available helper when its command-hash entry is stale.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Hook is sourced] --> B{Fixed FHS helper exists?}
  B -->|Yes| C[Pin fixed absolute path]
  B -->|No| D[Resolve from source-time PATH]
  D --> E{Absolute executable?}
  E -->|Yes| F[Pin helper for session]
  E -->|No| G[Mark helper unavailable]
  F --> H[Enable capture and protocol-v3 support]
  G --> I[Disable helper readiness or capture]
```
</details>

<!-- /greptile_comment -->
