### PR TITLE
Fix shell receipt activation, database reloads, and costly runtime paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
         run: node tests/openclaw-shell-resolver.mjs
       - name: IPython execution-vector extraction contract
         run: node tests/ipython-vector-extraction.mjs
+      - name: npm launcher exit and signal contract
+        run: node tests/npm-launcher.mjs
       - name: Install interactive shell conformance dependencies
         if: matrix.name == 'Linux'
         run: sudo apt-get update && sudo apt-get install --yes fish zsh

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,6 +7,14 @@ on:
   workflow_dispatch:
   workflow_call:
 
+# Replace only superseded PR checks. Other events get a unique run group so
+# neither running nor pending scheduled, dispatched, or release-gate work is
+# replaced. The file-specific prefix also separates this reusable workflow
+# from its Release caller, whose github.workflow value it inherits.
+concurrency:
+  group: fuzz-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ on:
   # option could enable publication and offering one would only imply otherwise.
   workflow_dispatch:
 
+# Replace only superseded PR validation. Tag pushes and manual dispatches keep
+# distinct run groups, including their pending jobs and publication gates.
+# Keep this prefix distinct from the reusable Fuzz workflow's group.
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Shell initialization binds Bash, zsh, and fish hooks to the running native executable, so npm and other process-spawning launchers no longer prevent strict receipt registration. The npm launcher also preserves signal termination instead of reporting success.
+- On Unix, shell initialization binds Bash, zsh, and fish hooks to the running native executable, so npm and other process-spawning launchers no longer prevent strict receipt registration. Other platforms retain shell PATH resolution. The npm launcher also preserves signal termination instead of reporting success.
 - Sourcing `shell/tirith.sh` locates its own directory correctly in Bash and zsh, including installations with spaces or apostrophes in the path.
 - Long-running processes detect ThreatDB replacements within the same second and changes to the selected database path. Reloads retain signature verification and rollback protection.
 - Trial subscriptions can refresh license tokens, consistently with the database's authorization checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recent-log commands seek backward through a bounded suffix instead of parsing the entire audit history. Both the inspected bytes and individual line lengths are capped.
 - Bash prompt callbacks avoid unnecessary history capture subprocesses while preserving typed-command and history-change checks.
 - Legacy session correlation reuses one privacy-projected event window when expiring warning markers, avoiding repeated redaction of every event for each retained signature.
+- Fuzz and packaging workflows cancel superseded pull-request checks so current changes reach runners sooner. Release-tag and other non-PR runs remain independent.
 
 ## [0.4.1] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command analysis compiles custom rules once per request and only redacts diagnostic rule IDs when a warning is emitted. The per-thread DSL regex cache has a bounded number of retained entries.
 - Recent-log commands seek backward through a bounded suffix instead of parsing the entire audit history. Both the inspected bytes and individual line lengths are capped.
 - Bash prompt callbacks avoid unnecessary history capture subprocesses while preserving typed-command and history-change checks.
+- Legacy session correlation reuses one privacy-projected event window when expiring warning markers, avoiding repeated redaction of every event for each retained signature.
 
 ## [0.4.1] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Shell initialization binds Bash, zsh, and fish hooks to the running native executable, so npm and other process-spawning launchers no longer prevent strict receipt registration. The npm launcher also preserves signal termination instead of reporting success.
+- Sourcing `shell/tirith.sh` locates its own directory correctly in Bash and zsh, including installations with spaces or apostrophes in the path.
+- Long-running processes detect ThreatDB replacements within the same second and changes to the selected database path. Reloads retain signature verification and rollback protection.
+- Trial subscriptions can refresh license tokens, consistently with the database's authorization checks.
+- Daemon enrichment uses the same resolved policy as initial analysis, avoiding inconsistent decisions when configuration changes during a request.
+- Recent-log diagnostics report when older history was not searched. `explain` provides usable guidance for finding entries outside that window.
+
+### Performance
+
+- Legacy ThreatDB lookups for npm, RubyGems, Go, and Maven use the sorted package index directly. Registries with spelling aliases retain canonical lookup behavior.
+- Command analysis compiles custom rules once per request and only redacts diagnostic rule IDs when a warning is emitted. The per-thread DSL regex cache has a bounded number of retained entries.
+- Recent-log commands seek backward through a bounded suffix instead of parsing the entire audit history. Both the inspected bytes and individual line lengths are capped.
+- Bash prompt callbacks avoid unnecessary history capture subprocesses while preserving typed-command and history-change checks.
+
 ## [0.4.1] - 2026-09-02
 
 ### Added

--- a/crates/tirith-core/src/audit_aggregator.rs
+++ b/crates/tirith-core/src/audit_aggregator.rs
@@ -115,7 +115,10 @@ pub struct HookStats {
 /// Result of reading an audit log, including accounting for skipped lines.
 pub struct ReadLogResult {
     pub records: Vec<AuditRecord>,
+    /// Malformed JSON lines in the portion actually inspected.
     pub skipped_lines: usize,
+    /// Older history was not inspected because a tail limit was reached.
+    pub truncated: bool,
 }
 
 /// Read and parse all records from a JSONL audit log, STREAMING line-by-line via
@@ -130,38 +133,139 @@ pub fn read_log(path: &Path) -> Result<ReadLogResult, String> {
     parse_log_from_reader(reader, Some(path))
 }
 
-/// repo-0479/0480/0481: bounded variant for diagnostic consumers — keeps only
-/// the NEWEST `max_records` parsed records, so a huge or attacker-inflated
-/// audit log cannot hang or OOM `doctor`, `explain`, or `incident`.
+const AUDIT_TAIL_BYTES: u64 = 16 * 1024 * 1024;
+const AUDIT_TAIL_LINE_BYTES: usize = 1024 * 1024;
+const AUDIT_TAIL_LINES: usize = 100_000;
+const AUDIT_TAIL_CHUNK_BYTES: usize = 64 * 1024;
+
+/// Read the newest `max_records` valid records, returned in file order.
+///
+/// Diagnostic consumers inspect at most 16 MiB / 100,000 physical lines from
+/// the end of a regular file, stopping as soon as enough records are found.
+/// Individual lines are limited to 1 MiB, matching the audit writer. Malformed
+/// JSON is warned about and skipped; invalid UTF-8 and read errors are terminal.
+/// Only the inspected suffix contributes to `skipped_lines`. When a limit leaves
+/// older history unread, `truncated` and a stderr warning report partial coverage.
+/// The input is never modified. Concurrent appends are deferred to the next read.
 pub fn read_log_tail(path: &Path, max_records: usize) -> Result<ReadLogResult, String> {
-    let file =
-        std::fs::File::open(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
-    let reader = std::io::BufReader::new(file);
-    let mut records: std::collections::VecDeque<AuditRecord> =
-        std::collections::VecDeque::with_capacity(max_records.min(1024));
-    let mut skipped_lines = 0usize;
-    for (idx, line) in reader.lines().enumerate() {
-        let line_num = idx + 1;
-        match line {
-            Ok(line) => {
-                let mut one = Vec::new();
-                parse_log_line(&line, line_num, Some(path), &mut one, &mut skipped_lines);
-                if let Some(record) = one.into_iter().next() {
-                    if records.len() >= max_records {
-                        records.pop_front();
-                    }
-                    records.push_back(record);
+    // Allow arbitrarily large history while rejecting FIFOs/devices before a
+    // blocking read. The bound applies to bytes read, not the file's total size.
+    let mut file = crate::util::open_regular_capped(path, u64::MAX)
+        .map_err(|e| format!("Failed to read {}: {e:?}", path.display()))?;
+    let result = read_log_tail_from_reader(&mut file, max_records, Some(path))
+        .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    if result.truncated {
+        eprintln!(
+            "tirith: warning: audit history in {} was limited to its recent tail \
+             ({} records; at most {max_records} records, 16 MiB, or {AUDIT_TAIL_LINES} lines); \
+             older history was not inspected",
+            path.display(),
+            result.records.len(),
+        );
+    }
+    Ok(result)
+}
+
+fn read_log_tail_from_reader(
+    reader: &mut (impl std::io::Read + std::io::Seek),
+    max_records: usize,
+    source: Option<&Path>,
+) -> std::io::Result<ReadLogResult> {
+    use std::io::SeekFrom;
+
+    let end = reader.seek(SeekFrom::End(0))?;
+    let mut result = ReadLogResult {
+        records: Vec::with_capacity(max_records.min(1024)),
+        skipped_lines: 0,
+        truncated: false,
+    };
+    if max_records == 0 {
+        result.truncated = end != 0;
+        return Ok(result);
+    }
+
+    let start = end.saturating_sub(AUDIT_TAIL_BYTES);
+    let mut position = end;
+    let mut buffer = Vec::new();
+    let mut lines = 0;
+    while position > start {
+        let size = (position - start).min(AUDIT_TAIL_CHUNK_BYTES as u64) as usize;
+        position -= size as u64;
+        // Carry only the incomplete line at the beginning of the last chunk.
+        // Complete lines are parsed directly from slices, without copying or
+        // reversing every byte in ordinary audit records.
+        let carried = buffer.len();
+        buffer.resize(size + carried, 0);
+        buffer.copy_within(..carried, size);
+        reader.seek(SeekFrom::Start(position))?;
+        // A concurrent truncate is an error, rather than accepting a partial
+        // read or spinning. Reads never extend beyond the initial EOF snapshot.
+        reader.read_exact(&mut buffer[..size])?;
+        let mut remaining = buffer.len();
+        while let Some(index) = buffer[..remaining].iter().rposition(|&byte| byte == b'\n') {
+            let offset = position + index as u64;
+            // A final newline terminates the preceding physical line; it
+            // does not create an extra empty line after EOF.
+            if offset + 1 != end {
+                parse_tail_line(
+                    &buffer[index + 1..remaining],
+                    offset + 1,
+                    source,
+                    &mut result,
+                )?;
+                lines += 1;
+                if result.records.len() == max_records || lines == AUDIT_TAIL_LINES {
+                    result.truncated = offset != 0;
+                    result.records.reverse();
+                    return Ok(result);
                 }
             }
-            Err(e) => {
-                return Err(format!("Failed to read {}: {e}", path.display()));
-            }
+            remaining = index;
+        }
+        buffer.truncate(remaining);
+        if buffer.len() > AUDIT_TAIL_LINE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "audit line exceeds 1 MiB limit",
+            ));
         }
     }
-    Ok(ReadLogResult {
-        records: records.into_iter().collect(),
-        skipped_lines,
-    })
+
+    if start == 0 {
+        parse_tail_line(&buffer, 0, source, &mut result)?;
+    } else {
+        // The byte budget may end inside a line. Do not parse a fragment as a
+        // record or report it as malformed JSON.
+        result.truncated = true;
+    }
+    result.records.reverse();
+    Ok(result)
+}
+
+fn parse_tail_line(
+    line: &[u8],
+    offset: u64,
+    source: Option<&Path>,
+    result: &mut ReadLogResult,
+) -> std::io::Result<()> {
+    if line.len() > AUDIT_TAIL_LINE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "audit line exceeds 1 MiB limit",
+        ));
+    }
+    let line = std::str::from_utf8(line)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    // Absolute line numbers require scanning all older history. The known byte
+    // offset locates malformed tail records without that unbounded scan.
+    parse_log_line(
+        line,
+        format_args!("at byte {offset}"),
+        source,
+        &mut result.records,
+        &mut result.skipped_lines,
+    );
+    Ok(())
 }
 
 /// Streaming counterpart of [`parse_log`]: pulls one line at a time from
@@ -193,6 +297,7 @@ pub fn parse_log_from_reader(
     Ok(ReadLogResult {
         records,
         skipped_lines,
+        truncated: false,
     })
 }
 
@@ -208,6 +313,7 @@ pub fn parse_log(content: &str, source: Option<&Path>) -> ReadLogResult {
     ReadLogResult {
         records,
         skipped_lines,
+        truncated: false,
     }
 }
 
@@ -215,7 +321,7 @@ pub fn parse_log(content: &str, source: Option<&Path>) -> ReadLogResult {
 /// Shared by [`parse_log`] and [`parse_log_from_reader`] for identical results.
 fn parse_log_line(
     line: &str,
-    line_num: usize,
+    line_num: impl std::fmt::Display,
     source: Option<&Path>,
     records: &mut Vec<AuditRecord>,
     skipped_lines: &mut usize,
@@ -235,7 +341,11 @@ fn parse_log_line(
 
 /// One-line stderr warning for a skipped audit line, shared so both paths emit
 /// identical text.
-fn warn_malformed_line(line_num: usize, source: Option<&Path>, e: &dyn std::fmt::Display) {
+fn warn_malformed_line(
+    line_num: impl std::fmt::Display,
+    source: Option<&Path>,
+    e: &dyn std::fmt::Display,
+) {
     match source {
         Some(path) => eprintln!(
             "tirith: warning: skipping malformed audit line {} in {}: {e}",
@@ -754,6 +864,183 @@ fn html_escape(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn tail_record(id: &str, command: &str) -> String {
+        serde_json::json!({
+            "timestamp": "2026-09-11T00:00:00Z",
+            "action": "Block",
+            "event_id": id,
+            "command_redacted": command,
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn tail_preserves_order_and_skips_only_inspected_malformed_lines() {
+        let a = tail_record("a", "");
+        let b = tail_record("b", "");
+        let c = tail_record("c", "");
+        for ending in ["", "\n", "\r\n"] {
+            let content = format!("old invalid JSON\n{a}\r\n{b}\n\ninvalid JSON\r\n{c}{ending}");
+            let mut reader = std::io::Cursor::new(content.as_bytes());
+            let tail = read_log_tail_from_reader(&mut reader, 2, None).unwrap();
+            assert_eq!(tail.records.len(), 2);
+            assert_eq!(tail.records[0].event_id.as_deref(), Some("b"));
+            assert_eq!(tail.records[1].event_id.as_deref(), Some("c"));
+            assert_eq!(tail.skipped_lines, 1);
+            assert!(tail.truncated);
+
+            let tail = read_log_tail_from_reader(&mut reader, 10, None).unwrap();
+            let full = parse_log(&content, None);
+            assert_eq!(export_json(&tail.records), export_json(&full.records));
+            assert_eq!(tail.skipped_lines, full.skipped_lines);
+            assert!(!tail.truncated);
+        }
+    }
+
+    #[test]
+    fn tail_handles_empty_zero_and_exact_record_limits() {
+        for content in [String::new(), "\n\r\n".into()] {
+            let tail =
+                read_log_tail_from_reader(&mut std::io::Cursor::new(content), 1, None).unwrap();
+            assert!(tail.records.is_empty());
+            assert!(!tail.truncated);
+        }
+        let content = format!("{}\n", tail_record("only", ""));
+        let mut reader = std::io::Cursor::new(content);
+        let zero = read_log_tail_from_reader(&mut reader, 0, None).unwrap();
+        assert!(zero.records.is_empty());
+        assert!(zero.truncated);
+        let one = read_log_tail_from_reader(&mut reader, 1, None).unwrap();
+        assert_eq!(one.records.len(), 1);
+        assert!(!one.truncated);
+    }
+
+    struct CountedReader {
+        inner: std::io::Cursor<Vec<u8>>,
+        bytes_read: usize,
+    }
+
+    impl std::io::Read for CountedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let count = std::io::Read::read(&mut self.inner, buffer)?;
+            self.bytes_read += count;
+            Ok(count)
+        }
+    }
+
+    impl std::io::Seek for CountedReader {
+        fn seek(&mut self, position: std::io::SeekFrom) -> std::io::Result<u64> {
+            std::io::Seek::seek(&mut self.inner, position)
+        }
+    }
+
+    #[test]
+    fn tail_reads_only_recent_chunks_independent_of_history_size() {
+        let suffix = format!("{}\n{}\n", tail_record("b", ""), tail_record("c", ""));
+        for history_size in [AUDIT_TAIL_CHUNK_BYTES, 10 * AUDIT_TAIL_CHUNK_BYTES] {
+            let mut bytes = vec![b'x'; history_size];
+            bytes.push(b'\n');
+            bytes.extend_from_slice(suffix.as_bytes());
+            let mut reader = CountedReader {
+                inner: std::io::Cursor::new(bytes),
+                bytes_read: 0,
+            };
+            let tail = read_log_tail_from_reader(&mut reader, 2, None).unwrap();
+            assert_eq!(tail.records.len(), 2);
+            assert_eq!(tail.skipped_lines, 0);
+            assert!(tail.truncated);
+            assert_eq!(reader.bytes_read, AUDIT_TAIL_CHUNK_BYTES);
+        }
+    }
+
+    #[test]
+    fn tail_reassembles_unicode_lines_across_chunk_boundaries() {
+        let command = "é🦀".repeat(AUDIT_TAIL_CHUNK_BYTES / 3);
+        let content = format!("{}\r\n", tail_record("unicode", &command));
+        let tail = read_log_tail_from_reader(&mut std::io::Cursor::new(content), 1, None).unwrap();
+        assert_eq!(tail.records[0].command_redacted, command);
+        assert!(!tail.truncated);
+    }
+
+    #[test]
+    fn tail_byte_limit_discards_partial_record_without_counting_it_malformed() {
+        let line = format!("{}\n", tail_record("large", &"x".repeat(1024)));
+        let count = AUDIT_TAIL_BYTES as usize / line.len() + 2;
+        let mut reader = CountedReader {
+            inner: std::io::Cursor::new(line.repeat(count).into_bytes()),
+            bytes_read: 0,
+        };
+        let tail = read_log_tail_from_reader(&mut reader, usize::MAX, None).unwrap();
+        assert!(tail.truncated);
+        assert_eq!(tail.skipped_lines, 0);
+        assert_eq!(tail.records.len(), AUDIT_TAIL_BYTES as usize / line.len());
+        assert_eq!(reader.bytes_read, AUDIT_TAIL_BYTES as usize);
+    }
+
+    #[test]
+    fn tail_bounds_work_even_when_no_valid_records_exist() {
+        let mut reader = std::io::Cursor::new(vec![b'\n'; AUDIT_TAIL_LINES + 2]);
+        let tail = read_log_tail_from_reader(&mut reader, 10, None).unwrap();
+        assert!(tail.records.is_empty());
+        assert_eq!(tail.skipped_lines, 0);
+        assert!(tail.truncated);
+    }
+
+    #[test]
+    fn tail_rejects_oversized_lines_and_invalid_utf8() {
+        for bytes in [vec![b'x'; AUDIT_TAIL_LINE_BYTES + 1], vec![0xff, b'\n']] {
+            let error = read_log_tail_from_reader(&mut std::io::Cursor::new(bytes), 1, None)
+                .err()
+                .expect("invalid input must fail");
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        }
+    }
+
+    #[test]
+    fn tail_reads_regular_file_without_modifying_it_and_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let content = format!("{}\n{}\n", tail_record("a", ""), tail_record("b", ""));
+        std::fs::write(&path, &content).unwrap();
+        let result = read_log_tail(&path, 1).unwrap();
+        assert_eq!(result.records[0].event_id.as_deref(), Some("b"));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), content);
+        assert!(read_log_tail(dir.path(), 1).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tail_rejects_fifo_without_waiting_for_a_writer() {
+        use std::os::unix::ffi::OsStrExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.fifo");
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) }, 0);
+        assert!(read_log_tail(&path, 1).is_err());
+    }
+
+    #[test]
+    fn tail_read_errors_are_terminal() {
+        struct FailedReader;
+        impl std::io::Seek for FailedReader {
+            fn seek(&mut self, _: std::io::SeekFrom) -> std::io::Result<u64> {
+                Ok(1024)
+            }
+        }
+        impl std::io::Read for FailedReader {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "read failed",
+                ))
+            }
+        }
+        let error = read_log_tail_from_reader(&mut FailedReader, 1, None)
+            .err()
+            .expect("read errors must fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+    }
 
     fn sample_records() -> Vec<AuditRecord> {
         vec![

--- a/crates/tirith-core/src/custom_rule_dsl.rs
+++ b/crates/tirith-core/src/custom_rule_dsl.rs
@@ -38,7 +38,7 @@
 //!   (install/add commands plus Docker image refs as the `docker` ecosystem).
 
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 
 use regex::Regex;
 use serde::de::{self, Deserializer, MapAccess, Visitor};
@@ -685,22 +685,40 @@ fn check_regex(field: &str, pattern: &str) -> Result<(), String> {
         .map_err(|e| format!("{field}: invalid regex: {e}"))
 }
 
-thread_local! {
-    /// Per-thread compiled-regex cache for the DSL `*_matches` predicates,
-    /// avoiding recompiling the same pattern on every `evaluate()`.
-    static REGEX_CACHE: RefCell<HashMap<String, Regex>> = RefCell::new(HashMap::new());
+const MAX_CACHED_REGEXES: usize = 128;
+
+#[derive(Default)]
+struct RegexCache {
+    patterns: HashMap<String, Regex>,
+    insertion_order: VecDeque<String>,
 }
 
-/// Compile `pat` once per thread and return a cheap clone of the cached `Regex`.
+thread_local! {
+    /// Per-thread compiled-regex cache for the DSL `*_matches` predicates,
+    /// avoiding recompiling the same pattern on every `evaluate()`. Bound its
+    /// retained entries so policy changes in a long-lived process cannot retain
+    /// every previously evaluated pattern. FIFO eviction keeps hits constant-time.
+    static REGEX_CACHE: RefCell<RegexCache> = RefCell::new(RegexCache::default());
+}
+
+/// Return a cheap clone while `pat` remains in this thread's cache; compile it
+/// again after eviction without changing match semantics.
 /// `None` if it fails to compile (validated patterns never hit that path).
 fn cached_regex(pat: &str) -> Option<Regex> {
     REGEX_CACHE.with(|cache| {
-        if let Some(re) = cache.borrow().get(pat) {
+        if let Some(re) = cache.borrow().patterns.get(pat) {
             return Some(re.clone());
         }
         match Regex::new(pat) {
             Ok(re) => {
-                cache.borrow_mut().insert(pat.to_string(), re.clone());
+                let mut cache = cache.borrow_mut();
+                if cache.patterns.len() == MAX_CACHED_REGEXES {
+                    if let Some(oldest) = cache.insertion_order.pop_front() {
+                        cache.patterns.remove(&oldest);
+                    }
+                }
+                cache.insertion_order.push_back(pat.to_string());
+                cache.patterns.insert(pat.to_string(), re.clone());
                 Some(re)
             }
             Err(_) => None,
@@ -1138,6 +1156,111 @@ any:
                 !evaluate(&clause, &miss),
                 "non-matching host should not fire"
             );
+        }
+    }
+
+    #[test]
+    fn regex_cache_bounds_policy_churn_and_recompiles_evicted_patterns() {
+        REGEX_CACHE.with(|cache| *cache.borrow_mut() = RegexCache::default());
+        let first = r"^/repo_0/[a-z0-9]+\.rs$";
+        let ctx = DslEvalContext {
+            file_path: Some("/repo_0/main.rs"),
+            ..Default::default()
+        };
+        assert!(evaluate(&WhenClause::FilePathMatches(first.into()), &ctx));
+
+        // Simulate successive policy revisions; old clauses have been dropped
+        // before each next evaluation, so only the cache can retain them.
+        for i in 1..=MAX_CACHED_REGEXES * 3 {
+            let clause = WhenClause::FilePathMatches(format!(r"^/repo_{i}/[a-z0-9]+\.rs$"));
+            assert!(!evaluate(&clause, &ctx));
+            REGEX_CACHE.with(|cache| {
+                let cache = cache.borrow();
+                assert!(cache.patterns.len() <= MAX_CACHED_REGEXES);
+                assert_eq!(cache.patterns.len(), cache.insertion_order.len());
+            });
+        }
+        REGEX_CACHE.with(|cache| {
+            let cache = cache.borrow();
+            assert_eq!(cache.patterns.len(), MAX_CACHED_REGEXES);
+            assert!(!cache.patterns.contains_key(first));
+        });
+
+        // Invalid patterns neither evict a valid entry nor become cache entries.
+        let before = REGEX_CACHE.with(|cache| cache.borrow().insertion_order.clone());
+        assert!(cached_regex("(").is_none());
+        REGEX_CACHE.with(|cache| assert_eq!(cache.borrow().insertion_order, before));
+
+        assert!(evaluate(&WhenClause::FilePathMatches(first.into()), &ctx));
+        REGEX_CACHE.with(|cache| {
+            let cache = cache.borrow();
+            assert!(cache.patterns.contains_key(first));
+            assert_eq!(cache.patterns.len(), MAX_CACHED_REGEXES);
+        });
+    }
+
+    #[test]
+    fn regex_eviction_preserves_all_predicates_and_unknown_contexts() {
+        let hit = DslEvalContext {
+            urls: vec![DslUrl {
+                host: "api.evil.com",
+                scheme: "https",
+                reputation: Reputation::Unknown,
+            }],
+            packages: vec![DslPackage {
+                ecosystem: "npm".into(),
+                name: "Left-Pad",
+                reputation: PkgReputation::Unknown,
+            }],
+            file_path: Some("/repo/.env"),
+            ..Default::default()
+        };
+        let miss = DslEvalContext {
+            file_path: Some("/repo/main.rs"),
+            ..Default::default()
+        };
+        let cases = [
+            (
+                WhenClause::UrlHostMatches(r"\.evil\.com$".into()),
+                ScanContext::Exec,
+            ),
+            (
+                WhenClause::PackageNameMatches("^left-pad$".into()),
+                ScanContext::Paste,
+            ),
+            (
+                WhenClause::FilePathMatches(r"/\.env$".into()),
+                ScanContext::FileScan,
+            ),
+        ];
+        for (clause, context) in cases {
+            let negated = WhenClause::Not(Box::new(clause.clone()));
+            for _ in 0..2 {
+                assert!(evaluate(&clause, &hit));
+                assert!(!evaluate(&clause, &miss));
+                assert_eq!(
+                    evaluate_in_context(&clause, &hit, context),
+                    TruthValue::True
+                );
+                assert_eq!(
+                    evaluate_in_context(&negated, &miss, context),
+                    TruthValue::True
+                );
+                let unavailable = if context == ScanContext::FileScan {
+                    ScanContext::Exec
+                } else {
+                    ScanContext::FileScan
+                };
+                assert_eq!(
+                    evaluate_in_context(&negated, &hit, unavailable),
+                    TruthValue::Unknown
+                );
+
+                // Evict every pattern above between the first and second pass.
+                for i in 0..MAX_CACHED_REGEXES {
+                    assert!(cached_regex(&format!("^cache-churn-{i}$")).is_some());
+                }
+            }
         }
     }
 

--- a/crates/tirith-core/src/engine.rs
+++ b/crates/tirith-core/src/engine.rs
@@ -2822,8 +2822,14 @@ fn analyze_inner_with_policy_and_pdf_coverage(
     // A regex-only organization rule can intentionally match an otherwise-clean
     // command, just as a semantic DSL rule can. Never return Allow before the
     // complete rule pass merely because the built-in coarse scan was clean.
-    let custom_rules_triggered = gate_policy.as_ref().is_some_and(|policy| {
-        crate::rules::custom::compile_rules(&policy.custom_rules)
+    // Retain this request's compilation for the full pass. The gate and rule
+    // evaluation use the same effective policy, including when compilation
+    // drops every rule, so neither validation nor diagnostics need to run twice.
+    let gate_custom_rules = gate_policy
+        .as_ref()
+        .map(|policy| crate::rules::custom::compile_rules(&policy.custom_rules));
+    let custom_rules_triggered = gate_custom_rules.as_ref().is_some_and(|compiled| {
+        compiled
             .iter()
             .any(|rule| rule.contexts.contains(&ctx.scan_context))
     });
@@ -3543,7 +3549,9 @@ fn analyze_inner_with_policy_and_pdf_coverage(
     }
 
     if !policy.custom_rules.is_empty() {
-        let compiled = crate::rules::custom::compile_rules(&policy.custom_rules);
+        // FileScan has no gate compilation; Exec/Paste reuse its exact matchers.
+        let compiled = gate_custom_rules
+            .unwrap_or_else(|| crate::rules::custom::compile_rules(&policy.custom_rules));
         // `analyzed_input` is prelude-stripped (Exec) / verbatim (Paste/FileScan),
         // so custom regex rules match the real command, not the card wrapper.
         let mut custom_findings =
@@ -5385,6 +5393,47 @@ mod tests {
              fast-exit; got tier {}",
             v_dead.tier_reached
         );
+    }
+
+    #[test]
+    fn custom_rule_policy_changes_do_not_reuse_previous_matchers() {
+        let _state = isolate_state();
+        let dir = tempfile::tempdir().unwrap();
+        let mut policy = Policy::try_parse_yaml(
+            "custom_rules:\n  \
+             - id: changing-rule\n    \
+             pattern: '^whoami$'\n    \
+             severity: critical\n    \
+             title: changing rule\n    \
+             context: [exec, paste, file]\n",
+        )
+        .unwrap();
+        let mut changed_policy = policy.clone();
+        changed_policy.custom_rules[0].pattern = Some("^hostname$".into());
+
+        for context in [ScanContext::Exec, ScanContext::Paste, ScanContext::FileScan] {
+            let mut ctx = exec_ctx_in("whoami", dir.path());
+            ctx.scan_context = context;
+            ctx.file_path = Some(dir.path().join("notes.txt"));
+            let matched = analyze_with_policy_without_bypass(&ctx, &policy);
+            assert!(matched
+                .findings
+                .iter()
+                .any(|finding| { finding.custom_rule_id.as_deref() == Some("changing-rule") }));
+
+            // Keep the same rule ID and update only its regex. A compilation
+            // retained beyond this analysis must not apply the previous policy.
+            let unmatched = analyze_with_policy_without_bypass(&ctx, &changed_policy);
+            assert!(unmatched
+                .findings
+                .iter()
+                .all(|finding| { finding.custom_rule_id.as_deref() != Some("changing-rule") }));
+        }
+
+        // A rule removed from the effective policy must restore the clean gate.
+        policy.custom_rules.clear();
+        let clean = analyze_with_policy_without_bypass(&exec_ctx_in("whoami", dir.path()), &policy);
+        assert_eq!(clean.tier_reached, 1);
     }
 
     #[test]

--- a/crates/tirith-core/src/event_buffer.rs
+++ b/crates/tirith-core/src/event_buffer.rs
@@ -1024,32 +1024,52 @@ pub fn signature_event_timestamps(sig: &str) -> impl Iterator<Item = &str> {
 /// sequence allocation is unique within the owning session, while accepting the
 /// old id as an output/matching authority would preserve a secret-bearing value.
 pub fn signature_references_live_event(sig: &str, events: &[TypedEvent]) -> bool {
-    let events: Vec<TypedEvent> = events
-        .iter()
-        .map(privacy_project_correlation_event)
-        .collect();
-    sig.split('|').skip(1).any(|part| {
-        if let Some(rest) = part.strip_prefix("e:") {
-            let Some((_, sequence)) = rest.rsplit_once(':') else {
-                return false;
-            };
-            let Ok(sequence) = sequence.parse::<u64>() else {
-                return false;
-            };
-            events
+    LiveCorrelationEvents::new(events).references_signature(sig)
+}
+
+/// One request's privacy-projected event window for marker expiry. Keep the
+/// owned events private: every construction must cross the same projection as
+/// the public single-signature helper, including directly constructed events.
+/// Reusing this snapshot avoids redoing secret/metadata redaction for every
+/// retained signature while the session lock keeps the source window unchanged.
+pub(crate) struct LiveCorrelationEvents {
+    events: Vec<TypedEvent>,
+}
+
+impl LiveCorrelationEvents {
+    pub(crate) fn new(events: &[TypedEvent]) -> Self {
+        Self {
+            events: events
                 .iter()
-                .any(|event| event.sequence > 0 && event.sequence == sequence)
-        } else {
-            let timestamp = part.strip_prefix("t:").unwrap_or(part);
-            let Some(timestamp) = canonical_correlation_timestamp(timestamp) else {
-                return false;
-            };
-            events.iter().any(|event| {
-                canonical_correlation_timestamp(&event.timestamp).as_deref()
-                    == Some(timestamp.as_str())
-            })
+                .map(privacy_project_correlation_event)
+                .collect(),
         }
-    })
+    }
+
+    pub(crate) fn references_signature(&self, sig: &str) -> bool {
+        sig.split('|').skip(1).any(|part| {
+            if let Some(rest) = part.strip_prefix("e:") {
+                let Some((_, sequence)) = rest.rsplit_once(':') else {
+                    return false;
+                };
+                let Ok(sequence) = sequence.parse::<u64>() else {
+                    return false;
+                };
+                self.events
+                    .iter()
+                    .any(|event| event.sequence > 0 && event.sequence == sequence)
+            } else {
+                let timestamp = part.strip_prefix("t:").unwrap_or(part);
+                let Some(timestamp) = canonical_correlation_timestamp(timestamp) else {
+                    return false;
+                };
+                self.events.iter().any(|event| {
+                    canonical_correlation_timestamp(&event.timestamp).as_deref()
+                        == Some(timestamp.as_str())
+                })
+            }
+        })
+    }
 }
 
 /// SecretWrite THEN Network within 30s -> CRITICAL.
@@ -1965,6 +1985,65 @@ mod tests {
             &hit.signature,
             &[secret, network]
         ));
+    }
+
+    #[test]
+    fn batch_signature_expiry_matches_single_calls_for_private_and_legacy_events() {
+        let secret = format!("ghp_{}", "Q".repeat(36));
+        let mut current = ev("2026-01-01T02:00:00+02:00".into(), EventKind::Network);
+        current.sequence = 41;
+        current.event_id = secret.clone();
+        current.metadata.insert(
+            "host".into(),
+            format!("https://operator:{secret}@mainnet.infura.io/v3/providerToken123456789"),
+        );
+        current.metadata.insert(
+            "path".into(),
+            format!("/Users/alice/private/{secret}/config.yaml"),
+        );
+        let legacy = ev("2026-01-02T00:00:00Z".into(), EventKind::FileWrite);
+        // Projection strips terminal controls before timestamp matching. A
+        // batch must not accidentally index unprojected timestamps instead.
+        let mut projected_timestamp = ev("2026-01-03T00:00:00Z".into(), EventKind::FileWrite);
+        projected_timestamp.timestamp = "\x1b[31m2026-01-03T00:00:00Z".into();
+        let mut invalid_timestamp = ev("not a timestamp".into(), EventKind::FileDelete);
+        invalid_timestamp.sequence = 7;
+        let events = vec![current, legacy, projected_timestamp, invalid_timestamp];
+        let original = events.clone();
+        let batch = LiveCorrelationEvents::new(&events);
+        assert_eq!(events, original, "projection must not mutate caller events");
+        assert_eq!(batch.events[0].event_id, "legacy-event-41");
+        assert!(batch.events[0]
+            .metadata
+            .values()
+            .all(|value| !value.contains(&secret) && !value.contains("/Users/alice")));
+
+        for (signature, expected) in [
+            ("MassFileDeletion|e:legacy-event-41:41", true),
+            ("MassFileDeletion|e:old:opaque:id:41", true),
+            ("MassFileDeletion|e::7", true),
+            ("MassFileDeletion|e:zero:0", false),
+            ("MassFileDeletion|e:dead:999", false),
+            ("MassFileDeletion|t:2026-01-01T00:00:00Z", true),
+            ("MassFileDeletion|2026-01-02T02:00:00+02:00", true),
+            ("MassFileDeletion|t:2026-01-03T00:00:00Z", true),
+            ("MassFileDeletion|t:2025-01-01T00:00:00Z", false),
+            ("MassFileDeletion|e:missing-separator", false),
+            ("MassFileDeletion|e:bad:not-a-number", false),
+            ("MassFileDeletion|e:bad:18446744073709551616", false),
+            ("MassFileDeletion|t:not a timestamp", false),
+            ("MassFileDeletion|not a timestamp", false),
+            ("MassFileDeletion|e:bad:no|t:bad|e:live:41", true),
+            ("MassFileDeletion|e:dead:999|e:live:7", true),
+            ("MassFileDeletion|", false),
+            ("MassFileDeletion", false),
+            ("", false),
+        ] {
+            let single = signature_references_live_event(signature, &events);
+            assert_eq!(single, expected, "single: {signature}");
+            assert_eq!(batch.references_signature(signature), single, "{signature}");
+            assert!(!LiveCorrelationEvents::new(&[]).references_signature(signature));
+        }
     }
 
     #[test]

--- a/crates/tirith-core/src/event_buffer.rs
+++ b/crates/tirith-core/src/event_buffer.rs
@@ -2016,7 +2016,11 @@ mod tests {
         assert!(batch.events[0]
             .metadata
             .values()
-            .all(|value| !value.contains(&secret) && !value.contains("/Users/alice")));
+            .all(|value| !value.contains(&secret)));
+        assert_eq!(
+            batch.events[0].metadata.get("host").map(String::as_str),
+            Some("[REDACTED:GitHub PAT]")
+        );
 
         for (signature, expected) in [
             ("MassFileDeletion|e:legacy-event-41:41", true),

--- a/crates/tirith-core/src/rules/custom.rs
+++ b/crates/tirith-core/src/rules/custom.rs
@@ -17,6 +17,15 @@ fn diagnostic_text(value: &str) -> String {
     .replace('\t', "\\t")
 }
 
+/// Redact only when a warning is formatted; valid rules emit no diagnostics.
+struct DiagnosticRuleId<'a>(&'a str);
+
+impl std::fmt::Display for DiagnosticRuleId<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&diagnostic_text(self.0))
+    }
+}
+
 /// The matcher half of a compiled custom rule: a regex or a `when:` clause
 /// (M13 ch4 DSL). A rule carries exactly one.
 pub enum CompiledMatcher {
@@ -76,7 +85,7 @@ fn parse_contexts(rule: &CustomRule) -> Vec<ScanContext> {
 pub fn compile_rules(rules: &[CustomRule]) -> Vec<CompiledCustomRule> {
     let mut compiled = Vec::new();
     for rule in rules {
-        let rule_id = diagnostic_text(&rule.id);
+        let rule_id = DiagnosticRuleId(&rule.id);
         if let Err(e) = rule.validate_shape() {
             let error = diagnostic_text(&e.to_string());
             eprintln!("tirith: warning: custom rule '{rule_id}' {error}, skipping");
@@ -409,6 +418,24 @@ mod tests {
         assert!(diagnostic.contains("REDACTED"), "{diagnostic}");
 
         assert_eq!(diagnostic_text("ordinary-rule"), "ordinary-rule");
+    }
+
+    #[test]
+    fn lazy_rule_id_diagnostics_keep_secrets_paths_and_controls_redacted() {
+        let secret = format!("ghp_{}", "R".repeat(36));
+        let id = format!("rule={secret} /Users/alice/private/config.yaml\n\t\x1b[31m");
+        let warning = format!(
+            "tirith: warning: custom rule '{}' has no valid contexts, skipping",
+            DiagnosticRuleId(&id)
+        );
+        assert!(!warning.contains(&secret), "{warning}");
+        assert!(!warning.contains("/Users/alice"), "{warning}");
+        assert!(!warning.contains(['\n', '\r', '\t', '\x1b']), "{warning}");
+        assert!(warning.contains("REDACTED"), "{warning}");
+        assert_eq!(
+            DiagnosticRuleId("ordinary-rule").to_string(),
+            "ordinary-rule"
+        );
     }
 
     #[test]

--- a/crates/tirith-core/src/session_warnings.rs
+++ b/crates/tirith-core/src/session_warnings.rs
@@ -1357,11 +1357,15 @@ fn record_fresh_correlation_warnings(
     }
 
     // Expire presentation markers in lockstep with the persisted event window.
-    let live_events: Vec<crate::event_buffer::TypedEvent> =
-        session.typed_events.iter().cloned().collect();
-    session
-        .surfaced_correlations
-        .retain(|sig| crate::event_buffer::signature_references_live_event(sig, &live_events));
+    // Only warning/presentation state changed above, so `events` is still the
+    // current window. Project it once for the entire marker batch, rather than
+    // redoing full event redaction for each of up to 800 retained signatures.
+    if !session.surfaced_correlations.is_empty() {
+        let live_events = crate::event_buffer::LiveCorrelationEvents::new(&events);
+        session
+            .surfaced_correlations
+            .retain(|sig| live_events.references_signature(sig));
+    }
     while session.surfaced_correlations.len() > MAX_SURFACED_CORRELATIONS {
         session.surfaced_correlations.pop_front();
     }

--- a/crates/tirith-core/src/threatdb.rs
+++ b/crates/tirith-core/src/threatdb.rs
@@ -935,6 +935,15 @@ pub fn canonical_package_name(eco: Ecosystem, name: &str) -> String {
     }
 }
 
+/// These registries use the same key bytes in both database formats. Other
+/// ecosystems need the legacy canonical index to include spelling aliases.
+fn package_name_preserves_spelling(eco: Ecosystem) -> bool {
+    matches!(
+        eco,
+        Ecosystem::Npm | Ecosystem::RubyGems | Ecosystem::Go | Ecosystem::Maven
+    )
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VersionEquivalence {
     Equal,
@@ -1765,13 +1774,14 @@ impl ThreatDb {
     /// canonical v2 key may intentionally retain multiple evidence claims:
     /// combining their versions, scope, and metadata into one physical record
     /// would let an unrelated broad claim overwrite stronger exact evidence.
-    /// v1 records must retain their historical spellings for old readers, so a
-    /// new reader performs a bounded linear fallback and canonicalizes each
-    /// stored key at comparison time. There can be more than one v1 spelling of
+    /// v1 records must retain their historical spellings for old readers. For
+    /// registries whose identity preserves spelling, the same hash search is
+    /// valid in v1. Other registries need a lazily built canonical index, since
+    /// there can be more than one v1 spelling of
     /// one modern identity (`foo.bar`, `foo__bar`), and every physical claim in
     /// either format must participate in assessment.
     fn package_record_indices(&self, eco: Ecosystem, canonical_name: &str) -> Vec<u32> {
-        if self.format_version >= 2 {
+        if self.format_version >= 2 || package_name_preserves_spelling(eco) {
             let target_hash = pkg_key_hash(eco, canonical_name.as_bytes());
             let mut lo = 0;
             let mut hi = self.pkg_index_count;
@@ -1811,10 +1821,21 @@ impl ThreatDb {
             .get_or_init(|| {
                 let mut index = std::collections::HashMap::new();
                 for idx in 0..self.pkg_index_count {
-                    let Some(record) = self
-                        .pkg_index_entry(idx)
-                        .and_then(|(data_off, _)| self.parse_pkg_record(data_off as usize))
-                    else {
+                    let Some((data_off, _)) = self.pkg_index_entry(idx) else {
+                        continue;
+                    };
+                    // Skip direct-index ecosystems before parsing their version
+                    // lists or allocating canonical names. They never use this
+                    // map, and can comprise most of a legacy database.
+                    if self
+                        .data
+                        .get(data_off as usize)
+                        .and_then(|&value| Ecosystem::from_u8(value))
+                        .is_some_and(package_name_preserves_spelling)
+                    {
+                        continue;
+                    }
+                    let Some(record) = self.parse_pkg_record(data_off as usize) else {
                         continue;
                     };
                     index
@@ -2999,23 +3020,57 @@ fn merge_assessments(
 static CACHE: OnceLock<ThreatDbCache> = OnceLock::new();
 
 struct ThreatDbCache {
-    db: RwLock<Option<Arc<ThreatDb>>>,
+    state: RwLock<Option<CachedThreatDb>>,
     last_mtime_check: AtomicU64,
-    loaded_mtime: AtomicU64,
 }
 
+struct CachedThreatDb {
+    db: Arc<ThreatDb>,
+    source: CacheSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CacheFile {
+    path: PathBuf,
+    modified: std::time::SystemTime,
+    len: u64,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl CacheFile {
+    fn from_path(path: PathBuf) -> Option<Self> {
+        let metadata = std::fs::metadata(&path).ok()?;
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt;
+        Some(Self {
+            path,
+            modified: metadata.modified().ok()?,
+            len: metadata.len(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+        })
+    }
+}
+
+/// Compare complete source metadata, retaining subsecond changes and resolved
+/// paths. A seconds-only combined stamp misses rapid overlay replacements and
+/// switches to a different DB file with the same timestamp.
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct CacheSource {
-    primary_path: PathBuf,
-    supplemental_path: Option<PathBuf>,
-    combined_mtime: u64,
+    primary: CacheFile,
+    supplemental: Option<CacheFile>,
 }
 
 impl ThreatDbCache {
     fn new() -> Self {
         let cache = Self {
-            db: RwLock::new(None),
+            state: RwLock::new(None),
             last_mtime_check: AtomicU64::new(0),
-            loaded_mtime: AtomicU64::new(0),
         };
         // Attempt initial load
         cache.force_reload();
@@ -3029,14 +3084,21 @@ impl ThreatDbCache {
             self.last_mtime_check.store(now, Ordering::Relaxed);
             match current_cache_source() {
                 Some(source) => {
-                    if source.combined_mtime != self.loaded_mtime.load(Ordering::Relaxed) {
+                    let changed = self.state.read().ok().is_some_and(|guard| {
+                        guard.as_ref().is_none_or(|cached| cached.source != source)
+                    });
+                    if changed {
                         self.reload(&source, false);
                     }
                 }
                 None => self.clear(),
             }
         }
-        self.db.read().ok()?.clone()
+        self.state
+            .read()
+            .ok()?
+            .as_ref()
+            .map(|cached| Arc::clone(&cached.db))
     }
 
     fn force_reload(&self) {
@@ -3048,15 +3110,7 @@ impl ThreatDbCache {
     }
 
     fn reload(&self, source: &CacheSource, allow_downgrade: bool) {
-        let current_seq = self
-            .db
-            .read()
-            .ok()
-            .and_then(|guard| guard.as_ref().map(|db| db.build_sequence))
-            .unwrap_or(0);
-        let loaded_mtime = self.loaded_mtime.load(Ordering::Relaxed);
-
-        match ThreatDb::load_from_path(&source.primary_path, 0) {
+        match ThreatDb::load_from_path(&source.primary.path, 0) {
             Ok(primary_db) => {
                 if let Err(e) = primary_db.verify_signature() {
                     eprintln!(
@@ -3067,31 +3121,38 @@ impl ThreatDbCache {
                 // Supplemental overlays are intentionally NOT signature-verified
                 // (authenticity is anchored to local machine policy, not CI);
                 // `load_from_path` still validates binary structure/header/version.
-                let supplemental_db =
-                    source.supplemental_path.as_ref().and_then(
-                        |path| match ThreatDb::load_from_path(path, 0) {
-                            Ok(db) => Some(db),
-                            Err(e) => {
-                                eprintln!(
+                let supplemental_db = source.supplemental.as_ref().and_then(|file| {
+                    match ThreatDb::load_from_path(&file.path, 0) {
+                        Ok(db) => Some(db),
+                        Err(e) => {
+                            eprintln!(
                                 "tirith: warning: failed to load supplemental threat DB {}: {e}",
-                                path.display()
+                                file.path.display()
                             );
-                                None
-                            }
-                        },
-                    );
+                            None
+                        }
+                    }
+                });
                 let new_db = primary_db.with_supplemental(supplemental_db);
-                if should_replace_cached_db(
-                    current_seq,
-                    new_db.build_sequence,
-                    loaded_mtime,
-                    source.combined_mtime,
-                    allow_downgrade,
-                ) {
-                    if let Ok(mut guard) = self.db.write() {
-                        *guard = Some(Arc::new(new_db));
-                        self.loaded_mtime
-                            .store(source.combined_mtime, Ordering::Relaxed);
+                if let Ok(mut guard) = self.state.write() {
+                    // Read the currently accepted sequence under the publication
+                    // lock: another reload may have completed during validation.
+                    let current_seq = guard.as_ref().map_or(0, |cached| cached.db.build_sequence);
+                    let source_changed =
+                        guard.as_ref().is_none_or(|cached| cached.source != *source);
+                    if should_replace_cached_db(
+                        current_seq,
+                        new_db.build_sequence,
+                        source_changed,
+                        allow_downgrade,
+                    ) {
+                        // Publish the DB and its accepted source together. A bad
+                        // signature, malformed primary DB, or rollback never
+                        // advances it. Invalid supplemental data is still omitted.
+                        *guard = Some(CachedThreatDb {
+                            db: Arc::new(new_db),
+                            source: source.clone(),
+                        });
                     }
                 }
             }
@@ -3102,24 +3163,22 @@ impl ThreatDbCache {
     }
 
     fn clear(&self) {
-        if let Ok(mut guard) = self.db.write() {
+        if let Ok(mut guard) = self.state.write() {
             *guard = None;
         }
-        self.loaded_mtime.store(0, Ordering::Relaxed);
     }
 }
 
 fn should_replace_cached_db(
     current_sequence: u64,
     new_sequence: u64,
-    loaded_mtime: u64,
-    new_mtime: u64,
+    source_changed: bool,
     allow_downgrade: bool,
 ) -> bool {
     allow_downgrade
         || current_sequence == 0
         || new_sequence > current_sequence
-        || (new_sequence == current_sequence && new_mtime != loaded_mtime)
+        || (new_sequence == current_sequence && source_changed)
 }
 
 fn unix_now() -> u64 {
@@ -3127,15 +3186,6 @@ fn unix_now() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
-}
-
-fn path_mtime_epoch(path: &Path) -> Option<u64> {
-    let meta = std::fs::metadata(path).ok()?;
-    meta.modified()
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()
-        .map(|d| d.as_secs())
 }
 
 /// Derive the `*-v2.dat` sibling of a `.dat` path: replace a trailing `.dat`
@@ -3186,28 +3236,12 @@ fn resolve_preferring_v2(
 fn current_cache_source() -> Option<CacheSource> {
     // Prefer the v2 primary/supplemental files when present and parseable; an
     // old binary never reaches this code and only ever reads the v1 names.
-    let primary_path = ThreatDb::resolve_primary_path()?;
-    let primary_mtime = path_mtime_epoch(&primary_path)?;
-    let supplemental_path = ThreatDb::resolve_supplemental_path().filter(|path| path.exists());
-    let supplemental_mtime = supplemental_path
-        .as_ref()
-        .and_then(|path| path_mtime_epoch(path))
-        .unwrap_or(0);
-
+    let primary = CacheFile::from_path(ThreatDb::resolve_primary_path()?)?;
+    let supplemental = ThreatDb::resolve_supplemental_path().and_then(CacheFile::from_path);
     Some(CacheSource {
-        primary_path,
-        supplemental_path,
-        combined_mtime: combined_mtime_from_parts(primary_mtime, supplemental_mtime),
+        primary,
+        supplemental,
     })
-}
-
-fn combined_mtime_from_parts(primary_mtime: u64, supplemental_mtime: u64) -> u64 {
-    primary_mtime.rotate_left(13) ^ supplemental_mtime.rotate_left(29) ^ 0x5448_5245_4154_4442
-}
-
-#[cfg(test)]
-fn combined_mtime_epoch() -> Option<u64> {
-    current_cache_source().map(|source| source.combined_mtime)
 }
 
 /// Builder for creating threat DB files (used by the compiler binary to
@@ -4549,6 +4583,87 @@ mod tests {
         }
     }
 
+    #[test]
+    fn package_index_matches_linear_identity_lookup_in_both_formats() {
+        let key = SigningKey::from_bytes(&[23u8; 32]);
+        let identities = [
+            (Ecosystem::Npm, "CasePkg", "casepkg"),
+            (Ecosystem::RubyGems, "CaseGem", "casegem"),
+            (Ecosystem::Go, "example.org/CaseMod", "example.org/casemod"),
+            (
+                Ecosystem::Maven,
+                "org.example:CaseJar",
+                "org.example:casejar",
+            ),
+            (Ecosystem::PyPI, "Case.Pkg", "case__pkg"),
+            (Ecosystem::Crates, "Case_Crate", "case-crate"),
+            (Ecosystem::NuGet, "Case.Pkg", "case.pkg"),
+            (
+                Ecosystem::Npm,
+                "collision-dceuwm5peg8j",
+                "collision-8mseactbvp7x",
+            ),
+        ];
+        // The equal-hash run must compare the actual names as well. These are
+        // distinct npm identities with a frozen FNV-1a collision.
+        assert_eq!(
+            pkg_key_hash(Ecosystem::Npm, b"collision-dceuwm5peg8j"),
+            pkg_key_hash(Ecosystem::Npm, b"collision-8mseactbvp7x")
+        );
+        for format in [ThreatDbFormat::V1, ThreatDbFormat::V2] {
+            let mut writer = ThreatDbWriter::new(1_700_000_000, 46);
+            for &(eco, name, alternate) in &identities {
+                for (name, source, version) in [
+                    (name, ThreatSource::OssfMalicious, "1.0.0"),
+                    (name, ThreatSource::DatadogMalicious, "2.0.0"),
+                    (alternate, ThreatSource::OssfMalicious, "3.0.0"),
+                ] {
+                    writer.add_package(
+                        eco,
+                        name,
+                        &[version],
+                        source,
+                        Confidence::Confirmed,
+                        false,
+                        None,
+                    );
+                }
+            }
+            let db = ThreatDb::from_bytes(writer.build_format(format, &key).unwrap(), 0).unwrap();
+            // A cold miss and a hit in each spelling-preserving registry must
+            // not initialize the map covering unrelated legacy registries.
+            for &(eco, name, alternate) in &identities[..4] {
+                assert!(db.package_record_indices(eco, "absent").is_empty());
+                assert!(!db.package_record_indices(eco, name).is_empty());
+                assert!(!db.package_record_indices(eco, alternate).is_empty());
+                assert!(db.legacy_package_index.get().is_none());
+            }
+            // Compare with all physical records, including separate evidence
+            // claims in v2 and the multiple legacy spellings of one identity.
+            for &(eco, name, alternate) in &identities {
+                for query in [name, alternate, "absent"] {
+                    let canonical = canonical_package_name(eco, query);
+                    let expected: Vec<_> = (0..db.pkg_index_count)
+                        .filter(|&idx| {
+                            db.pkg_index_entry(idx)
+                                .and_then(|(off, _)| db.parse_pkg_record(off as usize))
+                                .is_some_and(|record| {
+                                    record.ecosystem == eco
+                                        && canonical_package_name(eco, record.name) == canonical
+                                })
+                        })
+                        .collect();
+                    assert_eq!(db.package_record_indices(eco, &canonical), expected);
+                }
+            }
+            if let Some(index) = db.legacy_package_index.get() {
+                assert!(index
+                    .keys()
+                    .all(|(eco, _)| !package_name_preserves_spelling(*eco)));
+            }
+        }
+    }
+
     /// Simulate the exact package lookup shipped by a v1-only reader: raw key
     /// hash plus literal affected-version comparison, with no canonicalization.
     fn legacy_v1_exact_package_lookup(
@@ -5420,23 +5535,193 @@ mod tests {
     }
 
     #[test]
-    fn test_combined_mtime_requires_primary_db() {
+    fn test_cache_source_requires_primary_db() {
         let guard = isolated_global_state();
         let primary = guard.roots().threatdb.clone();
         let supplemental = guard.roots().threatdb_supplemental.clone();
 
-        assert_eq!(combined_mtime_epoch(), None);
+        assert_eq!(current_cache_source(), None);
 
         std::fs::write(&supplemental, b"overlay").unwrap();
-        assert_eq!(combined_mtime_epoch(), None);
+        assert_eq!(current_cache_source(), None);
 
         std::fs::remove_file(&supplemental).unwrap();
         std::fs::write(&primary, b"primary").unwrap();
-        let primary_only = combined_mtime_epoch().expect("primary mtime");
+        let primary_only = current_cache_source().expect("primary mtime");
 
         std::fs::write(&supplemental, b"overlay-updated").unwrap();
-        let combined = combined_mtime_epoch().expect("combined mtime");
+        let combined = current_cache_source().expect("combined mtime");
         assert_ne!(primary_only, combined);
+    }
+
+    fn set_cache_test_mtime(path: &Path, nanos: u32) {
+        let modified = std::time::UNIX_EPOCH + std::time::Duration::new(1_700_000_000, nanos);
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(modified))
+            .unwrap();
+    }
+
+    fn write_cache_test_overlay(path: &Path, name: &str, nanos: u32) {
+        let mut writer = ThreatDbWriter::new(1_700_000_000, 1);
+        writer.add_package(
+            Ecosystem::Npm,
+            name,
+            &["1.0.0"],
+            ThreatSource::OssfMalicious,
+            Confidence::Confirmed,
+            true,
+            None,
+        );
+        writer
+            .write_to(path, &SigningKey::from_bytes(&[7u8; 32]))
+            .unwrap();
+        set_cache_test_mtime(path, nanos);
+    }
+
+    #[test]
+    fn periodic_cache_check_detects_same_second_overlay_replacement() {
+        let guard = isolated_global_state();
+        let primary = &guard.roots().threatdb;
+        let supplemental = &guard.roots().threatdb_supplemental;
+        std::fs::copy(signed_fixture_db_path(), primary).unwrap();
+        write_cache_test_overlay(supplemental, "old-package", 100_000_000);
+        let cache = ThreatDbCache::new();
+        let before = cache.get().unwrap();
+        let old_source = cache.state.read().unwrap().as_ref().unwrap().source.clone();
+
+        write_cache_test_overlay(supplemental, "new-package", 200_000_000);
+        let new_source = current_cache_source().unwrap();
+        assert_eq!(old_source.primary, new_source.primary);
+        let old_overlay = old_source.supplemental.unwrap();
+        let new_overlay = new_source.supplemental.unwrap();
+        assert_eq!(old_overlay.len, new_overlay.len);
+        assert_eq!(
+            old_overlay
+                .modified
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            new_overlay
+                .modified
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+        );
+        assert_ne!(old_overlay.modified, new_overlay.modified);
+
+        cache.last_mtime_check.store(0, Ordering::Relaxed);
+        let after = cache.get().unwrap();
+        assert!(after
+            .check_package(Ecosystem::Npm, "new-package", None)
+            .is_some());
+        assert!(after
+            .check_package(Ecosystem::Npm, "old-package", None)
+            .is_none());
+        assert!(before
+            .check_package(Ecosystem::Npm, "old-package", None)
+            .is_some());
+    }
+
+    #[test]
+    fn periodic_cache_check_detects_resolved_primary_and_overlay_path_changes() {
+        let guard = isolated_global_state();
+        let primary = &guard.roots().threatdb;
+        let supplemental = &guard.roots().threatdb_supplemental;
+        std::fs::copy(signed_fixture_db_path(), primary).unwrap();
+        set_cache_test_mtime(primary, 100_000_000);
+        write_cache_test_overlay(supplemental, "old-package", 100_000_000);
+        let cache = ThreatDbCache::new();
+        let before = cache.get().unwrap();
+
+        // An identical signed file at the preferred path is still a different
+        // source. Resolution accepts either format at the preferred v2 name.
+        let preferred_primary = ThreatDb::default_path_v2().unwrap();
+        std::fs::hard_link(primary, &preferred_primary).unwrap();
+        cache.last_mtime_check.store(0, Ordering::Relaxed);
+        let after_primary = cache.get().unwrap();
+        assert!(!Arc::ptr_eq(&before, &after_primary));
+        assert_eq!(
+            cache
+                .state
+                .read()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .source
+                .primary
+                .path,
+            preferred_primary
+        );
+
+        let preferred_overlay = ThreatDb::supplemental_path_v2().unwrap();
+        write_cache_test_overlay(&preferred_overlay, "new-package", 100_000_000);
+        cache.last_mtime_check.store(0, Ordering::Relaxed);
+        let after_overlay = cache.get().unwrap();
+        assert!(after_overlay
+            .check_package(Ecosystem::Npm, "new-package", None)
+            .is_some());
+        assert!(after_overlay
+            .check_package(Ecosystem::Npm, "old-package", None)
+            .is_none());
+        assert_eq!(
+            cache
+                .state
+                .read()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .source
+                .supplemental
+                .as_ref()
+                .unwrap()
+                .path,
+            preferred_overlay
+        );
+    }
+
+    #[test]
+    fn invalid_signature_does_not_advance_accepted_cache_source() {
+        let guard = isolated_global_state();
+        let primary = &guard.roots().threatdb;
+        std::fs::copy(signed_fixture_db_path(), primary).unwrap();
+        set_cache_test_mtime(primary, 100_000_000);
+        let cache = ThreatDbCache::new();
+        let before = cache.get().unwrap();
+        let accepted_source = cache.state.read().unwrap().as_ref().unwrap().source.clone();
+
+        // A valid binary structure signed with an untrusted key must retain the
+        // old DB and fingerprint, so a later corrected update is still retried.
+        write_cache_test_overlay(primary, "untrusted-package", 200_000_000);
+        cache.last_mtime_check.store(0, Ordering::Relaxed);
+        let rejected = cache.get().unwrap();
+        assert!(Arc::ptr_eq(&before, &rejected));
+        assert_eq!(
+            cache.state.read().unwrap().as_ref().unwrap().source,
+            accepted_source
+        );
+
+        std::fs::copy(signed_fixture_db_path(), primary).unwrap();
+        set_cache_test_mtime(primary, 200_000_000);
+        cache.last_mtime_check.store(0, Ordering::Relaxed);
+        let corrected = cache.get().unwrap();
+        assert!(!Arc::ptr_eq(&before, &corrected));
+        assert_eq!(
+            cache.state.read().unwrap().as_ref().unwrap().source,
+            current_cache_source().unwrap()
+        );
+    }
+
+    #[test]
+    fn cache_source_changes_preserve_sequence_rollback_rules() {
+        assert!(!should_replace_cached_db(42, 41, true, false));
+        assert!(!should_replace_cached_db(42, 42, false, false));
+        assert!(should_replace_cached_db(42, 42, true, false));
+        assert!(should_replace_cached_db(42, 43, false, false));
+        assert!(should_replace_cached_db(42, 41, true, true));
+        assert!(should_replace_cached_db(0, 0, false, false));
     }
 
     #[test]

--- a/crates/tirith/assets/shell/lib/bash-hook.bash
+++ b/crates/tirith/assets/shell/lib/bash-hook.bash
@@ -101,7 +101,16 @@ case "$_TIRITH_BASH_BIN" in
   /*) [[ -x "$_TIRITH_BASH_BIN" ]] || _TIRITH_BASH_BIN="" ;;
   *) _TIRITH_BASH_BIN="" ;;
 esac
-_tirith_resolved_bin="$(type -P tirith 2>/dev/null || true)"
+if [[ "$#" -eq 2 && "$1" == "--tirith-executable" ]]; then
+  # `tirith init` supplies its native executable as source arguments, so npm
+  # and version-manager launchers do not become receipt-operation parents.
+  # Source arguments are temporary and do not trust an inherited env override.
+  _tirith_resolved_bin="$2"
+  [[ "$_tirith_resolved_bin" == /* && -f "$_tirith_resolved_bin" && -x "$_tirith_resolved_bin" ]] \
+    || _tirith_resolved_bin=""
+else
+  _tirith_resolved_bin="$(type -P tirith 2>/dev/null || true)"
+fi
 _TIRITH_BIN=""
 if [[ -n "$_tirith_resolved_bin" ]]; then
   _tirith_bin_name="${_tirith_resolved_bin##*/}"
@@ -1351,10 +1360,19 @@ _tirith_preexec() {
   [[ "${_TIRITH_BASH_INTERNAL:-0}" == "1" ]] && return 0
   local bash_cmd="${3:-$BASH_COMMAND}"
   local entry history_index="" history_line=""
-  if entry="$(_tirith_read_history_entry)"; then
-    history_index="${entry%%|*}"
-    history_line="${entry#*|}"
-  fi
+  # Startup and bracketed prompt callbacks never inspect a typed history line.
+  # Avoid two command-substitution forks on every automatic DEBUG fire. Keep
+  # reading in user/unbracketed phases, including typed prompt-sentinel names,
+  # so the origin and history-drift checks below retain their exact inputs.
+  case "${_TIRITH_PREEXEC_PHASE:-startup}" in
+    startup|prompt|off) ;;
+    *)
+      if entry="$(_tirith_read_history_entry)"; then
+        history_index="${entry%%|*}"
+        history_line="${entry#*|}"
+      fi
+      ;;
+  esac
 
   # Exact prompt sentinels are internal only when Bash reached them through the
   # installed prompt bracket. A user who types the private function name gets a

--- a/crates/tirith/assets/shell/lib/fish-hook.fish
+++ b/crates/tirith/assets/shell/lib/fish-hook.fish
@@ -20,8 +20,14 @@ end
 
 # Pin the executable before any repository command can mutate PATH. Refuse an
 # interactive hook when fish cannot resolve an absolute executable path.
-set -g _TIRITH_BIN (command -s tirith 2>/dev/null)
-if not string match -q '/*' -- "$_TIRITH_BIN"; or not test -x "$_TIRITH_BIN"
+if test (count $argv) -eq 2; and test "$argv[1]" = --tirith-executable
+    # `tirith init` passes the native CLI as temporary source arguments. Do not
+    # put an npm/version-manager launcher between the shell and its receipts.
+    set -g _TIRITH_BIN "$argv[2]"
+else
+    set -g _TIRITH_BIN (command -s tirith 2>/dev/null)
+end
+if not string match -q '/*' -- "$_TIRITH_BIN"; or not test -f "$_TIRITH_BIN"; or not test -x "$_TIRITH_BIN"
     if status is-interactive
         printf '%s\n' 'tirith: executable not found; fish hooks disabled' >&2
         set -g TIRITH_STATUS off

--- a/crates/tirith/assets/shell/lib/zsh-hook.zsh
+++ b/crates/tirith/assets/shell/lib/zsh-hook.zsh
@@ -23,7 +23,14 @@ fi
 
 # Pin the executable before any repository command can mutate PATH. All hook
 # callbacks use this absolute path for the lifetime of the shell session.
-_TIRITH_BIN="${commands[tirith]:-}"
+if [[ "$#" -eq 2 && "$1" == "--tirith-executable" ]]; then
+  # Bind native CLI source arguments from `tirith init`, bypassing launchers
+  # that would otherwise break the direct-parent receipt registration.
+  _TIRITH_BIN="$2"
+  [[ "$_TIRITH_BIN" == /* && -f "$_TIRITH_BIN" && -x "$_TIRITH_BIN" ]] || _TIRITH_BIN=""
+else
+  _TIRITH_BIN="${commands[tirith]:-}"
+fi
 if [[ -n "$_TIRITH_BIN" ]]; then
   _TIRITH_BIN="${_TIRITH_BIN:A}"
 fi

--- a/crates/tirith/assets/shell/tirith.sh
+++ b/crates/tirith/assets/shell/tirith.sh
@@ -4,22 +4,34 @@
 # Usage: eval "$(tirith init)" or `. /path/to/tirith.sh`
 
 _tirith_detect_shell() {
-  if [ -n "$ZSH_VERSION" ]; then
+  if [ -n "${ZSH_VERSION:-}" ]; then
     echo "zsh"
-  elif [ -n "$BASH_VERSION" ]; then
+  elif [ -n "${BASH_VERSION:-}" ]; then
     echo "bash"
-  elif [ -n "$FISH_VERSION" ]; then
+  elif [ -n "${FISH_VERSION:-}" ]; then
     echo "fish"
-  elif [ -n "$PSVersionTable" ]; then
+  elif [ -n "${PSVersionTable:-}" ]; then
     echo "powershell"
   else
     echo "unknown"
   fi
 }
 
-_tirith_dir="$(cd "$(dirname "$0")" && pwd)"
-
 _tirith_shell="$(_tirith_detect_shell)"
+
+# This file is sourced: in Bash, $0 still identifies the caller, and zsh's
+# FUNCTION_ARGZERO option can change it too. Locate the source itself, without
+# invoking PATH helpers or allowing CDPATH to alter the captured directory.
+case "$_tirith_shell" in
+  bash) _tirith_source="${BASH_SOURCE[0]}" ;;
+  zsh) _tirith_source="${(%):-%x}" ;;
+  *) return 0 ;;
+esac
+case "$_tirith_source" in
+  */*) _tirith_dir="${_tirith_source%/*}" ;;
+  *) _tirith_dir="." ;;
+esac
+_tirith_dir="$(CDPATH= builtin cd -P -- "$_tirith_dir" && builtin pwd)" || return 1
 
 case "$_tirith_shell" in
   zsh)
@@ -38,4 +50,4 @@ case "$_tirith_shell" in
     ;;
 esac
 
-unset _tirith_dir _tirith_shell
+unset _tirith_dir _tirith_shell _tirith_source

--- a/crates/tirith/src/cli/daemon.rs
+++ b/crates/tirith/src/cli/daemon.rs
@@ -434,6 +434,16 @@ pub fn try_daemon_check(
 
 #[cfg(unix)]
 fn handle_request(req: &DaemonRequest) -> DaemonResponse {
+    handle_request_with_analysis(req, engine::analyze_returning_policy)
+}
+
+#[cfg(unix)]
+fn handle_request_with_analysis(
+    req: &DaemonRequest,
+    analyze: impl FnOnce(
+        &AnalysisContext,
+    ) -> (tirith_core::verdict::Verdict, tirith_core::policy::Policy),
+) -> DaemonResponse {
     let empty_resp = |error: Option<String>, code: i32| DaemonResponse {
         action: Action::Allow,
         findings: vec![],
@@ -528,8 +538,10 @@ fn handle_request(req: &DaemonRequest) -> DaemonResponse {
         clipboard_source: tirith_core::clipboard::ClipboardSourceState::Unread,
     };
 
-    let mut verdict = engine::analyze(&ctx);
-    let policy = tirith_core::policy::Policy::discover(ctx.cwd.as_deref());
+    // Retain the engine's resolved policy, including remote policy and local
+    // overlays. Rediscovery costs another read/fetch and can give enrichment a
+    // different policy if configuration changes during the request.
+    let (mut verdict, policy) = analyze(&ctx);
 
     let mut late_findings = tirith_core::threatdb_api::enrich_command_with_network(
         &req.input,
@@ -1478,6 +1490,57 @@ mod tests {
             .expect("offline runtime finding");
         assert_eq!(runtime.severity, tirith_core::verdict::Severity::Critical);
         assert_eq!(resp.action, Action::Block);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_enrichment_retains_engine_policy_when_configuration_changes() {
+        let global = GlobalStateGuard::new().expect("isolated daemon policy state");
+        let policy_dir = global.roots().policy.join(".tirith");
+        std::fs::create_dir_all(&policy_dir).unwrap();
+        let policy_path = policy_dir.join("policy.yaml");
+        std::fs::write(
+            &policy_path,
+            "severity_overrides:\n  analysis_incomplete: CRITICAL\n",
+        )
+        .unwrap();
+        let req = super::DaemonRequest {
+            command: "check".into(),
+            input: "pip install tirith-daemon-policy-snapshot-fixture==9.9.9".into(),
+            context: "exec".into(),
+            cwd: Some(global.roots().cwd.display().to_string()),
+            shell: Some("posix".into()),
+            interactive: false,
+            bypass_requested: false,
+            offline: true,
+        };
+
+        let response = super::handle_request_with_analysis(&req, |ctx| {
+            let analyzed = tirith_core::engine::analyze_returning_policy(ctx);
+            assert_eq!(
+                analyzed
+                    .1
+                    .severity_override(&tirith_core::verdict::RuleId::AnalysisIncomplete),
+                Some(tirith_core::verdict::Severity::Critical)
+            );
+            // Model a policy deployment immediately after initial analysis.
+            // A second discovery would weaken the late offline-coverage finding.
+            std::fs::write(
+                &policy_path,
+                "severity_overrides:\n  analysis_incomplete: INFO\n",
+            )
+            .unwrap();
+            analyzed
+        });
+        let runtime = response
+            .raw_findings
+            .as_deref()
+            .unwrap_or(&[])
+            .iter()
+            .find(|finding| finding.description.contains("skipped by offline mode"))
+            .expect("offline runtime finding");
+        assert_eq!(runtime.severity, tirith_core::verdict::Severity::Critical);
+        assert_eq!(response.action, Action::Block);
     }
 
     fn base_response() -> DaemonResponse {

--- a/crates/tirith/src/cli/doctor.rs
+++ b/crates/tirith/src/cli/doctor.rs
@@ -932,6 +932,7 @@ pub(super) fn create_policy_contained(
 /// Findings hidden by the current paranoia level.
 #[derive(Debug, Clone, serde::Serialize)]
 struct DetectionGapInfo {
+    audit_history_truncated: bool,
     total_commands: usize,
     blocked: usize,
     warned: usize,
@@ -1049,6 +1050,7 @@ fn check_detection_gaps() -> Option<DetectionGapInfo> {
     let current_paranoia = policy.paranoia;
 
     Some(DetectionGapInfo {
+        audit_history_truncated: read_result.truncated,
         total_commands,
         blocked,
         warned,
@@ -2850,6 +2852,9 @@ fn print_human(info: &DoctorInfo) {
     if let Some(ref gaps) = info.detection_gaps {
         println!();
         println!("Detection coverage (last 7 days)");
+        if gaps.audit_history_truncated {
+            println!("  Recent audit tail only; older history was not inspected.");
+        }
         println!(
             "  {} commands scanned, {} blocked, {} warned",
             gaps.total_commands, gaps.blocked, gaps.warned
@@ -2866,9 +2871,7 @@ fn print_human(info: &DoctorInfo) {
         );
 
         if gaps.hidden_findings == 0 && gaps.records_with_raw > 0 {
-            println!(
-                "  No hidden findings — detection coverage is complete at current paranoia level"
-            );
+            println!("  No hidden findings in the analyzed records at current paranoia level");
         } else if gaps.hidden_findings == 0 && gaps.records_with_raw == 0 {
             println!(
                 "  No raw detection data available (all records are pre-upgrade). Cannot assess hidden findings."

--- a/crates/tirith/src/cli/explain.rs
+++ b/crates/tirith/src/cli/explain.rs
@@ -79,10 +79,11 @@ fn resolve_finding_id(id: &str) -> Result<RuleId, String> {
         .find(|r| r.event_id.as_deref() == Some(event_id));
 
     let Some(entry) = entry else {
-        if read.records.len() > AUDIT_SCAN_LIMIT {
+        if read.truncated {
             return Err(format!(
-                "finding ID {id:?} not found in the {scanned} most-recent audit entries (cap is {AUDIT_SCAN_LIMIT}); \
-                 narrow via `tirith audit export --since <duration>` and re-run"
+                "finding ID {id:?} not found in the {scanned} most-recent audit entries inspected \
+                 (limit is {AUDIT_SCAN_LIMIT} records or the bounded recent tail); older history was not searched. \
+                 Use `tirith audit export --since <duration>` to locate the rule ID, then `tirith explain --rule <rule_id>`"
             ));
         }
         return Err(format!(

--- a/crates/tirith/src/cli/incident.rs
+++ b/crates/tirith/src/cli/incident.rs
@@ -519,7 +519,12 @@ fn append_timeline(s: &mut String, since: Option<u64>) {
     // repo-0481: bounded tail read (the incident window only needs the newest
     // records; the full log can be arbitrarily large).
     let records = match tirith_core::audit_aggregator::read_log_tail(&path, 10_000) {
-        Ok(r) => r.records,
+        Ok(r) => {
+            if r.truncated {
+                s.push_str("_Recent audit tail only; older history was not inspected._\n\n");
+            }
+            r.records
+        }
         Err(e) => {
             s.push_str(&format!("_Could not read audit log: {e}_\n\n"));
             return;
@@ -603,7 +608,12 @@ fn append_top_findings(s: &mut String, since: Option<u64>) {
     // repo-0481: bounded tail read (the incident window only needs the newest
     // records; the full log can be arbitrarily large).
     let records = match tirith_core::audit_aggregator::read_log_tail(&path, 10_000) {
-        Ok(r) => r.records,
+        Ok(r) => {
+            if r.truncated {
+                s.push_str("_Recent audit tail only; older history was not inspected._\n\n");
+            }
+            r.records
+        }
         Err(e) => {
             s.push_str(&format!("_Could not read audit log: {e}_\n\n"));
             return;

--- a/crates/tirith/src/cli/init.rs
+++ b/crates/tirith/src/cli/init.rs
@@ -22,14 +22,20 @@ fn native_hook_source_line(shell: &str, hook: &Path, executable: &Path) -> Resul
     let hook = hook
         .to_str()
         .ok_or_else(|| "shell hook path is not valid UTF-8".to_string())?;
-    let executable = executable
-        .to_str()
-        .ok_or_else(|| "native executable path is not valid UTF-8".to_string())?;
     let quote = if shell == "fish" {
         fish_single_quote
     } else {
         posix_single_quote
     };
+    // Native Windows paths do not satisfy the POSIX hooks' absolute-path
+    // contract. Strict receipts are unavailable there, so preserve each
+    // shell's existing PATH resolution instead of passing a native path.
+    if !cfg!(unix) {
+        return Ok(format!("source {}", quote(hook)));
+    }
+    let executable = executable
+        .to_str()
+        .ok_or_else(|| "native executable path is not valid UTF-8".to_string())?;
     Ok(format!(
         "source {} --tirith-executable {}",
         quote(hook),
@@ -733,6 +739,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn native_hook_binding_quotes_both_paths_as_literal_source_arguments() {
         let line = native_hook_source_line(
             "bash",
@@ -744,6 +751,25 @@ mod tests {
             line,
             "source '/hook'\\''s dir/$hook\nfile' --tirith-executable '/native'\\''s dir/$(not-a-command)/tirith'"
         );
+    }
+
+    #[test]
+    #[cfg(not(unix))]
+    fn native_hook_binding_preserves_non_unix_shell_path_resolution() {
+        for (shell, expected) in [
+            ("bash", "source 'C:/hook'\\''s dir/hook'"),
+            ("zsh", "source 'C:/hook'\\''s dir/hook'"),
+            ("fish", "source 'C:/hook\\'s dir/hook'"),
+        ] {
+            let line = native_hook_source_line(
+                shell,
+                Path::new("C:/hook's dir/hook"),
+                Path::new(r"\\?\C:\native\tirith.exe"),
+            )
+            .unwrap();
+            assert_eq!(line, expected, "shell={shell}");
+            assert!(!line.contains("--tirith-executable"));
+        }
     }
 
     #[test]

--- a/crates/tirith/src/cli/init.rs
+++ b/crates/tirith/src/cli/init.rs
@@ -12,6 +12,31 @@ fn powershell_single_quote(path: &str) -> String {
     format!("'{}'", path.replace('\'', "''"))
 }
 
+fn fish_single_quote(path: &str) -> String {
+    // Fish interprets backslash escapes inside single quotes, unlike POSIX
+    // shells. Escape backslashes before apostrophes to preserve exact bytes.
+    format!("'{}'", path.replace('\\', "\\\\").replace('\'', "\\'"))
+}
+
+fn native_hook_source_line(shell: &str, hook: &Path, executable: &Path) -> Result<String, String> {
+    let hook = hook
+        .to_str()
+        .ok_or_else(|| "shell hook path is not valid UTF-8".to_string())?;
+    let executable = executable
+        .to_str()
+        .ok_or_else(|| "native executable path is not valid UTF-8".to_string())?;
+    let quote = if shell == "fish" {
+        fish_single_quote
+    } else {
+        posix_single_quote
+    };
+    Ok(format!(
+        "source {} --tirith-executable {}",
+        quote(hook),
+        quote(executable)
+    ))
+}
+
 /// Render an exact Nushell string literal. Nushell's single-quoted strings do
 /// not support embedded apostrophes or escapes, so paths are always emitted as
 /// double-quoted literals with every special/control character encoded.
@@ -107,14 +132,36 @@ pub fn run(shell: Option<&str>, prompt_status: bool) -> i32 {
     };
 
     let hook_dir = find_hook_dir();
+    // npm and version-manager launchers add a process between the shell and
+    // Tirith. Receipt registration requires the native binary to be the shell's
+    // direct child. Bind each new initialization to this running installation,
+    // rather than resolving the launcher again from PATH inside the hook.
+    let native_executable = if matches!(shell, "bash" | "zsh" | "fish") {
+        match std::env::current_exe().and_then(std::fs::canonicalize) {
+            Ok(path) => Some(path),
+            Err(error) => {
+                eprintln!("tirith: cannot locate the native executable for shell hooks: {error}");
+                return 1;
+            }
+        }
+    } else {
+        None
+    };
 
     match shell {
         "zsh" => {
             if let Some(dir) = &hook_dir {
-                println!(
-                    "source {}",
-                    posix_single_quote(&dir.join("lib/zsh-hook.zsh").display().to_string())
-                );
+                match native_hook_source_line(
+                    shell,
+                    &dir.join("lib/zsh-hook.zsh"),
+                    native_executable.as_ref().unwrap(),
+                ) {
+                    Ok(line) => println!("{line}"),
+                    Err(error) => {
+                        eprintln!("tirith: {error}");
+                        return 1;
+                    }
+                }
             } else {
                 eprintln!("tirith: could not locate or materialize shell hooks.");
                 return 1;
@@ -129,10 +176,17 @@ pub fn run(shell: Option<&str>, prompt_status: bool) -> i32 {
         }
         "bash" => {
             if let Some(dir) = &hook_dir {
-                println!(
-                    "source {}",
-                    posix_single_quote(&dir.join("lib/bash-hook.bash").display().to_string())
-                );
+                match native_hook_source_line(
+                    shell,
+                    &dir.join("lib/bash-hook.bash"),
+                    native_executable.as_ref().unwrap(),
+                ) {
+                    Ok(line) => println!("{line}"),
+                    Err(error) => {
+                        eprintln!("tirith: {error}");
+                        return 1;
+                    }
+                }
             } else {
                 eprintln!("tirith: could not locate or materialize shell hooks.");
                 return 1;
@@ -147,10 +201,17 @@ pub fn run(shell: Option<&str>, prompt_status: bool) -> i32 {
         }
         "fish" => {
             if let Some(dir) = &hook_dir {
-                println!(
-                    "source {}",
-                    posix_single_quote(&dir.join("lib/fish-hook.fish").display().to_string())
-                );
+                match native_hook_source_line(
+                    shell,
+                    &dir.join("lib/fish-hook.fish"),
+                    native_executable.as_ref().unwrap(),
+                ) {
+                    Ok(line) => println!("{line}"),
+                    Err(error) => {
+                        eprintln!("tirith: {error}");
+                        return 1;
+                    }
+                }
             } else {
                 eprintln!("tirith: could not locate or materialize shell hooks.");
                 return 1;
@@ -661,14 +722,85 @@ fn materialize_hooks_at(data_dir: &Path) -> Result<(PathBuf, bool), String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        materialize_hooks_at, materialized_hooks_match_at, normalize_shell_name,
-        nushell_string_literal, posix_single_quote, powershell_single_quote,
+        materialize_hooks_at, materialized_hooks_match_at, native_hook_source_line,
+        normalize_shell_name, nushell_string_literal, posix_single_quote, powershell_single_quote,
         prompt_status_snippet_for,
     };
     use std::path::Path;
 
     fn prompt_status_snippet(shell: &str) -> String {
         prompt_status_snippet_for(shell, Path::new("/opt/Tirith Bin/tirith"))
+    }
+
+    #[test]
+    fn native_hook_binding_quotes_both_paths_as_literal_source_arguments() {
+        let line = native_hook_source_line(
+            "bash",
+            Path::new("/hook's dir/$hook\nfile"),
+            Path::new("/native's dir/$(not-a-command)/tirith"),
+        )
+        .unwrap();
+        assert_eq!(
+            line,
+            "source '/hook'\\''s dir/$hook\nfile' --tirith-executable '/native'\\''s dir/$(not-a-command)/tirith'"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn native_hook_binding_rejects_lossy_path_identity() {
+        use std::os::unix::ffi::OsStrExt as _;
+        let invalid = Path::new(std::ffi::OsStr::from_bytes(b"/bin/non-utf8-\xff"));
+        for shell in ["bash", "zsh", "fish"] {
+            assert!(native_hook_source_line(shell, invalid, Path::new("/bin/tirith")).is_err());
+            assert!(native_hook_source_line(shell, Path::new("/shell/hook"), invalid).is_err());
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn native_hook_binding_preserves_fish_source_argument_identity() {
+        use std::process::Command;
+
+        let root = tempfile::tempdir().unwrap();
+        for component in [
+            r"double\\backslash",
+            "mixed\\'apostrophe",
+            "trailing\\",
+            "white space\tand\nnewline",
+        ] {
+            let directory = root.path().join(component);
+            std::fs::create_dir(&directory).unwrap();
+            let hook = directory.join("hook.fish");
+            std::fs::write(&hook, "builtin printf '%s\\0' \"$argv[1]\" \"$argv[2]\"\n").unwrap();
+            // Include a trailing backslash in the executable argument as well
+            // as its directory: the closing quote must remain unambiguous.
+            let executable = directory.join("native's binary\\");
+            let line = native_hook_source_line("fish", &hook, &executable).unwrap();
+            let output = match Command::new("fish")
+                .args(["--no-config", "-c", &line])
+                .env("HOME", root.path())
+                .output()
+            {
+                Ok(output) => output,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    eprintln!("skipping fish source argument test: fish is not installed");
+                    return;
+                }
+                Err(error) => panic!("could not execute fish: {error}"),
+            };
+            assert!(
+                output.status.success(),
+                "component={component:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let expected = format!("--tirith-executable\0{}\0", executable.to_str().unwrap());
+            assert_eq!(
+                output.stdout,
+                expected.as_bytes(),
+                "component={component:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tirith/tests/shell_conformance.rs
+++ b/crates/tirith/tests/shell_conformance.rs
@@ -1082,6 +1082,114 @@ fn bash_enter_degradation_restores_custom_ctrl_o_bindings() {
 }
 
 // === fish ===
+
+/// npm's Node launcher must only run `init`; subsequent receipt operations
+/// must run the native binary directly under each interactive shell.
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn npm_init_preserves_native_shell_receipts_and_allow_block_delivery() {
+    use std::os::unix::fs::{symlink, PermissionsExt as _};
+
+    let node = match std::process::Command::new("node")
+        .args(["-p", "process.platform + '-' + process.arch"])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => {
+            eprintln!("skipping npm shell integration: Node is not installed");
+            return;
+        }
+    };
+    let platform = String::from_utf8(node.stdout).unwrap();
+    let mut shells = Vec::new();
+    if let Some(shell) = modern_bash() {
+        shells.push(("bash", shell, vec!["--noprofile", "--norc", "-i"]));
+    }
+    if let Some(shell) = zsh_bin() {
+        shells.push(("zsh", shell, vec!["-f", "-i"]));
+    }
+    if let Some(shell) = fish_bin() {
+        shells.push(("fish", shell, vec!["--no-config", "-i"]));
+    }
+    for (family, shell, arguments) in shells {
+        let mut env = IsolatedEnv::new();
+        let bin = env.workdir.join("npm bin");
+        std::fs::create_dir(&bin).unwrap();
+        let launcher = bin.join("tirith");
+        std::fs::copy(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../npm/tirith/bin/tirith"),
+            &launcher,
+        )
+        .unwrap();
+        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let package = bin
+            .join("node_modules/@sheeki03")
+            .join(format!("tirith-{}", platform.trim()));
+        std::fs::create_dir_all(package.join("bin")).unwrap();
+        std::fs::write(package.join("package.json"), "{}").unwrap();
+        symlink(pty_support::tirith_bin(), package.join("bin/tirith")).unwrap();
+        env.set(
+            "PATH",
+            &format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        );
+        if family == "bash" {
+            env.set("TIRITH_BASH_MODE", "enter");
+            env.seed_bash_enter_capability(
+                "works",
+                &pty_support::bash_version_string(&shell).unwrap(),
+                &shell,
+            );
+        }
+        let allowed = env.workdir.join("npm-allowed");
+        let blocked = env.workdir.join("npm-blocked");
+        let mut sess = PtySession::spawn(&env, &shell, &arguments);
+        sess.send_line(match family {
+            "fish" => "function fish_prompt; printf 'TIRITH_PTY> '; end",
+            "zsh" => "PROMPT='TIRITH_PTY> '; RPROMPT=''",
+            _ => "PS1='TIRITH_PTY> '",
+        });
+        sess.expect("TIRITH_PTY> ");
+        sess.wait_idle(QUIET, SETTLE_MAX);
+        sess.clear_buffer();
+        sess.send_line(&if family == "fish" {
+            "tirith init --shell fish | source".to_string()
+        } else {
+            format!("eval \"$(tirith init --shell {family})\"")
+        });
+        sess.expect("TIRITH_PTY> ");
+        sess.wait_idle(QUIET, SETTLE_MAX);
+        sess.clear_buffer();
+        sess.send_line("printf 'NPM_PROTOCOL<%s>\\n' \"$_TIRITH_RECEIPT_PROTOCOL\"");
+        sess.expect("NPM_PROTOCOL<3>");
+        sess.wait_idle(QUIET, SETTLE_MAX);
+        let before = strict_ledger_counts(&env);
+        assert!(
+            before.1 >= 1,
+            "{family}: protocol probe must create a receipt"
+        );
+        sess.clear_buffer();
+        sess.send_line(&format!("printf 'ALLOWED\\n' >> '{}'", allowed.display()));
+        let body = wait_for_marker(&allowed, "ALLOWED", MARKER_MAX);
+        assert_eq!(count_occurrences(&body, "ALLOWED"), 1, "{family}");
+        let after_allowed = strict_ledger_counts(&env);
+        assert_eq!(after_allowed, (0, before.1 + 1), "{family}");
+        sess.clear_buffer();
+        sess.send_line(&format!(
+            "printf 'true' | bash && touch '{}'",
+            blocked.display()
+        ));
+        sess.expect("BLOCKED");
+        sess.wait_idle(QUIET, SETTLE_MAX);
+        assert!(!blocked.exists(), "{family}: rejected command executed");
+        assert_eq!(strict_ledger_counts(&env), after_allowed, "{family}");
+        sess.close();
+    }
+}
+
 // The fish hook binds Enter to `_tirith_check_command`, ending with
 // `commandline -f execute` (fish's supported line-accept). Delivery is reliable;
 // the harness answers fish 4.x's terminal probes so startup doesn't hang.

--- a/crates/tirith/tests/shell_helper_portability.rs
+++ b/crates/tirith/tests/shell_helper_portability.rs
@@ -85,6 +85,134 @@ fn fixture() -> tempfile::TempDir {
 }
 
 #[test]
+fn explicit_native_source_argument_bypasses_launchers_without_changing_path() {
+    for (family, shell) in shells() {
+        let root = fixture();
+        let native = root.path().join("native's binary");
+        executable(&native, "printf 'NATIVE_EXECUTED\\n'");
+        let bin = quote(&root.path().join("good bin"));
+        let hook = quote(&pty_support::embedded_hook(&format!(
+            "{family}-hook.{family}"
+        )));
+        let native = quote(&native);
+        let script = if family == "fish" {
+            format!(
+                r#"set -gx PATH {bin}; set argv caller arguments
+source {hook} --tirith-executable {native}
+test "$argv[1]" = caller; and test "$argv[2]" = arguments; or exit 1
+test "$PATH" = {bin}; or exit 2
+command "$_TIRITH_BIN"
+"#
+            )
+        } else {
+            format!(
+                r#"PATH={bin}; set -- caller arguments
+source {hook} --tirith-executable {native}
+[[ "$1" == caller && "$2" == arguments ]] || exit 1
+[[ "$PATH" == {bin} ]] || exit 2
+command "$_TIRITH_BIN"
+"#
+            )
+        };
+        let output = run(&shell, family, root.path(), false, &script);
+        assert_eq!(output.stdout, b"NATIVE_EXECUTED\n", "{family}");
+    }
+}
+
+#[test]
+fn source_loader_resolves_itself_independently_of_caller_and_cdpath() {
+    let mut candidates = shells();
+    if !candidates
+        .iter()
+        .any(|(_, path)| path == Path::new("/bin/bash"))
+    {
+        candidates.push(("bash", PathBuf::from("/bin/bash")));
+    }
+    for (family, shell) in candidates {
+        if family == "fish" {
+            continue;
+        }
+        let root = tempfile::tempdir().unwrap();
+        let directory = root.path().join("hook's directory");
+        fs::create_dir_all(directory.join("lib")).unwrap();
+        let loader = directory.join("tirith.sh");
+        fs::copy(pty_support::embedded_hook("../tirith.sh"), &loader).unwrap();
+        fs::write(
+            directory.join(format!("lib/{family}-hook.{family}")),
+            "builtin printf 'LOADED_FROM_SOURCE\\n'\n",
+        )
+        .unwrap();
+        for source in [&loader, &PathBuf::from("hook's directory/tirith.sh")] {
+            let script = format!(
+                "PATH=/missing; CDPATH=/does/not/exist; {}; source {}",
+                if family == "zsh" {
+                    "unsetopt functionargzero"
+                } else {
+                    ":"
+                },
+                quote(source)
+            );
+            let output = run(&shell, family, root.path(), false, &script);
+            assert_eq!(output.stdout, b"LOADED_FROM_SOURCE\n", "{family}");
+            assert!(output.stderr.is_empty(), "{family}: {output:?}");
+        }
+    }
+}
+
+#[test]
+fn bash_prompt_fast_path_preserves_typed_sentinels_and_history_drift() {
+    for shell in [
+        PathBuf::from("/bin/bash"),
+        pty_support::modern_bash().unwrap_or_else(|| PathBuf::from("/bin/bash")),
+    ] {
+        let root = fixture();
+        let history_log = root.path().join("history.log");
+        let check_log = root.path().join("check.log");
+        executable(
+            &root.path().join("good bin/tirith"),
+            &format!("printf '%s\\n' \"$*\" >> {}", quote(&check_log)),
+        );
+        let script = format!(
+            r#"PATH={bin}:/usr/bin:/bin
+source {hook}
+_TIRITH_PREEXEC_PROMPT_GUARDS=1
+_TIRITH_RECEIPT_PROTOCOL=0
+_tirith_read_history_entry() {{ printf 'read\n' >> {history_log}; printf '%s\n' "$_TEST_HISTORY"; }}
+_tirith_preexec_prompt_guards_attached() {{ return 0; }}
+_tirith_preexec_block_current_line() {{ printf 'DRIFT_BLOCKED\n'; return 1; }}
+for phase in startup prompt off; do
+    _TIRITH_PREEXEC_PHASE="$phase"
+    _tirith_preexec 1 1 'automatic_prompt_work'
+    _tirith_preexec 1 1 '_tirith_preexec_prompt_begin'
+done
+[[ ! -e {history_log} ]] || exit 11
+_TIRITH_PREEXEC_PHASE=user
+_TIRITH_PREEXEC_ACTIVE_DECISION=''
+_TEST_HISTORY='1|_tirith_preexec_prompt_begin'
+_tirith_preexec 2 1 '_tirith_preexec_prompt_begin'
+[[ "$_TIRITH_PREEXEC_PHASE" == user ]] || exit 12
+_TIRITH_PREEXEC_PHASE=user
+_TIRITH_PREEXEC_ENFORCE=1
+_TIRITH_PREEXEC_ACTIVE_DECISION=''
+_TEST_HISTORY='2|echo prior_command'
+_tirith_preexec 3 1 'echo changed_command'
+[[ $? == 1 ]] || exit 13
+"#,
+            bin = quote(&root.path().join("good bin")),
+            hook = quote(&pty_support::embedded_hook("bash-hook.bash")),
+            history_log = quote(&history_log),
+        );
+        let output = run(&shell, "bash", root.path(), false, &script);
+        assert_eq!(fs::read_to_string(history_log).unwrap(), "read\nread\n");
+        assert_eq!(
+            fs::read_to_string(check_log).unwrap(),
+            "check --shell posix --warn-only -- _tirith_preexec_prompt_begin\n"
+        );
+        assert!(String::from_utf8_lossy(&output.stdout).contains("DRIFT_BLOCKED"));
+    }
+}
+
+#[test]
 fn helper_resolution_ignores_hashes_functions_and_relative_path_entries() {
     for (family, shell) in shells() {
         let root = fixture();

--- a/npm/tirith/bin/tirith
+++ b/npm/tirith/bin/tirith
@@ -39,8 +39,21 @@ try {
 try {
   execFileSync(binPath, process.argv.slice(2), { stdio: "inherit" });
 } catch (e) {
-  if (e.status !== undefined) {
+  if (typeof e.status === "number") {
     process.exit(e.status);
   }
-  throw e;
+  if (e.signal) {
+    // execFileSync reports a signalled child with status=null. Passing null to
+    // process.exit would turn a crash or interruption into successful exit 0.
+    // Preserve the signal for calling shells, with a failure fallback on
+    // platforms that cannot deliver that signal to the launcher.
+    process.exitCode = 1;
+    try {
+      process.kill(process.pid, e.signal);
+    } catch {
+      process.exit(1);
+    }
+  } else {
+    throw e;
+  }
 }

--- a/shell/lib/bash-hook.bash
+++ b/shell/lib/bash-hook.bash
@@ -101,7 +101,16 @@ case "$_TIRITH_BASH_BIN" in
   /*) [[ -x "$_TIRITH_BASH_BIN" ]] || _TIRITH_BASH_BIN="" ;;
   *) _TIRITH_BASH_BIN="" ;;
 esac
-_tirith_resolved_bin="$(type -P tirith 2>/dev/null || true)"
+if [[ "$#" -eq 2 && "$1" == "--tirith-executable" ]]; then
+  # `tirith init` supplies its native executable as source arguments, so npm
+  # and version-manager launchers do not become receipt-operation parents.
+  # Source arguments are temporary and do not trust an inherited env override.
+  _tirith_resolved_bin="$2"
+  [[ "$_tirith_resolved_bin" == /* && -f "$_tirith_resolved_bin" && -x "$_tirith_resolved_bin" ]] \
+    || _tirith_resolved_bin=""
+else
+  _tirith_resolved_bin="$(type -P tirith 2>/dev/null || true)"
+fi
 _TIRITH_BIN=""
 if [[ -n "$_tirith_resolved_bin" ]]; then
   _tirith_bin_name="${_tirith_resolved_bin##*/}"
@@ -1351,10 +1360,19 @@ _tirith_preexec() {
   [[ "${_TIRITH_BASH_INTERNAL:-0}" == "1" ]] && return 0
   local bash_cmd="${3:-$BASH_COMMAND}"
   local entry history_index="" history_line=""
-  if entry="$(_tirith_read_history_entry)"; then
-    history_index="${entry%%|*}"
-    history_line="${entry#*|}"
-  fi
+  # Startup and bracketed prompt callbacks never inspect a typed history line.
+  # Avoid two command-substitution forks on every automatic DEBUG fire. Keep
+  # reading in user/unbracketed phases, including typed prompt-sentinel names,
+  # so the origin and history-drift checks below retain their exact inputs.
+  case "${_TIRITH_PREEXEC_PHASE:-startup}" in
+    startup|prompt|off) ;;
+    *)
+      if entry="$(_tirith_read_history_entry)"; then
+        history_index="${entry%%|*}"
+        history_line="${entry#*|}"
+      fi
+      ;;
+  esac
 
   # Exact prompt sentinels are internal only when Bash reached them through the
   # installed prompt bracket. A user who types the private function name gets a

--- a/shell/lib/fish-hook.fish
+++ b/shell/lib/fish-hook.fish
@@ -20,8 +20,14 @@ end
 
 # Pin the executable before any repository command can mutate PATH. Refuse an
 # interactive hook when fish cannot resolve an absolute executable path.
-set -g _TIRITH_BIN (command -s tirith 2>/dev/null)
-if not string match -q '/*' -- "$_TIRITH_BIN"; or not test -x "$_TIRITH_BIN"
+if test (count $argv) -eq 2; and test "$argv[1]" = --tirith-executable
+    # `tirith init` passes the native CLI as temporary source arguments. Do not
+    # put an npm/version-manager launcher between the shell and its receipts.
+    set -g _TIRITH_BIN "$argv[2]"
+else
+    set -g _TIRITH_BIN (command -s tirith 2>/dev/null)
+end
+if not string match -q '/*' -- "$_TIRITH_BIN"; or not test -f "$_TIRITH_BIN"; or not test -x "$_TIRITH_BIN"
     if status is-interactive
         printf '%s\n' 'tirith: executable not found; fish hooks disabled' >&2
         set -g TIRITH_STATUS off

--- a/shell/lib/zsh-hook.zsh
+++ b/shell/lib/zsh-hook.zsh
@@ -23,7 +23,14 @@ fi
 
 # Pin the executable before any repository command can mutate PATH. All hook
 # callbacks use this absolute path for the lifetime of the shell session.
-_TIRITH_BIN="${commands[tirith]:-}"
+if [[ "$#" -eq 2 && "$1" == "--tirith-executable" ]]; then
+  # Bind native CLI source arguments from `tirith init`, bypassing launchers
+  # that would otherwise break the direct-parent receipt registration.
+  _TIRITH_BIN="$2"
+  [[ "$_TIRITH_BIN" == /* && -f "$_TIRITH_BIN" && -x "$_TIRITH_BIN" ]] || _TIRITH_BIN=""
+else
+  _TIRITH_BIN="${commands[tirith]:-}"
+fi
 if [[ -n "$_TIRITH_BIN" ]]; then
   _TIRITH_BIN="${_TIRITH_BIN:A}"
 fi

--- a/shell/tirith.sh
+++ b/shell/tirith.sh
@@ -4,22 +4,34 @@
 # Usage: eval "$(tirith init)" or `. /path/to/tirith.sh`
 
 _tirith_detect_shell() {
-  if [ -n "$ZSH_VERSION" ]; then
+  if [ -n "${ZSH_VERSION:-}" ]; then
     echo "zsh"
-  elif [ -n "$BASH_VERSION" ]; then
+  elif [ -n "${BASH_VERSION:-}" ]; then
     echo "bash"
-  elif [ -n "$FISH_VERSION" ]; then
+  elif [ -n "${FISH_VERSION:-}" ]; then
     echo "fish"
-  elif [ -n "$PSVersionTable" ]; then
+  elif [ -n "${PSVersionTable:-}" ]; then
     echo "powershell"
   else
     echo "unknown"
   fi
 }
 
-_tirith_dir="$(cd "$(dirname "$0")" && pwd)"
-
 _tirith_shell="$(_tirith_detect_shell)"
+
+# This file is sourced: in Bash, $0 still identifies the caller, and zsh's
+# FUNCTION_ARGZERO option can change it too. Locate the source itself, without
+# invoking PATH helpers or allowing CDPATH to alter the captured directory.
+case "$_tirith_shell" in
+  bash) _tirith_source="${BASH_SOURCE[0]}" ;;
+  zsh) _tirith_source="${(%):-%x}" ;;
+  *) return 0 ;;
+esac
+case "$_tirith_source" in
+  */*) _tirith_dir="${_tirith_source%/*}" ;;
+  *) _tirith_dir="." ;;
+esac
+_tirith_dir="$(CDPATH= builtin cd -P -- "$_tirith_dir" && builtin pwd)" || return 1
 
 case "$_tirith_shell" in
   zsh)
@@ -38,4 +50,4 @@ case "$_tirith_shell" in
     ;;
 esac
 
-unset _tirith_dir _tirith_shell
+unset _tirith_dir _tirith_shell _tirith_source

--- a/tests/npm-launcher.mjs
+++ b/tests/npm-launcher.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "tirith-npm-launcher-"));
+const source = fileURLToPath(new URL("../npm/tirith/bin/tirith", import.meta.url));
+const launcher = path.join(root, "tirith.cjs");
+const platform = `${process.platform}-${process.arch}`;
+const packageName = `@sheeki03/tirith-${platform}`;
+const packageDir = path.join(root, "node_modules", packageName);
+const binary = path.join(packageDir, "bin", process.platform === "win32" ? "tirith.exe" : "tirith");
+const env = { ...process.env };
+delete env.NODE_OPTIONS;
+delete env.NODE_PATH;
+
+function launch(...args) {
+  const result = spawnSync(process.execPath, [launcher, ...args], {
+    cwd: root,
+    env,
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  assert.ifError(result.error);
+  return result;
+}
+
+try {
+  fs.copyFileSync(source, launcher);
+  const missingPackage = launch();
+  assert.equal(missingPackage.status, 1);
+  assert.match(missingPackage.stderr, /Could not find package/);
+  assert.ok(missingPackage.stderr.includes(packageName));
+  assert.match(missingPackage.stderr, /npm install tirith --force/);
+
+  fs.mkdirSync(path.dirname(binary), { recursive: true });
+  fs.writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({ name: packageName }));
+  // Node supplies a real platform executable, so these assertions exercise
+  // execFileSync and OS exit/signal behavior without a Cargo build or release.
+  if (process.platform === "win32") {
+    fs.copyFileSync(process.execPath, binary);
+  } else {
+    fs.symlinkSync(process.execPath, binary);
+  }
+
+  const success = launch("-e", "process.stdout.write(process.argv[1])", "--", "literal ; $(argument)");
+  assert.equal(success.status, 0);
+  assert.equal(success.stdout, "literal ; $(argument)");
+  assert.equal(launch("-e", "process.exit(7)").status, 7);
+
+  const killed = launch("-e", "process.kill(process.pid, 'SIGTERM')");
+  assert.notEqual(killed.status, 0, "a terminated native child must never look successful");
+  if (process.platform !== "win32") {
+    assert.equal(killed.signal, "SIGTERM");
+  }
+
+  fs.unlinkSync(binary);
+  const missingBinary = launch();
+  assert.notEqual(missingBinary.status, 0);
+  assert.match(missingBinary.stderr, /ENOENT/);
+  console.log("npm launcher exit, signal, argument, and missing-installation checks passed");
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/tools/license-server/src/routes/refresh.rs
+++ b/tools/license-server/src/routes/refresh.rs
@@ -35,8 +35,9 @@ pub async fn refresh(
         AppError::Internal("subscription not found".into())
     })?;
 
-    // canceled still gets tokens — benefits continue until period end.
-    if sub.status != "active" && sub.status != "canceled" {
+    // Match the atomic publication gate: trials have benefits, and canceled
+    // subscriptions keep them until the provider sends period-end revocation.
+    if !matches!(sub.status.as_str(), "active" | "trialing" | "canceled") {
         return Err(AppError::PaymentRequired(
             "Subscription inactive. Renew at https://tirith.dev/account".into(),
         ));
@@ -100,4 +101,156 @@ pub async fn refresh(
         ],
         token,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use base64::Engine as _;
+
+    use crate::config::Config;
+    use crate::db::{CreatedData, CreatedOutcome, Db, UpdatedData};
+    use crate::sign::TokenSigner;
+
+    const API_KEY: &str = "tirith_refresh_route_test_key";
+
+    async fn test_state(status: &str, tier: &str) -> AppState {
+        let config = Config {
+            ed25519_seed_hex: "11".repeat(32),
+            polar_webhook_secret: "whsec_test".into(),
+            polar_api_key: "polar_test".into(),
+            receipt_encryption_key: [7; 32],
+            product_tier_map: HashMap::new(),
+            kid: "test".into(),
+            token_ttl_days: 30,
+            port: 0,
+            database_url: ":memory:".into(),
+            receipt_base_url: None,
+            trusted_proxy: false,
+            backup_r2_endpoint: None,
+            backup_r2_bucket: None,
+            backup_r2_access_key_id: None,
+            backup_r2_secret_access_key: None,
+        };
+        let db = Db::open(":memory:").unwrap();
+        assert!(matches!(
+            db.process_subscription_created(CreatedData {
+                event_id: "evt_refresh_created".into(),
+                event_type: "subscription.active".into(),
+                subscription_id: "sub_refresh".into(),
+                customer_id: "customer_refresh".into(),
+                email: "refresh@example.invalid".into(),
+                tier: tier.into(),
+                product_id: "product_refresh".into(),
+                occurred_at: Some("2026-01-01T00:00:00Z".into()),
+                checkout_id: None,
+                key_hash: hex::encode(Sha256::digest(API_KEY.as_bytes())),
+                token: None,
+                token_expires_at: 0,
+                receipt_secret: "unused".into(),
+                api_key_enc: vec![],
+                api_key_nonce: vec![],
+            })
+            .await
+            .unwrap(),
+            CreatedOutcome::Provisioned
+        ));
+        if status != "active" {
+            db.process_subscription_updated(UpdatedData {
+                event_id: "evt_refresh_updated".into(),
+                event_type: "subscription.updated".into(),
+                subscription_id: "sub_refresh".into(),
+                new_status: status.into(),
+                customer_id: None,
+                email: None,
+                tier: None,
+                product_id: None,
+                occurred_at: Some("2026-01-02T00:00:00Z".into()),
+                resolved_tier: Some(tier.into()),
+                tier_unknown: false,
+            })
+            .await
+            .unwrap();
+        }
+        AppState {
+            db,
+            signer: Arc::new(
+                TokenSigner::from_hex_seed(&config.ed25519_seed_hex, config.kid.clone()).unwrap(),
+            ),
+            config: Arc::new(config),
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    async fn request(state: AppState, authorization: Option<&str>) -> axum::response::Response {
+        let mut headers = HeaderMap::new();
+        if let Some(value) = authorization {
+            headers.insert("authorization", value.parse().unwrap());
+        }
+        refresh(State(state), headers).await.into_response()
+    }
+
+    #[tokio::test]
+    async fn refresh_route_issues_valid_tokens_for_entitled_subscriptions() {
+        for status in ["active", "trialing", "canceled"] {
+            let state = test_state(status, "team").await;
+            let response = request(state.clone(), Some(&format!("Bearer {API_KEY}"))).await;
+            assert_eq!(response.status(), StatusCode::OK, "status={status}");
+            assert_eq!(response.headers()["cache-control"], "no-store");
+            let body = axum::body::to_bytes(response.into_body(), 4096)
+                .await
+                .unwrap();
+            let token = std::str::from_utf8(&body).unwrap();
+            let (payload, signature) = token.split_once('.').unwrap();
+            let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+            let payload = b64.decode(payload).unwrap();
+            let signature =
+                ed25519_dalek::Signature::from_slice(&b64.decode(signature).unwrap()).unwrap();
+            ed25519_dalek::SigningKey::from_bytes(&[0x11; 32])
+                .verifying_key()
+                .verify_strict(&payload, &signature)
+                .unwrap();
+            let payload: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+            assert_eq!(payload["tier"], "team");
+            assert!(payload["exp"].as_i64().unwrap() > chrono::Utc::now().timestamp());
+
+            // The route must have persisted the issuance through the atomic
+            // authorization/throttle check, not merely returned a signed token.
+            let repeated = request(state, Some(&format!("Bearer {API_KEY}"))).await;
+            assert_eq!(repeated.status(), StatusCode::TOO_MANY_REQUESTS);
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_route_rejects_revoked_or_inactive_subscriptions() {
+        for status in ["revoked", "past_due", "unrecognized_status"] {
+            let state = test_state(status, "team").await;
+            let response = request(state, Some(&format!("Bearer {API_KEY}"))).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "status={status}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_route_rejects_invalid_credentials_and_tiers() {
+        let state = test_state("active", "team").await;
+        for authorization in [
+            None,
+            Some("Bearer "),
+            Some("Basic key"),
+            Some("Bearer invalid"),
+        ] {
+            let response = request(state.clone(), authorization).await;
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        }
+        let state = test_state("active", "unrecognized_tier").await;
+        let response = request(state, Some(&format!("Bearer {API_KEY}"))).await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
 }


### PR DESCRIPTION
Command checks and diagnostics did unnecessary work, and several installation paths silently lost functionality. This change restores strict shell receipts through npm launchers, fixes stale ThreatDB reloads, and reduces work in analysis and audit-history commands.

- Bind Bash, zsh, and fish initialization to the current native executable on Unix with shell-specific quoting; retain source-only initialization on other platforms. Preserve ordinary and signal exit behavior in the npm launcher, fix the sourced shell loader, and skip unnecessary Bash prompt history captures.
- Use the sorted legacy package index for registries whose identities preserve spelling, retain canonical aliases and all evidence claims, compile custom rules once per request, and bound retained DSL regex entries.
- Publish the cached ThreatDB and its exact source metadata together. Same-second replacements and selected-path changes trigger reloads while signatures and sequence rollback checks remain enforced.
- Read a bounded recent audit suffix and disclose partial coverage in explain, doctor, and incident output. Reuse the engine's resolved policy during daemon enrichment.
- Reuse one privacy-projected event window when expiring legacy session-correlation markers, preserving the public single-query API and matching behavior.
- Allow trial subscriptions to refresh license tokens consistently with the database authorization gate.
- Cancel superseded PR fuzz and packaging checks with distinct reusable-workflow groups; keep each non-PR run independent so release and publication gates are preserved.

Regression coverage includes real shell argument identity and npm PTY receipt delivery, hash collisions and canonical package identities, policy/cache churn, signature rejection, bounded audit reads and malformed input, and route-level token issuance. Shell quoting also passed 18 direct Bash/zsh/fish argument-identity checks.

Local validation: the full workspace compiles; formatting, source/asset parity, Node contracts, 67 license-server tests, 104 ThreatDB tests, 26 audit tests, six shell portability tests, and the new daemon and native-path tests pass. The full shell conformance suite passed 32 tests with two existing ignored tests, including real npm-launched Bash/zsh/fish receipt and allow/block delivery. The final core suite passed 5,742 tests with zero failures and two existing ignored tests. Final validation at a2e52218897f11da1b9b3ceeb2e505c1db64ce63 passed all 52 checks with no failures: Linux/macOS/Windows workspace tests, Rust 1.83, lint and dependency checks, all 13 fuzz targets, benchmarks, six release architectures, npm/Debian/RPM packaging, and GNU/RPM runtime compatibility. Publication-only jobs were correctly skipped for this pull request. Independent review found no remaining actionable defects.

The bounded audit fixture reads 4,915,200 bytes instead of 97,200,000 bytes for the newest 10,000 records. In an alternating local comparison, the optimized reader measured approximately 2,605 to 164 ms on that fixture and 109 to 103 ms on a 4.86 MB fixture. These isolate the reader with identical debug dependencies and are not end-to-end release CLI latency claims.

Allocation probes with 32 custom rules fall from approximately 29,874 to 18,328 allocations per full analysis (38.6%). After 768 distinct DSL patterns, retained heap falls from 10.11 MB to 1.72 MB and remains bounded. These use identical debug dependencies; timing is excluded because host contention was substantial.

This PR updates source and unreleased notes; it does not create an application release or deploy the license service.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63093937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, workflow, or maintainability issue remains.

<h3>Summary</h3>

- Pins Bash, zsh, and fish hooks to the running native executable with shell-specific quoting and preserves npm child exit and signal behavior.
- Publishes ThreatDB data with exact source metadata, detects subsecond and path changes, and accelerates legacy package lookups without weakening identity matching.
- Reuses compiled custom rules, resolved daemon policy, and privacy-projected correlation windows while bounding the DSL regex cache.
- Adds bounded reverse audit-tail reads and discloses partial diagnostic coverage.
- Aligns trial license refresh with the atomic database authorization gate.
- Cancels only superseded pull-request workflow runs while keeping release and other non-PR runs independent.

<h3>Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Launcher[npm or direct launcher] --> Init[tirith init]
  Init -->|native executable argument| Hook[Bash / zsh / fish hook]
  Hook --> Check[Native Tirith check]
  Check --> Engine[Analysis engine]
  Engine --> Rules[Per-request compiled custom rules]
  Engine --> Cache[ThreatDB cache]
  Cache -->|atomic DB + source publication| ThreatDB[Verified ThreatDB]
  Engine --> Policy[Resolved policy snapshot]
  Policy --> Daemon[Daemon enrichment]
  Engine --> Audit[Bounded recent audit reader]
  Audit --> Diagnostics[Explain / Doctor / Incident]
```

<sub>Reviews (1) · Last reviewed commit: ["Cancel superseded pull request fuzz and ..."](https://github.com/sheeki03/tirith/commit/a2e52218897f11da1b9b3ceeb2e505c1db64ce63)</sub>

<!-- /greptile_comment -->