### PR TITLE
Release 0.4.2

### DIFF
--- a/.github/threatdb-source-pins.json
+++ b/.github/threatdb-source-pins.json
@@ -3,11 +3,11 @@
   "sources": {
     "datadog_malicious_software_packages": {
       "candidate_policy": "default_branch_head",
-      "commit": "2d09839012cedc387ce438debeb77884ac2a242c",
-      "commit_timestamp": "2026-08-31T04:05:01Z",
+      "commit": "31a2ba215bcf891cfc751c3cb769e272bc6158c5",
+      "commit_timestamp": "2026-09-11T08:15:54Z",
       "max_lag_hours": 168,
       "repository": "DataDog/malicious-software-packages-dataset",
-      "selected_at": "2026-08-31T19:22:30Z"
+      "selected_at": "2026-09-11T11:43:22Z"
     },
     "ecosystems_typosquatting_dataset": {
       "candidate_policy": "default_branch_head",
@@ -19,11 +19,11 @@
     },
     "ossf_malicious_packages": {
       "candidate_policy": "latest_assign_ids",
-      "commit": "54642f7ee96e780b046660519b028fefb635375a",
-      "commit_timestamp": "2026-08-31T18:32:57Z",
+      "commit": "fed4af1871531557d07163a06e148ddf3b643140",
+      "commit_timestamp": "2026-09-11T08:26:52Z",
       "max_lag_hours": 48,
       "repository": "ossf/malicious-packages",
-      "selected_at": "2026-08-31T19:22:30Z"
+      "selected_at": "2026-09-11T11:43:22Z"
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
           cp -R shell/. docker-ci-smoke/shell/
           cp Dockerfile docker-ci-smoke/
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
         with:
           image: tonistiigi/binfmt:qemu-v9.2.0@sha256:ea2f0dd74e74f101df59f9a6b31d0960994060c7982a921cbceecee0f1841125
           platforms: arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,7 +503,7 @@ jobs:
 
       - name: Set up QEMU for the aarch64 runtime proof
         if: matrix.arch == 'aarch64'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
         with:
           image: tonistiigi/binfmt:qemu-v9.2.0@sha256:ea2f0dd74e74f101df59f9a6b31d0960994060c7982a921cbceecee0f1841125
           platforms: arm64
@@ -1155,7 +1155,7 @@ jobs:
           cp Dockerfile docker-arm64/
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0

--- a/.github/workflows/threatdb.yml
+++ b/.github/workflows/threatdb.yml
@@ -622,7 +622,7 @@ jobs:
       # later v2-side failure (the version-tag preflight or an index validation
       # error) cannot skip the v1 publish that old clients depend on.
       - name: Publish release (v1 + legacy manifest)
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ env.THREATDB_RELEASE_TAG }}
           prerelease: true
@@ -896,7 +896,7 @@ jobs:
         # clients keep updating. The v2 index file is only generated when the gate
         # is on, so fail_on_unmatched_files stays meaningful here.
         if: ${{ env.ENABLE_THREATDB_V2 == 'true' }}
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ env.THREATDB_RELEASE_TAG }}
           prerelease: true
@@ -913,7 +913,7 @@ jobs:
       # anti-drop baseline needed for safe reactivation.
       - name: Publish release (retained non-discovery v2 baseline)
         if: ${{ env.ENABLE_THREATDB_V2 == 'true' }}
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ env.THREATDB_RELEASE_TAG }}
           prerelease: true
@@ -928,7 +928,7 @@ jobs:
       # the previous index untouched; clients never discover a partial generation.
       - name: Publish release (signed generation index commit point)
         if: ${{ env.ENABLE_THREATDB_V2 == 'true' }}
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ env.THREATDB_RELEASE_TAG }}
           prerelease: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Legacy session correlation reuses one privacy-projected event window when expiring warning markers, avoiding repeated redaction of every event for each retained signature.
 - Fuzz and packaging workflows cancel superseded pull-request checks so current changes reach runners sooner. Release-tag and other non-PR runs remain independent.
 
+### Maintenance
+
+- Refresh the reviewed OpenSSF and DataDog source snapshots to September 11 revisions and synchronize their `NOTICE` attribution entries (#245).
+- Update pinned QEMU setup, GitHub release, and SARIF upload actions to their reviewed upstream patch/minor releases (#242).
+
 ## [0.4.1] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-09-11
+
 ### Fixed
 
+- Shell hooks resolve and pin trusted helpers on NixOS and other systems without standard FHS helper paths instead of discarding ordinary commands (#239).
+- `doctor` recognizes mise shims that resolve to the current executable instead of warning that they shadow it (#240).
+- Shell and paste analysis no longer misclassify Go `./...` package patterns, ordinary home-directory paths, or Codex zsh environment snapshots using `[[` and `alias -L` as incomplete analysis (#235, #236, #237).
+- ThreatDB updates quietly use the supported v1 channel when a dual-mode deployment has not published its v2 index. Authentication, integrity, and other server failures still surface (#238).
+- ThreatDB source fetching accepts npm metadata served as `application/octet-stream` only after strict JSON-object and exact package-name validation, preventing a legitimate registry response from stopping publication.
+- ThreatDB provenance compares timestamps as instants, accepting equivalent timezone offsets from Git while retaining canonical UTC provenance and chronological checks.
+- The source-pin watcher isolates write permissions, supports the repository workflow token, finds existing proposal PRs reliably, and rejects stale generated manifest transitions.
 - On Unix, shell initialization binds Bash, zsh, and fish hooks to the running native executable, so npm and other process-spawning launchers no longer prevent strict receipt registration. Other platforms retain shell PATH resolution. The npm launcher also preserves signal termination instead of reporting success.
 - Sourcing `shell/tirith.sh` locates its own directory correctly in Bash and zsh, including installations with spaces or apostrophes in the path.
 - Long-running processes detect ThreatDB replacements within the same second and changes to the selected database path. Reloads retain signature verification and rollback protection.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,7 +3181,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tirith"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "chrono",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "tirith-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arboard",
  "base64",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "tirith-license-server"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "tirith-sign"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "chrono",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "tirith-test-support"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 rust-version = "1.83"
 
 [workspace.dependencies]
-tirith-core = { version = "0.4.1", path = "crates/tirith-core" }
+tirith-core = { version = "0.4.2", path = "crates/tirith-core" }
 tirith-test-support = { path = "crates/tirith-test-support" }
 clap = { version = "4", features = ["derive"] }
 url = "2"

--- a/NOTICE
+++ b/NOTICE
@@ -21,7 +21,7 @@ Mozilla Foundation — Public Suffix List
 
 OpenSSF — malicious-packages
   Source: https://github.com/ossf/malicious-packages
-  Pinned revision: 54642f7ee96e780b046660519b028fefb635375a
+  Pinned revision: fed4af1871531557d07163a06e148ddf3b643140
   License: Creative Commons Attribution 4.0 (CC-BY-4.0)
   Used for: Confirmed malicious package, artifact, and network records
 
@@ -29,7 +29,7 @@ OpenSSF — malicious-packages
 
 Datadog Security Labs — malicious-software-packages-dataset
   Source: https://github.com/DataDog/malicious-software-packages-dataset
-  Pinned revision: 2d09839012cedc387ce438debeb77884ac2a242c
+  Pinned revision: 31a2ba215bcf891cfc751c3cb769e272bc6158c5
   License: Apache License 2.0 (Apache-2.0)
   Used for: Human-triaged npm and PyPI malicious package manifests
 

--- a/README.md
+++ b/README.md
@@ -1246,7 +1246,7 @@ Disable: `export TIRITH_LOG=0`
 - [Cookbook](docs/cookbook.md), policy examples for common setups
 - [Troubleshooting](docs/troubleshooting.md), shell quirks, latency, false positives
 - [Compatibility](docs/compatibility.md), stable vs experimental surface
-- [0.4.1 release notes](docs/release-notes-0.4.1.md), what the current patch release changes, and the [0.4.0 release notes](docs/release-notes-0.4.0.md) for the 0.4 line's highlights, limitations, and publication contract
+- [0.4.2 release notes](docs/release-notes-0.4.2.md), what the current patch release changes, and the [0.4.0 release notes](docs/release-notes-0.4.0.md) for the 0.4 line's highlights, limitations, and publication contract
 - [Release checklist](docs/release-checklist.md), protected publication sequence and registry verification
 - [Security policy](SECURITY.md), vulnerability reporting
 - [Uninstall](docs/uninstall.md), clean removal per shell and package manager

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,5 +89,5 @@ lines receive best-effort support only; upgrade before reporting a result as a
 current-version vulnerability. Code on an unreleased branch or integration
 stack is not a supported release until its protected tag and artifacts exist.
 
-Beginning with v0.4.0, 0.4.x is the supported release line, and v0.4.1 is the
+Beginning with v0.4.0, 0.4.x is the supported release line, and v0.4.2 is the
 current published patch. The 0.3.x line now receives best-effort support only.

--- a/TIRITH.md
+++ b/TIRITH.md
@@ -7,7 +7,7 @@
 > capability contract. Use the [README](README.md),
 > [changelog](CHANGELOG.md), [capability matrix](docs/capability-matrix.md),
 > [enforcement coverage](docs/enforcement-coverage.md), and
-> [0.4.1 release notes](docs/release-notes-0.4.1.md) for current behavior.
+> [0.4.2 release notes](docs/release-notes-0.4.2.md) for current behavior.
 
 > Browsers solved homograph attacks years ago. Terminals haven't. tirith is the browser-equivalent safety net for the terminal.
 

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
         tirith scan --ci --fail-on "$INPUT_FAIL_ON" "${IGNORE_ARGS[@]}" -- "$INPUT_PATH"
     - name: Upload SARIF
       if: always() && inputs.sarif == 'true'
-      uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         sarif_file: results.sarif
       continue-on-error: true

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,7 +1,7 @@
 # Compatibility and Stability
 
-This matrix describes Tirith 0.4.1. The
-[0.4.1 release notes](release-notes-0.4.1.md) cover what that patch release
+This matrix describes Tirith 0.4.2. The
+[0.4.2 release notes](release-notes-0.4.2.md) cover what that patch release
 changes, and the [0.4.0 release notes](release-notes-0.4.0.md) summarize the
 0.4 line's published capabilities, compatibility boundaries, and remaining
 limitations.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,8 +2,8 @@
 
 ## Release sequence
 
-Substitute the release version for `<VERSION>` throughout (for example `0.4.1`,
-tagged `v0.4.1`). The changelog and release notes describe the final tree. The
+Substitute the release version for `<VERSION>` throughout (for example `0.4.2`,
+tagged `v0.4.2`). The changelog and release notes describe the final tree. The
 workspace version stays on the previous release until the integration tree is
 known, then the release commit performs the version and documentation
 transition below:
@@ -189,10 +189,16 @@ serving the new version everywhere.
 
 ## Post-publication verification
 
-- Verify the GitHub Release contains every expected platform archive, Debian
-  and RPM package, installer, checksums, signature, certificate, SBOM, and
-  provenance artifact. Re-run verification against the downloaded public
-  bytes, not the runner workspace.
+- Verify the GitHub Release contains all six platform archives, the Debian
+  and RPM packages, the installer, and the checksum manifest with its detached
+  signature and certificate. Re-run verification against the downloaded public
+  bytes, not the runner workspace. The current pipeline does not publish an
+  SBOM attachment.
+- Verify Debian and RPM build provenance through GitHub's artifact attestation
+  service, binding the downloaded package digest to this repository's
+  `release.yml`, the exact release tag, and its commit. These attestations are
+  stored by GitHub, not attached as release files. npm provenance is published
+  with each registry package and must be checked through that registry.
 - Verify `tirith` and `tirith-core` at `<VERSION>` on crates.io and all six
   exact `<VERSION>` npm packages (the unscoped root `tirith` plus the five
   scoped `@sheeki03/tirith-*` platform packages; a scoped `@sheeki03/tirith` is

--- a/docs/release-notes-0.4.2.md
+++ b/docs/release-notes-0.4.2.md
@@ -52,6 +52,11 @@ supports the repository workflow token, and finds existing proposals reliably.
 Generated manifest transitions reject stale publication pointers. Source-pin
 proposals still require review before adoption.
 
+The reviewed OpenSSF and DataDog snapshots advance to September 11 revisions,
+with matching attribution entries in `NOTICE`. The candidate snapshots passed
+source fetching and compilation before adoption; upstream scripts are not run.
+The ecosyste.ms pin remains unchanged.
+
 Dual-mode clients quietly use the supported v1 channel when the server has not
 published a v2 index. Authentication, signature, integrity, and other server
 failures remain visible

--- a/docs/release-notes-0.4.2.md
+++ b/docs/release-notes-0.4.2.md
@@ -1,0 +1,132 @@
+# Tirith 0.4.2 release notes
+
+Tirith 0.4.2 is a reliability and performance patch for the 0.4 line. It fixes
+shell integration failures and ordinary-command false positives, restores
+reliable ThreatDB publication and reloads, and reduces repeated work in command
+analysis and diagnostics. It adds no top-level command.
+
+The [0.4.0 release notes](release-notes-0.4.0.md) describe the feature set and
+platform boundaries; the [0.4.1 release notes](release-notes-0.4.1.md) explain
+the Bash enter-mode behavior introduced by that release.
+
+## Shells and everyday commands
+
+- **NixOS and non-FHS installations:** hooks resolve and pin trusted helper
+  executables instead of assuming `/usr/bin` and `/bin` contain them. Ordinary
+  commands are no longer discarded because those helper paths are absent
+  ([#239](https://github.com/sheeki03/tirith/issues/239)).
+- **npm installations:** on Unix, initialization binds Bash, zsh, and fish
+  hooks to the running native Tirith executable. The Node launcher no longer
+  sits between the shell and receipt registration. Other platforms retain
+  shell PATH resolution. The npm launcher also preserves signal termination
+  and nonzero child exits.
+- **Sourced loaders:** `shell/tirith.sh` finds its own directory in Bash and
+  zsh, including installation paths containing spaces or apostrophes.
+- **mise installations:** `doctor` recognizes a shim that resolves to the
+  current executable instead of reporting a shadow-binary conflict
+  ([#240](https://github.com/sheeki03/tirith/issues/240)).
+- **False positives:** Go `./...` package patterns, ordinary home-directory
+  paths, and Codex zsh environment snapshots using `[[` and `alias -L` no
+  longer produce the reported incomplete-analysis errors
+  ([#235](https://github.com/sheeki03/tirith/issues/235),
+  [#236](https://github.com/sheeki03/tirith/issues/236),
+  [#237](https://github.com/sheeki03/tirith/issues/237)).
+
+These changes retain signature, ownership, receipt, and enforcement checks.
+Unsupported containment platforms remain unsupported; this patch does not
+extend the Linux-only package-installation or capsule guarantees.
+
+## ThreatDB publication and updates
+
+The daily source fetch previously failed when npm returned valid package
+metadata as `application/octet-stream`. The fetcher now accepts that response
+only after strict JSON-object parsing and an exact package-name check. Invalid
+metadata still aborts the publication transaction.
+
+Git timestamps are compared as instants, so equivalent timezone offsets no
+longer fail provenance checks. Written provenance remains canonical UTC and
+retains chronological validation.
+
+The source-pin watcher separates read-only validation from PR publication,
+supports the repository workflow token, and finds existing proposals reliably.
+Generated manifest transitions reject stale publication pointers. Source-pin
+proposals still require review before adoption.
+
+Dual-mode clients quietly use the supported v1 channel when the server has not
+published a v2 index. Authentication, signature, integrity, and other server
+failures remain visible
+([#238](https://github.com/sheeki03/tirith/issues/238)). The minimum client
+version for the v2 database remains 0.4.0.
+
+Long-running processes now detect same-second database replacements and changes
+to the selected database path. The cache publishes the accepted database and
+its source metadata together, retaining signature and sequence rollback checks.
+
+## Performance and diagnostics
+
+- Legacy database lookups for npm, RubyGems, Go, and Maven use their sorted
+  package index directly. Ecosystems with spelling aliases retain canonical
+  lookup behavior.
+- Custom rules compile once per analysis request. The per-thread DSL regex
+  cache is bounded, and rule-ID redaction is deferred until a warning is emitted.
+- Recent-log commands read a bounded suffix instead of parsing the entire audit
+  history. `explain`, `doctor`, and incident reports disclose partial coverage.
+  Doctor JSON gains the additive `audit_history_truncated` field.
+- Bash prompt callbacks avoid unnecessary history-capture subprocesses.
+- Legacy session correlation projects its event window once when expiring a
+  batch of warning markers, preserving the existing matching and privacy rules.
+- Daemon enrichment reuses the policy resolved for the initial analysis,
+  preventing inconsistent decisions if configuration changes during a request.
+
+Fuzz and packaging workflows cancel superseded pull-request checks. Release-tag,
+scheduled, and other non-PR runs remain independent.
+
+The license-service source also fixes token refresh for entitled trial
+subscriptions. Operators running that service must deploy the updated service;
+upgrading a CLI installation alone does not deploy a license backend.
+
+## Upgrade
+
+Use the package manager that owns your installation:
+
+```bash
+npm install -g tirith@0.4.2
+cargo install tirith --version 0.4.2 --locked
+brew update && brew upgrade tirith
+```
+
+```powershell
+scoop update
+scoop update tirith
+choco upgrade tirith --version=0.4.2
+```
+
+Standalone installations can use `tirith update`, which verifies the release
+before replacing the executable. Signed platform archives, the installer,
+Debian/RPM packages, and verification material are available from
+[GitHub Releases](https://github.com/sheeki03/tirith/releases/tag/v0.4.2).
+The release workflow also updates the project Homebrew tap, Scoop bucket, AUR
+package, and versioned GHCR images.
+
+Homebrew core and Chocolatey community moderation are independent of the
+project's publication jobs. Check the version your package manager offers; if
+it has not reached 0.4.2, use the project tap or a signed GitHub release artifact.
+Distribution-maintained packages, including nixpkgs, may also update later.
+Do not mix installation methods without first resolving which binary your
+shell invokes.
+
+After updating, restart your shell and agent host, then run:
+
+```bash
+tirith --version
+tirith doctor
+tirith threat-db update
+```
+
+For Bash, `tirith doctor --simulate-enter` refreshes the delivery/blocking
+self-test for the installed Bash binary. Restart Bash afterward to load the
+verified mode. Agent integrations can be refreshed using their existing
+`tirith setup <host>` command.
+
+Thanks to everyone who reported problems and supplied reproductions. The
+reports above directly shaped this release.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,6 +91,15 @@ Hermes installs as self-replaceable, and move ThreatDB source pinning onto one
 reviewed manifest with a proposal-only watcher. The
 [0.4.1 release notes](release-notes-0.4.1.md) carry the upgrade guidance.
 
+## Published: 0.4.2
+
+A reliability and performance patch. It fixes NixOS helper resolution, npm
+shell receipt activation, several ordinary-command false positives, ThreatDB
+publication and cache reloads, and misleading update/diagnostic messages.
+Custom-rule compilation, regex retention, recent-log reads, and legacy session
+correlation perform less repeated work. The
+[0.4.2 release notes](release-notes-0.4.2.md) describe the fixes and upgrade steps.
+
 ## Publication contract
 
 A release is cut only from the final default-branch tree after the cross-platform

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2295,7 +2295,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tirith-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arboard",
  "base64",


### PR DESCRIPTION
Prepare Tirith 0.4.2 from the reviewed default-branch fixes. The release covers NixOS and npm shell integration, ordinary-command false positives, ThreatDB publication/reloads, and reduced work in rules and diagnostics.

- Bump the workspace and internal dependency to 0.4.2 and regenerate both Cargo lockfiles without changing registry dependencies.
- Publish a complete changelog and versioned release notes, update current-version links, and align the release checklist with the signed assets and registry/package attestations the workflow actually produces.
- Incorporate the reviewed action updates from #242 and source snapshots from #245. Synchronize both NOTICE revisions, addressing https://github.com/sheeki03/tirith/pull/245#discussion_r3988852557.

All seven open PRs were reviewed against current main, including available CodeRabbit/Greptile feedback. #241, #200, #191, #167, and #163 are superseded by current implementations and regression coverage; their old changes are not reapplied. The three post-0.4.1 merged fix PRs (#243, #244, #246) were also checked for retrievable feedback. CodeRabbit auto-review is disabled, so a full review is requested explicitly here.

Source-pin review verified ahead-only ancestry, the OpenSSF Assign IDs boundary, unchanged licenses, and the successful exact-candidate fetch/compile. The DataDog delta retains the existing metadata schema. GitHub truncates OpenSSF's comparison file list, so this does not claim manual inspection of every advisory. Upstream scripts are not executed.

Local formatting, source-pin tests, workflow validation, and diff checks pass. Both public crates packaged and compiled successfully using Cargo's temporary registry, verifying the CLI against the exact unpublished 0.4.2 core package. Independent final-patch review found no actionable defects. All 53 checks on final commit 068504364dd5220e94d52646fe07ce022df85e8c passed, including platform tests/builds, Rust 1.83, fuzz, benchmarks, package assembly, and release compatibility. CodeRabbit full review and Greptile completed without actionable comments. Package templates and the ThreatDB v2 minimum client version remain unchanged by design.
