### PR TITLE
docs: pin the GitHub Action example to version 0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,8 +860,9 @@ See `mcp/clients/` for the host-specific guides that are available.
 **GitHub Action** with SARIF upload to GitHub Security tab:
 
 ```yaml
-- uses: sheeki03/tirith@v1
+- uses: sheeki03/tirith@v0.4.2
   with:
+    version: 0.4.2
     fail_on: high
     sarif: true
 ```


### PR DESCRIPTION
The CI/CD example referenced `sheeki03/tirith@v1`, but the repository has no `v1` tag. Use the existing `v0.4.2` action tag and explicitly select CLI version `0.4.2`, binding both the installer and binary version.

Verified the public tag resolves to release commit `46bc68193dc307474fff103a277007e06a2a778c`, and its action supports the `version` input. `git diff --check` passes. This changes only the README example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the CI/CD GitHub Action example to use Tirith version 0.4.2 explicitly.
  - Replaced the floating version reference with a pinned version for more predictable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63128109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only change appears safe to merge.

<h3>Summary</h3>

- Keeps the action implementation and installed binary on the same release.
- Preserves the documented SARIF upload and `fail_on: high` configuration.

<sub>Reviews (1) · Last reviewed commit: ["docs: pin the GitHub Action example to v..."](https://github.com/sheeki03/tirith/commit/5e5104ac45097b37e9026eedc084a6f295c2aaee)</sub>

<!-- /greptile_comment -->