### PR TITLE
fix(install): keep user-only installs and updates unprivileged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,10 @@ jobs:
         run: node tests/ipython-vector-extraction.mjs
       - name: npm launcher exit and signal contract
         run: node tests/npm-launcher.mjs
+      - name: Windows user installer release contract
+        if: matrix.name == 'Windows'
+        shell: pwsh
+        run: ./tests/windows-install.ps1
       - name: Install interactive shell conformance dependencies
         if: matrix.name == 'Linux'
         run: sudo apt-get update && sudo apt-get install --yes fish zsh
@@ -281,6 +285,10 @@ jobs:
         run: sh tests/install-sh/verify_sha256.sh
       - name: package-approval helper return-path tests
         run: sh tests/install-sh/package_approval_helper_returns.sh
+      - name: Optional approval helper installation tests
+        run: sh tests/install-sh/optional_helper.sh
+      - name: Paired installer rollback tests
+        run: sh tests/install-sh/paired_rollback.sh
 
   artifact-roundtrip-produce:
     name: Artifact protocol (upload)

--- a/README.md
+++ b/README.md
@@ -606,6 +606,8 @@ use. On x86_64 Linux, only `tirith pkg approve` requires a trusted
 `/usr/bin/sudo` and the root-owned approval helper for fresh administrator
 confirmation. If that authority is unavailable, approval remains blocked;
 ordinary command checks and shell protection continue to work.
+The [installation privileges guide](docs/install-privileges.md) covers all
+package formats, manual installs, updates, and removal.
 
 The Linux GNU release binaries target a GLIBC 2.28 ceiling. CI runs both
 x86_64 and aarch64 tarballs on AlmaLinux 8, Amazon Linux 2023, and Rocky Linux

--- a/crates/tirith-core/src/selfupdate.rs
+++ b/crates/tirith-core/src/selfupdate.rs
@@ -84,10 +84,10 @@ impl InstallMethod {
             InstallMethod::Apt => {
                 // Not in the Debian/Ubuntu archives; the .deb is a GitHub release
                 // artifact, so `apt upgrade` won't find it.
-                Some("download the latest tirith_*.deb from the GitHub releases page and `sudo dpkg -i` it")
+                Some("download the latest tirith_*.deb from the GitHub releases page and install it with `dpkg -i` from a root session, or use `sudo dpkg -i`")
             }
             InstallMethod::Dnf => {
-                Some("download the latest tirith-*.rpm from the GitHub releases page and `sudo rpm -U` it")
+                Some("download the latest tirith-*.rpm from the GitHub releases page and install it with `rpm -U` from a root session, or use `sudo rpm -U`")
             }
             InstallMethod::SelfManaged | InstallMethod::Unknown => None,
         }

--- a/crates/tirith/src/cli/selfupdate.rs
+++ b/crates/tirith/src/cli/selfupdate.rs
@@ -946,7 +946,10 @@ fn run_verify_self(prov: &Provenance, hermes_managed: bool) -> VerifySelfOutcome
     let helper_note: Option<String> = None;
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     if let Err(reason) = verify_installed_package_approval_helper(workdir.path(), &target) {
-        if install_method_requires_package_approval_helper(&prov.install_method) && !hermes_managed
+        if install_method_requires_package_approval_helper(
+            &prov.install_method,
+            managed_helper_state_present(),
+        ) && !hermes_managed
         {
             return VerifySelfOutcome::verdict(VerificationStatus::Failed { reason });
         }
@@ -973,11 +976,12 @@ fn run_verify_self(prov: &Provenance, hermes_managed: bool) -> VerifySelfOutcome
 }
 
 #[cfg(any(test, all(target_os = "linux", target_arch = "x86_64")))]
-fn install_method_requires_package_approval_helper(method: &InstallMethod) -> bool {
-    matches!(
-        method,
-        InstallMethod::SelfManaged | InstallMethod::Apt | InstallMethod::Dnf
-    )
+fn install_method_requires_package_approval_helper(
+    method: &InstallMethod,
+    helper_present: bool,
+) -> bool {
+    matches!(method, InstallMethod::Apt | InstallMethod::Dnf)
+        || (matches!(method, InstallMethod::SelfManaged) && helper_present)
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -1116,8 +1120,7 @@ pub fn update(allow_unsigned: bool, rollback: bool, dry_run: bool, yes: bool, js
 }
 
 fn update_effects(
-    method: &InstallMethod,
-    hermes_managed: bool,
+    updates_privileged_helper: bool,
     dry_run: bool,
 ) -> BTreeSet<tirith_core::effects::CommandEffectKind> {
     let mut effects = [tirith_core::effects::CommandEffectKind::NetworkEgress]
@@ -1125,7 +1128,7 @@ fn update_effects(
         .collect::<BTreeSet<_>>();
     if !dry_run {
         effects.insert(tirith_core::effects::CommandEffectKind::FilesystemWrite);
-        if install_method_updates_privileged_helper(method, hermes_managed) {
+        if updates_privileged_helper {
             effects.insert(tirith_core::effects::CommandEffectKind::ResourceEscalation);
         }
     }
@@ -1133,28 +1136,63 @@ fn update_effects(
 }
 
 fn rollback_effects(
-    method: &InstallMethod,
-    hermes_managed: bool,
+    updates_privileged_helper: bool,
 ) -> BTreeSet<tirith_core::effects::CommandEffectKind> {
     let mut effects = [tirith_core::effects::CommandEffectKind::FilesystemWrite]
         .into_iter()
         .collect::<BTreeSet<_>>();
-    if install_method_updates_privileged_helper(method, hermes_managed) {
+    if updates_privileged_helper {
         effects.insert(tirith_core::effects::CommandEffectKind::ResourceEscalation);
     }
     effects
 }
 
-fn install_method_updates_privileged_helper(method: &InstallMethod, hermes_managed: bool) -> bool {
+fn install_method_updates_privileged_helper(
+    method: &InstallMethod,
+    hermes_managed: bool,
+    helper_present: bool,
+) -> bool {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
-        !hermes_managed && install_method_requires_package_approval_helper(method)
+        !hermes_managed && install_method_requires_package_approval_helper(method, helper_present)
     }
     #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
     {
-        let _ = (method, hermes_managed);
+        let _ = (method, hermes_managed, helper_present);
         false
     }
+}
+
+#[cfg(any(test, all(target_os = "linux", target_arch = "x86_64")))]
+fn helper_state_present_at(paths: &[&Path]) -> bool {
+    paths
+        .iter()
+        .any(|path| match std::fs::symlink_metadata(path) {
+            Ok(_) => true,
+            Err(error) => error.kind() != std::io::ErrorKind::NotFound,
+        })
+}
+
+fn managed_helper_state_present() -> bool {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        helper_state_present_at(&[
+            Path::new(PACKAGE_APPROVAL_HELPER_PATH),
+            Path::new(PACKAGE_APPROVAL_HELPER_BACKUP),
+            Path::new(PACKAGE_APPROVAL_HELPER_PREVIOUSLY_ABSENT),
+        ])
+    }
+    #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+    {
+        false
+    }
+}
+
+fn ensure_helper_state_unchanged(expected: bool) -> Result<(), String> {
+    if managed_helper_state_present() != expected {
+        return Err("package-approval helper state changed during the update; retry before replacing either binary".to_string());
+    }
+    Ok(())
 }
 
 fn ensure_hermes_install_still_proven(provenance: &CliProvenance) -> Result<(), String> {
@@ -1226,7 +1264,13 @@ fn run_update(
     };
     let expected_rollback_sha = hash_file_opt(&previous_backup_path(&binary_path));
     let hermes_managed = prov.is_hermes_managed();
-    let effects = update_effects(&prov.install_method, hermes_managed, dry_run);
+    let helper_present = managed_helper_state_present();
+    let updates_privileged_helper = install_method_updates_privileged_helper(
+        &prov.install_method,
+        hermes_managed,
+        helper_present,
+    );
+    let effects = update_effects(updates_privileged_helper, dry_run);
     let authorization =
         match prepare_self_authorization::<tirith_core::task_boundary::SelfUpdateBoundary>(
             match self_boundary_envelope(
@@ -1240,6 +1284,7 @@ fn run_update(
                     "binary_preimage_sha256": expected_binary_sha.clone(),
                     "rollback_preimage_sha256": expected_rollback_sha.clone(),
                     "allow_unsigned": allow_unsigned,
+                    "updates_privileged_helper": updates_privileged_helper,
                     "dry_run": dry_run,
                     "release_origin": REPO,
                 }),
@@ -1436,10 +1481,14 @@ fn run_update(
         emit_update_error(json, &error);
         return 1;
     }
+    if !hermes_managed {
+        if let Err(error) = ensure_helper_state_unchanged(helper_present) {
+            emit_update_error(json, &error);
+            return 1;
+        }
+    }
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    let helper_install = if !hermes_managed
-        && install_method_requires_package_approval_helper(&prov.install_method)
-    {
+    let helper_install = if updates_privileged_helper {
         let archive_sha256 = match &archive_verdict {
             ArchiveVerdict::Ok { archive_sha256, .. } => archive_sha256,
             _ => unreachable!("failed archive verdict returned above"),
@@ -1695,7 +1744,13 @@ fn run_rollback(prov: &CliProvenance, dry_run: bool, yes: bool, json: bool) -> i
         }
     };
     let hermes_managed = prov.is_hermes_managed();
-    let effects = rollback_effects(&prov.install_method, hermes_managed);
+    let helper_present = managed_helper_state_present();
+    let updates_privileged_helper = install_method_updates_privileged_helper(
+        &prov.install_method,
+        hermes_managed,
+        helper_present,
+    );
+    let effects = rollback_effects(updates_privileged_helper);
     let authorization =
         match prepare_self_authorization::<tirith_core::task_boundary::SelfUpdateBoundary>(
             match self_boundary_envelope(
@@ -1706,6 +1761,7 @@ fn run_rollback(prov: &CliProvenance, dry_run: bool, yes: bool, json: bool) -> i
                     "binary_preimage_sha256": expected_binary_sha.clone(),
                     "rollback_path": backup.to_str(),
                     "rollback_preimage_sha256": expected_rollback_sha.clone(),
+                    "updates_privileged_helper": updates_privileged_helper,
                     "dry_run": false,
                 }),
                 Some(&binary_path),
@@ -1730,13 +1786,14 @@ fn run_rollback(prov: &CliProvenance, dry_run: bool, yes: bool, json: bool) -> i
         return 1;
     }
 
+    if !hermes_managed {
+        if let Err(error) = ensure_helper_state_unchanged(helper_present) {
+            emit_update_error(json, &error);
+            return 1;
+        }
+    }
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    let helper_restore = if !hermes_managed
-        && install_method_requires_package_approval_helper(&prov.install_method)
-        && (Path::new(PACKAGE_APPROVAL_HELPER_PATH).is_file()
-            || Path::new(PACKAGE_APPROVAL_HELPER_BACKUP).is_file()
-            || Path::new(PACKAGE_APPROVAL_HELPER_PREVIOUSLY_ABSENT).is_file())
-    {
+    let helper_restore = if updates_privileged_helper {
         use std::ffi::OsStr;
         let had_previous = Path::new(PACKAGE_APPROVAL_HELPER_BACKUP).is_file();
         let previously_absent = Path::new(PACKAGE_APPROVAL_HELPER_PREVIOUSLY_ABSENT).is_file();
@@ -3612,18 +3669,22 @@ mod tests {
     fn hermes_updates_never_request_privileged_helper_effects() {
         use tirith_core::effects::CommandEffectKind;
 
-        let update = update_effects(&InstallMethod::SelfManaged, true, false);
+        let manages_helper =
+            install_method_updates_privileged_helper(&InstallMethod::SelfManaged, true, true);
+        let update = update_effects(manages_helper, false);
         assert!(update.contains(&CommandEffectKind::NetworkEgress));
         assert!(update.contains(&CommandEffectKind::FilesystemWrite));
         assert!(!update.contains(&CommandEffectKind::ResourceEscalation));
-        let rollback = rollback_effects(&InstallMethod::SelfManaged, true);
+        let rollback = rollback_effects(manages_helper);
         assert!(rollback.contains(&CommandEffectKind::FilesystemWrite));
         assert!(!rollback.contains(&CommandEffectKind::ResourceEscalation));
 
         #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
         {
-            let standalone_update = update_effects(&InstallMethod::SelfManaged, false, false);
-            let standalone_rollback = rollback_effects(&InstallMethod::SelfManaged, false);
+            let manages_helper =
+                install_method_updates_privileged_helper(&InstallMethod::SelfManaged, false, true);
+            let standalone_update = update_effects(manages_helper, false);
+            let standalone_rollback = rollback_effects(manages_helper);
             assert!(standalone_update.contains(&CommandEffectKind::ResourceEscalation));
             assert!(standalone_rollback.contains(&CommandEffectKind::ResourceEscalation));
         }
@@ -3659,11 +3720,12 @@ mod tests {
         std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o775)).unwrap();
         assert!(ensure_hermes_install_still_proven(&provenance).is_err());
         assert!(provenance.is_hermes_managed());
-        let effects = update_effects(
+        let manages_helper = install_method_updates_privileged_helper(
             &provenance.install_method,
             provenance.is_hermes_managed(),
-            false,
+            true,
         );
+        let effects = update_effects(manages_helper, false);
         assert!(!effects.contains(&CommandEffectKind::ResourceEscalation));
     }
 
@@ -3922,13 +3984,20 @@ mod tests {
     #[test]
     fn native_helper_is_required_only_for_install_methods_that_ship_it() {
         assert!(install_method_requires_package_approval_helper(
-            &InstallMethod::SelfManaged
+            &InstallMethod::SelfManaged,
+            true,
+        ));
+        assert!(!install_method_requires_package_approval_helper(
+            &InstallMethod::SelfManaged,
+            false,
         ));
         assert!(install_method_requires_package_approval_helper(
-            &InstallMethod::Apt
+            &InstallMethod::Apt,
+            false,
         ));
         assert!(install_method_requires_package_approval_helper(
-            &InstallMethod::Dnf
+            &InstallMethod::Dnf,
+            false,
         ));
         for method in [
             InstallMethod::Npm,
@@ -3937,7 +4006,48 @@ mod tests {
             InstallMethod::Aur,
             InstallMethod::Unknown,
         ] {
-            assert!(!install_method_requires_package_approval_helper(&method));
+            assert!(!install_method_requires_package_approval_helper(
+                &method, true
+            ));
+        }
+    }
+
+    #[test]
+    fn manual_install_without_helper_never_requests_elevation() {
+        use tirith_core::effects::CommandEffectKind;
+
+        let manages_helper =
+            install_method_updates_privileged_helper(&InstallMethod::SelfManaged, false, false);
+        assert!(!manages_helper);
+        let update = update_effects(manages_helper, false);
+        let rollback = rollback_effects(manages_helper);
+        assert!(update.contains(&CommandEffectKind::FilesystemWrite));
+        assert!(rollback.contains(&CommandEffectKind::FilesystemWrite));
+        assert!(!update.contains(&CommandEffectKind::ResourceEscalation));
+        assert!(!rollback.contains(&CommandEffectKind::ResourceEscalation));
+    }
+
+    #[test]
+    fn helper_backups_and_invalid_entries_keep_the_paired_update_boundary() {
+        let directory = tempfile::tempdir().unwrap();
+        let live = directory.path().join("helper");
+        let backup = directory.path().join("helper.previous");
+        let absent = directory.path().join("helper.previously-absent");
+        let paths = [live.as_path(), backup.as_path(), absent.as_path()];
+        assert!(!helper_state_present_at(&paths));
+        std::fs::write(&backup, b"previous-helper").unwrap();
+        assert!(helper_state_present_at(&paths));
+        std::fs::remove_file(&backup).unwrap();
+        std::fs::write(&absent, b"").unwrap();
+        assert!(helper_state_present_at(&paths));
+        std::fs::remove_file(&absent).unwrap();
+        std::fs::create_dir(&live).unwrap();
+        assert!(helper_state_present_at(&paths));
+        #[cfg(unix)]
+        {
+            std::fs::remove_dir(&live).unwrap();
+            std::os::unix::fs::symlink(directory.path().join("missing"), &live).unwrap();
+            assert!(helper_state_present_at(&paths));
         }
     }
 

--- a/docs/install-privileges.md
+++ b/docs/install-privileges.md
@@ -1,0 +1,65 @@
+# Installation and administrator privileges
+
+Tirith's ordinary checks, shell integration, agent setup, and doctor do not
+require sudo or administrator privileges. Installing into a protected system
+directory or changing a system package database requires an administrator;
+sudo is one way to obtain that access, and an existing root session also works.
+
+| Channel | Install, update, and removal | Native package approval |
+| --- | --- | --- |
+| Debian / Ubuntu `.deb` | Administrator manages the system package database. Sudo is suggested, not required. | The package ships a root-owned helper on x86_64 Linux. Issuance also needs trusted `/usr/bin/sudo`. |
+| RPM | Administrator manages the system package database. Sudo is suggested, not required. | The x86_64 package ships the helper; issuance needs trusted `/usr/bin/sudo`. |
+| AUR | Build as the normal user; package installation/removal needs an administrator. Sudo is an optional x86_64 dependency. | The x86_64 package ships the helper. The aarch64 package does not support issuance. |
+| Shell installer | Defaults to the user's `~/.local/bin` and needs no elevation for a fresh install. An existing helper is updated as a protected pair. | Explicitly opt in with `TIRITH_INSTALL_APPROVAL_HELPER=1`; see below. |
+| Manual release archive | Copy the CLI into a user-writable directory without elevation. A protected system destination requires administrator access. | A helper copied into a home directory cannot issue approvals. |
+| Cargo | A user-owned Cargo prefix needs no elevation. Update with Cargo. | User-installed helper binaries are not trusted native authorities. |
+| npm | A user-owned npm prefix needs no elevation. A system prefix follows its filesystem permissions. Update with npm. | The npm packages do not install a privileged helper. |
+| Homebrew | Use the normal Homebrew account and package-manager update/removal commands. | The formula does not install a privileged helper. |
+| Nix | A user profile needs no sudo. System configuration changes follow the host's administrator policy. | The flake does not install a trusted helper into the fixed authority paths. |
+| mise / asdf | User-owned tool directories need no elevation; update/remove through the owning manager. | Extracting the archive into a tool directory does not install a trusted authority. |
+| Windows installer / Scoop | The installer uses LocalAppData and user PATH; Scoop defaults to a user install. | Native package-approval issuance is unsupported on Windows. |
+| Chocolatey | Follow the permissions of the Chocolatey installation, commonly an administrator-managed system prefix. The Tirith package does not request elevation itself. | Native package-approval issuance is unsupported on Windows. |
+| Docker | Image construction installs system dependencies; the released runtime runs as the `tirith` user and contains no sudo dependency. | The runtime image does not install the native authority. |
+
+## Optional helper for manual Linux installs
+
+The shell installer accepts `TIRITH_INSTALL_APPROVAL_HELPER=0` (the default)
+or `TIRITH_INSTALL_APPROVAL_HELPER=1`. Other values are rejected. On a fresh
+x86_64 Linux installation, `0` installs only the CLI; checks and shell
+protection work, while `tirith pkg approve` remains unavailable. Set `1` when
+running the installer to also install the root-owned helper. That operation
+requires a root session or trusted `/usr/bin/sudo`. The opt-in is rejected on
+platforms where native approval issuance is unsupported.
+
+If the manual helper or its rollback state already exists under
+`/usr/local/libexec`, either setting preserves paired installation. Setting
+`0` cannot skip updating an existing helper. Removing or replacing a protected
+helper still requires administrator access.
+
+`tirith update` and `tirith update --rollback` keep a manual installation
+without helper state unprivileged. When helper state exists, they preserve the
+paired update and rollback checks. Package-managed installations are directed
+to their owning package manager instead of being overwritten by self-update.
+`tirith verify-self` verifies a manual CLI without requiring an optional helper;
+an installed manual helper, or a helper required by the Debian/RPM package,
+must still match the release.
+
+## Approval, setup, and cleanup
+
+Fresh package approvals require a non-root interactive operator, a protected
+helper, and trusted `/usr/bin/sudo` with fresh administrator confirmation.
+Missing sudo, unsafe permissions, noninteractive execution, and passwordless
+approval channels remain blocked. Running `tirith pkg approve` as root does
+not bypass operator-presence checks. Existing approval verification continues
+to require the protected public keyring.
+
+`tirith init` prints shell integration, and `tirith setup` writes the selected
+user/project integration files with ownership and symlink checks. They do not
+invoke sudo. A protected destination must be configured by its administrator.
+Doctor and ordinary command checks remain usable without the approval helper.
+
+Uninstall the CLI with its owning package manager or remove its user-owned
+binary, then remove the shell/integration entries and user data. Only remove a
+shared privileged helper and `/etc/tirith/package-approval` after all
+installations using them are gone. The [uninstall guide](uninstall.md) lists
+the exact paths.

--- a/docs/install-privileges.md
+++ b/docs/install-privileges.md
@@ -7,9 +7,9 @@ sudo is one way to obtain that access, and an existing root session also works.
 
 | Channel | Install, update, and removal | Native package approval |
 | --- | --- | --- |
-| Debian / Ubuntu `.deb` | Administrator manages the system package database. Sudo is suggested, not required. | The package ships a root-owned helper on x86_64 Linux. Issuance also needs trusted `/usr/bin/sudo`. |
-| RPM | Administrator manages the system package database. Sudo is suggested, not required. | The x86_64 package ships the helper; issuance needs trusted `/usr/bin/sudo`. |
-| AUR | Build as the normal user; package installation/removal needs an administrator. Sudo is an optional x86_64 dependency. | The x86_64 package ships the helper. The aarch64 package does not support issuance. |
+| Debian / Ubuntu `.deb` | Administrator manages the system package database. No sudo dependency or suggestion. | The package ships an inert root-owned helper on x86_64 Linux. Explicit issuance also needs trusted `/usr/bin/sudo`. |
+| RPM | Administrator manages the system package database. No sudo dependency or suggestion. | The x86_64 package ships an inert helper; explicit issuance needs trusted `/usr/bin/sudo`. |
+| AUR | Build as the normal user; package installation/removal needs an administrator. No sudo dependency or suggestion. | The x86_64 package ships an inert helper. The aarch64 package does not support issuance. |
 | Shell installer | Defaults to the user's `~/.local/bin` and needs no elevation for a fresh install. An existing helper is updated as a protected pair. | Explicitly opt in with `TIRITH_INSTALL_APPROVAL_HELPER=1`; see below. |
 | Manual release archive | Copy the CLI into a user-writable directory without elevation. A protected system destination requires administrator access. | A helper copied into a home directory cannot issue approvals. |
 | Cargo | A user-owned Cargo prefix needs no elevation. Update with Cargo. | User-installed helper binaries are not trusted native authorities. |
@@ -22,6 +22,12 @@ sudo is one way to obtain that access, and an existing root session also works.
 | Docker | Image construction installs system dependencies; the released runtime runs as the `tirith` user and contains no sudo dependency. | The runtime image does not install the native authority. |
 
 ## Optional helper for manual Linux installs
+
+Tirith never installs sudo, grants passwordless sudo access, creates a sudoers
+rule, starts an elevated approval service, or invokes the approval authority
+as part of ordinary command checks. The packaged helper has ordinary executable
+permissions, with no setuid/setgid bits. Its private key is created only during
+an explicitly requested, freshly confirmed `tirith pkg approve` operation.
 
 The shell installer accepts `TIRITH_INSTALL_APPROVAL_HELPER=0` (the default)
 or `TIRITH_INSTALL_APPROVAL_HELPER=1`. Other values are rejected. On a fresh
@@ -57,6 +63,16 @@ to require the protected public keyring.
 user/project integration files with ownership and symlink checks. They do not
 invoke sudo. A protected destination must be configured by its administrator.
 Doctor and ordinary command checks remain usable without the approval helper.
+
+`tirith status --json` and the full `tirith doctor --json` report the separate
+`package_approval` capability. `unavailable` means protected helper or sudo
+prerequisites are missing or untrusted; `unsupported` identifies other
+platforms. `available_on_explicit_request` means filesystem prerequisites are
+present, not that any approval was issued or administrator access was verified.
+All states report `automatic_elevation: false` and
+`ordinary_protection_requires_sudo: false`. `pkg approve` refuses missing native
+prerequisites before policy-server access, resolver execution, or quarantine
+work, with an explanation of the optional feature and how to enable it.
 
 Uninstall the CLI with its owning package manager or remove its user-owned
 binary, then remove the shell/integration entries and user data. Only remove a

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,5 +1,12 @@
 # Uninstall
 
+Removing files in your home directory needs no administrator privileges.
+System packages, a root-owned approval helper, and its system keyring require
+administrator privileges. The examples use `sudo` for those operations;
+omit it when already in a root session. You do not need to install `sudo`
+to remove Tirith. See [installation privileges](install-privileges.md) for
+the requirements of each distribution channel.
+
 ## Remove shell hook
 
 Remove the `tirith init` hook line from your shell config:
@@ -75,6 +82,12 @@ sudo dnf remove tirith
 ### Shell script install
 ```sh
 rm ~/.local/bin/tirith
+```
+
+If you enabled the optional package-approval helper, remove it from an
+administrator session after all installations using it have been removed:
+
+```sh
 sudo rm -f /usr/local/libexec/tirith-package-approval-authority
 sudo rm -f /usr/local/libexec/tirith-package-approval-authority.tirith-previous
 sudo rm -f /usr/local/libexec/tirith-package-approval-authority.tirith-previous.absent

--- a/packaging/windows/install.ps1
+++ b/packaging/windows/install.ps1
@@ -3,6 +3,28 @@
 
 $ErrorActionPreference = 'Stop'
 
+function Get-TirithWindowsReleaseAsset {
+    param($Release)
+    $assetName = 'tirith-x86_64-pc-windows-msvc.zip'
+    $selectedAssets = @($Release.assets | Where-Object { $_.name -ceq $assetName })
+    if ($selectedAssets.Count -ne 1) {
+        throw "Expected exactly one $assetName release asset; found $($selectedAssets.Count)"
+    }
+    return $selectedAssets[0]
+}
+
+function Get-TirithReleaseCertificateIdentity {
+    param([string]$Tag)
+    if ($Tag -cnotmatch '^v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$') {
+        throw 'The release tag is not a Tirith version'
+    }
+    return "https://github.com/sheeki03/tirith/.github/workflows/release.yml@refs/tags/$Tag"
+}
+
+if ($env:TIRITH_INSTALL_PS_LIB -eq '1') {
+    return
+}
+
 $installDir = "$env:LOCALAPPDATA\tirith\bin"
 $profileLine = "Invoke-Expression (& `"$installDir\tirith.exe`" init --shell powershell)"
 
@@ -17,15 +39,11 @@ if (!(Test-Path $installDir)) {
 $repo = "sheeki03/tirith"
 $releaseUrl = "https://api.github.com/repos/$repo/releases/latest"
 $release = Invoke-RestMethod -Uri $releaseUrl
-$asset = $release.assets | Where-Object { $_.name -like "*Windows*" } | Select-Object -First 1
+$asset = Get-TirithWindowsReleaseAsset $release
+$certificateIdentity = Get-TirithReleaseCertificateIdentity $release.tag_name
 $checksums = $release.assets | Where-Object { $_.name -eq "checksums.txt" } | Select-Object -First 1
 $checksumsSig = $release.assets | Where-Object { $_.name -eq "checksums.txt.sig" } | Select-Object -First 1
 $checksumsPem = $release.assets | Where-Object { $_.name -eq "checksums.txt.pem" } | Select-Object -First 1
-
-if (!$asset) {
-    Write-Error "Could not find Windows release asset"
-    exit 1
-}
 
 $zipPath = "$env:TEMP\tirith.zip"
 $checksumsPath = "$env:TEMP\tirith-checksums.txt"
@@ -103,7 +121,7 @@ if (!$cosign) {
         & cosign verify-blob `
             --signature $sigPath `
             --certificate $pemPath `
-            --certificate-identity-regexp '^https://github\.com/sheeki03/tirith/\.github/workflows/' `
+            --certificate-identity $certificateIdentity `
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' `
             $checksumsPath
         if ($LASTEXITCODE -ne 0) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,6 +29,50 @@ PAIRED_HELPER_BACKUP=""
 PAIRED_HELPER_HAD_PREVIOUS=0
 PAIRED_HELPER_PREVIOUS_SHA256=""
 PAIRED_HELPER_NEW_SHA256=""
+PAIRED_HELPER_MANAGED=0
+
+package_approval_helper_state_present() {
+  for helper_path in "$PAIRED_HELPER_DEST" \
+      "${PAIRED_HELPER_DEST}.tirith-previous" \
+      "${PAIRED_HELPER_DEST}.tirith-previous.absent"; do
+    if [ -e "$helper_path" ] || [ -L "$helper_path" ]; then
+      return 0
+    fi
+  done
+  helper_parent="${PAIRED_HELPER_DEST%/*}"
+  while :; do
+    if { [ -e "$helper_parent" ] || [ -L "$helper_parent" ]; } &&
+       { [ ! -d "$helper_parent" ] || [ ! -x "$helper_parent" ]; }; then
+      return 0
+    fi
+    [ "$helper_parent" = / ] && break
+    helper_parent="${helper_parent%/*}"
+    [ -n "$helper_parent" ] || helper_parent=/
+  done
+  return 1
+}
+
+select_package_approval_helper() {
+  case "${TIRITH_INSTALL_APPROVAL_HELPER:-0}" in
+    0|1) ;;
+    *) err "TIRITH_INSTALL_APPROVAL_HELPER must be 0 or 1" ;;
+  esac
+  PAIRED_HELPER_MANAGED=0
+  if [ "$TARGET" != "x86_64-unknown-linux-gnu" ]; then
+    if [ "${TIRITH_INSTALL_APPROVAL_HELPER:-0}" = "1" ]; then
+      err "native package approval is supported only on x86_64 Linux"
+    fi
+    return 0
+  fi
+  if [ "${TIRITH_INSTALL_APPROVAL_HELPER:-0}" = "1" ] ||
+     package_approval_helper_state_present; then
+    PAIRED_HELPER_MANAGED=1
+  fi
+  if [ "$PAIRED_HELPER_MANAGED" = "1" ] &&
+     [ "$(id -u)" -ne 0 ] && [ ! -x /usr/bin/sudo ]; then
+    err "updating or installing the root-owned package-approval helper requires administrator privileges; run from a root session or use /usr/bin/sudo"
+  fi
+}
 
 err() {
   printf 'error: %s\n' "$1" >&2
@@ -106,7 +150,7 @@ paired_exit_handler() {
     fi
     # Always attempt the helper restoration even if the main restoration
     # failed. The two results are combined only after both attempts finish.
-    if [ "${TARGET:-}" = "x86_64-unknown-linux-gnu" ]; then
+    if [ "$PAIRED_HELPER_MANAGED" = "1" ]; then
       if restore_package_approval_helper; then
         helper_restore_ok=1
       fi
@@ -425,6 +469,7 @@ install_package_approval_helper() {
 
 main() {
   detect_platform
+  select_package_approval_helper
   resolve_version
 
   local tmpdir
@@ -477,7 +522,12 @@ main() {
     [ "$main_backup_sum" = "$PAIRED_MAIN_PREVIOUS_SHA256" ] \
       || err "the Tirith backup did not match the installed binary"
   fi
-  if [ "$TARGET" = "x86_64-unknown-linux-gnu" ]; then
+  if [ "$PAIRED_HELPER_MANAGED" = "0" ] &&
+     [ "$TARGET" = "x86_64-unknown-linux-gnu" ] &&
+     package_approval_helper_state_present; then
+    err "package-approval helper state changed during installation; retry before replacing either binary"
+  fi
+  if [ "$PAIRED_HELPER_MANAGED" = "1" ]; then
     if [ -f "$PAIRED_HELPER_DEST" ]; then
       PAIRED_HELPER_HAD_PREVIOUS=1
       helper_previous_sum="$(run_root /usr/bin/sha256sum "$PAIRED_HELPER_DEST")" \
@@ -498,7 +548,7 @@ main() {
   # From this point through both exact readbacks, EXIT and signal paths restore
   # and verify both preimages. Arm before the helper is the first published.
   PAIRED_ROLLBACK_ARMED=1
-  if [ "$TARGET" = "x86_64-unknown-linux-gnu" ]; then
+  if [ "$PAIRED_HELPER_MANAGED" = "1" ]; then
     archive_sha256="${CHECKSUM_LINE%% *}"
     if ! install_package_approval_helper "${tmpdir}/${ARCHIVE}" "$archive_sha256"; then
       err "could not install the root-owned package-approval helper"
@@ -517,7 +567,7 @@ main() {
     || err "could not read back the installed Tirith binary"
   [ "$main_installed_sum" = "$PAIRED_MAIN_NEW_SHA256" ] \
     || err "installed Tirith binary failed exact readback verification"
-  if [ "$TARGET" = "x86_64-unknown-linux-gnu" ]; then
+  if [ "$PAIRED_HELPER_MANAGED" = "1" ]; then
     [ -n "$PAIRED_HELPER_NEW_SHA256" ] \
       || err "installed package-approval helper was not read back and verified"
   fi
@@ -529,6 +579,10 @@ main() {
 
   info ""
   info "tirith installed to ${INSTALL_DIR}/tirith"
+  if [ "$TARGET" = "x86_64-unknown-linux-gnu" ] && [ "$PAIRED_HELPER_MANAGED" = "0" ]; then
+    info "Native package approval is unavailable; command checks and shell protection are ready."
+    info "To enable package approval, rerun with TIRITH_INSTALL_APPROVAL_HELPER=1."
+  fi
 
   # PATH advice
   case ":${PATH}:" in
@@ -546,7 +600,7 @@ main() {
   info ""
   info "To uninstall:"
   info "  rm ${INSTALL_DIR}/tirith"
-  if [ "$TARGET" = "x86_64-unknown-linux-gnu" ]; then
+  if [ "$PAIRED_HELPER_MANAGED" = "1" ]; then
     info "  sudo rm /usr/local/libexec/tirith-package-approval-authority"
     info "  sudo rm -f /usr/local/libexec/tirith-package-approval-authority.tirith-previous"
     info "  sudo rm -f /usr/local/libexec/tirith-package-approval-authority.tirith-previous.absent"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -601,9 +601,13 @@ main() {
   info "To uninstall:"
   info "  rm ${INSTALL_DIR}/tirith"
   if [ "$PAIRED_HELPER_MANAGED" = "1" ]; then
-    info "  sudo rm /usr/local/libexec/tirith-package-approval-authority"
-    info "  sudo rm -f /usr/local/libexec/tirith-package-approval-authority.tirith-previous"
-    info "  sudo rm -f /usr/local/libexec/tirith-package-approval-authority.tirith-previous.absent"
+    helper_remove_command="rm"
+    if [ "$(id -u)" -ne 0 ]; then
+      helper_remove_command="sudo rm"
+    fi
+    info "  ${helper_remove_command} /usr/local/libexec/tirith-package-approval-authority"
+    info "  ${helper_remove_command} -f /usr/local/libexec/tirith-package-approval-authority.tirith-previous"
+    info "  ${helper_remove_command} -f /usr/local/libexec/tirith-package-approval-authority.tirith-previous.absent"
   fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -580,8 +580,9 @@ main() {
   info ""
   info "tirith installed to ${INSTALL_DIR}/tirith"
   if [ "$TARGET" = "x86_64-unknown-linux-gnu" ] && [ "$PAIRED_HELPER_MANAGED" = "0" ]; then
-    info "Native package approval is unavailable; command checks and shell protection are ready."
-    info "To enable package approval, rerun with TIRITH_INSTALL_APPROVAL_HELPER=1."
+    info "Native package approval is unavailable; ordinary command checks and shell protection do not require it."
+    info "Only if you need package approval, rerun with TIRITH_INSTALL_APPROVAL_HELPER=1."
+    info "Helper provisioning needs a root session or trusted /usr/bin/sudo; issuing approvals needs sudo and fresh interactive administrator confirmation."
   fi
 
   # PATH advice

--- a/tests/install-sh/optional_helper.sh
+++ b/tests/install-sh/optional_helper.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+mkdir -p "$work/fixture" "$work/payload"
+printf '#!/bin/sh\nprintf "tirith fixture\\n"\n' > "$work/payload/tirith"
+tar czf "$work/fixture/release.tar.gz" -C "$work/payload" tirith
+(
+  # shellcheck disable=SC1090
+  TIRITH_INSTALL_SH_LIB=1 . "$INSTALL_SH"
+  printf '%s  release.tar.gz\n' "$(sha256_file "$work/fixture/release.tar.gz")"
+) > "$work/fixture/checksums.txt"
+
+run_install_case() {
+  CASE_DIR="$work/$1" FIXTURE_DIR="$work/fixture" INSTALL_SH="$INSTALL_SH" \
+    FAIL_INSTALL="$2" sh -c '
+    set -eu
+    TIRITH_INSTALL_SH_LIB=1 . "$INSTALL_SH"
+    mkdir -p "$CASE_DIR/bin"
+    INSTALL_DIR="$CASE_DIR/bin"
+    PAIRED_HELPER_DEST="$CASE_DIR/helper"
+    TIRITH_INSTALL_APPROVAL_HELPER=0
+    detect_platform() { TARGET=x86_64-unknown-linux-gnu; ARCHIVE=release.tar.gz; }
+    resolve_version() { VERSION=v9.9.9; }
+    resolve_latest_version() { :; }
+    download_url() { printf "%s/%s\n" "$FIXTURE_DIR" "$1"; }
+    fetch() { cp "$1" "$2"; }
+    verify_cosign() { :; }
+    run_root() { printf "unexpected elevation\n" > "$CASE_DIR/elevated"; return 1; }
+    install_package_approval_helper() {
+      printf "unexpected helper installation\n" > "$CASE_DIR/helper-attempted"
+      return 1
+    }
+    if [ "$FAIL_INSTALL" = 1 ]; then
+      printf "old-main\n" > "$INSTALL_DIR/tirith"
+      install() {
+        case "$3" in
+          */tirith) return 1 ;;
+          *) command install "$@" ;;
+        esac
+      }
+    fi
+    main
+  '
+}
+
+run_install_case fresh 0 > "$work/fresh.log"
+cmp "$work/payload/tirith" "$work/fresh/bin/tirith"
+test ! -e "$work/fresh/elevated"
+test ! -e "$work/fresh/helper-attempted"
+grep -q 'Native package approval is unavailable' "$work/fresh.log"
+if run_install_case failed 1 > "$work/failed.log" 2>&1; then
+  echo 'failed installation unexpectedly succeeded' >&2
+  exit 1
+fi
+test "$(cat "$work/failed/bin/tirith")" = old-main
+test ! -e "$work/failed/elevated"
+test ! -e "$work/failed/helper-attempted"
+
+CASE_DIR="$work/selection" INSTALL_SH="$INSTALL_SH" sh -c '
+  set -eu
+  TIRITH_INSTALL_SH_LIB=1 . "$INSTALL_SH"
+  mkdir -p "$CASE_DIR"
+  PAIRED_HELPER_DEST="$CASE_DIR/helper"
+  TARGET=x86_64-unknown-linux-gnu
+  id() { printf "0\n"; }
+  TIRITH_INSTALL_APPROVAL_HELPER=0
+  select_package_approval_helper
+  test "$PAIRED_HELPER_MANAGED" = 0
+  TIRITH_INSTALL_APPROVAL_HELPER=1
+  select_package_approval_helper
+  test "$PAIRED_HELPER_MANAGED" = 1
+  TIRITH_INSTALL_APPROVAL_HELPER=0
+  for path in "$PAIRED_HELPER_DEST" "${PAIRED_HELPER_DEST}.tirith-previous" \
+      "${PAIRED_HELPER_DEST}.tirith-previous.absent"; do
+    touch "$path"
+    select_package_approval_helper
+    test "$PAIRED_HELPER_MANAGED" = 1
+    rm "$path"
+  done
+  ln -s "$CASE_DIR/missing" "$PAIRED_HELPER_DEST"
+  select_package_approval_helper
+  test "$PAIRED_HELPER_MANAGED" = 1
+  rm "$PAIRED_HELPER_DEST"
+  TARGET=aarch64-unknown-linux-gnu
+  select_package_approval_helper
+  test "$PAIRED_HELPER_MANAGED" = 0
+  if (TIRITH_INSTALL_APPROVAL_HELPER=1; select_package_approval_helper) 2>/dev/null; then
+    exit 1
+  fi
+  if (TIRITH_INSTALL_APPROVAL_HELPER=yes; select_package_approval_helper) 2>/dev/null; then
+    exit 1
+  fi
+'
+
+if [ "$(id -u)" -ne 0 ]; then
+  CASE_DIR="$work/inaccessible" INSTALL_SH="$INSTALL_SH" sh -c '
+    set -eu
+    TIRITH_INSTALL_SH_LIB=1 . "$INSTALL_SH"
+    mkdir -p "$CASE_DIR/grandparent/parent"
+    PAIRED_HELPER_DEST="$CASE_DIR/grandparent/parent/helper"
+    touch "$PAIRED_HELPER_DEST"
+    chmod 000 "$CASE_DIR/grandparent"
+    trap '\''chmod 700 "$CASE_DIR/grandparent"'\'' EXIT HUP INT TERM
+    package_approval_helper_state_present
+    TARGET=x86_64-unknown-linux-gnu
+    TIRITH_INSTALL_APPROVAL_HELPER=0
+    id() { printf "0\n"; }
+    select_package_approval_helper
+    test "$PAIRED_HELPER_MANAGED" = 1
+  '
+fi
+
+echo 'PASS: fresh installation and rollback avoid elevation; existing helper state remains paired'

--- a/tests/install-sh/paired_rollback.sh
+++ b/tests/install-sh/paired_rollback.sh
@@ -15,6 +15,7 @@ run_rollback_case() {
     TIRITH_INSTALL_SH_LIB=1 . "$INSTALL_SH"
     run_root() { "$@"; }
     TARGET=x86_64-unknown-linux-gnu
+    PAIRED_HELPER_MANAGED=1
     PAIRED_TMPDIR="$CASE_DIR/runtime"
     PAIRED_MAIN_DEST="$CASE_DIR/main"
     PAIRED_HELPER_DEST="$CASE_DIR/helper"
@@ -71,6 +72,7 @@ if CASE_DIR="$both_case" INSTALL_SH="$INSTALL_SH" sh -c '
   TIRITH_INSTALL_SH_LIB=1 . "$INSTALL_SH"
   run_root() { "$@"; }
   TARGET=x86_64-unknown-linux-gnu
+  PAIRED_HELPER_MANAGED=1
   PAIRED_TMPDIR="$CASE_DIR/runtime"
   PAIRED_MAIN_DEST="$CASE_DIR/main"
   PAIRED_HELPER_DEST="$CASE_DIR/helper"

--- a/tests/windows-install.ps1
+++ b/tests/windows-install.ps1
@@ -1,0 +1,52 @@
+$ErrorActionPreference = 'Stop'
+$previousLibraryMode = $env:TIRITH_INSTALL_PS_LIB
+try {
+    $env:TIRITH_INSTALL_PS_LIB = '1'
+    . "$PSScriptRoot/../packaging/windows/install.ps1"
+} finally {
+    $env:TIRITH_INSTALL_PS_LIB = $previousLibraryMode
+}
+
+$asset = [pscustomobject]@{
+    name = 'tirith-x86_64-pc-windows-msvc.zip'
+    browser_download_url = 'https://example.invalid/windows.zip'
+}
+$release = [pscustomobject]@{
+    tag_name = 'v0.4.2'
+    assets = @([pscustomobject]@{ name = 'Windows-unrelated.zip' }, $asset)
+}
+$selected = Get-TirithWindowsReleaseAsset $release
+if ($selected.browser_download_url -ne $asset.browser_download_url) {
+    throw 'Canonical Windows archive was not selected'
+}
+foreach ($assetCount in @(0, 2)) {
+    $fixtureAssets = @()
+    if ($assetCount -eq 2) {
+        $fixtureAssets = @($asset, $asset)
+    }
+    $rejected = $false
+    try {
+        Get-TirithWindowsReleaseAsset ([pscustomobject]@{ assets = $fixtureAssets }) | Out-Null
+    } catch {
+        $rejected = $true
+    }
+    if (!$rejected) {
+        throw 'Missing or duplicate Windows assets were accepted'
+    }
+}
+$identity = Get-TirithReleaseCertificateIdentity 'v0.4.2'
+if ($identity -cne 'https://github.com/sheeki03/tirith/.github/workflows/release.yml@refs/tags/v0.4.2') {
+    throw 'Certificate identity is not bound to the selected release tag'
+}
+foreach ($tag in @('threatdb-2026-09-12', 'main', 'v0.4.2/../../main', '')) {
+    $rejected = $false
+    try {
+        Get-TirithReleaseCertificateIdentity $tag | Out-Null
+    } catch {
+        $rejected = $true
+    }
+    if (!$rejected) {
+        throw "Invalid release tag was accepted: $tag"
+    }
+}
+Write-Output 'PASS: Windows installer resolves canonical assets and binds signature identity without installation or elevation'


### PR DESCRIPTION
Fresh x86_64 Linux shell installs and manual self-updates currently create a privileged approval helper even when the user only needs ordinary command checks. Keep new user-local installs and updates unprivileged unless the helper is explicitly requested or its protected state already exists. Bind the helper decision into update authorization, recheck it before mutation, and retain paired update/rollback for live helpers, rollback state, invalid entries, and inaccessible ancestors. `TIRITH_INSTALL_APPROVAL_HELPER=0` cannot bypass an existing helper.

The Windows user installer also fails to find current release archives because it searches for `*Windows*`. Require exactly one canonical archive and bind the signature identity to the selected version's release workflow. Update installer, package-manager, and removal guidance to distinguish administrator access from a dependency on sudo, with a privilege matrix for every distribution channel. Fresh Linux installs explain that package approval is unavailable by default and name both explicit helper provisioning and fresh sudo confirmation requirements; ordinary protection does not require it.

Validation:

- POSIX installer tests passed on macOS and as UID 65534 in pinned, sudo-free Debian 12: fresh install, failure rollback, optional helper selection, existing helper/backup/marker/symlink state, invalid opt-in values, unsupported architecture, and inaccessible grandparent.
- Existing checksum verification, helper return-path, and paired rollback tests passed.
- Windows release-selection/signature tests passed with checksum-verified PowerShell 7.6.6; the same test is wired into Windows CI. The test performs no installation or elevation.
- Formatting, diff checks, actionlint, and ShellCheck passed (excluding existing SC3043 portability warnings for `local`).
- Local `cargo test -p tirith --bin tirith selfupdate::tests --locked`: 46 passed, including protected helper state, unprivileged update effects, preserved rollback points, stale preimages, signature binding, and policy denial before writes.
- Current head `3dce8f2d`: all 53 applicable CI checks pass, with 12 expected skips and no failures. Native Linux, macOS, Windows, and configured-package validation are green. All four POSIX installer fixture suites also passed after integration.

Stacked on #251. No version bump or published artifact changes.
