### PR TITLE
Clarify curl numeric URL diagnostics and destination extraction

### DIFF
--- a/crates/tirith-core/src/engine.rs
+++ b/crates/tirith-core/src/engine.rs
@@ -3260,7 +3260,11 @@ fn analyze_inner_with_policy_and_pdf_coverage(
             let raw_path = extract_raw_path_from_url(&url_info.raw);
             let normalized_path = url_info.parsed.path().map(normalize::normalize_path);
 
-            let hostname_findings = crate::rules::hostname::check(&url_info.parsed, &policy);
+            let hostname_findings = crate::rules::hostname::check_with_raw_url(
+                &url_info.parsed,
+                &policy,
+                Some(&url_info.raw),
+            );
             findings.extend(hostname_findings);
 
             let path_findings = crate::rules::path::check(
@@ -3270,8 +3274,11 @@ fn analyze_inner_with_policy_and_pdf_coverage(
             );
             findings.extend(path_findings);
 
-            let transport_findings =
-                crate::rules::transport::check(&url_info.parsed, url_info.in_sink_context);
+            let transport_findings = crate::rules::transport::check_with_raw_url(
+                &url_info.parsed,
+                url_info.in_sink_context,
+                Some(&url_info.raw),
+            );
             findings.extend(transport_findings);
 
             let ecosystem_findings = crate::rules::ecosystem::check_with_extraction_index(

--- a/crates/tirith-core/src/extract.rs
+++ b/crates/tirith-core/src/extract.rs
@@ -1853,6 +1853,10 @@ fn extract_urls_depth(input: &str, shell: ShellType, depth: usize) -> Vec<Extrac
     for (seg_idx, segment) in segments.iter().enumerate() {
         let sink_context = is_sink_context(segment, &segments, shell);
         let resolved = resolve_segment_command_for_shell(segment, shell);
+        let curl_destinations = resolved
+            .as_ref()
+            .filter(|command| command.name == "curl")
+            .map(|command| crate::rules::command::curl_url_operands(&command.args, shell));
 
         // Suppress URL extraction ONLY for the arg span of a first-segment
         // tirith inspection subcommand — not the whole segment. Leading env
@@ -1951,7 +1955,37 @@ fn extract_urls_depth(input: &str, shell: ShellType, depth: usize) -> Vec<Extrac
             }
         }
         for source in &url_sources {
-            push_urls_from_source(source, shell, seg_idx, sink_context, &mut results);
+            push_urls_from_source_with_curl_operands(
+                source,
+                shell,
+                seg_idx,
+                sink_context,
+                curl_destinations.as_deref(),
+                &mut results,
+            );
+        }
+
+        if let Some(destinations) = &curl_destinations {
+            // curl does not use SCP's user@host:path shorthand. Its option
+            // grammar decides which words are URL operands; parse those as
+            // URL authorities even when the generic regex resembles SCP.
+            for raw in destinations {
+                let parsed = if has_leading_uri_scheme(raw) {
+                    // curl also accepts schemes outside URL_REGEX's generic
+                    // shortlist, including explicit scp:// and sftp:// URLs.
+                    parse_curl_destination(raw)
+                } else if let Some(parsed) = parse_schemeless_destination(raw) {
+                    parsed
+                } else {
+                    continue;
+                };
+                results.push(ExtractedUrl {
+                    raw: raw.clone(),
+                    parsed,
+                    segment_index: seg_idx,
+                    in_sink_context: sink_context,
+                });
+            }
         }
 
         // Schemeless URLs in sink contexts. Skip docker/podman/nerdctl — their
@@ -1959,7 +1993,7 @@ fn extract_urls_depth(input: &str, shell: ShellType, depth: usize) -> Vec<Extrac
         let is_docker_cmd = resolved
             .as_ref()
             .is_some_and(|cmd| matches!(cmd.name.as_str(), "docker" | "podman" | "nerdctl"));
-        if sink_context && !is_docker_cmd {
+        if sink_context && !is_docker_cmd && curl_destinations.is_none() {
             if let Some(cmd) = resolved.as_ref() {
                 // scp/rsync args are remote specs (parse_scp_remote_spec below)
                 // or local file paths — never schemeless domains. Skip the
@@ -2330,10 +2364,84 @@ fn push_urls_from_source(
     in_sink_context: bool,
     results: &mut Vec<ExtractedUrl>,
 ) {
+    push_urls_from_source_with_curl_operands(
+        source,
+        shell,
+        segment_index,
+        in_sink_context,
+        None,
+        results,
+    );
+}
+
+/// curl normalizes ordinary numeric IPv4 authorities independently of scheme.
+/// The URL crate leaves non-special schemes such as sftp as opaque domains.
+/// Keep this adjustment in curl operand context and retain the original host
+/// for diagnostics. Encoded/trailing-dot spellings have version-dependent curl
+/// behavior and are deliberately outside this normalization contract.
+fn parse_curl_destination(raw: &str) -> parse::UrlLike {
+    let mut value = parse::parse_url(raw);
+    if let parse::UrlLike::Standard { parsed, .. } = &mut value {
+        if let Some(url::Host::Domain(host)) = parsed.host() {
+            if !host.ends_with('.')
+                // WHATWG treats a bare hex prefix as zero; curl retains it as
+                // a hostname, including within a dotted authority.
+                && host.split('.').all(|part| !part.eq_ignore_ascii_case("0x"))
+                && host
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() || matches!(byte, b'x' | b'X' | b'.'))
+            {
+                if let Ok(url::Host::Ipv4(address)) = url::Host::parse(host) {
+                    // A URL with a host is hierarchical, and the typed address
+                    // is valid independently of the URL's existing scheme.
+                    parsed
+                        .set_ip_host(std::net::IpAddr::V4(address))
+                        .expect("an existing hierarchical URL accepts a typed IP host");
+                }
+            }
+        }
+    }
+    value
+}
+
+fn push_urls_from_source_with_curl_operands(
+    source: &str,
+    shell: ShellType,
+    segment_index: usize,
+    in_sink_context: bool,
+    curl_operands: Option<&[String]>,
+    results: &mut Vec<ExtractedUrl>,
+) {
     let normalized = crate::rules::command::normalize_shell_token(source, shell);
     for mat in URL_REGEX.find_iter(&normalized) {
         let raw = mat.as_str().to_string();
-        let url = parse::parse_url(&raw);
+        if let Some(operands) = curl_operands {
+            if !has_leading_uri_scheme(&raw) {
+                continue;
+            }
+            // A selected sftp:// operand also matches the generic regex at
+            // ftp://. The complete operand below is authoritative; suppress
+            // only a proven suffix of that same spelling, including attached
+            // --url= / -x values. Other embedded URL text keeps its old scan.
+            let starts_inside_operand_scheme = operands.iter().any(|operand| {
+                if !has_leading_uri_scheme(operand) || operand.len() <= raw.len() {
+                    return false;
+                }
+                let suffix_start = operand.len() - raw.len();
+                let scheme_end = operand.find("://").unwrap();
+                suffix_start < scheme_end
+                    && operand.get(suffix_start..) == Some(raw.as_str())
+                    && normalized[..mat.start()].ends_with(&operand[..suffix_start])
+            });
+            if starts_inside_operand_scheme {
+                continue;
+            }
+        }
+        let url = if curl_operands.is_some_and(|operands| operands.contains(&raw)) {
+            parse_curl_destination(&raw)
+        } else {
+            parse::parse_url(&raw)
+        };
         results.push(ExtractedUrl {
             raw,
             parsed: url,
@@ -12499,7 +12607,9 @@ fn parse_schemeless_destination_inner(s: &str, apply_noise_heuristic: bool) -> O
         return None;
     }
 
-    let is_ip = host.parse::<std::net::IpAddr>().is_ok();
+    // host_str() retains brackets around IPv6; use the typed host so a bare
+    // bracketed IPv6 destination is not discarded by the file-noise filter.
+    let is_ip = matches!(parsed.host(), Some(url::Host::Ipv4(_) | url::Host::Ipv6(_)));
     let has_explicit_port = parsed.port().is_some();
     let has_query_or_fragment = parsed.query().is_some() || parsed.fragment().is_some();
     let has_meaningful_path = parsed.path() != "/" && !parsed.path().is_empty();

--- a/crates/tirith-core/src/parse.rs
+++ b/crates/tirith-core/src/parse.rs
@@ -205,23 +205,12 @@ fn leading_scheme_separator(raw: &str) -> Option<usize> {
 /// Split userinfo from authority on the LAST unencoded `@` (so `user%40name@host`
 /// resolves to `host` — `%40` is userinfo, not a separator).
 fn split_userinfo(authority: &str) -> &str {
-    let bytes = authority.as_bytes();
-    let mut last_at = None;
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            i += 3;
-            continue;
-        }
-        if bytes[i] == b'@' {
-            last_at = Some(i);
-        }
-        i += 1;
-    }
-    match last_at {
-        Some(idx) => &authority[idx + 1..],
-        None => authority,
-    }
+    // Percent-encoded @ is spelled %40 and contains no literal separator.
+    // Even malformed escapes must not hide a following literal @, which the
+    // URL parser still treats as the userinfo boundary.
+    authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host)
 }
 
 /// Extract host from a host:port string, handling IPv6 brackets.
@@ -408,6 +397,24 @@ mod tests {
         let raw = "http://user%40name@host.com/path";
         let host = extract_raw_host(raw);
         assert_eq!(host, Some("host.com".to_string()));
+    }
+
+    #[test]
+    fn test_raw_host_malformed_percent_cannot_hide_userinfo_separator() {
+        for userinfo in [
+            "user:q7z9canary%",
+            "user:q7z9canary%x",
+            "user:q7z9canary%%",
+            "user%40name:q7z9canary",
+        ] {
+            for host in ["0x08080808", "8.8.8.8", "[2001:db8::1]"] {
+                let raw = format!("https://{userinfo}@{host}:8080/path");
+                assert_eq!(extract_raw_host(&raw).as_deref(), Some(host), "{raw}");
+                let parsed = parse_url(&raw);
+                assert!(matches!(&parsed, UrlLike::Standard { .. }), "{parsed:?}");
+                assert_eq!(parsed.raw_host(), Some(host), "{raw}");
+            }
+        }
     }
 
     #[test]

--- a/crates/tirith-core/src/rules/command.rs
+++ b/crates/tirith-core/src/rules/command.rs
@@ -4514,25 +4514,43 @@ fn push_fetch_option_destinations(
     destinations: &mut Vec<String>,
     kind: FetchOptionValueKind,
     value: &str,
+    include_mapped_peers: bool,
 ) {
     match kind {
         FetchOptionValueKind::Destination => destinations.push(value.to_string()),
         FetchOptionValueKind::HttpieProxy => {
             destinations.push(httpie_proxy_peer(value).to_string())
         }
-        FetchOptionValueKind::CurlConnectTo => {
+        FetchOptionValueKind::CurlConnectTo if include_mapped_peers => {
             if let Some(peer) = curl_connect_to_peer(value) {
                 destinations.push(peer.to_string());
             }
         }
-        FetchOptionValueKind::CurlResolve => {
+        FetchOptionValueKind::CurlResolve if include_mapped_peers => {
             destinations.extend(curl_resolve_peers(value).into_iter().map(str::to_string))
         }
-        FetchOptionValueKind::NonDestination => {}
+        FetchOptionValueKind::CurlConnectTo
+        | FetchOptionValueKind::CurlResolve
+        | FetchOptionValueKind::NonDestination => {}
     }
 }
 
+/// URL-like curl operands for extraction. Connection/DNS mapping fields remain
+/// network-policy peers, but are not themselves scheme-less URL operands.
+pub(crate) fn curl_url_operands(args: &[String], shell: ShellType) -> Vec<String> {
+    fetch_destination_operands("curl", args, shell, false)
+}
+
 fn url_fetch_destination_operands(command: &str, args: &[String], shell: ShellType) -> Vec<String> {
+    fetch_destination_operands(command, args, shell, true)
+}
+
+fn fetch_destination_operands(
+    command: &str,
+    args: &[String],
+    shell: ShellType,
+    include_mapped_peers: bool,
+) -> Vec<String> {
     let mut destinations = Vec::new();
     let mut pending = None;
     let mut options_terminated = false;
@@ -4540,7 +4558,12 @@ fn url_fetch_destination_operands(command: &str, args: &[String], shell: ShellTy
     for arg in args {
         let normalized = normalize_shell_token(arg, shell);
         if let Some(kind) = pending.take() {
-            push_fetch_option_destinations(&mut destinations, kind, &normalized);
+            push_fetch_option_destinations(
+                &mut destinations,
+                kind,
+                &normalized,
+                include_mapped_peers,
+            );
             continue;
         }
         if !options_terminated && normalized == "--" {
@@ -4556,9 +4579,12 @@ fn url_fetch_destination_operands(command: &str, args: &[String], shell: ShellTy
         if !options_terminated && option_spelling.starts_with('-') && option_spelling != "-" {
             if let Some(option) = fetch_option_value(command, &option_spelling) {
                 match (option.kind, option.attached) {
-                    (kind, Some(value)) if !value.is_empty() => {
-                        push_fetch_option_destinations(&mut destinations, kind, value)
-                    }
+                    (kind, Some(value)) if !value.is_empty() => push_fetch_option_destinations(
+                        &mut destinations,
+                        kind,
+                        value,
+                        include_mapped_peers,
+                    ),
                     (_, Some(_)) => {}
                     (kind, None) => pending = Some(kind),
                 }

--- a/crates/tirith-core/src/rules/hostname.rs
+++ b/crates/tirith-core/src/rules/hostname.rs
@@ -6,6 +6,16 @@ use crate::verdict::{Evidence, Finding, RuleId, Severity};
 
 /// Run all hostname rules against a parsed URL.
 pub fn check(url: &UrlLike, policy: &Policy) -> Vec<Finding> {
+    check_with_raw_url(url, policy, None)
+}
+
+/// Preserve the extracted operand when schemeless parsing has normalized its
+/// host. Keep the public UrlLike representation and rule entry point unchanged.
+pub(crate) fn check_with_raw_url(
+    url: &UrlLike,
+    policy: &Policy,
+    raw_url: Option<&str>,
+) -> Vec<Finding> {
     let mut findings = Vec::new();
 
     if let Some(raw_host) = url.raw_host() {
@@ -18,7 +28,7 @@ pub fn check(url: &UrlLike, policy: &Policy) -> Vec<Finding> {
 
     if let Some(host) = url.host() {
         check_punycode_domain(host, &mut findings);
-        check_raw_ip(host, &mut findings);
+        check_raw_ip(url, raw_url, &mut findings);
         check_lookalike_tld(host, &mut findings);
     }
 
@@ -173,47 +183,63 @@ fn check_userinfo_trick(url: &UrlLike, findings: &mut Vec<Finding>) {
     }
 }
 
-fn check_raw_ip(host: &str, findings: &mut Vec<Finding>) {
-    if let Ok(ip) = host.parse::<std::net::Ipv4Addr>() {
+fn check_raw_ip(url: &UrlLike, raw_url: Option<&str>, findings: &mut Vec<Finding>) {
+    let Some(host) = url.host() else {
+        return;
+    };
+    let (title, address_kind) = if let Ok(ip) = host.parse::<std::net::Ipv4Addr>() {
         // Loopback (127.x) is benign local development — skip.
         if ip.octets()[0] == 127 {
             return;
         }
-        findings.push(Finding {
-            rule_id: RuleId::RawIpUrl,
-            severity: Severity::Medium,
-            title: "URL uses raw IP address".to_string(),
-            description: format!("URL points to IP address {host} instead of a domain name"),
-            evidence: vec![Evidence::Url {
-                raw: host.to_string(),
-            }],
-            human_view: None,
-            agent_view: None,
-            mitre_id: None,
-            custom_rule_id: None,
-        });
-        return;
-    }
-    let stripped = host.trim_start_matches('[').trim_end_matches(']');
-    if let Ok(ip) = stripped.parse::<std::net::Ipv6Addr>() {
+        ("URL uses raw IP address", "IP address")
+    } else {
+        let stripped = host.trim_start_matches('[').trim_end_matches(']');
+        let Ok(ip) = stripped.parse::<std::net::Ipv6Addr>() else {
+            return;
+        };
         // IPv6 loopback (::1) or IPv4-mapped loopback (::ffff:127.x) is benign — skip.
         if ip.is_loopback() || ip.to_ipv4_mapped().is_some_and(|v4| v4.octets()[0] == 127) {
             return;
         }
-        findings.push(Finding {
-            rule_id: RuleId::RawIpUrl,
-            severity: Severity::Medium,
-            title: "URL uses raw IPv6 address".to_string(),
-            description: format!("URL points to IPv6 address {host} instead of a domain name"),
-            evidence: vec![Evidence::Url {
-                raw: host.to_string(),
-            }],
-            human_view: None,
-            agent_view: None,
-            mitre_id: None,
-            custom_rule_id: None,
-        });
-    }
+        ("URL uses raw IPv6 address", "IPv6 address")
+    };
+
+    // Standard URLs retain their original host. Schemeless URLs retain it only
+    // in ExtractedUrl.raw; use the same temporary scheme as the extractor to
+    // separate userinfo/port/path without displaying credentials as host text.
+    let schemeless_raw_host = if matches!(url, UrlLike::SchemelessHostPath { .. }) {
+        raw_url.and_then(|raw| {
+            let authority = raw.strip_prefix("//").unwrap_or(raw);
+            crate::parse::extract_raw_host(&format!("http://{authority}"))
+        })
+    } else {
+        None
+    };
+    let raw_host = schemeless_raw_host
+        .as_deref()
+        .or_else(|| url.raw_host())
+        .unwrap_or(host);
+    let description = if raw_host == host {
+        format!("URL points to {address_kind} {host} instead of a domain name")
+    } else {
+        format!(
+            "URL host '{raw_host}' is interpreted as {address_kind} {host} instead of a domain name"
+        )
+    };
+    findings.push(Finding {
+        rule_id: RuleId::RawIpUrl,
+        severity: Severity::Medium,
+        title: title.to_string(),
+        description,
+        evidence: vec![Evidence::Url {
+            raw: raw_host.to_string(),
+        }],
+        human_view: None,
+        agent_view: None,
+        mitre_id: None,
+        custom_rule_id: None,
+    });
 }
 
 fn check_non_standard_port(host: &str, port: u16, findings: &mut Vec<Finding>) {

--- a/crates/tirith-core/src/rules/transport.rs
+++ b/crates/tirith-core/src/rules/transport.rs
@@ -4,6 +4,16 @@ use crate::verdict::{Evidence, Finding, RuleId, Severity};
 
 /// Run transport rules against a parsed URL.
 pub fn check(url: &UrlLike, in_sink_context: bool) -> Vec<Finding> {
+    check_with_raw_url(url, in_sink_context, None)
+}
+
+/// Use the extracted operand for schemeless evidence; raw_str() reconstructs
+/// this variant from its normalized host and can otherwise hide numeric syntax.
+pub(crate) fn check_with_raw_url(
+    url: &UrlLike,
+    in_sink_context: bool,
+    raw_url: Option<&str>,
+) -> Vec<Finding> {
     let mut findings = Vec::new();
 
     check_plain_http_to_sink(url, in_sink_context, &mut findings);
@@ -17,7 +27,11 @@ pub fn check(url: &UrlLike, in_sink_context: bool) -> Vec<Finding> {
             description:
                 "URL without explicit scheme passed to a command that downloads/executes content"
                     .to_string(),
-            evidence: vec![Evidence::Url { raw: url.raw_str() }],
+            evidence: vec![Evidence::Url {
+                raw: raw_url
+                    .map(schemeless_evidence)
+                    .unwrap_or_else(|| url.raw_str()),
+            }],
             human_view: None,
             agent_view: None,
             mitre_id: None,
@@ -26,6 +40,24 @@ pub fn check(url: &UrlLike, in_sink_context: bool) -> Vec<Finding> {
     }
 
     findings
+}
+
+// Keep the original destination spelling without introducing userinfo that the
+// previous host+path evidence omitted. Query/path text was already retained.
+fn schemeless_evidence(raw: &str) -> String {
+    let authority_start = if raw.starts_with("//") { 2 } else { 0 };
+    let tail_start = raw[authority_start..]
+        .find(['/', '?', '#'])
+        .map(|offset| authority_start + offset)
+        .unwrap_or(raw.len());
+    match raw[authority_start..tail_start].rfind('@') {
+        Some(at) => format!(
+            "{}{}",
+            &raw[..authority_start],
+            &raw[authority_start + at + 1..]
+        ),
+        None => raw.to_string(),
+    }
 }
 
 fn check_plain_http_to_sink(url: &UrlLike, in_sink: bool, findings: &mut Vec<Finding>) {
@@ -194,6 +226,22 @@ fn scan_curl_short_options(argument: &str) -> CurlShortOptionScan {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn schemeless_evidence_preserves_destination_without_credentials() {
+        for raw in [
+            "user:password@0x08080808:8080/path?x=1",
+            "user%40name:password@0x08080808:8080/path?x=1",
+        ] {
+            assert_eq!(schemeless_evidence(raw), "0x08080808:8080/path?x=1");
+            assert_eq!(
+                schemeless_evidence(&format!("//{raw}")),
+                "//0x08080808:8080/path?x=1"
+            );
+        }
+        assert_eq!(schemeless_evidence("8080"), "8080");
+        assert_eq!(schemeless_evidence("8080/path@name"), "8080/path@name");
+    }
 
     #[test]
     fn test_quoted_insecure_flags() {

--- a/crates/tirith-core/tests/curl_destination_extraction.rs
+++ b/crates/tirith-core/tests/curl_destination_extraction.rs
@@ -1,0 +1,211 @@
+//! curl's URL operands use URL authority syntax; nc/scp keep their own grammar.
+
+use tirith_core::extract::extract_urls;
+use tirith_core::parse::UrlLike;
+use tirith_core::tokenize::ShellType;
+
+#[test]
+fn curl_bare_ipv6_and_numeric_userinfo_are_url_authorities() {
+    for (raw, expected) in [
+        ("[2001:db8::1]", "[2001:db8::1]"),
+        ("[2001:0db8:0000:0000:0000:0000:0000:0001]", "[2001:db8::1]"),
+        ("user@134744072:8080/path", "8.8.8.8"),
+        ("user@0x08080808:8080/path", "8.8.8.8"),
+        ("user@010.010.010.010:8080/path", "8.8.8.8"),
+        ("user@8.526344:8080/path", "8.8.8.8"),
+        ("user:password@0x08080808:8080/path", "8.8.8.8"),
+        ("user@8.8.8.8:8080/path", "8.8.8.8"),
+        ("user@host.example:8080/path", "host.example"),
+        ("[::1]", "[::1]"),
+    ] {
+        for option in ["", "--url ", "--url=", "-- "] {
+            let input = format!("curl -sv {option}'{raw}'");
+            let urls = extract_urls(&input, ShellType::Posix);
+            assert_eq!(urls.len(), 1, "{input}: {urls:?}");
+            assert_eq!(urls[0].raw, raw, "{input}");
+            assert_eq!(urls[0].parsed.host(), Some(expected), "{input}");
+            assert!(matches!(urls[0].parsed, UrlLike::SchemelessHostPath { .. }));
+            assert!(urls[0].in_sink_context);
+        }
+    }
+}
+
+#[test]
+fn curl_option_values_cannot_turn_into_scp_or_schemeless_destinations() {
+    for options in [
+        "--local-port 8080",
+        "--local-port=8080",
+        "--output user@134744072:8080/path",
+        "--output=user@134744072:8080/path",
+        "-ouser@134744072:8080/path",
+        "--header user@134744072:8080/path",
+        "--data user:password@134744072:8080/path",
+        "--data '[2001:db8::1]'",
+    ] {
+        let input = format!("curl {options} https://example.com/");
+        let urls = extract_urls(&input, ShellType::Posix);
+        assert_eq!(urls.len(), 1, "{input}: {urls:?}");
+        assert_eq!(urls[0].parsed.host(), Some("example.com"));
+    }
+    // -H is consumed as -d's value; the following word is a real URL operand.
+    let urls = extract_urls("curl -d -H user@134744072:8080/path", ShellType::Posix);
+    assert_eq!(urls.len(), 1, "{urls:?}");
+    assert_eq!(urls[0].parsed.host(), Some("8.8.8.8"));
+}
+
+#[test]
+fn curl_connection_mappings_are_not_schemeless_url_operands() {
+    let input = "curl --resolve example.com:443:192.0.2.10 --connect-to example.com:443:198.51.100.10:8443 https://example.com/";
+    let urls = extract_urls(input, ShellType::Posix);
+    assert_eq!(urls.len(), 1, "{urls:?}");
+    assert_eq!(urls[0].parsed.host(), Some("example.com"));
+}
+
+#[test]
+fn port_numbers_remain_urls_only_in_curl_url_positions() {
+    for input in [
+        "nc 203.0.113.10 8080",
+        "ncat 203.0.113.10 8082",
+        "netcat 2001:db8::1 8080",
+        "printf '%s' '[2001:db8::1]'",
+        "echo 8080 134744072",
+        "cp 8080 8082",
+    ] {
+        assert!(extract_urls(input, ShellType::Posix).is_empty(), "{input}");
+    }
+    let urls = extract_urls("curl --local-port 8080 8082", ShellType::Posix);
+    assert_eq!(urls.len(), 1, "{urls:?}");
+    assert_eq!(urls[0].raw, "8082");
+    assert_eq!(urls[0].parsed.host(), Some("0.0.31.146"));
+    let urls = extract_urls("curl 203.0.113.10 8080", ShellType::Posix);
+    assert_eq!(urls.len(), 2, "{urls:?}");
+}
+
+#[test]
+fn remote_copy_commands_keep_scp_paths() {
+    for input in [
+        "scp user@134744072:8080/path destination",
+        "rsync -av user@134744072:8080/path destination",
+        "git clone user@134744072:8080/path",
+    ] {
+        let urls = extract_urls(input, ShellType::Posix);
+        assert_eq!(urls.len(), 1, "{input}: {urls:?}");
+        // The generic parser has always left undotted SCP hosts unparsed.
+        // Preserve that exact baseline instead of normalizing the integer as
+        // curl does or silently broadening SCP parsing in this correction.
+        assert_eq!(urls[0].raw, "user@134744072:8080/path");
+        assert!(
+            matches!(&urls[0].parsed, UrlLike::Unparsed { raw, raw_host, raw_path }
+            if raw == "user@134744072:8080/path" && raw_host.is_none() && raw_path.is_none())
+        );
+    }
+    for command in ["scp", "rsync -av", "git clone"] {
+        for host in ["8.8.8.8", "host.example"] {
+            let input = format!("{command} user@{host}:8080/path destination");
+            let urls = extract_urls(&input, ShellType::Posix);
+            assert_eq!(urls.len(), 1, "{input}: {urls:?}");
+            assert!(
+                matches!(&urls[0].parsed, UrlLike::Scp { user, host: actual, path }
+                if user.as_deref() == Some("user") && actual == host && path == "8080/path")
+            );
+        }
+    }
+    // The same spelling with a nonnumeric "port" is not a curl URL, and curl
+    // does not reinterpret it as SCP's remote path shorthand.
+    assert!(extract_urls("curl user@host.example:repo/path", ShellType::Posix).is_empty());
+}
+
+#[test]
+fn curl_explicit_scp_and_sftp_urls_still_expose_their_host() {
+    for scheme in ["http", "https", "ftp", "scp", "sftp"] {
+        let raw = format!("{scheme}://user@8.8.8.8:22/path");
+        for prefix in ["", "--url ", "--url=", "--proxy=", "-x", "-svx"] {
+            let input = format!("curl {prefix}'{raw}'");
+            let urls = extract_urls(&input, ShellType::Posix);
+            assert_eq!(urls.len(), 1, "{input}: {urls:?}");
+            assert_eq!(urls[0].raw, raw, "{input}");
+            assert_eq!(urls[0].parsed.host(), Some("8.8.8.8"));
+            assert_eq!(urls[0].parsed.scheme(), Some(scheme));
+            assert!(matches!(urls[0].parsed, UrlLike::Standard { .. }));
+        }
+    }
+}
+
+#[test]
+fn wrapped_curl_and_executable_substitutions_keep_destination_context() {
+    for input in [
+        "env curl 'user@134744072:8080/path'",
+        "sh -c 'curl user@134744072:8080/path'",
+        "curl --data \"$(curl user@134744072:8080/path)\" https://example.com/",
+    ] {
+        let urls = extract_urls(input, ShellType::Posix);
+        assert!(
+            urls.iter().any(|url| url.parsed.host() == Some("8.8.8.8")
+                && url.in_sink_context
+                && matches!(url.parsed, UrlLike::SchemelessHostPath { .. })),
+            "{input}: {urls:?}"
+        );
+    }
+}
+
+#[test]
+fn curl_scheme_suffix_filter_preserves_independent_and_embedded_urls() {
+    for input in [
+        "curl sftp://user@8.8.8.8:22/path ftp://user@8.8.8.8:22/path",
+        "curl --url=sftp://user@8.8.8.8:22/path --header 'Location: ftp://user@8.8.8.8:22/path'",
+        "curl -xsftp://user@8.8.8.8:22/path --data 'see ftp://user@8.8.8.8:22/path'",
+    ] {
+        let urls = extract_urls(input, ShellType::Posix);
+        assert_eq!(urls.len(), 2, "{input}: {urls:?}");
+        for scheme in ["ftp", "sftp"] {
+            assert_eq!(
+                urls.iter()
+                    .filter(|url| url.parsed.scheme() == Some(scheme))
+                    .count(),
+                1,
+                "{input}: {urls:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn curl_non_special_schemes_normalize_numeric_hosts_without_changing_components() {
+    for scheme in ["sftp", "scp", "ftps", "smtp", "ssh"] {
+        for (host, canonical) in [
+            ("134744072", "8.8.8.8"),
+            ("0x08080808", "8.8.8.8"),
+            ("010.010.010.010", "8.8.8.8"),
+            ("8.526344", "8.8.8.8"),
+            ("8080", "0.0.31.144"),
+            ("0x0", "0.0.0.0"),
+            ("0x00.1", "0.0.0.1"),
+            ("0x", "0x"),
+            ("0X", "0X"),
+            ("0x.1", "0x.1"),
+            ("8.0x", "8.0x"),
+            ("0x7f.0x", "0x7f.0x"),
+            ("0x.0x.0x.0x", "0x.0x.0x.0x"),
+            ("host.example", "host.example"),
+            ("4294967296", "4294967296"),
+            ("8.8.8.8.", "8.8.8.8."),
+        ] {
+            let raw = format!("{scheme}://user:password@{host}:8022/path?x=1#part");
+            let urls = extract_urls(&format!("curl '{raw}'"), ShellType::Posix);
+            assert_eq!(urls.len(), 1, "{raw}: {urls:?}");
+            assert_eq!(urls[0].raw, raw);
+            assert_eq!(urls[0].parsed.host(), Some(canonical), "{raw}");
+            assert_eq!(urls[0].parsed.raw_host(), Some(host));
+            let UrlLike::Standard { parsed, .. } = &urls[0].parsed else {
+                panic!("{urls:?}")
+            };
+            assert_eq!(parsed.scheme(), scheme);
+            assert_eq!(parsed.username(), "user");
+            assert_eq!(parsed.password(), Some("password"));
+            assert_eq!(parsed.port(), Some(8022));
+            assert_eq!(parsed.path(), "/path");
+            assert_eq!(parsed.query(), Some("x=1"));
+            assert_eq!(parsed.fragment(), Some("part"));
+        }
+    }
+}

--- a/crates/tirith-core/tests/raw_ip_url_diagnostics.rs
+++ b/crates/tirith-core/tests/raw_ip_url_diagnostics.rs
@@ -1,0 +1,259 @@
+//! Numeric URL operands remain destinations; diagnostics preserve their spelling.
+
+use tirith_core::clipboard::ClipboardSourceState;
+use tirith_core::engine::{self, AnalysisContext};
+use tirith_core::extract::ScanContext;
+use tirith_core::tokenize::ShellType;
+use tirith_core::verdict::{Evidence, Finding, RuleId, Severity, Verdict};
+use tirith_test_support::GlobalStateGuard;
+
+fn analyze(input: &str) -> Verdict {
+    engine::analyze(&AnalysisContext {
+        input: input.into(),
+        shell: ShellType::Posix,
+        scan_context: ScanContext::Exec,
+        raw_bytes: None,
+        interactive: false,
+        cwd: Some(std::env::current_dir().unwrap().display().to_string()),
+        file_path: None,
+        repo_root: None,
+        is_config_override: false,
+        clipboard_html: None,
+        card_ref: None,
+        clipboard_source: ClipboardSourceState::AbsentOrInvalid,
+    })
+}
+
+fn raw_ip_findings(verdict: &Verdict) -> Vec<&Finding> {
+    verdict
+        .findings
+        .iter()
+        .filter(|finding| finding.rule_id == RuleId::RawIpUrl)
+        .collect()
+}
+
+fn assert_raw_evidence(finding: &Finding, expected: &str) {
+    assert!(
+        matches!(finding.evidence.as_slice(), [Evidence::Url { raw }] if raw == expected),
+        "expected URL evidence {expected:?}: {finding:?}"
+    );
+}
+
+#[test]
+fn numeric_destinations_show_original_host_and_canonical_address() {
+    let _state = GlobalStateGuard::new().unwrap();
+    // curl accepts every non-option operand as a URL, including values in the
+    // port range. These normalizations also match libcurl's offline URL API.
+    for (raw, canonical) in [
+        ("8080", "0.0.31.144"),
+        ("8082", "0.0.31.146"),
+        ("65535", "0.0.255.255"),
+        ("65536", "0.1.0.0"),
+        ("134744072", "8.8.8.8"),
+        ("0x08080808", "8.8.8.8"),
+        ("01002004010", "8.8.8.8"),
+        ("010.010.010.010", "8.8.8.8"),
+        ("8.526344", "8.8.8.8"),
+        ("8.8.2056", "8.8.8.8"),
+    ] {
+        for scheme in ["", "http://"] {
+            let operand = format!("{scheme}{raw}");
+            let verdict = analyze(&format!("curl -sv {operand}"));
+            let findings = raw_ip_findings(&verdict);
+            assert_eq!(findings.len(), 1, "{operand}: {verdict:?}");
+            let finding = findings[0];
+            assert_eq!(finding.severity, Severity::Medium);
+            assert_eq!(
+                finding.description,
+                format!("URL host '{raw}' is interpreted as IP address {canonical} instead of a domain name")
+            );
+            assert_raw_evidence(finding, raw);
+            let schemeless: Vec<_> = verdict
+                .findings
+                .iter()
+                .filter(|finding| finding.rule_id == RuleId::SchemelessToSink)
+                .collect();
+            assert_eq!(
+                schemeless.len(),
+                usize::from(scheme.is_empty()),
+                "{operand}"
+            );
+            if let Some(finding) = schemeless.first() {
+                assert_raw_evidence(finding, &operand);
+            }
+        }
+    }
+}
+
+#[test]
+fn separate_numeric_operand_is_not_a_port_for_the_previous_url() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for (raw, canonical) in [("8080", "0.0.31.144"), ("8082", "0.0.31.146")] {
+        let verdict = analyze(&format!("curl -sv 203.0.113.10 {raw}"));
+        let findings = raw_ip_findings(&verdict);
+        assert_eq!(findings.len(), 2, "{verdict:?}");
+        let numeric = findings
+            .iter()
+            .find(|finding| finding.description.contains(canonical))
+            .unwrap();
+        assert_raw_evidence(numeric, raw);
+        let dotted = findings
+            .iter()
+            .find(|finding| finding.description.contains("203.0.113.10"))
+            .unwrap();
+        assert_eq!(
+            dotted.description,
+            "URL points to IP address 203.0.113.10 instead of a domain name"
+        );
+        assert_raw_evidence(dotted, "203.0.113.10");
+    }
+}
+
+#[test]
+fn actual_option_values_are_consumed_but_following_urls_remain_visible() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for options in [
+        "--local-port 8080",
+        "--local-port=8080",
+        "--connect-timeout 8080",
+        "--output 8080",
+        "-o8080",
+    ] {
+        let verdict = analyze(&format!("curl {options} https://example.com"));
+        assert!(
+            raw_ip_findings(&verdict).is_empty(),
+            "{options}: {verdict:?}"
+        );
+        assert!(
+            verdict
+                .findings
+                .iter()
+                .all(|finding| finding.rule_id != RuleId::SchemelessToSink),
+            "{options}: {verdict:?}"
+        );
+    }
+    for command in ["curl --local-port 8080 8082", "curl --url 8082"] {
+        let verdict = analyze(command);
+        let findings = raw_ip_findings(&verdict);
+        assert_eq!(findings.len(), 1, "{command}: {verdict:?}");
+        assert_raw_evidence(findings[0], "8082");
+    }
+}
+
+#[test]
+fn explicit_port_stays_attached_to_its_host() {
+    let _state = GlobalStateGuard::new().unwrap();
+    let verdict = analyze("curl -sv http://203.0.113.10:8080/");
+    let findings = raw_ip_findings(&verdict);
+    assert_eq!(findings.len(), 1, "{verdict:?}");
+    assert_raw_evidence(findings[0], "203.0.113.10");
+    assert!(verdict
+        .findings
+        .iter()
+        .all(|finding| finding.rule_id != RuleId::SchemelessToSink));
+}
+
+#[test]
+fn schemeless_host_evidence_excludes_userinfo_port_and_path() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for operand in [
+        "0x08080808:8081/payload?x=1#part",
+        "user@0x08080808/payload?x=1#part",
+        "//0x08080808:8081/payload?x=1#part",
+    ] {
+        let verdict = analyze(&format!("curl -sv '{operand}'"));
+        let findings = raw_ip_findings(&verdict);
+        assert_eq!(findings.len(), 1, "{verdict:?}");
+        assert_raw_evidence(findings[0], "0x08080808");
+        let schemeless = verdict
+            .findings
+            .iter()
+            .find(|finding| finding.rule_id == RuleId::SchemelessToSink)
+            .unwrap();
+        assert_raw_evidence(schemeless, operand.strip_prefix("user@").unwrap_or(operand));
+    }
+}
+
+#[test]
+fn ipv6_spelling_is_preserved_and_loopback_exemptions_are_unchanged() {
+    let _state = GlobalStateGuard::new().unwrap();
+    let raw = "[2001:0db8:0000:0000:0000:0000:0000:0001]";
+    for operand in [format!("{raw}:8080/"), format!("http://{raw}/")] {
+        let verdict = analyze(&format!("curl -sv '{operand}'"));
+        let findings = raw_ip_findings(&verdict);
+        assert_eq!(findings.len(), 1, "{verdict:?}");
+        assert_eq!(findings[0].description, format!("URL host '{raw}' is interpreted as IPv6 address [2001:db8::1] instead of a domain name"));
+        assert_raw_evidence(findings[0], raw);
+    }
+    for raw in [
+        "127.0.0.1",
+        "2130706433",
+        "0x7f000001",
+        "0177.0.0.1",
+        "[::1]",
+        "[::ffff:127.0.0.1]",
+    ] {
+        let verdict = analyze(&format!("curl -sv 'http://{raw}/'"));
+        assert!(raw_ip_findings(&verdict).is_empty(), "{raw}: {verdict:?}");
+    }
+}
+
+#[test]
+fn malformed_percent_userinfo_never_enters_raw_ip_diagnostics() {
+    let _state = GlobalStateGuard::new().unwrap();
+    let canary = "q7z9canary";
+    for userinfo in [
+        "user:q7z9canary%",
+        "user:q7z9canary%x",
+        "user:q7z9canary%%",
+        "user%40name:q7z9canary",
+    ] {
+        for scheme in ["", "//", "https://"] {
+            let operand = format!("{scheme}{userinfo}@0x08080808:8080/path");
+            let verdict = analyze(&format!("curl '{operand}'"));
+            let findings = raw_ip_findings(&verdict);
+            assert_eq!(findings.len(), 1, "{operand}: {verdict:?}");
+            assert_raw_evidence(findings[0], "0x08080808");
+            assert_eq!(findings[0].description, "URL host '0x08080808' is interpreted as IP address 8.8.8.8 instead of a domain name");
+            assert!(!serde_json::to_string(findings[0]).unwrap().contains(canary));
+            if scheme != "https://" {
+                let schemeless = verdict
+                    .findings
+                    .iter()
+                    .find(|finding| finding.rule_id == RuleId::SchemelessToSink)
+                    .unwrap();
+                let prefix = if scheme == "//" { "//" } else { "" };
+                assert_raw_evidence(schemeless, &format!("{prefix}0x08080808:8080/path"));
+            }
+        }
+    }
+}
+
+#[test]
+fn explicit_curl_non_special_schemes_keep_numeric_ip_detection() {
+    let _state = GlobalStateGuard::new().unwrap();
+    for scheme in ["sftp", "scp", "ftps", "smtp"] {
+        for raw in ["134744072", "0x08080808", "010.010.010.010", "8.526344"] {
+            let operand = format!("{scheme}://user:password@{raw}:8022/path");
+            let verdict = analyze(&format!("curl '{operand}'"));
+            let findings = raw_ip_findings(&verdict);
+            assert_eq!(findings.len(), 1, "{operand}: {verdict:?}");
+            assert_raw_evidence(findings[0], raw);
+            assert_eq!(findings[0].description,
+                format!("URL host '{raw}' is interpreted as IP address 8.8.8.8 instead of a domain name"));
+            assert!(!serde_json::to_string(findings[0])
+                .unwrap()
+                .contains("password"));
+            assert!(verdict
+                .findings
+                .iter()
+                .all(|finding| finding.rule_id != RuleId::SchemelessToSink));
+        }
+        let verdict = analyze(&format!("curl '{scheme}://2130706433/path'"));
+        assert!(raw_ip_findings(&verdict).is_empty(), "{verdict:?}");
+        for domain in ["0x", "0X", "0x.1", "8.0x", "0x7f.0x", "0x.0x.0x.0x"] {
+            let verdict = analyze(&format!("curl '{scheme}://{domain}/path'"));
+            assert!(raw_ip_findings(&verdict).is_empty(), "{verdict:?}");
+        }
+    }
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -399,6 +399,22 @@ tirith's Tier 1 fast path (no URLs detected) targets <2ms. If you notice latency
 2. If Tier 1 is slow, check for extremely long command strings
 3. Policy file loading (Tier 2) adds ~1ms. Use `tirith doctor` to see policy paths
 
+## Numeric curl destinations and ports
+
+`curl HOST PORT` supplies two URL operands. For example, curl interprets the
+second operand in `curl -sv 203.0.113.10 8080` as the numeric IPv4 host
+`0.0.31.144`. A destination port belongs in the URL:
+`curl -sv http://203.0.113.10:8080/`.
+
+Curl also accepts decimal, hexadecimal, octal and shortened dotted IPv4 hosts.
+Tirith preserves those destinations in analysis and shows both the original host
+and its canonical address when they differ. Values consumed by options such as
+`--local-port 8080` or `--output 8080` are not additional destinations. Netcat's
+separate `HOST PORT` grammar is different.
+
+See curl's [URL operand rules](https://curl.se/docs/manpage.html#URL) and
+[numeric address syntax](https://curl.se/docs/url-syntax.html#numerical-ipv4-addresses).
+
 ## False positives
 
 If a command is incorrectly blocked or warned:


### PR DESCRIPTION
`curl http://example.test 8080` supplies two URL operands. The diagnostic previously showed only the normalized `0.0.31.144`, obscuring which input caused the finding. Preserve the original numeric or IPv6 host spelling and explain its canonical address; keep actual `HOST:PORT` syntax and consumed option values distinct.

Reuse curl's option grammar for destination extraction, handle bare IPv6 and curl userinfo as URL authorities, and avoid duplicate `ftp://` extraction inside an `sftp://` operand. Normalize supported numeric hosts for curl's non-special schemes while retaining URL components. Split userinfo at the final literal `@` so malformed percent escapes cannot place credentials into host evidence. Existing rule IDs, severity, loopback exemptions and public URL/rule APIs remain unchanged.

Validation: all 17 new extraction and diagnostic regressions and all 5,744 core unit tests pass natively on macOS ARM against current main at version 0.4.2, with two existing ignored tests. All 53 applicable CI checks pass at head `3998ed261b08db782811c03c6293784b5e149058`, including Linux, macOS, Windows, MSRV, packaging and smoke tests; twelve publication/conditional checks are skipped. No merge or release has been performed. An earlier integrated candidate also passed 511 targeted parser/extraction/rule checks, and the final integrated fix passed strict workspace Clippy.

The numeric normalization addition covers ASCII numeric authorities without trailing dots. Existing curl-versus-generic-parser differences for encoded/trailing-dot hosts and special-scheme empty-hex components require separate client-specific authority work; this change does not claim full curl URL-parser equivalence.

Fixes #255.
